### PR TITLE
style parser should not fail (just warn) when style contains types missing in database

### DIFF
--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -347,7 +347,7 @@ void Parser::WAYGROUP(size_t priority) {
 			
 			if (!wayType) {
 			 std::string e="Unknown way type '"+wayTypeName+"'";
-			 SemErr(e.c_str());
+			 SemWarning(e.c_str());
 			}
 			else if (!wayType->CanBeWay()) {
 			 std::string e="Tyype '"+wayTypeName+"' is not a way type";
@@ -369,7 +369,7 @@ void Parser::WAYGROUP(size_t priority) {
 			
 			if (!wayType) {
 			 std::string e="Unknown way type '"+wayTypeName+"'";
-			 SemErr(e.c_str());
+			 SemWarning(e.c_str());
 			}
 			else if (!wayType->CanBeWay()) {
 			 std::string e="Tyype '"+wayTypeName+"' is not a way type";
@@ -1098,7 +1098,7 @@ void Parser::STYLEFILTER_TYPE(StyleFilter& filter) {
 		if (!type) {
 		 std::string e="Unknown type '"+name+"'";
 		
-		 SemErr(e.c_str());
+		 SemWarning(e.c_str());
 		}
 		else if (filter.HasTypes() &&
 		        !filter.HasType(type)) {
@@ -1119,7 +1119,7 @@ void Parser::STYLEFILTER_TYPE(StyleFilter& filter) {
 			if (!type) {
 			 std::string e="Unknown type '"+name+"'";
 			
-			 SemErr(e.c_str());
+			 SemWarning(e.c_str());
 			}
 			else if (filter.HasTypes() &&
 			        !filter.HasType(type)) {


### PR DESCRIPTION
Hi, I was experimenting with new map types. I added new type to import definition (map.ost) and then I created style (.oss) for it. Just for check that style file is correct, I tried to open it. And it fails, because it contains types that are not in my old database!

It is not optimal. I can imagine situations when user generate or download database and then use it for months. When he update application (and style) it should work even that database types are outdated.

This commit change semantic errors just to warnings. I tested it with described usecase and it works. Can be some hidden problems here that I missed?