### PR TITLE
Drop libimport in sailfish

### DIFF
--- a/packaging/sailfish/libosmscout-qt.spec
+++ b/packaging/sailfish/libosmscout-qt.spec
@@ -2,7 +2,7 @@
 Name: libosmscout-qt
 
 Summary: libosmscout qt libraries
-Version: 0.0.git.20160915
+Version: 0.0.git.20161013
 Release: 1
 Group: Qt/Qt
 License: LGPL

--- a/packaging/sailfish/libosmscout-qt.spec
+++ b/packaging/sailfish/libosmscout-qt.spec
@@ -3,19 +3,19 @@ Name: libosmscout-qt
 
 Summary: libosmscout qt libraries
 Version: 0.0.git.20161013
-Release: 1
+Release: 2
 Group: Qt/Qt
 License: LGPL
 Source0:    %{name}-%{version}.tar.bz2
 
-Requires: protobuf
+#Requires: protobuf
 Requires: libmarisa
 #Requires: cairo
 #Requires: pango
 
 BuildRequires: cmake
 BuildRequires: pkgconfig(Qt5Core)
-BuildRequires: protobuf-devel
+#BuildRequires: protobuf-devel
 BuildRequires: libxml2-devel
 BuildRequires: libmarisa-devel
 #BuildRequires: cairo-devel
@@ -40,7 +40,7 @@ libosmscout qt libraries - development files
 
 mkdir build-rpm
 cd build-rpm
-%cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DOSMSCOUT_BUILD_MAP_OPENGL=OFF -DOSMSCOUT_BUILD_IMPORT=ON -DOSMSCOUT_BUILD_MAP_AGG=OFF -DOSMSCOUT_BUILD_MAP_CAIRO=OFF -DOSMSCOUT_BUILD_MAP_SVG=OFF -DOSMSCOUT_BUILD_MAP_IOSX=OFF -DOSMSCOUT_BUILD_TESTS=OFF -DOSMSCOUT_BUILD_DEMOS=OFF -DOSMSCOUT_BUILD_BINDING_JAVA=OFF -DOSMSCOUT_BUILD_BINDING_CSHARP=OFF -DOSMSCOUT_BUILD_DOC_API=OFF -DOSMSCOUT_BUILD_CLIENT_QT=ON -DOSMSCOUT_BUILD_TOOL_OSMSCOUT2=OFF -DOSMSCOUT_BUILD_TOOL_STYLEEDITOR=OFF -DGPERFTOOLS_USAGE=OFF -DOSMSCOUT_BUILD_TOOL_IMPORT=OFF -DOSMSCOUT_BUILD_TOOL_DUMPDATA=OFF ..
+%cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DOSMSCOUT_BUILD_MAP_OPENGL=OFF -DOSMSCOUT_BUILD_IMPORT=OFF -DOSMSCOUT_BUILD_MAP_AGG=OFF -DOSMSCOUT_BUILD_MAP_CAIRO=OFF -DOSMSCOUT_BUILD_MAP_SVG=OFF -DOSMSCOUT_BUILD_MAP_IOSX=OFF -DOSMSCOUT_BUILD_TESTS=OFF -DOSMSCOUT_BUILD_DEMOS=OFF -DOSMSCOUT_BUILD_BINDING_JAVA=OFF -DOSMSCOUT_BUILD_BINDING_CSHARP=OFF -DOSMSCOUT_BUILD_DOC_API=OFF -DOSMSCOUT_BUILD_CLIENT_QT=ON -DOSMSCOUT_BUILD_TOOL_OSMSCOUT2=OFF -DOSMSCOUT_BUILD_TOOL_STYLEEDITOR=OFF -DGPERFTOOLS_USAGE=OFF -DOSMSCOUT_BUILD_TOOL_IMPORT=OFF -DOSMSCOUT_BUILD_TOOL_DUMPDATA=OFF ..
 make %{?_smp_mflags}
 cd ..
 
@@ -59,7 +59,7 @@ ctest -V %{?_smp_mflags}
 %files
 %defattr(-, root, root, 0755)
 %{_libdir}/libosmscout.so
-%{_libdir}/libosmscout_import.so
+#%{_libdir}/libosmscout_import.so
 %{_libdir}/libosmscout_map.so
 %{_libdir}/libosmscout_map_qt.so
 %{_libdir}/libosmscout_client_qt.so


### PR DESCRIPTION
By dropping import library, we can also drop protobuf dependency of the default package in Sailfish. I commented the corresponding code out, so we could enable it later, if needed.
