### PR TITLE
Docker images for build on Ubuntu 16.04 (cmake, autoconf)

### DIFF
--- a/ci/docker/ubuntu_16.04_gcc_autoconf/Dockerfile
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+          git make libtool pkg-config \
+          libxml2-dev libprotobuf-dev protobuf-compiler \
+          libagg-dev \
+          libfreetype6-dev \
+          libcairo2-dev \
+          libpangocairo-1.0-0 libpango1.0-dev \
+          qt5-default qtdeclarative5-dev libqt5svg5-dev qtlocation5-dev \
+          freeglut3 freeglut3-dev \
+          libmarisa-dev \
+          doxygen \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+          autoconf automake \
+          gcc \
+    && rm -rf /var/lib/apt/lists/*
+          
+RUN mkdir /work
+
+COPY data/build.sh /work
+RUN chmod +x /work/build.sh
+
+WORKDIR /work
+CMD ./build.sh

--- a/ci/docker/ubuntu_16.04_gcc_autoconf/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t libosmscout/ubuntu_16.04_gcc_autoconf .

--- a/ci/docker/ubuntu_16.04_gcc_autoconf/data/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/data/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+git clone git://git.code.sf.net/p/libosmscout/code libosmscout
+
+cd libosmscout
+. ./setupAutoconf.sh
+env
+make full
+

--- a/ci/docker/ubuntu_16.04_gcc_autoconf/run.sh
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run libosmscout/ubuntu_16.04_gcc_autoconf

--- a/ci/docker/ubuntu_16.04_gcc_cmake/Dockerfile
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+          git make libtool pkg-config \
+          libxml2-dev libprotobuf-dev protobuf-compiler \
+          libagg-dev \
+          libfreetype6-dev \
+          libcairo2-dev \
+          libpangocairo-1.0-0 libpango1.0-dev \
+          qt5-default qtdeclarative5-dev libqt5svg5-dev qtlocation5-dev \
+          freeglut3 freeglut3-dev \
+          libmarisa-dev \
+          doxygen \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+          cmake \
+          gcc \
+    && rm -rf /var/lib/apt/lists/*
+          
+RUN mkdir /work
+
+COPY data/build.sh /work
+RUN chmod +x /work/build.sh
+
+WORKDIR /work
+CMD ./build.sh

--- a/ci/docker/ubuntu_16.04_gcc_cmake/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t libosmscout/ubuntu_16.04_gcc_cmake .

--- a/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+git clone git://git.code.sf.net/p/libosmscout/code libosmscout
+
+env
+
+cd libosmscout
+mkdir build
+cd build
+cmake ..
+make
+

--- a/ci/docker/ubuntu_16.04_gcc_cmake/run.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run libosmscout/ubuntu_16.04_gcc_cmake


### PR DESCRIPTION
These two commits creates Docker images for build on latest Ubuntu (16.04)

Current autoconf build on Ubuntu 16.04 is affected by bug [sf #19](https://sourceforge.net/p/libosmscout/bugs/19/) caused by dual (PIC and non-PIC) agg distribution.


