### PR TITLE
Label word wrap

### DIFF
--- a/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
@@ -62,6 +62,7 @@ public slots:
   void onStylesheetFilenameChanged();
 
 private:
+  double                        canvasOverrun; // scale of rendered canvas, relative to screen dimensions
   osmscout::MercatorProjection  projection;
 
   mutable QMutex                lastRequestMutex;

--- a/libosmscout-client-qt/include/osmscout/TiledDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/TiledDBThread.h
@@ -87,6 +87,9 @@ private:
   bool                          onlineTilesEnabled;
   bool                          offlineTilesEnabled;
 
+  int                           screenWidth;
+  int                           screenHeight;
+
 public:
   TiledDBThread(QStringList databaseLookupDirectories, 
                 QString stylesheetFilename, 

--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -42,6 +42,7 @@ PlaneDBThread::PlaneDBThread(QStringList databaseLookupDirs,
                              QString stylesheetFilename,
                              QString iconDirectory)
  : DBThread(databaseLookupDirs, stylesheetFilename, iconDirectory),
+   canvasOverrun(1.5),
    pendingRenderingTimer(this),
    currentImage(NULL),
    currentCoord(0.0,0.0),
@@ -192,8 +193,8 @@ bool PlaneDBThread::RenderMap(QPainter& painter,
   painter.drawImage(QRectF(x1,y1,x2-x1,y2-y1),*finishedImage);
 
   RenderMapRequest extendedRequest=request;
-  extendedRequest.width*=1.5;
-  extendedRequest.height*=1.5;
+  extendedRequest.width*=canvasOverrun;
+  extendedRequest.height*=canvasOverrun;
   bool needsNoRepaint=finishedImage->width()==(int) extendedRequest.width &&
                       finishedImage->height()==(int) extendedRequest.height &&
                       finishedCoord==request.coord &&
@@ -389,6 +390,11 @@ void PlaneDBThread::DrawMap()
     drawParameter.SetRenderBackground(false); // we draw background before MapPainter
     drawParameter.SetRenderUnknowns(false); // it is necessary to disable it with multiple databases
     drawParameter.SetRenderSeaLand(renderSea);
+
+    drawParameter.SetLabelLineMinCharCount(15);
+    drawParameter.SetLabelLineMaxCharCount(500);
+    drawParameter.SetLabelLineFitToArea(true);
+    drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight())/canvasOverrun);
 
     // create copy of projection
     osmscout::MercatorProjection renderProjection;

--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -392,7 +392,7 @@ void PlaneDBThread::DrawMap()
     drawParameter.SetRenderSeaLand(renderSea);
 
     drawParameter.SetLabelLineMinCharCount(15);
-    drawParameter.SetLabelLineMaxCharCount(500);
+    drawParameter.SetLabelLineMaxCharCount(30);
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight())/canvasOverrun);
 

--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -31,6 +31,9 @@
 #include <QDebug>
 #include <QDir>
 
+#include <QScreen>
+#include <QGuiApplication>
+
 #include <osmscout/util/Logger.h>
 #include <osmscout/util/StopClock.h>
 
@@ -48,6 +51,11 @@ TiledDBThread::TiledDBThread(QStringList databaseLookupDirs,
    tileDownloader(NULL) // it will be created in different thread
 {
   osmscout::log.Debug() << "TiledDBThread::TiledDBThread()";
+
+  QScreen *srn=QGuiApplication::primaryScreen();
+  screenWidth=srn->availableSize().width();
+  screenHeight=srn->availableSize().height();
+
 
   onlineTilesEnabled = Settings::GetInstance()->GetOnlineTilesEnabled();
   offlineTilesEnabled = Settings::GetInstance()->GetOfflineMap();
@@ -167,6 +175,11 @@ void TiledDBThread::DrawMap(QPainter &p, const osmscout::GeoCoord center, uint32
     drawParameter.SetRenderBackground(false);
     drawParameter.SetRenderUnknowns(false); // it is necessary to disable it with multiple sources
     drawParameter.SetRenderSeaLand(renderSea);
+
+    drawParameter.SetLabelLineMinCharCount(15);
+    drawParameter.SetLabelLineMaxCharCount(500);
+    drawParameter.SetLabelLineFitToArea(true);
+    drawParameter.SetLabelLineFitToWidth(std::min(screenWidth, screenHeight));
 
     // see Tiler.cpp example...
 

--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -177,7 +177,7 @@ void TiledDBThread::DrawMap(QPainter &p, const osmscout::GeoCoord center, uint32
     drawParameter.SetRenderSeaLand(renderSea);
 
     drawParameter.SetLabelLineMinCharCount(15);
-    drawParameter.SetLabelLineMaxCharCount(500);
+    drawParameter.SetLabelLineMaxCharCount(30);
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(screenWidth, screenHeight));
 

--- a/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
@@ -112,6 +112,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -120,6 +120,7 @@ namespace osmscout {
 
   void MapPainterAgg::GetTextDimension(const Projection& projection,
                                        const MapParameter& parameter,
+                                       double /*objectWidth*/,
                                        double fontSize,
                                        const std::string& text,
                                        double& xOff,

--- a/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
+++ b/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
@@ -90,6 +90,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -810,7 +810,7 @@ namespace osmscout {
       PangoFontMetrics *metrics=pango_context_get_metrics(context,
                                                           font,
                                                           pango_context_get_language(context));
-      size_t           proposedWidth=proposedWidth=std::floor(label.bx2-label.bx1)+1;
+      size_t           proposedWidth=std::floor(label.bx2-label.bx1)+1;
 
       pango_layout_set_text(layout,label.text.c_str(),label.text.length());
       pango_layout_set_alignment(layout,PANGO_ALIGN_CENTER);

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -632,6 +632,7 @@ namespace osmscout {
 
   void MapPainterCairo::GetTextDimension(const Projection& projection,
                                          const MapParameter& parameter,
+                                         double objectWidth,
                                          double fontSize,
                                          const std::string& text,
                                          double& xOff,
@@ -651,7 +652,13 @@ namespace osmscout {
     PangoFontMetrics *metrics=pango_context_get_metrics(context,
                                                         font,
                                                         pango_context_get_language(context));
-    size_t           proposedWidth=pango_font_metrics_get_approximate_char_width(metrics)*parameter.GetLabelLineCharCount();
+
+    double proposedWidth=proposedLabelWidth(parameter,
+                                            pango_font_metrics_get_approximate_char_width(metrics),
+                                            objectWidth,
+                                            text.length()
+                                            );
+
     PangoRectangle   extends;
 
     pango_layout_set_text(layout,text.c_str(),text.length());
@@ -803,7 +810,7 @@ namespace osmscout {
       PangoFontMetrics *metrics=pango_context_get_metrics(context,
                                                           font,
                                                           pango_context_get_language(context));
-      size_t           proposedWidth=pango_font_metrics_get_approximate_char_width(metrics)*parameter.GetLabelLineCharCount();
+      size_t           proposedWidth=proposedWidth=std::floor(label.bx2-label.bx1)+1;
 
       pango_layout_set_text(layout,label.text.c_str(),label.text.length());
       pango_layout_set_alignment(layout,PANGO_ALIGN_CENTER);

--- a/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
+++ b/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
@@ -94,6 +94,7 @@ namespace osmscout {
 
 		virtual void GetTextDimension(const Projection& projection,
 			const MapParameter& parameter,
+      double objectWidth,
 			double fontSize,
 			const std::string& text,
 			double& xOff,

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -376,7 +376,7 @@ namespace osmscout
 		}
 	}
 
-	void MapPainterDirectX::GetTextDimension(const Projection& projection, const MapParameter& parameter, double fontSize, const std::string& text, double& xOff, double& yOff, double& width, double& height)
+	void MapPainterDirectX::GetTextDimension(const Projection& projection, const MapParameter& parameter, double objectWidth, double fontSize, const std::string& text, double& xOff, double& yOff, double& width, double& height)
 	{
 #ifdef MBUC
 		std::wstring sample = s2w(text);

--- a/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
+++ b/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
@@ -92,6 +92,7 @@ namespace osmscout {
         
         void GetTextDimension(const Projection& projection,
                               const MapParameter& parameter,
+                              double objectWidth,
                               double fontSize,
                               const std::string& text,
                               double& xOff,

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -263,7 +263,7 @@ namespace osmscout {
         double yOff;
         double width;
         double height;
-        GetTextDimension(projection,parameter,fontSize,text,xOff,yOff,width,height);
+        GetTextDimension(projection,parameter,fontSize,/*objectWidth*/-1,text,xOff,yOff,width,height);
         return width;
     }
     
@@ -272,7 +272,7 @@ namespace osmscout {
         double yOff;
         double width;
         double height;
-        GetTextDimension(projection, parameter,fontSize,text,xOff,yOff,width,height);
+        GetTextDimension(projection, parameter,fontSize,/*objectWidth*/-1,text,xOff,yOff,width,height);
         return height;
     }
     
@@ -557,7 +557,7 @@ namespace osmscout {
                 
                 NSString *str = [nsText substringWithRange:NSMakeRange(i, 1)];
                 
-                GetTextDimension(projection, parameter,style.GetSize(), [str cStringUsingEncoding:NSUTF8StringEncoding], xOff, yOff, nww, nhh);
+                GetTextDimension(projection, parameter,style.GetSize(),/*objectWidth*/-1, [str cStringUsingEncoding:NSUTF8StringEncoding], xOff, yOff, nww, nhh);
                 x1 = charOrigin.GetX();
                 y1 = charOrigin.GetY();
                 if(!followPath(followPathHnd,nww, charOrigin)){

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -237,6 +237,7 @@ namespace osmscout {
      */
     void MapPainterIOS::GetTextDimension(const Projection& projection,
                                          const MapParameter& parameter,
+                                         double objectWidth,
                                          double fontSize,
                                          const std::string& text,
                                          double& xOff,

--- a/libosmscout-map-opengl/include/osmscout/MapPainterOpenGL.h
+++ b/libosmscout-map-opengl/include/osmscout/MapPainterOpenGL.h
@@ -61,6 +61,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -109,6 +109,7 @@ namespace osmscout {
 
   void MapPainterOpenGL::GetTextDimension(const Projection& /*projection*/,
                                           const MapParameter& /*parameter*/,
+                                          double /*objectWidth*/,
                                           double /*fontSize*/,
                                           const std::string& /*text*/,
                                           double& /*xOff*/,

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -95,6 +95,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -197,6 +197,7 @@ namespace osmscout {
 
   void MapPainterQt::GetTextDimension(const Projection& projection,
                                       const MapParameter& parameter,
+                                      double objectWidth,
                                       double fontSize,
                                       const std::string& text,
                                       double& xOff,
@@ -210,8 +211,13 @@ namespace osmscout {
     QFontMetrics fontMetrics=QFontMetrics(font);
     QString      string=QString::fromUtf8(text.c_str());
     QTextLayout  textLayout(string,font);
-    qreal        proposedWidth=parameter.GetLabelLineCharCount()*fontMetrics.averageCharWidth();
     qreal        leading=fontMetrics.leading() ;
+
+    qreal        proposedWidth=proposedLabelWidth(parameter,
+                                                  fontMetrics.averageCharWidth(),
+                                                  objectWidth,
+                                                  string.length()
+                                                  );
 
     width=0;
     height=0;
@@ -236,14 +242,13 @@ namespace osmscout {
     yOff=boundingBox.y();
   }
 
-  void LayoutTextLayout(const MapParameter& parameter,
-                        const QFontMetrics& fontMetrics,
+  void LayoutTextLayout(const QFontMetrics& fontMetrics,
+                        qreal proposedWidth,
                         QTextLayout& layout,
                         QRectF& boundingBox)
   {
     qreal width=0;
     qreal height=0;
-    qreal proposedWidth=parameter.GetLabelLineCharCount()*fontMetrics.averageCharWidth();
     qreal leading=fontMetrics.leading();
 
     // Calculate and layout all lines initial left aligned
@@ -286,6 +291,7 @@ namespace osmscout {
     QString      string=QString::fromUtf8(label.text.c_str());
     QFontMetrics fontMetrics=QFontMetrics(font);
     QTextLayout  textLayout(string,font);
+    qreal        proposedWidth=std::floor(label.bx2-label.bx1)+1; // try to make word wrapping more stable
 
     textLayout.setCacheEnabled(true);
 
@@ -308,8 +314,8 @@ namespace osmscout {
 
         textLayout.setAdditionalFormats(formatList);
 
-        LayoutTextLayout(parameter,
-                         fontMetrics,
+        LayoutTextLayout(fontMetrics,
+                         proposedWidth,
                          textLayout,
                          boundingBox);
 
@@ -332,8 +338,8 @@ namespace osmscout {
 
         textLayout.setAdditionalFormats(formatList);
 
-        LayoutTextLayout(parameter,
-                         fontMetrics,
+        LayoutTextLayout(fontMetrics,
+                         proposedWidth,
                          textLayout,
                          boundingBox);
 
@@ -350,8 +356,8 @@ namespace osmscout {
 
         textLayout.setAdditionalFormats(formatList);
 
-        LayoutTextLayout(parameter,
-                         fontMetrics,
+        LayoutTextLayout(fontMetrics,
+                         proposedWidth,
                          textLayout,
                          boundingBox);
 
@@ -402,8 +408,8 @@ namespace osmscout {
 
       textLayout.setAdditionalFormats(formatList);
 
-      LayoutTextLayout(parameter,
-                       fontMetrics,
+      LayoutTextLayout(fontMetrics,
+                       proposedWidth,
                        textLayout,
                        boundingBox);
 

--- a/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
@@ -98,6 +98,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -294,6 +294,7 @@ namespace osmscout {
 
   void MapPainterSVG::GetTextDimension(const Projection& projection,
                                        const MapParameter& parameter,
+                                       double /*objectWidth*/,
                                        double fontSize,
                                        const std::string& text,
                                        double& xOff,

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -340,7 +340,8 @@ namespace osmscout {
                            const IconStyleRef iconStyle,
                            const std::vector<TextStyleRef>& textStyles,
                            double x, double y,
-                           double objectHeight);
+                           double objectWidth=0,
+                           double objectHeight=0);
 
     void DrawWayDecorations(const StyleConfig& styleConfig,
                             const Projection& projection,
@@ -496,6 +497,7 @@ namespace osmscout {
       */
     virtual void GetTextDimension(const Projection& projection,
                                   const MapParameter& parameter,
+                                  double objectWidth,
                                   double fontSize,
                                   const std::string& text,
                                   double& xOff,
@@ -575,6 +577,15 @@ namespace osmscout {
                           const MapParameter& parameter,
                           const AreaData& area) = 0;
     //@}
+
+    /**
+      Compute suggested label width for given parameters.
+      It may be used by backend for layout labels with wrapping words.
+     */
+    virtual double proposedLabelWidth(const MapParameter& parameter,
+                                      double averageCharWidth,
+                                      double objectWidth,
+                                      size_t stringLength);
 
     /**
       Med level drawing routines that are already implemented by the base class, but which can be overwritten

--- a/libosmscout-map/include/osmscout/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscout/MapPainterNoOp.h
@@ -47,6 +47,7 @@ namespace osmscout {
 
     void GetTextDimension(const Projection& projection,
                           const MapParameter& parameter,
+                          double objectWidth,
                           double fontSize,
                           const std::string& text,
                           double& xOff,

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -54,7 +54,11 @@ namespace osmscout {
     bool                         drawWaysWithFixedWidth;    //!< Draw ways using the size of the style sheet, if if the way has a width explicitly given
 
     // Node and area labels
-    size_t                       labelLineCharCount;        //!< Labels will be word wrapped if  they are longer then the given characters
+    size_t                       labelLineMinCharCount;     //!< Labels will be _never_ word wrapped if they are shorter then the given characters
+    size_t                       labelLineMaxCharCount;     //!< Labels will be word wrapped if they are longer then the given characters
+    bool                         labelLineFitToArea;        //!< Labels will be word wrapped to fit object area
+    double                       labelLineFitToWidth;       //!< Labels will be word wrapped to fit given width in pixels
+
     double                       labelSpace;                //!< Space between point labels in mm (default 3).
     double                       plateLabelSpace;           //!< Space between plates in mm (default 5).
     double                       sameLabelSpace;            //!< Space between labels with the same value in mm (default 40)
@@ -96,7 +100,11 @@ namespace osmscout {
     void SetDrawFadings(bool drawFadings);
     void SetDrawWaysWithFixedWidth(bool drawWaysWithFixedWidth);
 
-    void SetLabelLineCharCount(size_t labelLineCharCount);
+    void SetLabelLineMinCharCount(size_t labelLineMinCharCount);
+    void SetLabelLineMaxCharCount(size_t labelLineMaxCharCount);
+    void SetLabelLineFitToArea(bool labelLineFitToArea);
+    void SetLabelLineFitToWidth(double labelLineFitToWidth);
+
     void SetLabelSpace(double labelSpace);
     void SetPlateLabelSpace(double plateLabelSpace);
     void SetSameLabelSpace(double sameLabelSpace);
@@ -172,9 +180,24 @@ namespace osmscout {
       return drawWaysWithFixedWidth;
     }
 
-    inline size_t GetLabelLineCharCount() const
+    inline size_t GetLabelLineMinCharCount() const
     {
-      return labelLineCharCount;
+      return labelLineMinCharCount;
+    }
+
+    inline size_t GetLabelLineMaxCharCount() const
+    {
+      return labelLineMaxCharCount;
+    }
+
+    inline bool GetLabelLineFitToArea() const
+    {
+      return labelLineFitToArea;
+    }
+
+    inline double GetLabelLineFitToWidth() const
+    {
+      return labelLineFitToWidth;
     }
 
     inline double GetLabelSpace() const

--- a/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
@@ -49,6 +49,7 @@ namespace osmscout {
 
   void MapPainterNoOp::GetTextDimension(const Projection& /*projection*/,
                                         const MapParameter& /*parameter*/,
+                                        double /*objectWidth*/,
                                         double fontSize,
                                         const std::string& text,
                                         double& xOff,

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -31,7 +31,10 @@ namespace osmscout {
     optimizeErrorToleranceMm(0.5),
     drawFadings(true),
     drawWaysWithFixedWidth(false),
-    labelLineCharCount(1000/*20*/),
+    labelLineMinCharCount(15),
+    labelLineMaxCharCount(1000/*20*/),
+    labelLineFitToArea(true),
+    labelLineFitToWidth(8000),
     labelSpace(1.0),
     plateLabelSpace(5.0),
     sameLabelSpace(40.0),
@@ -108,9 +111,23 @@ namespace osmscout {
     this->drawWaysWithFixedWidth=drawWaysWithFixedWidth;
   }
 
-  void MapParameter::SetLabelLineCharCount(size_t labelLineCharCount)
+  void MapParameter::SetLabelLineMinCharCount(size_t labelLineMinCharCount)
   {
-    this->labelLineCharCount=labelLineCharCount;
+    this->labelLineMinCharCount=labelLineMinCharCount;
+  }
+
+  void MapParameter::SetLabelLineMaxCharCount(size_t labelLineMaxCharCount)
+  {
+    this->labelLineMaxCharCount=labelLineMaxCharCount;
+  }
+  void MapParameter::SetLabelLineFitToArea(bool labelLineFitToArea)
+  {
+    this->labelLineFitToArea=labelLineFitToArea;
+  }
+
+  void MapParameter::SetLabelLineFitToWidth(double labelLineFitToWidth)
+  {
+    this->labelLineFitToWidth=labelLineFitToWidth;
   }
 
   void MapParameter::SetLabelSpace(double labelSpace)


### PR DESCRIPTION
Thank you Tim that you worked on support of multi-line labels! It was something that was missing to me.

I want to setup label word wrap in Qt/client code to some reasonable default. But configure just maximum label length don't provide enough flexibility. In many cases, I want to wrap labels to fit mobile screen width (even if it is rotated to landscape). For many areas make sense to fit labels even to area bounding box...

For that reason, I added extra `MapParameter` properties:
```
size_t labelLineCharCount;        //!< Labels will be word wrapped if  they are longer then the given characters
size_t labelLineMinCharCount;     //!< Labels will be _never_ word wrapped if they are shorter then the given characters
size_t labelLineMaxCharCount;     //!< Labels will be word wrapped if they are longer then the given characters
bool   labelLineFitToArea;        //!< Labels will be word wrapped to fit object area
double labelLineFitToWidth;       //!< Labels will be word wrapped to fit given width in pixels
```

There is a new utility method `MapPainter::proposedLabelWidth` that compute proposed label width. It is used in `MapPainterQt` and `MapPainterCairo`...