### PR TITLE
add IGNORESEALAND flag for elevation contours

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -156,17 +156,17 @@ TYPES
   TYPE elevation_contour_major
     = WAY ("contour"=="elevation" AND "contour_ext"=="elevation_major")
       {Ele}
-      PIN_WAY
+      IGNORESEALAND PIN_WAY
 
   TYPE elevation_contour_medium
     = WAY ("contour"=="elevation" AND "contour_ext"=="elevation_medium")
       {Ele}
-      PIN_WAY
+      IGNORESEALAND PIN_WAY
 
   TYPE elevation_contour_minor
     = WAY ("contour"=="elevation" AND "contour_ext"=="elevation_minor")
       {Ele}
-      PIN_WAY
+      IGNORESEALAND PIN_WAY
 
   //
   // Motorways and motorways-like (only for cars)


### PR DESCRIPTION
Digital elevation data are not precise and may contains
some artefacts even in sea. Importer then create "island"
around this artefact. IGNORESEALAND flag should avoid it.