### PR TITLE
Optimise contour labels

### DIFF
--- a/libosmscout-map-qt/include/osmscout/SimplifiedPath.h
+++ b/libosmscout-map-qt/include/osmscout/SimplifiedPath.h
@@ -39,6 +39,7 @@ namespace osmscout {
   private:
     qreal length;
     QVector<Segment> segments;
+    QVector<int> offsetIndex; // segment offset by length 100
     qreal minSegmentLength;
     QPointF end;
     qreal endDistance;

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -525,12 +525,19 @@ namespace osmscout {
           auto pos=glypRun.positions().at(g);
           indexes[0]=index;
           positions[0]=QPointF(0,pos.y());
+          QRectF boundingRect=glypRun.rawFont().boundingRect(index);
 
           qreal glyphOffset=upwards? (offset+stringWidth-pos.x()) : offset+pos.x();
           if (glyphOffset>pLength)
             continue;
 
           QPointF point=p.PointAtLength(glyphOffset);
+          // check if current glyph can be visible
+          qreal diagonal=boundingRect.width()+boundingRect.height(); // it is little bit longer than correct sqrt(w^2+h^2)
+          if (!painter->viewport().intersects(QRect(point.x()-diagonal, point.y()-diagonal,
+                                                    point.x()+diagonal, point.y()+diagonal))){
+            continue;
+          }
           qreal angle=p.AngleAtLengthDeg(glyphOffset);
           if (upwards){
             angle-=180;
@@ -539,7 +546,7 @@ namespace osmscout {
           setupTransformation(painter, point, angle, fontPixelSize*-0.7);
 
           QGlyphRun orphanGlyph;
-          //orphanGlyph.setBoundingRect();
+          orphanGlyph.setBoundingRect(boundingRect);
           orphanGlyph.setFlags(glypRun.flags());
           orphanGlyph.setGlyphIndexes(indexes);
           orphanGlyph.setOverline(glypRun.overline());

--- a/libosmscout-map-qt/src/osmscout/SimplifiedPath.cpp
+++ b/libosmscout-map-qt/src/osmscout/SimplifiedPath.cpp
@@ -26,6 +26,7 @@ namespace osmscout {
   SimplifiedPath::SimplifiedPath(qreal minSegmentLength):
     length(0), minSegmentLength(minSegmentLength), endDistance(0)
   {
+    offsetIndex<<0;
   }
 
   SimplifiedPath::~SimplifiedPath()
@@ -49,6 +50,12 @@ namespace osmscout {
         last.length=endDistance;
         last.angle=std::atan2(last.start.y()-y,x-last.start.x());
         segments[segments.size()-1]=last;
+
+        // fill offsetIndex
+        for (int i=offsetIndex.size();i<length/100;i++){
+          offsetIndex<<segments.size()-1;
+        }
+
         Segment s={end,length,0,0};
         segments<<s;
         endDistance=0;
@@ -70,7 +77,12 @@ namespace osmscout {
 
   const Segment& SimplifiedPath::segmentBefore(qreal offset) const
   {
-    for (const Segment &seg:segments){
+    int hundred=offset/100;
+    if (hundred>=offsetIndex.size())
+      return segments.last();
+    int i=offsetIndex[hundred];
+    for (;i<segments.size();i++){
+      const Segment &seg=segments[i];
       if (offset<(seg.offset+seg.length)){
         return seg;
       }


### PR DESCRIPTION
Hi. Until I have this part in my memory, I looked to open issues related with contour labels. I found this one: https://github.com/Framstag/libosmscout/issues/105 For Qt, it is now simple to drop glyphs that can't be visible. This is done in first commit. 

When I inspect rendering with `perf top`, I saw `SimplifiedPath::segmentBefore` method with ~5% cpu usage. This is improved by second commit that avoid iteration over all segments...

Then I used updated `Demos/PerformanceTest` (rendering was repeated 100x) to measure how was performance changed.

```
zoom level => improvement
16 => 2%
17 => 16%
18 => 38%
19 => 46%
20 => 37%
```

used arguments:
```
./build-$branch/Demos/PerformanceTest \
  ../europe-czech-republic-20161203-225207 \
  stylesheets/standard.oss   \
  50.088 14.418 50.086 14.421   \
  16 20  \
   256 256   \
  Qt
```