### PR TITLE
use render offset for some way names

### DIFF
--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -1045,6 +1045,11 @@ STYLE
          highway_via_ferrata_difficult,
          highway_via_ferrata_extreme] WAY.TEXT { label: Name.name; color: @wayLabelColor; size: 0.8;}
 
+   [TYPE highway_steps,
+         highway_via_ferrata_easy,
+         highway_via_ferrata_moderate,
+         highway_via_ferrata_difficult,
+         highway_via_ferrata_extreme] WAY.TEXT { displayOffset: 2mm;}
 
    [TYPE highway_pedestrian,
          highway_services,
@@ -1052,7 +1057,7 @@ STYLE
 
    [TYPE aerialway_gondola,
          aerialway_chair_lift,
-         aerialway_drag_lift] WAY.TEXT { label: Name.name; size: 1.0; color: @railwayLabelColor; }
+         aerialway_drag_lift] WAY.TEXT { label: Name.name; size: 1.0; color: @railwayLabelColor; displayOffset: 2.5mm;}
 
  }
 


### PR DESCRIPTION
It is used for ways where label color is too similar (low contrast)
with way color or way style is too disruptive for text (steps, ferrata).

Btw, thanks for this functionality Tim!