### PR TITLE
POC: split long ways - it is based on count of nodes (300) or real length (30 km)

### DIFF
--- a/libosmscout-import/include/osmscout/import/GenWayWayDat.h
+++ b/libosmscout-import/include/osmscout/import/GenWayWayDat.h
@@ -89,6 +89,10 @@ namespace osmscout {
                    std::list<RawWayRef>& ways,
                    std::multimap<OSMId,TurnRestrictionRef>& restrictions);
 
+    bool SplitLongWays(Progress& progress,
+                       std::list<RawWayRef>& ways,
+                       CoordDataFile::ResultMap& coordsMap);
+
     void WriteWay(Progress& progress,
                   const TypeConfig& typeConfig,
                   FileWriter& writer,

--- a/libosmscout-import/include/osmscout/import/RawWay.h
+++ b/libosmscout-import/include/osmscout/import/RawWay.h
@@ -114,6 +114,11 @@ namespace osmscout {
       return featureValueBuffer;
     }
 
+    inline FeatureValueBuffer& GetMutableFeatureValueBuffer()
+    {
+      return featureValueBuffer;
+    }
+
     bool IsOneway() const;
 
     void SetId(OSMId id);


### PR DESCRIPTION
Hi. We know that labeling of long ways has nasty performance impact (at least with Qt backend). You recently added limit for merging ways to keep node count < 300. But some ways are so dense that it may have real length 150 km just with 100 nodes on map. 

It was proven with one ferry line here: https://github.com/Karry/osmscout-sailfish/issues/8#issuecomment-244596229

Because of that, I created method that split long ways (based on real length or node count) in import process. I tested it and it improves rendering time ten times (from 12s to 2.4 s).

This is just a fast proof of concept. It need better log messages, progress reporting, enable OpenMP for loops, and configurable parameters instead of constants...
