### PR TITLE
remove useless option -DOSMSCOUT_BUILD_BINDING_CSHARP=off

### DIFF
--- a/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/data/build.sh
@@ -7,6 +7,6 @@ env
 cd libosmscout
 mkdir build
 cd build
-cmake -DOSMSCOUT_BUILD_BINDING_CSHARP=off ..
+cmake ..
 make
 


### PR DESCRIPTION
C# binding is disabled for gcc now