### PR TITLE
Docker images updates

### DIFF
--- a/ci/docker/archlinux_clang_autoconf/build.sh
+++ b/ci/docker/archlinux_clang_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/archlinux_clang_autoconf .

--- a/ci/docker/archlinux_gcc_autoconf/build.sh
+++ b/ci/docker/archlinux_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/archlinux_gcc_autoconf .

--- a/ci/docker/archlinux_gcc_cmake/build.sh
+++ b/ci/docker/archlinux_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/archlinux_gcc_cmake .

--- a/ci/docker/buildAll.sh
+++ b/ci/docker/buildAll.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd `dirname $0`
+set -xe
+
+./archlinux_clang_autoconf/build.sh
+./archlinux_gcc_autoconf/build.sh
+./archlinux_gcc_cmake/build.sh
+./debian_jessie_gcc_autoconf/build.sh
+./debian_jessie_gcc_cmake/build.sh
+./ubuntu_14.04_gcc_autoconf/build.sh
+./ubuntu_14.04_gcc_cmake/build.sh
+./ubuntu_15.10_gcc_autoconf/build.sh
+./ubuntu_15.10_gcc_cmake/build.sh
+./ubuntu_16.04_gcc_autoconf/build.sh
+./ubuntu_16.04_gcc_cmake/build.sh
+./ubuntu_16.10_gcc_autoconf/build.sh
+./ubuntu_16.10_gcc_cmake/build.sh

--- a/ci/docker/debian_jessie_gcc_autoconf/build.sh
+++ b/ci/docker/debian_jessie_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/debian_jessie_gcc_autoconf .

--- a/ci/docker/debian_jessie_gcc_cmake/Dockerfile
+++ b/ci/docker/debian_jessie_gcc_cmake/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
           libfreetype6-dev \
           libcairo2-dev \
           libpangocairo-1.0-0 libpango1.0-dev \
-          qt5-default qtdeclarative5-dev libqt5svg5-dev \
+          qt5-default qtdeclarative5-dev libqt5svg5-dev qtpositioning5-dev \
           freeglut3 freeglut3-dev \
           libmarisa-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/ci/docker/debian_jessie_gcc_cmake/build.sh
+++ b/ci/docker/debian_jessie_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/debian_jessie_gcc_cmake .

--- a/ci/docker/runAll.sh
+++ b/ci/docker/runAll.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd `dirname $0`
+set -xe
+
+./archlinux_clang_autoconf/run.sh
+./archlinux_gcc_autoconf/run.sh
+./archlinux_gcc_cmake/run.sh
+./debian_jessie_gcc_autoconf/run.sh
+./debian_jessie_gcc_cmake/run.sh
+./ubuntu_14.04_gcc_autoconf/run.sh
+./ubuntu_14.04_gcc_cmake/run.sh
+./ubuntu_15.10_gcc_autoconf/run.sh
+./ubuntu_15.10_gcc_cmake/run.sh
+./ubuntu_16.04_gcc_autoconf/run.sh
+./ubuntu_16.04_gcc_cmake/run.sh
+./ubuntu_16.10_gcc_autoconf/run.sh
+./ubuntu_16.10_gcc_cmake/run.sh

--- a/ci/docker/ubuntu_14.04_gcc_autoconf/build.sh
+++ b/ci/docker/ubuntu_14.04_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_14.04_gcc_autoconf .

--- a/ci/docker/ubuntu_14.04_gcc_cmake/build.sh
+++ b/ci/docker/ubuntu_14.04_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_14.04_gcc_cmake .

--- a/ci/docker/ubuntu_15.10_gcc_autoconf/build.sh
+++ b/ci/docker/ubuntu_15.10_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_15.10_gcc_autoconf .

--- a/ci/docker/ubuntu_15.10_gcc_cmake/build.sh
+++ b/ci/docker/ubuntu_15.10_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_15.10_gcc_cmake .

--- a/ci/docker/ubuntu_16.04_gcc_autoconf/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_16.04_gcc_autoconf .

--- a/ci/docker/ubuntu_16.04_gcc_cmake/build.sh
+++ b/ci/docker/ubuntu_16.04_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_16.04_gcc_cmake .

--- a/ci/docker/ubuntu_16.10_gcc_autoconf/build.sh
+++ b/ci/docker/ubuntu_16.10_gcc_autoconf/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_16.10_gcc_autoconf .

--- a/ci/docker/ubuntu_16.10_gcc_cmake/build.sh
+++ b/ci/docker/ubuntu_16.10_gcc_cmake/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+cd `dirname $0`
 docker build -t libosmscout/ubuntu_16.10_gcc_cmake .


### PR DESCRIPTION
- Debian Jessie docker: install Qt5 Positioning package to fix OSMScout2 build
- add script for test build in all docker environments, fix relative path to dockerfiles
