### PR TITLE
via_ferrata type and render styles

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -279,6 +279,22 @@ TYPES
       {Name, NameAlt}
       PATH[FOOT] LOCATION PIN_WAY
 
+  TYPE highway_via_ferrata_easy
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="0") OR ("via_ferrata_scale"=="1")))
+      {Name, NameAlt}
+
+  TYPE highway_via_ferrata_moderate
+    = WAY (("highway"=="via_ferrata") AND ("via_ferrata_scale"=="2"))
+      {Name, NameAlt}
+
+  TYPE highway_via_ferrata_difficult
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="3") OR ("via_ferrata_scale"=="4")))
+      {Name, NameAlt}
+
+  TYPE highway_via_ferrata_extreme
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="5") OR ("via_ferrata_scale"=="6")))
+      {Name, NameAlt}
+
   TYPE highway_bridleway
     = WAY AREA ("highway"=="bridleway")
       {Name, NameAlt}

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -240,6 +240,11 @@ CONST
   COLOR motorwayJunctionLabelColor = lighten(@motorwayColor, 0.5);
   COLOR trunkShieldColor           = @trunkColor;
   COLOR primaryShieldColor         = @primaryColor;
+
+  COLOR viaFerrataEasyColor        = darken(#fdac44, 0.4);
+  COLOR viaFerrataModerateColor    = #fdac44;
+  COLOR viaFerrataDifficultColor   = #ec4044;
+  COLOR viaFerrataExtremeColor     = #ff0000;
   
   // Buildings
   COLOR buildingColor              = #d9d9d9;
@@ -324,6 +329,22 @@ CONST
   COLOR postLabelColor             = darken(@postColor, 0.5);
 
   COLOR wallColor                  = #663e1b;
+
+  SYMBOL viaFerrataEasyCross
+    POLYGON -0.5,-0.5 0.5,0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataEasyColor;  }
+    POLYGON -0.5,0.5 0.5,-0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataEasyColor;  }
+
+  SYMBOL viaFerrataModerateCross
+    POLYGON -0.5,-0.5 0.5,0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataModerateColor;  }
+    POLYGON -0.5,0.5 0.5,-0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataModerateColor;  }
+
+  SYMBOL viaFerrataDifficultCross
+    POLYGON -0.5,-0.5 0.5,0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataDifficultColor;  }
+    POLYGON -0.5,0.5 0.5,-0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataDifficultColor;  }
+
+  SYMBOL viaFerrataExtremeCross
+    POLYGON -0.5,-0.5 0.5,0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataExtremeColor;  }
+    POLYGON -0.5,0.5 0.5,-0.5 { borderWidth: 0.1mm; borderColor:  @viaFerrataExtremeColor;  }
 
   SYMBOL oneway_arrow
     POLYGON 0,0.5 1,0 0,-0.5 { color:  @onewayArrowColor; }
@@ -922,6 +943,22 @@ STYLE
        WAY#rbridge {color: @bridgeColor; displayWidth: 0.2mm; displayOffset: 0.15mm;}
      }
    }
+   [TYPE highway_via_ferrata_easy]{
+       WAY {color: @viaFerrataEasyColor; displayWidth: 0.1mm; dash: 1,100;}
+       WAY.SYMBOL {symbol: viaFerrataEasyCross; symbolSpace: 2mm;}
+   }
+   [TYPE highway_via_ferrata_moderate]{
+       WAY {color: @viaFerrataModerateColor; displayWidth: 0.1mm; dash: 1,100;}
+       WAY.SYMBOL {symbol: viaFerrataModerateCross; symbolSpace: 2mm;}
+   }
+   [TYPE highway_via_ferrata_difficult]{
+       WAY {color: @viaFerrataDifficultColor; displayWidth: 0.1mm; dash: 1,100;}
+       WAY.SYMBOL {symbol: viaFerrataDifficultCross; symbolSpace: 2mm;}
+   }
+   [TYPE highway_via_ferrata_extreme]{
+       WAY {color: @viaFerrataExtremeColor; displayWidth: 0.1mm; dash: 1,100;}
+       WAY.SYMBOL {symbol: viaFerrataExtremeCross; symbolSpace: 2mm;}
+   }
   }
 
  [MAG @stepsMag-] {
@@ -994,7 +1031,12 @@ STYLE
          highway_cycleway,
          highway_footway,
          highway_bridleway,
-         highway_steps] WAY.TEXT { label: Name.name; color: @wayLabelColor; size: 0.8;}
+         highway_steps,
+         highway_via_ferrata_easy,
+         highway_via_ferrata_moderate,
+         highway_via_ferrata_difficult,
+         highway_via_ferrata_extreme] WAY.TEXT { label: Name.name; color: @wayLabelColor; size: 0.8;}
+
 
    [TYPE highway_pedestrian,
          highway_services,


### PR DESCRIPTION
Hi. I returned from my holidays in Austria (not so strange country ;-). One thing that was missing to me on map was [via ferrata](http://wiki.openstreetmap.org/wiki/Proposed_features/via_ferrata). So here is type definitions and styles. I select cross symbol for it.

![style-highway_via_ferrata](https://cloud.githubusercontent.com/assets/309458/17840019/3432c1b4-67fb-11e6-911a-4067faf1216f.png)
