### PR TITLE
libosmscout-map-cairo/CMakeLists.txt fixed to install headers

### DIFF
--- a/libosmscout-map-cairo/CMakeLists.txt
+++ b/libosmscout-map-cairo/CMakeLists.txt
@@ -46,5 +46,5 @@ install(TARGETS osmscout_map_cairo
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "private" EXCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "private/Config.h" EXCLUDE)
 install(FILES ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapCairoFeatures.h DESTINATION include/osmscout)


### PR DESCRIPTION
As for other backends, this fixes installation of required private header