### PR TITLE
Contact features, extend LocationService and LocationLookup demo

### DIFF
--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -55,6 +55,9 @@ void DumpLocationAtPlaceDescription(osmscout::LocationAtPlaceDescription& descri
 
   if (place.GetPOI()) {
     std::cout << "  - POI:      " << place.GetPOI()->name << std::endl;
+    if (place.GetObjectFeatures()){
+      std::cout << "  - type:     " << place.GetObjectFeatures()->GetType()->GetName() << std::endl;
+    }
   }
 
   if (place.GetAddress()) {
@@ -67,6 +70,26 @@ void DumpLocationAtPlaceDescription(osmscout::LocationAtPlaceDescription& descri
 
   if (place.GetAdminRegion()) {
     std::cout << "  - region:   " << place.GetAdminRegion()->name << std::endl;
+  }
+  
+  // print all features of this place
+  std::cout << std::endl;
+  if (place.GetObjectFeatures()){
+    for (auto featureInstance :place.GetObjectFeatures()->GetType()->GetFeatures()){
+      if (place.GetObjectFeatures()->HasFeature(featureInstance.GetIndex())){
+        osmscout::FeatureRef feature=featureInstance.GetFeature();
+        if (feature->HasValue() && feature->HasLabel()){
+          osmscout::FeatureValue *value=place.GetObjectFeatures()->GetValue(featureInstance.GetIndex());
+          if (value->GetLabel().empty()){
+            std::cout << "  + " << feature->GetName() << std::endl;
+          }else{
+            std::cout << "  + " << feature->GetName() << ": " << value->GetLabel() << std::endl;
+          }
+        }else{
+          std::cout << "  + " << feature->GetName() << std::endl;
+        }
+      }
+    }
   }
 }
 

--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -81,15 +81,33 @@ void DumpLocationAtPlaceDescription(osmscout::LocationAtPlaceDescription& descri
         if (feature->HasValue() && feature->HasLabel()){
           osmscout::FeatureValue *value=place.GetObjectFeatures()->GetValue(featureInstance.GetIndex());
           if (value->GetLabel().empty()){
-            std::cout << "  + " << feature->GetName() << std::endl;
+            std::cout << "  + feature " << feature->GetName() << std::endl;
           }else{
-            std::cout << "  + " << feature->GetName() << ": " << value->GetLabel() << std::endl;
+            std::cout << "  + feature " << feature->GetName() << ": " << value->GetLabel() << std::endl;
           }
         }else{
-          std::cout << "  + " << feature->GetName() << std::endl;
+          std::cout << "  + feature " << feature->GetName() << std::endl;
         }
       }
     }
+  }
+}
+
+void DumpParentAdminRegions(const osmscout::LocationServiceRef& locationService,
+                            const osmscout::AdminRegionRef& adminRegion)
+{
+  if (!adminRegion){
+    return;
+  }
+
+  std::cout << std::endl;
+  std::map<osmscout::FileOffset,osmscout::AdminRegionRef> regions;
+  locationService->ResolveAdminRegionHierachie(adminRegion, regions);
+  osmscout::FileOffset parentOffset = adminRegion->parentRegionOffset;
+  while (parentOffset != 0){
+    osmscout::AdminRegionRef region = regions[parentOffset];
+    std::cout << "  > parent region: " << region->name << std::endl;
+    parentOffset = region->parentRegionOffset;
   }
 }
 
@@ -150,14 +168,17 @@ int main(int argc, char* argv[])
 
   if (atNameDescription) {
     DumpLocationAtPlaceDescription(*atNameDescription);
+    DumpParentAdminRegions(locationService, atNameDescription->GetPlace().GetAdminRegion());
   }
 
   if (atAddressDescription) {
     DumpLocationAtPlaceDescription(*atAddressDescription);
+    DumpParentAdminRegions(locationService, atAddressDescription->GetPlace().GetAdminRegion());
   }
 
   if (atPOIDescription) {
     DumpLocationAtPlaceDescription(*atPOIDescription);
+    DumpParentAdminRegions(locationService, atPOIDescription->GetPlace().GetAdminRegion());
   }
 
   database->Close();

--- a/libosmscout/include/osmscout/Location.h
+++ b/libosmscout/include/osmscout/Location.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <osmscout/ObjectRef.h>
+#include <osmscout/TypeConfig.h>
 
 namespace osmscout {
   /**
@@ -224,6 +225,7 @@ namespace osmscout {
   {
   private:
     ObjectFileRef  object;      //!< Object the location is in
+    FeatureValueBufferRef objectFeatures;
     AdminRegionRef adminRegion; //!< Region the object is in, if set
     POIRef         poi;         //!< POI data, if set
     LocationRef    location;    //!< Location data, if set
@@ -231,6 +233,7 @@ namespace osmscout {
 
   public:
     Place(const ObjectFileRef& object,
+          const FeatureValueBufferRef objectFeatureBuff,
           const AdminRegionRef& adminRegion,
           const POIRef& poi,
           const LocationRef& location,
@@ -239,6 +242,11 @@ namespace osmscout {
     inline ObjectFileRef GetObject() const
     {
       return object;
+    }
+
+    inline FeatureValueBufferRef GetObjectFeatures() const
+    {
+      return objectFeatures;
     }
 
     inline AdminRegionRef GetAdminRegion() const

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -471,31 +471,6 @@ namespace osmscout {
                                           const AddressMatchVisitor::AddressResult& addressResult,
                                           LocationSearchResult& result) const;
 
-    /**
-     * Load areas of given types near to location.
-     * 
-     * @param location
-     * @param types
-     * @param candidates - result buffer
-     * @param maxDistance - lookup distance in meters
-     * @return true if success (it don't indicate non-empty result)
-     */
-    bool LoadNearAreas(const GeoCoord& location, const TypeInfoSet &types,
-                       std::vector<LocationDescriptionCandicate> &candidates,
-                       const double maxDistance=100);
-
-    bool LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types,
-                       std::vector<LocationDescriptionCandicate> &candidates,
-                       const double maxDistance=100);
-
-    bool DescribeLocationByName(const GeoCoord& location,
-                                LocationDescription& description);
-
-    bool DescribeLocationByAddress(const GeoCoord& location,
-                                   LocationDescription& description);
-
-    bool DescribeLocationByPOI(const GeoCoord& location,
-                               LocationDescription& description);
   public:
     LocationService(const DatabaseRef& database);
 
@@ -524,6 +499,38 @@ namespace osmscout {
 
     bool DescribeLocation(const GeoCoord& location,
                           LocationDescription& description);
+
+    /**
+     * Load areas of given types near to location.
+     * 
+     * @param location
+     * @param types
+     * @param candidates - unsorted result buffer
+     * @param maxDistance - lookup distance in meters
+     * @return true if no error (it don't indicate non-empty result)
+     */
+    bool LoadNearAreas(const GeoCoord& location, const TypeInfoSet &types,
+                       std::vector<LocationDescriptionCandicate> &candidates,
+                       const double maxDistance=100);
+
+    /**
+     * @see LoadNearNodes
+     */
+    bool LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types,
+                       std::vector<LocationDescriptionCandicate> &candidates,
+                       const double maxDistance=100);
+
+    bool DescribeLocationByName(const GeoCoord& location,
+                                LocationDescription& description,
+                                const double lookupDistance=100);
+
+    bool DescribeLocationByAddress(const GeoCoord& location,
+                                   LocationDescription& description,
+                                   const double lookupDistance=100);
+
+    bool DescribeLocationByPOI(const GeoCoord& location,
+                               LocationDescription& description,
+                               const double lookupDistance=100);
   };
 
   //! \ingroup Service

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -445,6 +445,8 @@ namespace osmscout {
     static bool DistanceComparator(const LocationDescriptionCandicate &a,
                                    const LocationDescriptionCandicate &b);
 
+    const FeatureValueBufferRef GetObjectFeatureBuffer(const ObjectFileRef &object);
+
     Place GetPlace(const std::list<ReverseLookupResult>& lookupResult);
 
     bool HandleAdminRegion(const LocationSearch& search,
@@ -469,11 +471,22 @@ namespace osmscout {
                                           const AddressMatchVisitor::AddressResult& addressResult,
                                           LocationSearchResult& result) const;
 
+    /**
+     * Load areas of given types near to location.
+     * 
+     * @param location
+     * @param types
+     * @param candidates - result buffer
+     * @param maxDistance - lookup distance in meters
+     * @return true if success (it don't indicate non-empty result)
+     */
     bool LoadNearAreas(const GeoCoord& location, const TypeInfoSet &types,
-                       std::vector<LocationDescriptionCandicate> &candidates);
+                       std::vector<LocationDescriptionCandicate> &candidates,
+                       const double maxDistance=100);
 
     bool LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types,
-                       std::vector<LocationDescriptionCandicate> &candidates);
+                       std::vector<LocationDescriptionCandicate> &candidates,
+                       const double maxDistance=100);
 
     bool DescribeLocationByName(const GeoCoord& location,
                                 LocationDescription& description);

--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -1103,6 +1103,8 @@ namespace osmscout {
     FeatureRef                                  featureLocation;
     FeatureRef                                  featureAddress;
     FeatureRef                                  featurePostalCode;
+    FeatureRef                                  featureWebsite;
+    FeatureRef                                  featurePhone;
     FeatureRef                                  featureAccess;
     FeatureRef                                  featureAccessRestricted;
     FeatureRef                                  featureLayer;

--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -1050,6 +1050,8 @@ namespace osmscout {
     bool operator!=(const FeatureValueBuffer& other) const;
   };
 
+  typedef std::shared_ptr<FeatureValueBuffer> FeatureValueBufferRef;
+
   static const uint32_t FILE_FORMAT_VERSION = 8;
 
   /**

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1346,6 +1346,134 @@ namespace osmscout {
                FeatureValueBuffer& buffer) const;
   };
 
+  class OSMSCOUT_API WebsiteFeatureValue : public FeatureValue
+  {
+  private:
+    std::string website;
+
+  public:
+    inline WebsiteFeatureValue()
+    {
+      // no code
+    }
+
+    inline WebsiteFeatureValue(const std::string& website)
+    : website(website)
+    {
+      // no code
+    }
+
+    inline void SetWebsite(const std::string& website)
+    {
+      this->website=website;
+    }
+
+    inline std::string GetWebsite() const
+    {
+      return website;
+    }
+
+    void Read(FileScanner& scanner);
+    void Write(FileWriter& writer);
+
+    FeatureValue& operator=(const FeatureValue& other);
+    bool operator==(const FeatureValue& other) const;
+  };
+
+  class OSMSCOUT_API WebsiteFeature : public Feature
+  {
+  private:
+    TagId tagWebsite;
+
+  public:
+    /** Name of this feature */
+    static const char* const NAME;
+
+    /** Name of the "name" label */
+    static const char* const NAME_LABEL;
+
+  public:
+    void Initialize(TypeConfig& typeConfig);
+
+    std::string GetName() const;
+
+    size_t GetValueSize() const;
+    FeatureValue* AllocateValue(void* buffer);
+
+    void Parse(Progress& progress,
+               const TypeConfig& typeConfig,
+               const FeatureInstance& feature,
+               const ObjectOSMRef& object,
+               const TagMap& tags,
+               FeatureValueBuffer& buffer) const;
+  };
+  
+
+  class OSMSCOUT_API PhoneFeatureValue : public FeatureValue
+  {
+  private:
+    std::string phone;
+
+  public:
+    inline PhoneFeatureValue()
+    {
+      // no code
+    }
+
+    inline PhoneFeatureValue(const std::string& phone)
+    : phone(phone)
+    {
+      // no code
+    }
+
+    inline void SetPhone(const std::string& phone)
+    {
+      this->phone=phone;
+    }
+
+    inline std::string GetPhone() const
+    {
+      return phone;
+    }
+
+    inline std::string GetLabel() const
+    {
+      return phone;
+    }
+
+    void Read(FileScanner& scanner);
+    void Write(FileWriter& writer);
+
+    FeatureValue& operator=(const FeatureValue& other);
+    bool operator==(const FeatureValue& other) const;
+  };
+
+  class OSMSCOUT_API PhoneFeature : public Feature
+  {
+  private:
+    TagId tagPhone;
+
+  public:
+    /** Name of this feature */
+    static const char* const NAME;
+
+  public:
+    void Initialize(TypeConfig& typeConfig);
+
+    std::string GetName() const;
+
+    size_t GetValueSize() const;
+    FeatureValue* AllocateValue(void* buffer);
+
+    void Parse(Progress& progress,
+               const TypeConfig& typeConfig,
+               const FeatureInstance& feature,
+               const ObjectOSMRef& object,
+               const TagMap& tags,
+               FeatureValueBuffer& buffer) const;
+  };
+  
+  
   /**
    * Helper template class for easy access to flag-like Features.
    *

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1082,6 +1082,11 @@ namespace osmscout {
       return postalCode;
     }
 
+    inline std::string GetLabel() const
+    {
+      return postalCode;
+    }
+
     void Read(FileScanner& scanner);
     void Write(FileWriter& writer);
 
@@ -1100,6 +1105,8 @@ namespace osmscout {
     static const char* const NAME;
 
   public:
+    PostalCodeFeature();
+
     void Initialize(TypeConfig& typeConfig);
 
     std::string GetName() const;
@@ -1373,6 +1380,11 @@ namespace osmscout {
       return website;
     }
 
+    inline std::string GetLabel() const
+    {
+      return website;
+    }
+
     void Read(FileScanner& scanner);
     void Write(FileWriter& writer);
 
@@ -1393,6 +1405,7 @@ namespace osmscout {
     static const char* const NAME_LABEL;
 
   public:
+    WebsiteFeature();
     void Initialize(TypeConfig& typeConfig);
 
     std::string GetName() const;
@@ -1458,6 +1471,7 @@ namespace osmscout {
     static const char* const NAME;
 
   public:
+    PhoneFeature();
     void Initialize(TypeConfig& typeConfig);
 
     std::string GetName() const;

--- a/libosmscout/src/osmscout/Location.cpp
+++ b/libosmscout/src/osmscout/Location.cpp
@@ -88,11 +88,13 @@ namespace osmscout {
   }
 
   Place::Place(const ObjectFileRef& object,
+               const FeatureValueBufferRef objectFeatures,
                const AdminRegionRef& adminRegion,
                const POIRef& poi,
                const LocationRef& location,
                const AddressRef& address)
   : object(object),
+    objectFeatures(objectFeatures),
     adminRegion(adminRegion),
     poi(poi),
     location(location),

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -1570,7 +1570,8 @@ namespace osmscout {
   }
 
   bool LocationService::DescribeLocationByName(const GeoCoord& location,
-                                               LocationDescription& description)
+                                               LocationDescription& description,
+                                               const double lookupDistance)
   {
     // search all addressable areas and nodes, sort it by distance, get first with name
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1594,7 +1595,8 @@ namespace osmscout {
     if (!nameTypes.Empty()) {
       if (!LoadNearAreas(location,
                          nameTypes,
-                         candidates)) {
+                         candidates,
+                         lookupDistance)) {
         return false;
       }
     }
@@ -1611,7 +1613,8 @@ namespace osmscout {
     if (!nameTypes.Empty()) {
       if (!LoadNearNodes(location,
                          nameTypes,
-                         candidates)) {
+                         candidates,
+                         lookupDistance)) {
         return false;
       }
     }
@@ -1680,7 +1683,8 @@ namespace osmscout {
   }
 
   bool LocationService::DescribeLocationByAddress(const GeoCoord& location,
-                                                  LocationDescription& description)
+                                                  LocationDescription& description,
+                                                  const double lookupDistance)
   {
     // search all addressable areas and nodes, sort it by distance, get first with address
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1704,7 +1708,8 @@ namespace osmscout {
     if (!addressTypes.Empty()) {
       if (!LoadNearAreas(location,
                          addressTypes,
-                         candidates)){
+                         candidates, 
+                         lookupDistance)){
         return false;
       }
     }
@@ -1721,7 +1726,8 @@ namespace osmscout {
     if (!addressTypes.Empty()) {
       if (!LoadNearNodes(location,
                          addressTypes,
-                         candidates)){
+                         candidates,
+                         lookupDistance)){
         return false;
       }
     }
@@ -1762,7 +1768,8 @@ namespace osmscout {
   }
 
   bool LocationService::DescribeLocationByPOI(const GeoCoord& location,
-                                              LocationDescription& description)
+                                              LocationDescription& description,
+                                              const double lookupDistance)
   {
     // search all addressable areas and nodes, sort it by distance, get first with address
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1786,7 +1793,8 @@ namespace osmscout {
     if (!poiTypes.Empty()) {
       if (!LoadNearAreas(location,
                          poiTypes,
-                         candidates)){
+                         candidates,
+                         lookupDistance)){
         return false;
       }
     }
@@ -1802,7 +1810,8 @@ namespace osmscout {
     if (!poiTypes.Empty()) {
       if (!LoadNearNodes(location,
                          poiTypes,
-                         candidates)){
+                         candidates,
+                         lookupDistance)){
         return false;
       }
     }

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -436,6 +436,39 @@ namespace osmscout {
   {
     assert(database);
   }
+  
+  const FeatureValueBufferRef LocationService::GetObjectFeatureBuffer(const ObjectFileRef &object)
+  {
+    FeatureValueBufferRef objectFeatureBuff;
+    NodeRef node;
+    WayRef way;
+    AreaRef area;
+    switch (object.GetType()){
+      case refNode:
+        if (database->GetNodeByOffset(object.GetFileOffset(), node)) {
+          objectFeatureBuff = std::make_shared<FeatureValueBuffer>();
+          objectFeatureBuff->Set(node->GetFeatureValueBuffer());
+        }      
+        break;
+      case refWay:
+        if (database->GetWayByOffset(object.GetFileOffset(), way)) {
+          objectFeatureBuff = std::make_shared<FeatureValueBuffer>();
+          objectFeatureBuff->Set(way->GetFeatureValueBuffer());
+        }      
+        break;
+      case refArea:
+        if (database->GetAreaByOffset(object.GetFileOffset(), area)) {
+          objectFeatureBuff = std::make_shared<FeatureValueBuffer>();
+          objectFeatureBuff->Set(area->GetFeatureValueBuffer());
+        }      
+        break;
+      case refNone:
+      default:
+        /* do nothing */
+        break;
+    }
+    return objectFeatureBuff;
+  }
 
   Place LocationService::GetPlace(const std::list<ReverseLookupResult>& lookupResult)
   {
@@ -464,6 +497,7 @@ namespace osmscout {
     }
 
     return Place(object,
+                 GetObjectFeatureBuffer(object),
                  adminRegion,
                  poi,
                  location,
@@ -1372,11 +1406,12 @@ namespace osmscout {
 
   bool LocationService::LoadNearAreas(const GeoCoord& location,
                                       const TypeInfoSet &types,
-                                      std::vector<LocationDescriptionCandicate> &candidates)
+                                      std::vector<LocationDescriptionCandicate> &candidates,
+                                      const double maxDistance)
   {
     TypeConfigRef           typeConfig=database->GetTypeConfig();
     AreaAreaIndexRef        areaAreaIndex=database->GetAreaAreaIndex();
-    GeoBox                  box100=GeoBox::BoxByCenterAndRadius(location,100);
+    GeoBox                  box=GeoBox::BoxByCenterAndRadius(location,maxDistance);
     NameFeatureLabelReader  nameFeatureLabelLeader(*typeConfig);
 
     if (!typeConfig ||
@@ -1387,7 +1422,7 @@ namespace osmscout {
     TypeInfoSet                loadedTypes;
 
     if (!areaAreaIndex->GetAreasInArea(*typeConfig,
-                                       box100,
+                                       box,
                                        std::numeric_limits<size_t>::max(),
                                        types,
                                        areaSpans,
@@ -1456,12 +1491,14 @@ namespace osmscout {
         }
       }
 
-      candidates.push_back(LocationDescriptionCandicate(ObjectFileRef(area->GetFileOffset(),refArea),
-                                                        nameFeatureLabelLeader.GetLabel(area->GetFeatureValueBuffer()),
-                                                        distance,
-                                                        bearing,
-                                                        atPlace,
-                                                        boundingBox.GetSize()));
+      if (distance*1000 <= maxDistance){
+        candidates.push_back(LocationDescriptionCandicate(ObjectFileRef(area->GetFileOffset(),refArea),
+                                                          nameFeatureLabelLeader.GetLabel(area->GetFeatureValueBuffer()),
+                                                          distance,
+                                                          bearing,
+                                                          atPlace,
+                                                          boundingBox.GetSize()));
+      }
     }
 
     osmscout::log.Debug() << "Found " << areas.size() << " areas near " << location.GetDisplayText();
@@ -1470,11 +1507,12 @@ namespace osmscout {
   }
 
   bool LocationService::LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types, 
-                                      std::vector<LocationDescriptionCandicate> &candidates)
+                                      std::vector<LocationDescriptionCandicate> &candidates,
+                                      const double maxDistance)
   {
     TypeConfigRef           typeConfig=database->GetTypeConfig();
     AreaNodeIndexRef        areaNodeIndex=database->GetAreaNodeIndex();
-    GeoBox                  box100=GeoBox::BoxByCenterAndRadius(location,100);
+    GeoBox                  box=GeoBox::BoxByCenterAndRadius(location,maxDistance);
     NameFeatureLabelReader  nameFeatureLabelLeader(*typeConfig);
 
     if (!typeConfig ||
@@ -1484,7 +1522,7 @@ namespace osmscout {
     std::vector<FileOffset>  offsets;
     TypeInfoSet              loadedAddressTypes;
 
-    if (!areaNodeIndex->GetOffsets(box100, types, offsets, loadedAddressTypes)) {
+    if (!areaNodeIndex->GetOffsets(box, types, offsets, loadedAddressTypes)) {
       return false;
     }
 
@@ -1504,14 +1542,16 @@ namespace osmscout {
 
     for (const auto &node: nodes) {
       double  distance=GetEllipsoidalDistance(location,node.get()->GetCoords()); // In Km
-      double  bearing=GetSphericalBearingInitial(node.get()->GetCoords(),location);
+      if (distance*1000 <= maxDistance){
+        double  bearing=GetSphericalBearingInitial(node.get()->GetCoords(),location);
 
-      candidates.push_back(LocationDescriptionCandicate(ObjectFileRef(node->GetFileOffset(),refNode),
-                                                        nameFeatureLabelLeader.GetLabel(node->GetFeatureValueBuffer()),
-                                                        distance,
-                                                        bearing,
-                                                        false,
-                                                        0.0));
+        candidates.push_back(LocationDescriptionCandicate(ObjectFileRef(node->GetFileOffset(),refNode),
+                                                          nameFeatureLabelLeader.GetLabel(node->GetFeatureValueBuffer()),
+                                                          distance,
+                                                          bearing,
+                                                          false,
+                                                          0.0));
+      }
     }
 
     osmscout::log.Debug() << "Found " << nodes.size() << " nodes near " << location.GetDisplayText();
@@ -1617,11 +1657,12 @@ namespace osmscout {
         poi->name=candidate.GetName();
         poi->regionOffset=0;
 
-        Place          place(candidate.GetRef(),
-                             adminRegion,
-                             poi,
-                             location,
-                             address);
+        Place place(candidate.GetRef(),
+                    GetObjectFeatureBuffer(candidate.GetRef()),
+                    adminRegion,
+                    poi,
+                    location,
+                    address);
 
         if (candidate.IsAtPlace()) {
           description.SetAtNameDescription(std::make_shared<LocationAtPlaceDescription>(place));
@@ -1788,7 +1829,8 @@ namespace osmscout {
         }
         else {
           description.SetAtPOIDescription(std::make_shared<LocationAtPlaceDescription>(place,
-                                                                                       candidate.GetDistance()*1000, candidate.GetBearing()));
+                                                                                       candidate.GetDistance()*1000, 
+                                                                                       candidate.GetBearing()));
         }
         return true;
       }

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -1004,6 +1004,12 @@ namespace osmscout {
     featurePostalCode = std::make_shared<PostalCodeFeature>();
     RegisterFeature(featurePostalCode);
 
+    featureWebsite = std::make_shared<WebsiteFeature>();
+    RegisterFeature(featureWebsite);
+
+    featurePhone = std::make_shared<PhoneFeature>();
+    RegisterFeature(featurePhone);
+
     featureBridge=std::make_shared<BridgeFeature>();
     RegisterFeature(featureBridge);
 
@@ -1215,7 +1221,7 @@ namespace osmscout {
     }
 
     // Something that has a name and is a POI automatically get the
-    // location and address features, too.
+    // location, address website and phone features, too.
     if (typeInfo->HasFeature(NameFeature::NAME) &&
         typeInfo->GetIndexAsPOI()) {
       if (!typeInfo->HasFeature(LocationFeature::NAME)) {
@@ -1223,6 +1229,12 @@ namespace osmscout {
       }
       if (!typeInfo->HasFeature(AddressFeature::NAME)) {
         typeInfo->AddFeature(featureAddress);
+      }
+      if (!typeInfo->HasFeature(WebsiteFeature::NAME)) {
+        typeInfo->AddFeature(featureWebsite);
+      }
+      if (!typeInfo->HasFeature(PhoneFeature::NAME)) {
+        typeInfo->AddFeature(featurePhone);
       }
     }
 

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -1387,6 +1387,11 @@ namespace osmscout {
 
   const char* const PostalCodeFeature::NAME = "PostalCode";
 
+  PostalCodeFeature::PostalCodeFeature()
+  {
+      RegisterLabel(NAME, 0);
+  }
+
   void PostalCodeFeature::Initialize(TypeConfig& typeConfig)
   {
     tagPostalCode=typeConfig.RegisterTag("postal_code");
@@ -1477,6 +1482,11 @@ namespace osmscout {
 
   const char* const WebsiteFeature::NAME = "Website";
 
+  WebsiteFeature::WebsiteFeature()
+  {
+    RegisterLabel(NAME, 0);
+  }
+
   void WebsiteFeature::Initialize(TypeConfig& typeConfig)
   {
     tagWebsite=typeConfig.RegisterTag("website");
@@ -1560,6 +1570,11 @@ namespace osmscout {
   }
 
   const char* const PhoneFeature::NAME = "Phone";
+
+  PhoneFeature::PhoneFeature()
+  {
+    RegisterLabel(NAME, 0);
+  }
 
   void PhoneFeature::Initialize(TypeConfig& typeConfig)
   {

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -17,6 +17,8 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <algorithm>
+
 #include <osmscout/TypeFeatures.h>
 
 #include <osmscout/util/Logger.h>
@@ -1442,6 +1444,180 @@ namespace osmscout {
     }
     catch (const std::exception &e) {
       progress.Error(std::string("PostalCodeFeature::Parse Exception ")+e.what());
+    }
+  }
+    
+  void WebsiteFeatureValue::Read(FileScanner& scanner)
+  {
+    scanner.Read(website);
+  }
+
+  void WebsiteFeatureValue::Write(FileWriter& writer)
+  {
+    writer.Write(website);
+  }
+
+  FeatureValue& WebsiteFeatureValue::operator=(const FeatureValue& other)
+  {
+    if (this!=&other) {
+      const WebsiteFeatureValue& otherValue=static_cast<const WebsiteFeatureValue&>(other);
+
+      website=otherValue.website;
+    }
+
+    return *this;
+  }
+
+  bool WebsiteFeatureValue::operator==(const FeatureValue& other) const
+  {
+    const WebsiteFeatureValue& otherValue=static_cast<const WebsiteFeatureValue&>(other);
+
+    return website==otherValue.website;
+  }
+
+  const char* const WebsiteFeature::NAME = "Website";
+
+  void WebsiteFeature::Initialize(TypeConfig& typeConfig)
+  {
+    tagWebsite=typeConfig.RegisterTag("website");
+  }
+
+  std::string WebsiteFeature::GetName() const
+  {
+    return NAME;
+  }
+
+  size_t WebsiteFeature::GetValueSize() const
+  {
+    return sizeof(WebsiteFeatureValue);
+  }
+
+  FeatureValue* WebsiteFeature::AllocateValue(void* buffer)
+  {
+    return new (buffer) WebsiteFeatureValue();
+  }
+
+  void WebsiteFeature::Parse(Progress& progress,
+                                const TypeConfig& /*typeConfig*/,
+                                const FeatureInstance& feature,
+                                const ObjectOSMRef& object,
+                                const TagMap& tags,
+                                FeatureValueBuffer& buffer) const
+  {
+    // ignore ways for now
+    if (object.GetType() == OSMRefType::osmRefWay)
+      return;
+
+    auto website=tags.find(tagWebsite);
+
+    std::string strValue;
+
+    if (website!=tags.end()) {
+      strValue = website->second;
+    }
+
+    try {
+      if (!strValue.empty()) {
+        size_t idx = feature.GetIndex();
+        FeatureValue* fv = buffer.AllocateValue(idx);
+        WebsiteFeatureValue* value=static_cast<WebsiteFeatureValue*>(fv);
+
+        value->SetWebsite(strValue);
+        //progress.Info(std::string("Found website ")+strValue+" for "+object.GetName());
+      }
+    }
+    catch (const std::exception &e) {
+      progress.Error(std::string("WebsiteFeature::Parse Exception ")+e.what());
+    }
+  }
+
+  void PhoneFeatureValue::Read(FileScanner& scanner)
+  {
+    scanner.Read(phone);
+  }
+
+  void PhoneFeatureValue::Write(FileWriter& writer)
+  {
+    writer.Write(phone);
+  }
+
+  FeatureValue& PhoneFeatureValue::operator=(const FeatureValue& other)
+  {
+    if (this!=&other) {
+      const PhoneFeatureValue& otherValue=static_cast<const PhoneFeatureValue&>(other);
+
+      phone=otherValue.phone;
+    }
+
+    return *this;
+  }
+
+  bool PhoneFeatureValue::operator==(const FeatureValue& other) const
+  {
+    const PhoneFeatureValue& otherValue=static_cast<const PhoneFeatureValue&>(other);
+
+    return phone==otherValue.phone;
+  }
+
+  const char* const PhoneFeature::NAME = "Phone";
+
+  void PhoneFeature::Initialize(TypeConfig& typeConfig)
+  {
+    tagPhone=typeConfig.RegisterTag("phone");
+  }
+
+  std::string PhoneFeature::GetName() const
+  {
+    return NAME;
+  }
+
+  size_t PhoneFeature::GetValueSize() const
+  {
+    return sizeof(PhoneFeatureValue);
+  }
+
+  FeatureValue* PhoneFeature::AllocateValue(void* buffer)
+  {
+    return new (buffer) PhoneFeatureValue();
+  }
+
+  void PhoneFeature::Parse(Progress& progress,
+                                const TypeConfig& /*typeConfig*/,
+                                const FeatureInstance& feature,
+                                const ObjectOSMRef& object,
+                                const TagMap& tags,
+                                FeatureValueBuffer& buffer) const
+  {
+    // ignore ways for now
+    if (object.GetType() == OSMRefType::osmRefWay)
+      return;
+
+    auto phone=tags.find(tagPhone);
+
+    std::string strValue;
+
+    if (phone!=tags.end()) {
+      strValue = phone->second;
+    }
+
+    try {
+      if (!strValue.empty()) {
+        // remove invalid characters from phone number [0123456789+;,] http://wiki.openstreetmap.org/wiki/Key:phone
+        // - there can be multiple phone numbers separated by semicolon (some mappers use comma)
+        strValue.erase(
+          std::remove_if(strValue.begin(), strValue.end(), [](char x){return (x<'0'||x>'9') && x!='+' && x!=';' && x!=',';}), 
+          strValue.end());
+        
+        size_t idx = feature.GetIndex();
+        FeatureValue* fv = buffer.AllocateValue(idx);
+        PhoneFeatureValue* value=static_cast<PhoneFeatureValue*>(fv);
+
+        value->SetPhone(strValue);
+        //progress.Info(std::string("Found phone ")+strValue+" for "+object.GetName());
+      }
+    }
+    catch (const std::exception &e) {
+      progress.Error(std::string("PhoneFeature::Parse Exception ")+e.what());
     }
   }
 

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -41,6 +41,8 @@ OST
       It automatically get the following features assigned:
       * Location
       * Address
+      * Website
+      * Phone
     ADDRESS:
       Objects should be indexed as address  
       It automatically get the following features assigned:


### PR DESCRIPTION
Goal of these changes is to provide functionality to search nearest POI of given type and view its website.

This PR adds two new features: phone and website. 

- These new features are automatically assigned to all POIs. 
- LocationService was extended to return object features on location lookup, some useful methods was changed to public.
- And finally, LocationDescription demo was extended to print all features of object and parent regions.

```
$ ./Demos/LocationDescription czech-republic 50.0893347 14.4982803
* Coordinate: 50.08933 N 14.49828 E
* 8.2m N of address: Osika, Žižkov
  - POI:      Osika
  - type:     amenity_restaurant
  - region:   Žižkov

  + feature Name: Osika
  + feature Website: http://osikarestaurant.cz/

  > parent region: Praha
...
```