### PR TITLE
fix libosmscout-map-agg build on Ubuntu:16.04

### DIFF
--- a/cmake/FindAgg.cmake
+++ b/cmake/FindAgg.cmake
@@ -23,7 +23,7 @@ FIND_PATH(LIBAGG_INCLUDE_DIRS
 )
 
 FIND_LIBRARY(LIBAGG_LIBRARIES
-    NAMES libagg agg libagg-2.5 agg-2.5
+    NAMES agg_pic libagg agg libagg-2.5 agg-2.5
     HINTS ${PC_LIBAGG_LIBDIR}
           ${PC_LIBAGG_LIBRARY_DIRS}
           $ENV{LIBAGG_HOME}/lib
@@ -41,7 +41,7 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBAGG DEFAULT_MSG LIBAGG_INCLUDE_DIRS LIBAGG_
 IF(LIBAGG_FOUND)
     PKG_CHECK_MODULES(PC_LIBAGGFT2 QUIET LIBAGGFT2)
     FIND_LIBRARY(LIBAGGFT2_LIBRARIES
-        NAMES aggfontfreetype libaggfontfreetype
+        NAMES aggfontfreetype_pic aggfontfreetype libaggfontfreetype
         HINTS ${PC_LIBAGG_LIBDIR}
               ${PC_LIBAGG_LIBRARY_DIRS}
               $ENV{LIBAGG_HOME}/lib


### PR DESCRIPTION
Agg library is distributed as static library in two variants on Ubuntu:
 - position dependent objects: /usr/lib/libagg.a
 - position independent ( -fPIC ) objects: /usr/lib/libagg_pic.a

Because libosmscout-map-agg is compiled as position independent,
we should search second variant of libagg first.

This patch fixes following error:

[100%] Linking CXX shared library libosmscout_map_agg.so
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/5/../../../../lib/libagg.a(agg_vcgen_contour.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC