### PR TITLE
make sure that LabelLayoutData.width is always set

### DIFF
--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -925,8 +925,16 @@ namespace osmscout {
         }
 
         data.fontSize=height/standardFontSize;
-        data.height=height;
         data.alpha=alpha;
+
+        GetTextDimension(projection,
+                         parameter,
+                         data.fontSize,
+                         label,
+                         data.xOff,
+                         data.yOff,
+                         data.width,
+                         data.height);
       }
       else {
         data.fontSize=textStyle->GetSize();


### PR DESCRIPTION
For some labels where is textStyle->GetAutoSize() is true was not
computed text bounding box. It keeps LabelLayoutData.width
uninitialised that may lead to unknown behaviour.

In some cases may lead to drawing stucks when width is huge negative number:
--- Placing: 'DPP Praha' -1.35753e+40 - 1.35753e+40, 1390.13 - 1411.33