### PR TITLE
Way splitting improvements

### DIFF
--- a/libosmscout-import/include/osmscout/import/RawWay.h
+++ b/libosmscout-import/include/osmscout/import/RawWay.h
@@ -114,9 +114,9 @@ namespace osmscout {
       return featureValueBuffer;
     }
 
-    inline FeatureValueBuffer& GetMutableFeatureValueBuffer()
+    inline void SetFeatureValueBuffer(const FeatureValueBuffer& other)
     {
-      return featureValueBuffer;
+      featureValueBuffer.Set(other);
     }
 
     bool IsOneway() const;

--- a/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
@@ -516,7 +516,7 @@ namespace osmscout {
         if (segment->GetId() == 0){
           segment->SetId(way->GetId());
           segment->SetType(way->GetType(), way->IsArea());
-          segment->GetMutableFeatureValueBuffer().Set(way->GetFeatureValueBuffer());
+          segment->SetFeatureValueBuffer(way->GetFeatureValueBuffer());
         }
         Coord current = coordsMap[*osmIdIt];
         

--- a/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
@@ -469,7 +469,10 @@ namespace osmscout {
   {
     // TODO: enable OMP parallelism
     std::list<RawWayRef> newWays;
-    
+
+    size_t currentWay=1;
+    size_t wayCount=ways.size();
+
     for (auto way: ways){
       //*wayIt;
       double length=0.0;
@@ -488,6 +491,9 @@ namespace osmscout {
         }
         split = length > 30.0;
       }
+
+      progress.SetProgress(currentWay,wayCount);
+      currentWay++;
 
       if (!split){
         newWays.push_back(way);
@@ -812,6 +818,7 @@ namespace osmscout {
         
         // split too long ways again to shorter segments
     // TODO: enable OMP parallelism    
+        progress.SetAction("Splitting too long ways");
 //#pragma omp parallel for
         for (int64_t typeIdx = 0; typeIdx<(int64_t)typeConfig->GetTypeCount(); typeIdx++) {
           size_t originalWayCount=waysByType[typeIdx].size();
@@ -821,7 +828,7 @@ namespace osmscout {
             
 //#pragma omp critical
             if (waysByType[typeIdx].size()>originalWayCount) {
-              progress.Info("Split long ways of '"+typeConfig->GetTypeInfo(typeIdx)->GetName()+"' from "+
+              progress.Info("Splitted long ways of '"+typeConfig->GetTypeInfo(typeIdx)->GetName()+"' from "+
                             NumberToString(originalWayCount)+" to "+NumberToString(waysByType[typeIdx].size())+ " way(s)");
               mergeCount+=originalWayCount-waysByType[typeIdx].size();
             }

--- a/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
@@ -467,7 +467,6 @@ namespace osmscout {
                      std::list<RawWayRef>& ways,
                      CoordDataFile::ResultMap& coordsMap)
   {
-    // TODO: enable OMP parallelism
     std::list<RawWayRef> newWays;
 
     size_t currentWay=1;
@@ -500,13 +499,12 @@ namespace osmscout {
         continue;
       }
       
-      std::cout << "  Spliting long way " << way->GetId() << 
-        " with " << way->GetNodeCount() << " nodes";
+      std::string msg = "Splitting long way " + NumberToString(way->GetId()) + 
+        " with " + NumberToString(way->GetNodeCount()) + " nodes";
       if (length > 0.0){
-        std::cout << " and real length " << length << " km";
+        msg += " and real length " + std::to_string(length) + " km";
       }
-      std::cout << std::endl;
-      //ways.erase(wayIt);
+      progress.Debug(msg);
       
       double segmentLength=0.0;
       size_t segmentNodeCnt=1;
@@ -536,8 +534,8 @@ namespace osmscout {
 
           segment->SetNodes(currentSegmentStart, osmIdIt);
           newWays.push_back(segment);
-          std::cout << "  - New segment " << segment->GetId() << 
-            " with " << segment->GetNodeCount() << " nodes and real length " << segmentLength << " km" << std::endl;
+          //std::cout << "  - New segment " << segment->GetId() << 
+          //  " with " << segment->GetNodeCount() << " nodes and real length " << segmentLength << " km" << std::endl;
           
           // reset segment
           segmentLength=0.0;
@@ -552,8 +550,8 @@ namespace osmscout {
       if (segment->GetId() != 0 && segmentNodeCnt >= 2){
         segment->SetNodes(segmentStart, osmIdIt);
         newWays.push_back(segment);        
-        std::cout << "  - New segment (last) " << segment->GetId() << 
-            " with " << segment->GetNodeCount() << " nodes and real length " << segmentLength << " km" << std::endl;
+        //std::cout << "  - New segment (last) " << segment->GetId() << 
+        //    " with " << segment->GetNodeCount() << " nodes and real length " << segmentLength << " km" << std::endl;
       }
     }
     

--- a/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
@@ -817,16 +817,15 @@ namespace osmscout {
         nodeIds.clear();
         
         // split too long ways again to shorter segments
-    // TODO: enable OMP parallelism    
         progress.SetAction("Splitting too long ways");
-//#pragma omp parallel for
+#pragma omp parallel for
         for (int64_t typeIdx = 0; typeIdx<(int64_t)typeConfig->GetTypeCount(); typeIdx++) {
           size_t originalWayCount=waysByType[typeIdx].size();
 
           if (originalWayCount>0) {
             SplitLongWays(progress, waysByType[typeIdx], coordsMap);        
             
-//#pragma omp critical
+#pragma omp critical
             if (waysByType[typeIdx].size()>originalWayCount) {
               progress.Info("Splitted long ways of '"+typeConfig->GetTypeInfo(typeIdx)->GetName()+"' from "+
                             NumberToString(originalWayCount)+" to "+NumberToString(waysByType[typeIdx].size())+ " way(s)");


### PR DESCRIPTION
Some minor improvements for code from https://github.com/Framstag/libosmscout/pull/110

- dont print to std::cout, use progress.Debug in SplitLongWays
- enable OpenMP for splitting ways
- report SplitLongWays progress
- use SetFeatureValueBuffer method for setup features, instead of GetMutableFeatureValueBuffer
