### PR TITLE
Fix tile cache

### DIFF
--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -260,6 +260,12 @@ void PlaneDBThread::TriggerMapRendering(const RenderMapRequest& request)
         std::list<osmscout::TileRef> tiles;
 
         db->mapService->LookupTiles(projection,tiles);
+        if (tiles.size()>db->mapService->GetCacheSize()){
+          osmscout::log.Debug() << "Increase tile cache size to " << tiles.size();
+          db->mapService->SetCacheSize(tiles.size());
+          // lookup tiles again
+          db->mapService->LookupTiles(projection,tiles);
+        }
         if (!db->mapService->LoadMissingTileDataAsync(searchParameter,*(db->styleConfig),tiles)) {
           osmscout::log.Error() << "*** Loading of data has error or was interrupted";
           continue;

--- a/libosmscout-map/include/osmscout/MapService.h
+++ b/libosmscout-map/include/osmscout/MapService.h
@@ -229,6 +229,7 @@ namespace osmscout {
     virtual ~MapService();
 
     void SetCacheSize(size_t cacheSize);
+    size_t GetCacheSize() const;
 
     void CleanupTileCache();
     void FlushTileCache();

--- a/libosmscout-map/include/osmscout/TileId.h
+++ b/libosmscout-map/include/osmscout/TileId.h
@@ -52,7 +52,7 @@ namespace osmscout {
   class OSMSCOUT_MAP_API TileId
   {
   private:
-    Magnification magnification; //!< the zoom level (0..n)
+    uint32_t      level;         //!< the zoom level (0..n)
     size_t        x;             //!< The x coordinate of the tile in relation to the zoom level
     size_t        y;             //!< The y coordinate of the tile in relation to the zoom level
     GeoBox        boundingBox;   //!< Bounding box of the tile
@@ -67,7 +67,7 @@ namespace osmscout {
      */
     inline size_t GetLevel() const
     {
-      return magnification.GetLevel();
+      return level;
     }
 
     /**

--- a/libosmscout-map/src/osmscout/MapService.cpp
+++ b/libosmscout-map/src/osmscout/MapService.cpp
@@ -121,6 +121,13 @@ namespace osmscout {
     cache.SetSize(cacheSize);
   }
 
+  size_t MapService::GetCacheSize() const
+  {
+    std::lock_guard<std::mutex> lock(stateMutex);
+
+    return cache.GetSize();
+  }
+
   /**
    * Evict tiles from cache until tile count <= cacheSize
    */

--- a/libosmscout-map/src/osmscout/MapService.cpp
+++ b/libosmscout-map/src/osmscout/MapService.cpp
@@ -845,7 +845,7 @@ namespace osmscout {
         StopClock     tileLoadingTime;
         Magnification magnification;
 
-        //std::cout << "Loading tile: " << (std::string)tile->GetId() << std::endl;
+        //std::cout << "Loading tile: " << tile->GetId().DisplayText() << std::endl;
 
         magnification.SetLevel(tile->GetId().GetLevel());
 
@@ -915,7 +915,7 @@ namespace osmscout {
 
       }
       else {
-        //std::cout << "Using cached tile: " << (std::string)tile->GetId() << std::endl;
+        //std::cout << "Using cached tile: " << tile->GetId().DisplayText() << std::endl;
       }
     }
 

--- a/libosmscout-map/src/osmscout/TileId.cpp
+++ b/libosmscout-map/src/osmscout/TileId.cpp
@@ -29,7 +29,7 @@ namespace osmscout {
   TileId::TileId(const Magnification& magnification,
                  size_t x,
                  size_t y)
-  : magnification(magnification),
+  : level(magnification.GetLevel()),
     x(x),
     y(y),
     boundingBox(GeoCoord(y*cellDimension[magnification.GetLevel()].height-90.0,
@@ -45,7 +45,7 @@ namespace osmscout {
    */
   std::string TileId::DisplayText() const
   {
-    return NumberToString(magnification.GetLevel())+ "." + NumberToString(y) + "." + NumberToString(x);
+    return NumberToString(level)+ "." + NumberToString(y) + "." + NumberToString(x);
   }
 
   /**
@@ -59,9 +59,9 @@ namespace osmscout {
   {
     Magnification zoomedOutMagnification;
 
-    assert(magnification.GetLevel()>0);
+    assert(level>0);
 
-    zoomedOutMagnification.SetLevel(magnification.GetLevel()-1);
+    zoomedOutMagnification.SetLevel(level-1);
 
     return TileId(zoomedOutMagnification,x/2,y/2);
   }
@@ -71,7 +71,7 @@ namespace osmscout {
    */
   bool TileId::operator==(const TileId& other) const
   {
-    return magnification==other.magnification &&
+    return level==other.level &&
            y==other.y &&
            x==other.x;
   }
@@ -81,7 +81,7 @@ namespace osmscout {
    */
   bool TileId::operator!=(const TileId& other) const
   {
-    return magnification!=other.magnification ||
+    return level!=other.level ||
            y!=other.y ||
            x!=other.x;
   }
@@ -92,8 +92,8 @@ namespace osmscout {
    */
   bool TileId::operator<(const TileId& other) const
   {
-    if (magnification!=other.magnification) {
-      return magnification<other.magnification;
+    if (level!=other.level) {
+      return level<other.level;
     }
 
     if (y!=other.y) {


### PR DESCRIPTION
Hi. 

This MR fixes duplicates objects in tile cache https://github.com/Framstag/libosmscout/issues/223 

It was nothing to do with asynchronous loading. Problem is that `TileId` uses `Magnification` object instead of zoom level. It leads to problem when ids created with little bit different magnifications are not equal and cache creates many tiles with duplicate content.
