### PR TITLE
allow building static and shared version of the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: None (CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+option(BUILD_SHARED_LIBS "Shared libraries " ON)  # SHARED lib default
+
 # compiler configurations
 if(WIN32)
   set(CMAKE_USE_RELATIVE_PATHS true)
@@ -249,6 +251,7 @@ add_subdirectory(libosmscout-extern)
 
 # display build configuration
 message(STATUS "libosmscout build configuration:")
+message(STATUS "Shared libraries:                        ${BUILD_SHARED_LIBS}")
 message(STATUS "core library:                            ${OSMSCOUT_BUILD_CORE}")
 message(STATUS "import library:                          ${OSMSCOUT_BUILD_IMPORT}")
 message(STATUS "map drawing interface:                   ${OSMSCOUT_BUILD_MAP}")

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -36,7 +36,7 @@ set(SOURCE_FILES
     src/osmscout/Settings.cpp
 )
 
-add_library(osmscout_client_qt SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_client_qt ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_client_qt PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/ClientQtFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/ClientQtFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-client-qt")

--- a/libosmscout-import/CMakeLists.txt
+++ b/libosmscout-import/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/import/pbf src/protobuf/fileformat.proto src/protobuf/osmformat.proto)
 
-add_library(osmscout_import SHARED ${SOURCE_FILES} ${HEADER_FILES} ${PROTO_SRCS} ${PROTO_HDRS})
+add_library(osmscout_import ${SOURCE_FILES} ${HEADER_FILES} ${PROTO_SRCS} ${PROTO_HDRS})
 set_property(TARGET osmscout_import PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/ImportFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/ImportFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-import")

--- a/libosmscout-map-agg/CMakeLists.txt
+++ b/libosmscout-map-agg/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SOURCE_FILES
     src/osmscout/MapPainterAgg.cpp
 )
 
-add_library(osmscout_map_agg SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map_agg ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map_agg PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapAggFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapAggFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "libosmscout-map-agg")

--- a/libosmscout-map-cairo/CMakeLists.txt
+++ b/libosmscout-map-cairo/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCE_FILES
     src/osmscout/MapPainterCairo.cpp
 )
 
-add_library(osmscout_map_cairo SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map_cairo ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map_cairo PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapCairoFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapCairoFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-map-cairo")

--- a/libosmscout-map-opengl/CMakeLists.txt
+++ b/libosmscout-map-opengl/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SOURCE_FILES
     src/osmscout/MapPainterOpenGL.cpp
 )
 
-add_library(osmscout_map_opengl SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map_opengl ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map_opengl PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapOpenGLFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapOpenGLFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-map-opengl")

--- a/libosmscout-map-qt/CMakeLists.txt
+++ b/libosmscout-map-qt/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCE_FILES
     src/osmscout/MapPainterQt.cpp
 )
 
-add_library(osmscout_map_qt SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map_qt ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map_qt PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapQtFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapQtFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-map-qt")

--- a/libosmscout-map-svg/CMakeLists.txt
+++ b/libosmscout-map-svg/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCE_FILES
     src/osmscout/MapPainterSVG.cpp
 )
 
-add_library(osmscout_map_svg SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map_svg ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map_svg PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapSVGFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapSVGFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-map-svg")

--- a/libosmscout-map/CMakeLists.txt
+++ b/libosmscout-map/CMakeLists.txt
@@ -31,7 +31,7 @@ set(SOURCE_FILES
 	src/osmscout/MapPainterNoOp.cpp
 )
 
-add_library(osmscout_map SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout_map ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout_map PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/MapFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/MapFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout-map")

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -156,7 +156,7 @@ if(MARISA_FOUND)
     list(APPEND SOURCE_FILES src/osmscout/TextSearchIndex.cpp)
 endif()
 
-add_library(osmscout SHARED ${SOURCE_FILES} ${HEADER_FILES})
+add_library(osmscout ${SOURCE_FILES} ${HEADER_FILES})
 set_property(TARGET osmscout PROPERTY CXX_STANDARD 11)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/CoreFeatures.h.cmake ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/CoreFeatures.h)
 create_private_config("${CMAKE_CURRENT_BINARY_DIR}/include/osmscout/private/Config.h" "osmscout")


### PR DESCRIPTION
This PR allows to build either shared (default) or static versions of the libraries. To build static version, specify 

```
cmake -DBUILD_SHARED_LIBS=false .... ..
```
during a build. This PR enables it for cmake builds only