### PR TITLE
MapView copy contructor should not transfer ownership in Qt hierarchy

### DIFF
--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -171,10 +171,15 @@ public:
   inline MapView(osmscout::GeoCoord center, double angle, osmscout::Magnification magnification):
     center(center), angle(angle), magnification(magnification) {}
 
+  /**
+   * This copy constructor don't transfer ownership
+   * in Qt hierarchy - it may cause troubles.
+   * @param mv
+   */
   inline MapView(const MapView &mv):
-    QObject(mv.parent()), center(mv.center), angle(mv.angle), magnification(mv.magnification) {}
+    QObject(), center(mv.center), angle(mv.angle), magnification(mv.magnification) {}
   
-  inline ~MapView(){}
+  virtual inline ~MapView(){}
   
   inline double GetLat(){ return center.lat; }
   inline double GetLon(){ return center.lon; }


### PR DESCRIPTION
Hi. OSMScout2 sometimes produces sigterm when application exits. I looked little bit closer to this issue, and it was from `MapView` destructor. Problem is that MapView needs to be derived from `QObject`, becase it exposes some properties (`Q_PROPERTY`) to QML world. It is available from `Settings` object to QML. Because of that, Settings have to provide MapView as a pointer. To prevent QML to steal ownership of MapView, its parent is setup to Settings object. QObject automatically deletes its own childs in destructor... 

Until now, everything is clear, following is little bit speculation: When `MapWidget::SetMapView` is called from QML, there is created copy of original MapView owned by Settings, this copy constructor setup parent of the new object to Settings too. But it is not pointer, but field of InputHandler object! At application end, when Settings is deleted, it wants to delete already deleted childs and it leads to **sigterm** because of double free.

I am not sure if this scenario is correct, but it is clear that copy constructor of QObject derivations can't copy ownership...