### PR TITLE
Fix MercatorProjection::GeoToPixel when linear interpolation is enabled

### DIFF
--- a/OSMScout2/src/DBThread.cpp
+++ b/OSMScout2/src/DBThread.cpp
@@ -490,12 +490,23 @@ void DBThread::DrawMap()
     drawParameter.SetRenderBackground(true);
     drawParameter.SetRenderSeaLand(true);
 
-    mapService->LookupTiles(projection,tiles);
+    // create copy of projection
+    osmscout::MercatorProjection renderProjection;
+    renderProjection.Set(projection.GetCenter(),
+                   projection.GetAngle(),
+                   projection.GetMagnification(),
+                   projection.GetDPI(),
+                   projection.GetWidth(),
+                   projection.GetHeight());
+
+    renderProjection.SetLinearInterpolationUsage(renderProjection.GetMagnification().GetLevel() >= 10);
+    
+    mapService->LookupTiles(renderProjection,tiles);
 
     mapService->ConvertTilesToMapData(tiles,data);
 
     if (drawParameter.GetRenderSeaLand()) {
-      mapService->GetGroundTiles(projection,
+      mapService->GetGroundTiles(renderProjection,
                                  data.groundTiles);
     }
 
@@ -506,7 +517,7 @@ void DBThread::DrawMap()
     p.setRenderHint(QPainter::TextAntialiasing);
     p.setRenderHint(QPainter::SmoothPixmapTransform);
 
-    bool success=painter->DrawMap(projection,
+    bool success=painter->DrawMap(renderProjection,
                                   drawParameter,
                                   data,
                                   &p);

--- a/libosmscout/src/osmscout/util/Projection.cpp
+++ b/libosmscout/src/osmscout/util/Projection.cpp
@@ -437,7 +437,7 @@ namespace osmscout {
     x=(coord.GetLon()-this->lon)*scaleGradtorad;
 
     if (useLinearInterpolation) {
-      y=(lat-this->lat)*scaledLatDeriv;
+      y=(coord.GetLat()-this->lat)*scaledLatDeriv;
     }
     else {
       y=(atanh(sin(coord.GetLat()*gradtorad))-latOffset)*scale;


### PR DESCRIPTION
In recent changes was created bug in mercator projection when linear interpolation is enabled. It was not visible in OSMScout2 because it don't use interpolation while render map. This MR should fix both.