### PR TITLE
GenWayAreaDat: Fix bugs

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenWayAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayAreaDat.cpp
@@ -325,8 +325,7 @@ namespace osmscout {
         rawWays.push_back(way);
 
         if (rawWays.size()>=rawWayBlockSize ||
-            nodeIds.size()>=nodeBlockSize ||
-            w==rawWayCount) {
+            nodeIds.size()>=nodeBlockSize) {
           CoordDataFile::ResultMap coordsMap;
 
           if (!coordDataFile.Get(nodeIds,
@@ -348,6 +347,26 @@ namespace osmscout {
           }
 
           rawWays.clear();
+        }
+      }
+
+      if (rawWays.size() != 0) {
+        CoordDataFile::ResultMap coordsMap;
+
+        if (!coordDataFile.Get(nodeIds,
+                               coordsMap)) {
+          std::cerr << "Cannot read nodes!" << std::endl;
+          return false;
+        }
+
+        for (const auto& rawWay : rawWays) {
+          WriteArea(parameter,
+                    progress,
+                    *typeConfig,
+                    areaWriter,
+                    writtenWayCount,
+                    coordsMap,
+                    *rawWay);
         }
       }
 

--- a/libosmscout-import/src/osmscout/import/GenWayAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayAreaDat.cpp
@@ -224,7 +224,7 @@ namespace osmscout {
 
     if (parameter.GetStrictAreas() &&
         !AreaIsSimple(ring.nodes)) {
-      progress.Error("Area "+NumberToString(wayId)+" of type '"+area.GetType()->GetName()+"' is not simple");
+      progress.Error("Area "+NumberToString(wayId)+" of type '"+ring.GetType()->GetName()+"' is not simple");
       return true;
     }
 


### PR DESCRIPTION
There are two bugs that this PR fixed:

1. The way areas are written to file when either the rawWays or the nodeIds fill the block size, or the last raw way is reached. However, the last raw way might not be an way area (i.e. IsArea() returns false, or is in blacklist). If so, all the way areas added after the last write will be lost. Therefore, flushing the remaining way areas should be done outside the loop.

2. If strict area is set to true, and the first ring of the area is not simple, then the program will always give seg fault, because the area.GetType() calls the GetType() of its first ring, and in the condition mentioned above, its first ring is NULL.