### PR TITLE
drop specific compiler flag c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,6 @@ if(APPLE AND NOT ANDROID)
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 endif ()
 
-add_definitions(-std=c++11)
-
 include(CheckTypeSize)
 CHECK_TYPE_SIZE("void*" OSMSCOUT_PTR_SIZE BUILTIN_TYPES_ONLY)
 if(OSMSCOUT_PTR_SIZE EQUAL 8)


### PR DESCRIPTION
I tested without this definition using new Sailfish SDK and Linux. This flag is not needed. If it has to be introduced, it should be done properly using CMAKE macros. Sorry for this mistake.   