### PR TITLE
Print object type and its features in LookupText demo

### DIFF
--- a/Demos/src/LookupText.cpp
+++ b/Demos/src/LookupText.cpp
@@ -19,7 +19,9 @@
 
 #include <iostream>
 #include <osmscout/TextSearchIndex.h>
+#include "<osmscout/Database.h>"
 #include <algorithm>
+
 
 void badInput()
 {
@@ -28,6 +30,26 @@ void badInput()
                "  ie. text(poi,loc,region,other).dat" << std::endl;
   std::cout << "ex:" << std::endl;
   std::cout << "./LookupText /path/to/imported/map/data" << std::endl;
+}
+
+void printDetails(const osmscout::FeatureValueBuffer& features)
+{
+  std::cout << "   - type:     " << features.GetType()->GetName() << std::endl;
+  for (auto featureInstance :features.GetType()->GetFeatures()){
+    if (features.HasFeature(featureInstance.GetIndex())){
+      osmscout::FeatureRef feature=featureInstance.GetFeature();
+      if (feature->HasValue() && feature->HasLabel()){
+        osmscout::FeatureValue *value=features.GetValue(featureInstance.GetIndex());
+        if (value->GetLabel().empty()){
+          std::cout << "   + feature " << feature->GetName() << std::endl;
+        }else{
+          std::cout << "   + feature " << feature->GetName() << ": " << value->GetLabel() << std::endl;
+        }
+      }else{
+        std::cout << "   + feature " << feature->GetName() << std::endl;
+      }
+    }
+  }
 }
 
 int main (int argc, char *argv[])
@@ -79,24 +101,43 @@ int main (int argc, char *argv[])
       continue;
     }
 
+    osmscout::DatabaseParameter databaseParameter;
+    osmscout::DatabaseRef       database(new osmscout::Database(databaseParameter));
+    if (!database->Open(path.c_str())) {
+      std::cerr << "Cannot open database" << std::endl;
+      return 1;
+    }
+
     // print out the results
     size_t printCount=0;
     osmscout::TextSearchIndex::ResultsMap::iterator it;
     for(it=results.begin(); it != results.end(); ++it) {
-      std::cout << "\"" <<it->first << "\" -> ";
+      std::cout << "\"" <<it->first << "\" -> " << std::endl;
       std::vector<osmscout::ObjectFileRef> &refs=it->second;
       std::size_t maxPrintedOffsets=5;
       std::size_t minRefCount=std::min(refs.size(),maxPrintedOffsets);
 
       for(size_t r=0; r < minRefCount; r++) {
         if(refs[r].GetType() == osmscout::refNode) {
-          std::cout << "N:" << refs[r].GetFileOffset() << " ";
+          std::cout << " * N:" << refs[r].GetFileOffset() << std::endl;
+          osmscout::NodeRef node;
+          if (database->GetNodeByOffset(refs[r].GetFileOffset(), node)){
+            printDetails(node->GetFeatureValueBuffer());
+          }
         }
         else if(refs[r].GetType() == osmscout::refWay) {
-          std::cout << "W:" << refs[r].GetFileOffset() << " ";
+          std::cout << " * W:" << refs[r].GetFileOffset() << std::endl;
+          osmscout::WayRef way;
+          if (database->GetWayByOffset(refs[r].GetFileOffset(), way)){
+            printDetails(way->GetFeatureValueBuffer());
+          }
         }
         else if(refs[r].GetType() == osmscout::refArea) {
-          std::cout << "A:" << refs[r].GetFileOffset() << " ";
+          std::cout << " * A:" << refs[r].GetFileOffset() << std::endl;
+          osmscout::AreaRef area;
+          if (database->GetAreaByOffset(refs[r].GetFileOffset(), area)){
+            printDetails(area->GetFeatureValueBuffer());
+          }
         }
       }
       if(refs.size() > 10) {


### PR DESCRIPTION
This demo now demonstrate how to retrieve objects by its type and file offset and print useful informations for it. 

LookupText requiere complete database now...

```
$ ./Demos/LookupText /media/karry/data/osm/osmscout/kokorinsko
* Searches are case-sensitive
* Displays up to 10 unique text results
* Displays up to 5 file offsets for each result
* Input at least 3 characters or 'q' to quit


Enter a search term:
Bosyn
"Bosyně" -> 
 * N:4125
   - type:     highway_bus_stop
   + feature Name: Bosyně
 * A:31755
   - type:     boundary_administrative
   + feature Name: Bosyně
   + feature AdminLevel
```