### PR TITLE
Fix two errors in qt client lib

### DIFF
--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -65,6 +65,9 @@ target_include_directories(osmscout_client_qt PRIVATE
 		${OSMSCOUT_BASE_DIR_SOURCE}/libosmscout-map/include
 		${OSMSCOUT_BASE_DIR_SOURCE}/libosmscout-map-qt/include
 		${Qt5Gui_INCLUDE_DIRS})
+if(MARISA_FOUND)
+    target_include_directories(osmscout_client_qt PRIVATE ${MARISA_INCLUDE_DIRS})
+endif()
 target_link_libraries(osmscout_client_qt
 		osmscout
 		osmscout_map

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include <QDebug>


### PR DESCRIPTION
Error 1: Missing marisa include directory for the project. DBThread.cpp includes TextSearchIndex.h which includes marisa.h
Error 2: M_E is not declared on all systems. Including cmath is only working in combination with _USE_MATH_DEFINES