### PR TITLE
Projection improvements

### DIFF
--- a/Demos/src/PerformanceTest.cpp
+++ b/Demos/src/PerformanceTest.cpp
@@ -288,10 +288,10 @@ int main(int argc, char* argv[])
   }
 #endif
 
-  osmscout::TileProjection      projection;
-  osmscout::MapParameter        drawParameter;
-  osmscout::AreaSearchParameter searchParameter;
-  std::list<LevelStats>         statistics;
+  osmscout::ApproximateTileProjection   projection;
+  osmscout::MapParameter                drawParameter;
+  osmscout::AreaSearchParameter         searchParameter;
+  std::list<LevelStats>                 statistics;
 
   searchParameter.SetUseMultithreading(true);
 

--- a/Demos/src/PerformanceTest.cpp
+++ b/Demos/src/PerformanceTest.cpp
@@ -288,10 +288,10 @@ int main(int argc, char* argv[])
   }
 #endif
 
-  osmscout::ApproximateTileProjection   projection;
-  osmscout::MapParameter                drawParameter;
-  osmscout::AreaSearchParameter         searchParameter;
-  std::list<LevelStats>                 statistics;
+  osmscout::TileProjection      projection;
+  osmscout::MapParameter        drawParameter;
+  osmscout::AreaSearchParameter searchParameter;
+  std::list<LevelStats>         statistics;
 
   searchParameter.SetUseMultithreading(true);
 
@@ -360,6 +360,7 @@ int main(int argc, char* argv[])
                        tileHeight);
 
         projection.GetDimensions(boundingBox);
+        projection.SetLinearInterpolationUsage(level >= 10);
 
         osmscout::StopClock dbTimer;
 

--- a/OSMScout2/src/DBThread.cpp
+++ b/OSMScout2/src/DBThread.cpp
@@ -573,7 +573,7 @@ bool DBThread::RenderMap(QPainter& painter,
     return true;
   }
 
-  osmscout::ApproximateMercatorProjection projection;
+  osmscout::MercatorProjection projection;
 
   projection.Set(finishedLon,
                  finishedLat,
@@ -582,6 +582,8 @@ bool DBThread::RenderMap(QPainter& painter,
                  dpi,
                  finishedImage->width(),
                  finishedImage->height());
+
+  projection.SetLinearInterpolationUsage(finishedMagnification.GetLevel() >= 10);
 
   osmscout::GeoBox boundingBox;
 

--- a/OSMScout2/src/DBThread.cpp
+++ b/OSMScout2/src/DBThread.cpp
@@ -573,7 +573,7 @@ bool DBThread::RenderMap(QPainter& painter,
     return true;
   }
 
-  osmscout::MercatorProjection projection;
+  osmscout::ApproximateMercatorProjection projection;
 
   projection.Set(finishedLon,
                  finishedLat,

--- a/OSMScout2/src/DBThread.h
+++ b/OSMScout2/src/DBThread.h
@@ -104,7 +104,7 @@ private:
   osmscout::LocationServiceRef  locationService;
   osmscout::MapServiceRef       mapService;
   osmscout::MapService::CallbackId callbackId;
-  osmscout::MercatorProjection  projection;
+  osmscout::ApproximateMercatorProjection projection;
   osmscout::RouterParameter     routerParameter;
   osmscout::RoutingServiceRef   router;
   osmscout::RoutePostprocessor  routePostprocessor;

--- a/OSMScout2/src/DBThread.h
+++ b/OSMScout2/src/DBThread.h
@@ -104,7 +104,7 @@ private:
   osmscout::LocationServiceRef  locationService;
   osmscout::MapServiceRef       mapService;
   osmscout::MapService::CallbackId callbackId;
-  osmscout::ApproximateMercatorProjection projection;
+  osmscout::MercatorProjection  projection;
   osmscout::RouterParameter     routerParameter;
   osmscout::RoutingServiceRef   router;
   osmscout::RoutePostprocessor  routePostprocessor;

--- a/libosmscout/include/osmscout/util/Projection.h
+++ b/libosmscout/include/osmscout/util/Projection.h
@@ -31,8 +31,6 @@
 
 namespace osmscout {
 
-#define MAG_LEVEL_LINEAR_OPT_THRESHOLD 10
-
   /**
    * \ingroup Geometry
    *
@@ -442,6 +440,9 @@ namespace osmscout {
     double scale;
     double scaleGradtorad; //!< Precalculated scale*Gradtorad
 
+    double scaledLatDeriv; //!< precalculated derivation of "latToYPixel" function in projection center scaled by gradtorad * scale
+    bool useLinearInterpolation; //!< switch to enable linear interpolation of latitude to pixel computation
+
   public:
     MercatorProjection();
 
@@ -522,64 +523,22 @@ namespace osmscout {
       return Move(pixel,0);
     }
 
+    virtual inline bool IsLinearInterpolationEnabled(){
+      return useLinearInterpolation;
+    }
+
+    /**
+     * Switch to enable/disable linear interpolation of latitude to pixel computation.
+     * It speedup GeoToPixel calculation with fractional error on small render area.
+     */
+    virtual inline void SetLinearInterpolationUsage(bool b){
+      useLinearInterpolation = b;
+    }
+
   protected:
     void GeoToPixel(const BatchTransformer& transformData) const;
   };
 
-  /**
-   * MercatorProjection that use some approximations on higher magnification levels.
-   */
-  class OSMSCOUT_API ApproximateMercatorProjection : public MercatorProjection
-  {
-  protected:
-    double scaledLatDeriv; //!< precalculated derivation of "latToYPixel" function in projection center scaled by gradtorad * scale
-
-  public:
-    inline ApproximateMercatorProjection(): MercatorProjection()
-    {
-    };
-
-    inline bool Set(double lon,double lat,
-                    const Magnification& magnification,
-                    size_t width,size_t height)
-    {
-      return Set(lon,lat,0,magnification,GetDPI(),width,height);
-    }
-
-    inline bool Set(double lon, double lat,
-                    double angle,
-                    const Magnification& magnification,
-                    size_t width, size_t height)
-    {
-      return Set(lon,lat,angle,magnification,GetDPI(),width,height);
-    }
-
-    inline bool Set(double lon, double lat,
-                    const Magnification& magnification,
-                    double dpi,
-                    size_t width, size_t height)
-    {
-      return Set(lon,lat,0,magnification,dpi,width,height);
-    }
-
-    bool Set(double lon, double lat,
-             double angle,
-             const Magnification& magnification,
-             double dpi,
-             size_t width, size_t height);
-
-    void GeoToPixel(double lon, double lat,
-                    double& x, double& y) const;
-
-    /**
-     * Converts a geo coordinate to a pixel coordinate
-     */
-    virtual inline void GeoToPixel(const GeoCoord& coord,
-                            double& x, double& y) const
-    {
-      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
-    }
-  };
 
   /**
    * Mercator projection as used by the OpenStreetMap tile rendering code.
@@ -596,6 +555,9 @@ namespace osmscout {
     double latOffset;
     double scale;
     double scaleGradtorad; //!< Precalculated scale*Gradtorad
+
+    double scaledLatDeriv; //!< precalculated derivation of "latToYPixel" function in projection center scaled by gradtorad * scale
+    bool useLinearInterpolation; //!< switch to enable linear interpolation of latitude to pixel computation
 
 #ifdef OSMSCOUT_HAVE_SSE2
     //some extra vars for special sse needs
@@ -659,43 +621,23 @@ namespace osmscout {
       GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
     }
 
+    virtual inline bool IsLinearInterpolationEnabled(){
+      return useLinearInterpolation;
+    }
+
+    /**
+     * Switch to enable/disable linear interpolation of latitude to pixel computation.
+     * It speedup GeoToPixel calculation with fractional error on small render area.
+     */
+    virtual inline void SetLinearInterpolationUsage(bool b){
+      useLinearInterpolation = b;
+    }
+
   protected:
 
     void GeoToPixel(const BatchTransformer& transformData) const;
   };
 
-  /**
-   * TileProjection that use some approximations on higher magnification levels.
-   */
-  class OSMSCOUT_API ApproximateTileProjection : public TileProjection
-  {
-  protected:
-    double scaledLatDeriv; //!< precalculated derivation of "latToYPixel" function in projection center scaled by gradtorad * scale
-
-    virtual bool SetInternal(double lonMin,double latMin,
-                     double lonMax,double latMax,
-                     const Magnification& magnification,
-                     double dpi,
-                     size_t width,size_t height);
-
-  public:
-    inline ApproximateTileProjection(): TileProjection()
-    {
-    }
-
-    void GeoToPixel(double lon, double lat,
-                    double& x, double& y) const;
-
-    /**
-     * Converts a geo coordinate to a pixel coordinate
-     */
-    virtual inline void GeoToPixel(const GeoCoord& coord,
-                            double& x, double& y) const
-    {
-      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
-    }
-
-  };
 }
 
 #endif

--- a/libosmscout/include/osmscout/util/Projection.h
+++ b/libosmscout/include/osmscout/util/Projection.h
@@ -296,8 +296,11 @@ namespace osmscout {
     /**
      * Converts a geo coordinate to a pixel coordinate
      */
-    virtual void GeoToPixel(const GeoCoord& coord,
-                            double& x, double& y) const = 0;
+    virtual inline void GeoToPixel(const GeoCoord& coord,
+                            double& x, double& y) const
+    {
+      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
+    }
 
   protected:
     virtual void GeoToPixel(const BatchTransformer& transformData) const = 0;
@@ -377,8 +380,14 @@ namespace osmscout {
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;
 
-    void GeoToPixel(const GeoCoord& coord,
-                    double& x, double& y) const;
+    /**
+     * Converts a geo coordinate to a pixel coordinate
+     */
+    virtual inline void GeoToPixel(const GeoCoord& coord,
+                            double& x, double& y) const
+    {
+      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
+    }
 
     bool Move(double horizPixel,
               double vertPixel);
@@ -479,8 +488,14 @@ namespace osmscout {
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;
 
-    void GeoToPixel(const GeoCoord& coord,
-                    double& x, double& y) const;
+    /**
+     * Converts a geo coordinate to a pixel coordinate
+     */
+    virtual inline void GeoToPixel(const GeoCoord& coord,
+                            double& x, double& y) const
+    {
+      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
+    }
 
     bool Move(double horizPixel,
               double vertPixel);
@@ -578,8 +593,14 @@ namespace osmscout {
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;
 
-    void GeoToPixel(const GeoCoord& coord,
-                    double& x, double& y) const;
+    /**
+     * Converts a geo coordinate to a pixel coordinate
+     */
+    virtual inline void GeoToPixel(const GeoCoord& coord,
+                            double& x, double& y) const
+    {
+      GeoToPixel(coord.GetLon(), coord.GetLat(), x, y);
+    }
 
   protected:
 

--- a/libosmscout/src/osmscout/util/Projection.cpp
+++ b/libosmscout/src/osmscout/util/Projection.cpp
@@ -239,28 +239,6 @@ namespace osmscout {
     x+=width/2;
   }
 
-  void MercatorProjectionOld::GeoToPixel(const GeoCoord& coord,
-                                         double& x, double& y) const
-  {
-    assert(valid);
-
-    // Screen coordinate relative to center of image
-    x=(coord.GetLon()-this->lon)*scaleGradtorad;
-    y=(atanh(sin(coord.GetLat()*gradtorad))-latOffset)*scale;
-
-    if (angle!=0.0) {
-      double xn=x*angleNegCos-y*angleNegSin;
-      double yn=x*angleNegSin+y*angleNegCos;
-
-      x=xn;
-      y=yn;
-    }
-
-    // Transform to canvas coordinate
-    y=height/2-y;
-    x+=width/2;
-  }
-
   void MercatorProjectionOld::GeoToPixel(const BatchTransformer& /*transformData*/) const
   {
     assert(false); //should not be called
@@ -467,28 +445,6 @@ namespace osmscout {
     x+=width/2;
   }
 
-  void MercatorProjection::GeoToPixel(const GeoCoord& coord,
-                                      double& x, double& y) const
-  {
-    assert(valid);
-
-    // Screen coordinate relative to center of image
-    x=(coord.GetLon()-this->lon)*scaleGradtorad;
-    y=(atanh(sin(coord.GetLat()*gradtorad))-latOffset)*scale;
-
-    if (angle!=0.0) {
-      double xn=x*angleNegCos-y*angleNegSin;
-      double yn=x*angleNegSin+y*angleNegCos;
-
-      x=xn;
-      y=yn;
-    }
-
-    // Transform to canvas coordinate
-    y=height/2-y;
-    x+=width/2;
-  }
-
   void MercatorProjection::GeoToPixel(const BatchTransformer& /*transformData*/) const
   {
     assert(false); //should not be called
@@ -648,13 +604,6 @@ namespace osmscout {
       y=height-(scale*atanh_sin_pd(lat*gradtorad)-latOffset);
     }
 
-    void TileProjection::GeoToPixel(const GeoCoord& coord,
-                                    double& x, double& y) const
-    {
-      x=coord.GetLon()*scaleGradtorad-lonOffset;
-      y=height-(scale*atanh_sin_pd(coord.GetLat()*gradtorad)-latOffset);
-    }
-
     //this basically transforms 2 coordinates in 1 call
     void TileProjection::GeoToPixel(const BatchTransformer& transformData) const
     {
@@ -676,13 +625,6 @@ namespace osmscout {
     {
       x=lon*scaleGradtorad-lonOffset;
       y=height-(scale*atanh(sin(lat*gradtorad))-latOffset);
-    }
-
-    void TileProjection::GeoToPixel(const GeoCoord& coord,
-                                    double& x, double& y) const
-    {
-      x=coord.GetLon()*scaleGradtorad-lonOffset;
-      y=height-(scale*atanh(sin(coord.GetLat()*gradtorad))-latOffset);
     }
 
     void TileProjection::GeoToPixel(const BatchTransformer& /*transformData*/) const


### PR DESCRIPTION
Hi. I see that `*Projection::GeoToPixel` method is relative expensive in callgrind results. It is better when SSE optimizations are enabled (TileProjection), but it is still one of hot spots in rendering code. It is even worse on slow arm processor without SIMD optimizations. So I prepared two new projections with simple optimization:
```
Vertical (y) coordinate [pixels] in Mercator projection is computed
as atanh(sin(latitude)). For small render areas with bigger magnification
can be this function aproximated by tangent in projection center. 
Horizontal coordinate computation can be simlified just to multiplication 
of latitude and scaled latitude fn. derivation.
It should be faster than `sin` and `atanh` computation.
```
I setup minimum magnification level for use this optimization to 10 now. Y coordinate inaccuracy should be around 1% (without math prove, tested by small amount of experiments). Error is slightly visible when magnification is setup to 10 and map is moved vertically...

Rendering for magnification level > 10 is about **5 ~ 10% faster** on armv7 and x86_64 (without SSE optimizations). You can see in *PerformanceTest* logs  from my phone (rendering was repeated 100x):
[scout-perf-projection.zip](https://github.com/Framstag/libosmscout/files/326013/scout-perf-projection.zip)

Btw, I will try to use SIMD optimizations on arm later...