### PR TITLE
Pedantic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(MINGW)
 endif()
 
 if((CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUCC) AND NOT MINGW)
+  add_definitions( -Wall -pedantic -fPIC )
   check_cxx_compiler_flag(-fvisibility=hidden OSMSCOUT_GCC_VISIBILITY)
   if(OSMSCOUT_GCC_VISIBILITY)
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE OSMSCOUT_GCC_VERSION)

--- a/libosmscout-import/src/osmscout/import/GenCoordDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenCoordDat.cpp
@@ -425,5 +425,3 @@ namespace osmscout {
     return true;
   }
 }
-
-                                   ;

--- a/libosmscout-import/src/osmscout/import/Preprocessor.cpp
+++ b/libosmscout-import/src/osmscout/import/Preprocessor.cpp
@@ -24,11 +24,11 @@ namespace osmscout {
   PreprocessorCallback::~PreprocessorCallback()
   {
     // no code
-  };
+  }
 
   Preprocessor::~Preprocessor()
   {
     // no code
-  };
+  }
 }
 

--- a/libosmscout/src/osmscout/RoutingService.cpp
+++ b/libosmscout/src/osmscout/RoutingService.cpp
@@ -1021,7 +1021,7 @@ namespace osmscout {
         objects.push_back(targetObject);
       }
 
-      for (int index=0; index<nodeIndexes.size()-1; index++) {
+      for (int index=0; index<(int)nodeIndexes.size()-1; index++) {
         size_t                  fromNodeIndex=nodeIndexes.at(index);
         osmscout::ObjectFileRef fromObject=objects.at(index);
         size_t                  toNodeIndex=nodeIndexes.at(index+1);
@@ -1043,7 +1043,7 @@ namespace osmscout {
 
         /* In intermediary via points the end of the previous part is the start of the */
         /* next part, we need to remove the duplicate point in the calculated route */
-        if (index<nodeIndexes.size()-2) {
+        if (index<(int)nodeIndexes.size()-2) {
           routePart->PopEntry();
         }
 

--- a/libosmscout/src/osmscout/util/FileWriter.cpp
+++ b/libosmscout/src/osmscout/util/FileWriter.cpp
@@ -744,7 +744,7 @@ namespace osmscout {
       throw IOException(filename,"Cannot write coordinate","File already in error state");
     }
 
-    char buffer[coordByteSize];
+    unsigned char buffer[coordByteSize];
 
     buffer[0]=0xff;
     buffer[1]=0xff;


### PR DESCRIPTION
These patches adding pedantic warning to CMake build (when compiler is GCC or Clang) - it can show possible problems in code. Second commit fix some of these warnings...