### PR TITLE
initialize maxSpace in LabelLayouter

### DIFF
--- a/libosmscout-map/src/osmscout/LabelLayouter.cpp
+++ b/libosmscout-map/src/osmscout/LabelLayouter.cpp
@@ -31,7 +31,8 @@ namespace osmscout {
     // no code
   }
 
-  LabelLayouter::LabelLayouter()
+  LabelLayouter::LabelLayouter():
+    maxScale(0)
   {
     // no code
   }


### PR DESCRIPTION
Fixes an issue with many labels rendered on SFOS