### PR TITLE
fix sign-compare warning

### DIFF
--- a/libosmscout/src/osmscout/util/File.cpp
+++ b/libosmscout/src/osmscout/util/File.cpp
@@ -64,7 +64,7 @@ namespace osmscout {
       throw IOException(filename,"Seeking end of file");
     }
 
-    unsigned long pos=ftell(file);
+    long int pos=ftell(file);
 
     if (pos==-1) {
       fclose(file);


### PR DESCRIPTION
gcc warning:
 File.cpp:69:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

ftell manual page:
 ftell() returns the current offset.  Otherwise, -1 is returned and errno is set to indicate the error.