### PR TITLE
Invalidate caches on stylesheet (re)load

### DIFF
--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -240,6 +240,7 @@ public slots:
                  std::unordered_map<std::string,bool> stylesheetFlags,
                  const QString &suffix="");
   virtual void Initialize() = 0;
+  virtual void InvalidateVisualCache() = 0;
   void Finalize();
   
   /**

--- a/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
@@ -95,10 +95,11 @@ public:
   virtual ~PlaneDBThread();
 
   virtual void Initialize();
-  
+
   virtual bool RenderMap(QPainter& painter,
                          const RenderMapRequest& request);
   
+  virtual void InvalidateVisualCache();
 };
 
 #endif

--- a/libosmscout-client-qt/include/osmscout/TiledDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/TiledDBThread.h
@@ -66,9 +66,6 @@ public slots:
   void onOfflineMapChanged(bool);
   virtual void Initialize();
 
-  virtual void onMapDPIChange(double dpi);
-  virtual void onRenderSeaChanged(bool);  
-
 private:
   QString                       tileCacheDirectory;
 
@@ -114,6 +111,8 @@ public:
   virtual bool RenderMap(QPainter& painter,
                          const RenderMapRequest& request);
   
+  virtual void InvalidateVisualCache();
+
 private:
 
   /**

--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -274,6 +274,15 @@ void PlaneDBThread::HandleInitialRenderingRequest()
   pendingRenderingTimer.start(INITIAL_DATA_RENDERING_TIMEOUT);
 }
 
+void PlaneDBThread::InvalidateVisualCache()
+{
+  QMutexLocker finishedLocker(&finishedMutex);
+  qDebug() << "Invalidate finished image";
+  if (finishedImage)
+    delete finishedImage;
+  finishedImage=NULL;
+}
+
 void PlaneDBThread::HandleTileStatusChanged(const osmscout::TileRef& changedTile)
 {
   //return; // FIXME: remove this return, make loading asynchronous

--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -703,15 +703,12 @@ void TiledDBThread::onStylesheetFilenameChanged(){
   emit Redraw();
 }
 
-void TiledDBThread::onMapDPIChange(double dpi)
+void TiledDBThread::InvalidateVisualCache()
 {
   // invalidate tile cache and emit Redraw
-  {
-      QMutexLocker locker(&tileCacheMutex);
-      offlineTileCache.invalidate();
-      offlineTileCache.clearPendingRequests();
-  }
-  DBThread::onMapDPIChange(dpi);
+  QMutexLocker locker(&tileCacheMutex);
+  offlineTileCache.invalidate();
+  offlineTileCache.clearPendingRequests();
 }
 
 void TiledDBThread::onlineTileProviderChanged()
@@ -749,14 +746,3 @@ void TiledDBThread::onOfflineMapChanged(bool b)
     }
     emit Redraw();    
 }
-
-void TiledDBThread::onRenderSeaChanged(bool b)
-{
-    {
-        QMutexLocker cacheLocker(&tileCacheMutex);
-        offlineTileCache.invalidate();
-        offlineTileCache.clearPendingRequests();
-    }
-    DBThread::onRenderSeaChanged(b);
-}
-

--- a/libosmscout-map/include/osmscout/DataTileCache.h
+++ b/libosmscout-map/include/osmscout/DataTileCache.h
@@ -101,6 +101,13 @@ namespace osmscout {
       complete=true;
     }
 
+    void SetIncomplete()
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+
+      complete=false;
+    }
+
     /**
      * Return 'true' if there was data already assigned to the tile
      */
@@ -418,7 +425,14 @@ namespace osmscout {
 
     void SetSize(size_t cacheSize);
 
+    inline size_t GetSize() const
+    {
+      return cacheSize;
+    }
+
     void CleanupCache();
+
+    void InvalidateCache();
 
     TileRef GetCachedTile(const TileId& id) const;
     TileRef GetTile(const TileId& id) const;

--- a/libosmscout-map/include/osmscout/MapService.h
+++ b/libosmscout-map/include/osmscout/MapService.h
@@ -215,7 +215,9 @@ namespace osmscout {
 
     void SetCacheSize(size_t cacheSize);
 
+    void CleanupTileCache();
     void FlushTileCache();
+    void InvalidateTileCache();
 
     void LookupTiles(const Magnification& magnification,
                      const GeoBox& boundingBox,

--- a/libosmscout-map/src/osmscout/DataTileCache.cpp
+++ b/libosmscout-map/src/osmscout/DataTileCache.cpp
@@ -90,6 +90,20 @@ namespace osmscout {
   }
 
   /**
+   * Mark all tiles as in cache as "incomplete".
+   */
+  void DataTileCache::InvalidateCache()
+  {
+    for (CacheEntry &entry: tileCache){
+      entry.tile->GetAreaData().SetIncomplete();
+      entry.tile->GetNodeData().SetIncomplete();
+      entry.tile->GetWayData().SetIncomplete();
+      entry.tile->GetOptimizedAreaData().SetIncomplete();
+      entry.tile->GetOptimizedWayData().SetIncomplete();
+    }
+  }
+
+  /**
    * Return the cache tiles with the given id. If the tiles is not cache,
    * an empty reference will be returned.
    */

--- a/libosmscout-map/src/osmscout/MapService.cpp
+++ b/libosmscout-map/src/osmscout/MapService.cpp
@@ -121,11 +121,36 @@ namespace osmscout {
     cache.SetSize(cacheSize);
   }
 
-  void MapService::FlushTileCache()
+  /**
+   * evict tiles from cache until tile count > cacheSize
+   */
+  void MapService::CleanupTileCache()
   {
     std::lock_guard<std::mutex> lock(stateMutex);
 
     cache.CleanupCache();
+  }
+
+  /**
+   * evict all tiles from cache
+   */
+  void MapService::FlushTileCache()
+  {
+    std::lock_guard<std::mutex> lock(stateMutex);
+
+    size_t size=cache.GetSize();
+    cache.SetSize(0);
+    cache.SetSize(size);
+  }
+
+  /**
+   * mark all tiles in cache as incomplete
+   */
+  void MapService::InvalidateTileCache()
+  {
+    std::lock_guard<std::mutex> lock(stateMutex);
+
+    cache.InvalidateCache();
   }
 
   MapService::TypeDefinitionRef MapService::GetTypeDefinition(const AreaSearchParameter& parameter,


### PR DESCRIPTION
These changes fixes stylesheet reloading, it invalidates (data) tile cache and visual cache in DB Thread - finished image for plane DB thread and offline tile cache for tiled DB thread.