### PR TITLE
 Extend LocationService::DescribeLocationByAddress to work with address nodes

### DIFF
--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -100,13 +100,16 @@ int main(int argc, char* argv[])
     }
     
     if (place.GetPOI()){
-        std::cout << "    POI:     " << place.GetPOI()->name << std::endl;
+        std::cout << "    POI:      " << place.GetPOI()->name << std::endl;
     }
     if (place.GetAddress()){
-        std::cout << "    address: " << place.GetAddress()->name << std::endl;
+        std::cout << "    address:  " << place.GetAddress()->name << std::endl;
+    }
+    if (place.GetLocation()){
+        std::cout << "    location: " << place.GetLocation()->name << std::endl;
     }
     if (place.GetAdminRegion()){
-        std::cout << "    region:  " << place.GetAdminRegion()->name << std::endl;
+        std::cout << "    region:   " << place.GetAdminRegion()->name << std::endl;
     }
   }
 

--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
     std::cerr << "lat is not numeric!" << std::endl;
     return 1;
   }
+  osmscout::log.Debug(false);
 
   osmscout::GeoCoord location(lat,lon);
 
@@ -87,14 +88,25 @@ int main(int argc, char* argv[])
   }
 
   if (atAddressDescription) {
+    osmscout::Place place = atAddressDescription->GetPlace();
     if (atAddressDescription->IsAtPlace()) {
-      std::cout << "Is at address: " << atAddressDescription->GetPlace().GetDisplayString() << std::endl;
+      std::cout << "Is at address: " << place.GetDisplayString() << std::endl;
     }
     else {
       std::cout.precision(1);
       std::cout << std::fixed << atAddressDescription->GetDistance() << "m ";
       std::cout << osmscout::BearingDisplayString(atAddressDescription->GetBearing());
-      std::cout << " of address: " << atAddressDescription->GetPlace().GetDisplayString() << std::endl;
+      std::cout << " of address: " << place.GetDisplayString() << std::endl;
+    }
+    
+    if (place.GetPOI()){
+        std::cout << "    POI:     " << place.GetPOI()->name << std::endl;
+    }
+    if (place.GetAddress()){
+        std::cout << "    address: " << place.GetAddress()->name << std::endl;
+    }
+    if (place.GetAdminRegion()){
+        std::cout << "    region:  " << place.GetAdminRegion()->name << std::endl;
     }
   }
 

--- a/libosmscout-import/include/osmscout/import/GenLocationIndex.h
+++ b/libosmscout-import/include/osmscout/import/GenLocationIndex.h
@@ -346,6 +346,23 @@ namespace osmscout {
                           RegionRef& rootRegion,
                           const RegionIndex& regionIndex);
 
+    /**
+     * Find location by its name in locations map.
+     *
+     * OSM data dont have strict rules how data should be organized.
+     * Sometimes tag "addr:street" (`locationName` in this method) contains
+     * not existent place (entry in `locations` map don't exists),
+     * many times it contains typos or lowercase/uppercase errors.
+     *
+     * This method try to fix some simple errors at least.
+     *
+     * @retrun true if success, false otherwise
+     */
+    bool FindLocation(Progress& progress,
+                      std::map<std::string,RegionLocation> &locations,
+                      const std::string &locationName,
+                      RegionLocation **location);
+    
     void AddAddressNodeToRegion(Progress& progress,
                                 Region& region,
                                 const FileOffset& fileOffset,

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -48,6 +48,40 @@ namespace osmscout {
   //! Reference counted reference to a LocationCoordDescription instance
   typedef std::shared_ptr<LocationCoordDescription> LocationCoordDescriptionRef;
 
+  class OSMSCOUT_API LocationDescriptionCandicate
+  {
+  private:
+    ObjectFileRef ref;
+    double        distance;
+    double        bearing;
+    bool          atPlace;
+  public:
+    inline LocationDescriptionCandicate(const ObjectFileRef &ref, const double distance, const double bearing, const bool atPlace):
+      ref(ref), distance(distance), bearing(bearing), atPlace(atPlace)
+    {
+    }
+
+    inline ObjectFileRef GetRef() const
+    {
+      return ref;
+    }
+
+    inline double GetDistance() const
+    {
+      return distance;
+    }
+
+    inline double GetBearing() const
+    {
+      return bearing;
+    }
+
+    inline bool IsAtPlace() const
+    {
+      return atPlace;
+    }
+  };
+
   /**
    * \ingroup Location
    *
@@ -360,6 +394,9 @@ namespace osmscout {
     DatabaseRef database;
 
   private:
+    static bool DistanceComparator(const LocationDescriptionCandicate &a,
+                                   const LocationDescriptionCandicate &b);
+
     bool HandleAdminRegion(const LocationSearch& search,
                            const LocationSearch::Entry& searchEntry,
                            const AdminRegionMatchVisitor::AdminRegionResult& adminRegionResult,
@@ -381,6 +418,12 @@ namespace osmscout {
                                           const LocationMatchVisitor::LocationResult& locationResult,
                                           const AddressMatchVisitor::AddressResult& addressResult,
                                           LocationSearchResult& result) const;
+
+    bool LoadNearAreas(const GeoCoord& location, const TypeInfoSet &types,
+                       std::vector<LocationDescriptionCandicate> &candidates);
+
+    bool LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types,
+                       std::vector<LocationDescriptionCandicate> &candidates);
 
     bool DescribeLocationByAddress(const GeoCoord& location,
                                    LocationDescription& description);

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -848,7 +848,7 @@ namespace osmscout {
 
   /**
    * \ingroup Geometry
-   *Calculates the initial bearing for a line from one coordinate two the other coordinate
+   *Calculates the initial bearing for a line from one coordinate to the other coordinate
    *on a sphere.
    */
   extern OSMSCOUT_API double GetSphericalBearingInitial(const GeoCoord& a,

--- a/libosmscout/src/osmscout/LocationIndex.cpp
+++ b/libosmscout/src/osmscout/LocationIndex.cpp
@@ -379,7 +379,7 @@ namespace osmscout {
 
       scanner.Read(address.name);
       objectFileRefReader.Read(address.object);
-
+      
       if (!visitor.Visit(region,
                          location,
                          address)) {
@@ -495,6 +495,7 @@ namespace osmscout {
                                        location,
                                        visitor,
                                        stopped)) {
+        scanner.Close();
         return false;
       }
 

--- a/libosmscout/src/osmscout/LocationIndex.cpp
+++ b/libosmscout/src/osmscout/LocationIndex.cpp
@@ -361,6 +361,12 @@ namespace osmscout {
                                                   AddressVisitor& visitor,
                                                   bool& stopped) const
   {
+    if (location.addressesOffset == 0){
+      // see LocationIndex::LoadRegionDataEntry
+      // if location don't have addresses, offset is set to 0
+      return true;
+    }
+
     uint32_t addressCount;
 
     scanner.SetPos(location.addressesOffset);


### PR DESCRIPTION
This pull request extend `LocationService::DescribeLocationByAddress` method to work with address nodes as discussed in issue https://github.com/Framstag/libosmscout/issues/58

The main change is in commit https://github.com/Framstag/libosmscout/commit/798be9e48c6693884198f35f0e445b383dd40484 , other commits contains small fixes and improvements related with addresses. 

I am not sure about commit https://github.com/Framstag/libosmscout/commit/7d48e698b53fbd5b7b6cd5ae069087673cfdc14b (find location by name, case insensitive)
I send question to *talk-cz* OSM mailing list, but I am not sure if we will be able to fix OSM data by some automatic script. I found around 10k these errors just in Prague! (All errors are imported from national address registry UIR-ADR.) I think that this problem is so common in Czechia that we should solve it in library. And similar problems can occurs in other countries too...

Edit: one user from OSM mailing list just suggest to ignore character size. This problem is common as geofabric validator shows: http://tools.geofabrik.de/osmi/?view=addresses&lon=14.49293&lat=50.09081&zoom=17&opacity=1.00&overlays=buildings,buildings_with_addresses,postal_code,street_not_found,nodes_with_addresses_interpolated,interpolation,interpolation_errors,nearest_points,nearest_roads
 and addresses are imported in monthly period from national database (not UIR-ADR, but RUIAN) and Czech cadastre don't want to fix street names... :-(