### PR TITLE
Add explicit 'using Projection::GeoToPixel' in derived projections

### DIFF
--- a/libosmscout/include/osmscout/util/Projection.h
+++ b/libosmscout/include/osmscout/util/Projection.h
@@ -377,6 +377,8 @@ namespace osmscout {
     bool PixelToGeo(double x, double y,
                     double& lon, double& lat) const;
 
+    using Projection::GeoToPixel;	// make every GeoToPixel available
+
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;
 
@@ -487,6 +489,8 @@ namespace osmscout {
 
     bool PixelToGeo(double x, double y,
                     double& lon, double& lat) const;
+
+    using Projection::GeoToPixel;	// make every GeoToPixel available
 
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;
@@ -601,6 +605,8 @@ namespace osmscout {
 
     bool PixelToGeo(double x, double y,
                     double& lon, double& lat) const;
+
+    using Projection::GeoToPixel;	// make every GeoToPixel available
 
     void GeoToPixel(double lon, double lat,
                     double& x, double& y) const;


### PR DESCRIPTION
Add explicit 'using Projection::GeoToPixel' in derived projections to avoid name hiding

It fixes compile error when:

    osmscout::MercatorProjection projection;
    double x;
    double y;
    projection.GeoToPixel(osmscout::GeoCoord(lat, lon), x, y);

fails with:

      error: no matching function for call to ‘osmscout::MercatorProjection::GeoToPixel(osmscout::GeoCoord, double&, double&)’

---

If I understand this C++ area correctly, implementation of `GeoToPixel(double lon, double lat ...` in derived classes (`MercatorProjection`) hides `GeoToPixel(const GeoCoord& coord ...` from `Projection`. It leads to compile problem when MercatorProjection is created as local variable...