### PR TITLE
fix build: with HAVE_LIB_GPERFTOOLS mallinfo undefined

### DIFF
--- a/Demos/src/PerformanceTest.cpp
+++ b/Demos/src/PerformanceTest.cpp
@@ -40,6 +40,7 @@
 #if defined(HAVE_LIB_GPERFTOOLS)
 #include <gperftools/tcmalloc.h>
 #include <gperftools/heap-profiler.h>
+#include <malloc.h> // mallinfo
 #else
 #if defined(HAVE_MALLINFO)
 #include <malloc.h> // mallinfo


### PR DESCRIPTION
I got compilation error on Linux/amd64/gcc 5.3 that here:
```
#if defined(HAVE_LIB_GPERFTOOLS)
        if (heapProfile){
            std::ostringstream buff;
            buff << "load-" << level << "-" << x << "-" << y;
            HeapProfilerDump(buff.str().c_str());
        }
        struct mallinfo alloc_info = tc_mallinfo();
#else
```

mallinfo undefined, this PR fix this issue for me.