### PR TITLE
Docker, Ubuntu 16.04/CMake - build Java bindings

### DIFF
--- a/ci/docker/ubuntu_16.04_gcc_autoconf/Dockerfile
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update && apt-get install -y \
           freeglut3 freeglut3-dev \
           libmarisa-dev \
           doxygen \
+          swig openjdk-8-jdk \
     && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update && apt-get install -y \
           autoconf automake \

--- a/ci/docker/ubuntu_16.04_gcc_cmake/Dockerfile
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update && apt-get install -y \
           freeglut3 freeglut3-dev \
           libmarisa-dev \
           doxygen \
+          swig openjdk-8-jdk \
     && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update && apt-get install -y \
           cmake \

--- a/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
@@ -7,6 +7,6 @@ env
 cd libosmscout
 mkdir build
 cd build
-cmake ..
+cmake -DOSMSCOUT_BUILD_BINDING_CSHARP=off ..
 make
 


### PR DESCRIPTION
These changes configure build for Java and C# bindings. But C# is disabled for now (`cmake -DOSMSCOUT_BUILD_BINDING_CSHARP=off`) because of issue https://github.com/Framstag/libosmscout/issues/73