### PR TITLE
don't allocate value buffer in FeatureValueBuffer if it isn't necessary

### DIFF
--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -956,7 +956,14 @@ namespace osmscout {
 
   private:
     void DeleteData();
-    void AllocateData();
+    void AllocateBits();
+    void AllocateValueBufferLazy();
+
+    inline FeatureValue* GetValueAndAllocateBuffer(size_t idx)
+    {
+      AllocateValueBufferLazy();
+      return static_cast<FeatureValue*>(static_cast<void*>(&featureValueBuffer[type->GetFeature(idx).GetOffset()]));
+    }
 
   public:
     FeatureValueBuffer();
@@ -989,8 +996,15 @@ namespace osmscout {
       return (featureBits[featureBit/8] & (1 << featureBit%8))!=0;
     }
 
+    /**
+     * Can return NULL value!
+     * HasFeature(idx) && GetFeature(idx).GetFeature()->HasValue()
+     *  should be called before accessing the value.
+     */
     inline FeatureValue* GetValue(size_t idx) const
     {
+      if (featureValueBuffer == NULL)
+        return NULL;
       return static_cast<FeatureValue*>(static_cast<void*>(&featureValueBuffer[type->GetFeature(idx).GetOffset()]));
     }
 

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -162,7 +162,10 @@ namespace osmscout {
 
   void FeatureValueBuffer::Set(const FeatureValueBuffer& other)
   {
-    if (other.GetType()) {
+    if (type) {
+      DeleteData();
+    }
+    if (other.GetType()) {    
       SetType(other.GetType());
 
       for (size_t idx=0; idx<other.GetFeatureCount(); idx++) {
@@ -181,9 +184,6 @@ namespace osmscout {
           }
         }
       }
-    }
-    else if (type) {
-      DeleteData();
     }
   }
 

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -195,7 +195,8 @@ namespace osmscout {
 
     this->type=type;
 
-    AllocateData();
+    AllocateBits();
+    featureValueBuffer=NULL; // buffer is allocated on first usage
   }
 
   void FeatureValueBuffer::DeleteData()
@@ -219,16 +220,21 @@ namespace osmscout {
     type=NULL;
   }
 
-  void FeatureValueBuffer::AllocateData()
+  void FeatureValueBuffer::AllocateBits()
   {
     if (type && type->HasFeatures()) {
       featureBits=new uint8_t[type->GetFeatureMaskBytes()]();
-      featureValueBuffer=static_cast<char*>(::operator new(type->GetFeatureValueBufferSize()));
     }
     else
     {
       featureBits=NULL;
-      featureValueBuffer=NULL;
+    }
+  }
+
+  void FeatureValueBuffer::AllocateValueBufferLazy()
+  {
+    if (featureValueBuffer == NULL && type && type->HasFeatures()){
+        featureValueBuffer=static_cast<char*>(::operator new(type->GetFeatureValueBufferSize()));
     }
   }
 
@@ -240,7 +246,7 @@ namespace osmscout {
     featureBits[byteIdx]=featureBits[byteIdx] | (1 << featureBit%8);
 
     if (type->GetFeature(idx).GetFeature()->HasValue()) {
-      FeatureValue* value=GetValue(idx);
+      FeatureValue* value=GetValueAndAllocateBuffer(idx);
 
       return type->GetFeature(idx).GetFeature()->AllocateValue(value);
     }
@@ -256,7 +262,7 @@ namespace osmscout {
 
     featureBits[byteIdx]=featureBits[byteIdx] & ~(1 << featureBit%8);
 
-    if (type->GetFeature(idx).GetFeature()->HasValue()) {
+    if (HasFeature(idx) && type->GetFeature(idx).GetFeature()->HasValue()) {
       FeatureValue* value=GetValue(idx);
 
       value->~FeatureValue();
@@ -294,7 +300,7 @@ namespace osmscout {
 
       if (HasFeature(idx) &&
           feature.GetFeature()->HasValue()) {
-        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValue(idx));
+        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValueAndAllocateBuffer(idx));
 
         value->Read(scanner);
       }
@@ -330,7 +336,7 @@ namespace osmscout {
 
       if (HasFeature(idx) &&
           feature.GetFeature()->HasValue()) {
-        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValue(idx));
+        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValueAndAllocateBuffer(idx));
 
         value->Read(scanner);
       }
@@ -369,7 +375,7 @@ namespace osmscout {
 
       if (HasFeature(idx) &&
           feature.GetFeature()->HasValue()) {
-        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValue(idx));
+        FeatureValue* value=feature.GetFeature()->AllocateValue(GetValueAndAllocateBuffer(idx));
 
         value->Read(scanner);
       }


### PR DESCRIPTION
Hi, I inspect libosmscout memory usage (with pprof) and found that allocations from FeatureValueBuffer occupy around 25% heap data (76MB from 315MB in one of my samples). On deeper look, I found that many (around 16MB) of allocated value buffers are never used! You can see it when you compile my "print-unused-value-buffer" branch:

https://github.com/karry-space-with-my-second-forks/libosmscout/tree/print-unused-value-buffer

As a simple solution, I allocate value buffer lazy. But now exist some danger in GetValue method. It can return NULL. But I don't found any unchecked usage.