### PR TITLE
use addr:place when addr:street is not available for address object

### DIFF
--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -277,6 +277,7 @@ namespace osmscout {
   private:
     TagId tagAddrStreet;
     TagId tagAddrHouseNr;
+    TagId tagAddrPlace;
 
   public:
     /** Name of this feature */
@@ -342,6 +343,7 @@ namespace osmscout {
   private:
     TagId tagAddrHouseNr;
     TagId tagAddrStreet;
+    TagId tagAddrPlace;
 
   public:
     /** Name of this feature */

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -312,6 +312,7 @@ namespace osmscout {
   {
     tagAddrHouseNr=typeConfig.RegisterTag("addr:housenumber");
     tagAddrStreet=typeConfig.RegisterTag("addr:street");
+    tagAddrPlace=typeConfig.RegisterTag("addr:place");
   }
 
   std::string LocationFeature::GetName() const
@@ -339,7 +340,12 @@ namespace osmscout {
     auto street=tags.find(tagAddrStreet);
 
     if (street==tags.end()) {
-      return;
+      // We are cheating here, but from library view, there is no 
+      // difference in addr:street or addr:place. It is just a address.
+      street=tags.find(tagAddrPlace);
+      if (street==tags.end()) {
+        return;
+      }
     }
 
     auto houseNr=tags.find(tagAddrHouseNr);
@@ -391,7 +397,8 @@ namespace osmscout {
 
   AddressFeature::AddressFeature()
   : tagAddrHouseNr(0),
-    tagAddrStreet(0)
+    tagAddrStreet(0),
+    tagAddrPlace(0)
   {
     RegisterLabel(NAME_LABEL,
                   NAME_LABEL_INDEX);
@@ -401,6 +408,7 @@ namespace osmscout {
   {
     tagAddrHouseNr=typeConfig.RegisterTag("addr:housenumber");
     tagAddrStreet=typeConfig.RegisterTag("addr:street");
+    tagAddrPlace=typeConfig.RegisterTag("addr:place");
   }
 
   std::string AddressFeature::GetName() const
@@ -428,7 +436,12 @@ namespace osmscout {
     auto street=tags.find(tagAddrStreet);
 
     if (street==tags.end()) {
-      return;
+      // We are cheating here, but from library view, there is no 
+      // difference in addr:street or addr:place. It is just a address.
+      street=tags.find(tagAddrPlace);
+      if (street==tags.end()) {
+        return;
+      }
     }
 
     auto houseNr=tags.find(tagAddrHouseNr);

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -1909,7 +1909,7 @@ TYPES
 
   // Addresses
   TYPE address
-    = NODE AREA (EXISTS "addr:street" AND EXISTS "addr:housenumber")
+    = NODE AREA ((EXISTS "addr:street" OR EXISTS "addr:place") AND EXISTS "addr:housenumber")
       ADDRESS
      
   //


### PR DESCRIPTION
In OSM data can be used "addr:place" instead of "addr:street" for addresses that don't contains street. http://wiki.openstreetmap.org/wiki/Key:addr:place It is usual for small villages. From library view, there is no difference. It is just a address :)

I have small question with this change: I am not able to open old imports now. If fails with error:
```
Requested and actual tag id do not match
```
It is possible to make these changes backward compatible? If I understand it correctly, `TagID` is used just for import right? When database is open for read, there is no need for these checks...? When I remove these check, loading of old database works without problem.