### PR TITLE
import osmscout/system/Math.h instead of math.h that is deprecated

### DIFF
--- a/libosmscout-map-qt/src/osmscout/SimplifiedPath.cpp
+++ b/libosmscout-map-qt/src/osmscout/SimplifiedPath.cpp
@@ -19,7 +19,7 @@
 
 #include <osmscout/SimplifiedPath.h>
 #include <QVector2D>
-#include <math.h>
+#include <osmscout/system/Math.h>
 
 namespace osmscout {
 


### PR DESCRIPTION
It should solve this Mac OS X problem: https://github.com/Framstag/libosmscout/issues/210