### PR TITLE
Fix av build

### DIFF
--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -20,7 +20,8 @@ IF %COMPILER%==msys2 (
   echo "Updating dependencies...
   bash -lc "pacman -S --needed --noconfirm pacman-mirrors"
   bash -lc "pacman -S --needed --noconfirm git"
-  
+  bash -lc "pacman -Syyu --noconfirm"
+
   IF %BUILDTOOL%==autoconf (
   echo Installing autoconf tools...
   bash -lc "pacman -S --needed --noconfirm git autoconf automake make"

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -426,6 +426,9 @@ namespace osmscout {
 
 #elif SIZEOF_WCHAR_T==2
 
+    static const int halfShift=10; /* used for shifting by 10 bits */
+    static const unsigned long halfBase=0x0010000UL;
+
     const wchar_t* source=text.c_str();
 
     while (source!=text.c_str()+text.length()) {


### PR DESCRIPTION
This PR should fix https://github.com/Framstag/libosmscout/issues/23 . It seems we had issues caused by 

Qt5 buggy package (similar issues were in Alexpux/MINGW-packages)
String.cpp was missing few constants required in msys2 64-bit

Please check that I used correct constants in String.cpp