### PR TITLE
import: workaround optimized way and area index generation problem

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
@@ -424,16 +424,22 @@ namespace osmscout
     // Write the bitmap with offsets for each cell
     // We prefill with zero and only overrite cells that have data
     // So zero means "no data for this cell"
+    FileOffset cellOffset=0;
     for (size_t i=0; i<data.cellXCount*data.cellYCount; i++) {
-      FileOffset cellOffset=0;
-
       writer.WriteFileOffset(cellOffset,
                              data.dataOffsetBytes);
     }
 
     FileOffset dataStartOffset;
-
     dataStartOffset=writer.GetPos();
+
+    // Move data start by one byte. It creates little bit larger output file.
+    // But without it 0 is valid cell offset and these data will not be visible,
+    // because for reader means that this cell has no data!
+
+    // TODO: when data format will be changing, consider usage ones (0xFF..FF)
+    // as empty placeholder
+    writer.WriteFileOffset(cellOffset, 1);
 
     // Now write the list of offsets of objects for every cell with content
     for (std::map<Pixel,std::list<FileOffset> >::const_iterator cell=cellOffsets.begin();

--- a/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
@@ -578,16 +578,22 @@ namespace osmscout
     // Write the bitmap with offsets for each cell
     // We prefill with zero and only overrite cells that have data
     // So zero means "no data for this cell"
+    FileOffset cellOffset=0;
     for (size_t i=0; i<data.cellXCount*data.cellYCount; i++) {
-      FileOffset cellOffset=0;
-
       writer.WriteFileOffset(cellOffset,
                              data.dataOffsetBytes);
     }
 
     FileOffset dataStartOffset;
-
     dataStartOffset=writer.GetPos();
+
+    // Move data start by one byte. It creates little bit larger output file.
+    // But without it 0 is valid cell offset and these data will not be visible,
+    // because for reader means that this cell has no data!
+
+    // TODO: when data format will be changing, consider usage ones (0xFF..FF)
+    // as empty placeholder
+    writer.WriteFileOffset(cellOffset, 1);
 
     // Now write the list of offsets of objects for every cell with content
     for (std::map<Pixel,std::list<FileOffset> >::const_iterator cell=cellOffsets.begin();


### PR DESCRIPTION
Problem is that zero cell offset is valid offset now. But zero for reader means
that this cell don't contains data! This cause that data in first cell are
never visible.

This workaround move data start by one byte. It creates little bit larger output file.
But generated format is bacward compatible and all cells with data are visible to
reader code.

TODO: when data format will be changing, consider usage ones (0xFF..FF)
as empty placeholder

Following screenshots (DrawMapQt moutput) shows that now are optimized data visible:

trunk import with bug
![map-1-bad](https://cloud.githubusercontent.com/assets/309458/17928082/559f8fee-69f9-11e6-86bb-870725afaf6d.png)
fixed optimized ways
![map-2-fixed-ways](https://cloud.githubusercontent.com/assets/309458/17928083/55be323c-69f9-11e6-84bf-35db1b239958.png)
fixed ways and areas
![map-3-fixed-ways-and-areas](https://cloud.githubusercontent.com/assets/309458/17928085/55f2cf4c-69f9-11e6-9271-d2164d069d85.png)


