### PR TITLE
improvement in import at some corner cases

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
@@ -469,7 +469,7 @@ namespace osmscout {
       if (region->CouldContain(*childRegion)) {
         for (const auto& regionArea : region->areas) {
           for (const auto& childRegionArea : childRegion->areas) {
-            if (IsAreaSubOfAreaQuorum(regionArea,childRegionArea)) {
+            if (IsAreaSubOfAreaOrSame(regionArea,childRegionArea)) {
               // If we already have the same name and are a "minor" reference, we skip...
               if (!(region->name==childRegion->name &&
                     region->reference.type<childRegion->reference.type)) {


### PR DESCRIPTION
This PR addresses an issue https://github.com/Framstag/libosmscout/issues/191 .

Turned out, that the some counties in Estonia were composed of several areas. Couple of villages that I checked were consisting of areas that were almost the same as one of the areas in a level above. 

This PR introduces 2 changes:

* there is a tolerance with which the areas are compared;
* instead of dividing by 20, 20.0 is used (one of the villages that I used had 15 nodes/20 = 0)

* allowing adding a region as a child when the areas are the same (as far as I understood,  compared regions are from different levels)  