### PR TITLE
add style definition for railway_narrow_gauge

### DIFF
--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -1030,6 +1030,7 @@ STYLE
 
      [TYPE railway_tram] WAY {color: #444444; displayWidth: 0.25mm; width: 5m;}
      [TYPE railway_light_rail] WAY {color: #b3b3b3; displayWidth: 0.25mm; width: 5m;}
+     [TYPE railway_narrow_gauge] WAY {color: #b3b3b3; displayWidth: 0.20mm; width: 4m;}
 
      [TYPE railway_subway] {
        WAY {color: #b3b3b3; dash: 1.5,1.5; displayWidth: 0.4mm; cap: butt; }
@@ -1075,6 +1076,7 @@ STYLE
      [TYPE railway_rail,
            railway_tram,
            railway_light_rail,
+           railway_narrow_gauge,
            railway_subway,
            public_transport_platform] WAY.TEXT { label: Name.name; size: 0.8; color: @railwayLabelColor; }
 


### PR DESCRIPTION
Hi. I added style definition for railway_narrow_gauge. It is already defined in import definition, just render style was missing. This type of rail is rare in Czechia, but usual in Switzerland. It is weird when you go to rail station, open map there are no rails :)

I am just thinking if we should render rails with property "rack=yes" with different style?
![railway_with_rack](https://cloud.githubusercontent.com/assets/309458/17657659/646913be-62c5-11e6-9aae-0a1d4dde2ff5.JPG)
