### PR TITLE
fix GetSphericalDistance methods in Geometry utils

### DIFF
--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -40,6 +40,11 @@
 
 namespace osmscout {
 
+  inline double DegToRad(double deg)
+  {
+    return  deg * M_PI / 180;
+  }
+
   /**
    * \defgroup Geometry Geometric helper
    *

--- a/libosmscout/src/osmscout/util/Geometry.cpp
+++ b/libosmscout/src/osmscout/util/Geometry.cpp
@@ -107,14 +107,16 @@ namespace osmscout {
                               double bLon, double bLat)
   {
     double r=6371.01; // Average radius of earth
-    double dLat=(bLat-aLat)*M_PI/180;
-    double dLon=(bLon-aLon)*M_PI/180;
+    double aLatRad=DegToRad(aLat);
+    double bLatRad=DegToRad(bLat);
+    double dLat=DegToRad(bLat-aLat);
+    double dLon=DegToRad(bLon-aLon);
 
-    double sindLonDiv2;
-    double cosdLonDiv2;
-    sincos(dLon/2, sindLonDiv2, cosdLonDiv2);
+    double sindLonDiv2=sin(dLon/2);
 
-    double a = sin(dLat/2)*sin(dLat/2)+cosdLonDiv2*cosdLonDiv2*sindLonDiv2*sindLonDiv2;
+    double a = sin(dLat/2)*sin(dLat/2)+
+        cos(aLatRad)*cos(bLatRad)*
+        sindLonDiv2*sindLonDiv2;
 
     double c = 2*atan2(sqrt(a),sqrt(1-a));
 
@@ -129,14 +131,16 @@ namespace osmscout {
                               const GeoCoord& b)
   {
     double r=6371.01; // Average radius of earth
-    double dLat=(b.GetLat()-a.GetLat())*M_PI/180;
-    double dLon=(b.GetLon()-a.GetLon())*M_PI/180;
+    double aLatRad=DegToRad(a.GetLat());
+    double bLatRad=DegToRad(b.GetLat());
+    double dLat=DegToRad(b.GetLat()-a.GetLat());
+    double dLon=DegToRad(b.GetLon()-a.GetLon());
 
-    double sindLonDiv2;
-    double cosdLonDiv2;
-    sincos(dLon/2, sindLonDiv2, cosdLonDiv2);
+    double sindLonDiv2=sin(dLon/2);
 
-    double aa = sin(dLat/2)*sin(dLat/2)+cosdLonDiv2*cosdLonDiv2*sindLonDiv2*sindLonDiv2;
+    double aa = sin(dLat/2)*sin(dLat/2)+
+        cos(aLatRad)*cos(bLatRad)*
+        sindLonDiv2*sindLonDiv2;
 
     double c = 2*atan2(sqrt(aa),sqrt(1-aa));
 


### PR DESCRIPTION
Hi. 

I saw some weird results in my experiments that are using GetSphericalDistance methods.
When I compare this method with algorithm described here: http://www.movable-type.co.uk/scripts/latlong.html
I found that this method is wrong. You can see it on these test: https://gist.github.com/Karry/85b767b25029ea543268c2808969ec4c

```
$ g++ test.cpp
$ ./a.out 
Prague to Brno
259.21
183.049

Over date line
222.356
222.39

Over north pole
7.80224e-13
222.39

Cross the world
7.80224e-13
20015.1
``` 

This MR fix it.