### PR TITLE
fix LabelEvent comparison

### DIFF
--- a/libosmscout-map/include/osmscout/LabelLayouter.h
+++ b/libosmscout-map/include/osmscout/LabelLayouter.h
@@ -65,7 +65,19 @@ namespace osmscout {
         return y<other.y;
       }
 
-      return x<other.x;
+      if (x!=other.x) {
+        return x<other.x;
+      }
+
+      if (label->id!=other.label->id){
+        return label->id<other.label->id;
+      }
+
+      if (label->y!=other.label->y){
+        return label->y<other.label->y;
+      }
+
+      return label->x<other.label->x;
     }
   };
 


### PR DESCRIPTION
It fixes this issue: https://github.com/Framstag/libosmscout/issues/207

Compare event position and `label->id` is not enough, there can be two **different** events for one label id that has equal (event) position, but different label position... 