### PR TITLE
Import: check if input files exists on start

### DIFF
--- a/Import/src/Import.cpp
+++ b/Import/src/Import.cpp
@@ -750,6 +750,18 @@ int main(int argc, char* argv[])
       std::cerr << "Destination ist not a directory!" << std::endl;
       return 1;
     }
+
+    for (auto mapfile: mapfiles){
+      if (!osmscout::ExistsInFilesystem(mapfile)) {
+        std::cerr << "Input " << mapfile << " does not exist!" << std::endl;
+        return 1;
+      }
+
+      if (osmscout::IsDirectory(mapfile)) {
+        std::cerr << "Input " << mapfile << " is a directory!" << std::endl;
+        return 1;
+      }
+    }
   }
   catch (osmscout::IOException& e) {
     // we ignore this exception, since it is likely a "not implemented" exception


### PR DESCRIPTION
When import contains more files (OSM area and contour lines for example), and you define bad name of the last one, import will fail after many minutes, when parsing of the previous files is done... 

This simple change check that all inputs exists on import start.