### PR TITLE
simplify searching of some feature value

### DIFF
--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -1048,6 +1048,23 @@ namespace osmscout {
     FeatureValueBuffer& operator=(const FeatureValueBuffer& other);
     bool operator==(const FeatureValueBuffer& other) const;
     bool operator!=(const FeatureValueBuffer& other) const;
+
+    template<class T> const T* findValue() const
+    {
+      for (auto &featureInstance :GetType()->GetFeatures()){
+          if (HasFeature(featureInstance.GetIndex())){
+            osmscout::FeatureRef feature=featureInstance.GetFeature();
+            if (feature->HasValue()){
+              osmscout::FeatureValue *value=GetValue(featureInstance.GetIndex());
+              const T *v = dynamic_cast<const T*>(value);
+              if (v!=NULL){
+                return v;
+              }
+            }
+          }
+      }
+      return NULL;
+    }
   };
 
   typedef std::shared_ptr<FeatureValueBuffer> FeatureValueBufferRef;


### PR DESCRIPTION
This change adds template method findValue() to FeatureValueBuffer,
it helps to find specific feature value for database objects.
    
Usage:
```    
    const osmscout::NameFeatureValue *n = node->GetFeatureValueBuffer()
                                           .findValue<osmscout::NameFeatureValue>();
    
    if (n){
      qDebug() << "name: " << QString::fromStdString(n->GetLabel());
    }
```