### PR TITLE
Fix StyleEditor compile on Mac OSX, add libosmscout-client-qt.pro

### DIFF
--- a/StyleEditor/StyleEditor.pro
+++ b/StyleEditor/StyleEditor.pro
@@ -6,10 +6,19 @@ CONFIG += qt warn_on debug link_pkgconfig thread c++11 silent
 
 QT += core gui widgets qml quick
 
-PKGCONFIG += libosmscout-map-qt libosmscout-client-qt
-
 !macx {
+  PKGCONFIG += libosmscout-map-qt libosmscout-client-qt
   gcc:QMAKE_CXXFLAGS += -fopenmp
+} else {
+  INCLUDEPATH+=../../libosmscout/include
+  INCLUDEPATH+=../../libosmscout-client-qt/include
+  INCLUDEPATH+=../../libosmscout-map/include
+  INCLUDEPATH+=../../libosmscout-map-qt/include
+
+  LIBS+=-L../../libosmscout-client-qt/build -losmscout-client-qt
+  LIBS+=-L../../libosmscout-map-qt/build -losmscout-map-qt
+  LIBS+=-L../../libosmscout-map/src/.libs -losmscoutmap
+  LIBS+=-L../../libosmscout/src/.libs -losmscout
 }
 
 release: DESTDIR = release

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     stylesheetFilename = cmdLineArgs.at(2);
   }else{
     if (cmdLineArgs.size() > 1){
-      stylesheetFilename = cmdLineArgs.at(1) + "standard.oss";
+      stylesheetFilename = cmdLineArgs.at(1) + QDir::separator() + "standard.oss";
     }else{
       stylesheetFilename = QString("stylesheets") + QDir::separator() + "standard.oss";
     }

--- a/libosmscout-client-qt/libosmscout-client-qt.pro
+++ b/libosmscout-client-qt/libosmscout-client-qt.pro
@@ -1,0 +1,69 @@
+QT       += quick opengl
+
+TARGET = osmscout-client-qt
+TEMPLATE = lib
+CONFIG += staticlib
+INCLUDEPATH += include ../libosmscout-map/include ../libosmscout-map-qt/include ../libosmscout/include ../../../marisa/lib
+
+SOURCES += \
+    src/osmscout/AvailableMapsModel.cpp \
+    src/osmscout/DBThread.cpp \
+    src/osmscout/InputHandler.cpp \
+    src/osmscout/LocationEntry.cpp \
+    src/osmscout/LocationInfoModel.cpp \
+    src/osmscout/MapDownloadsModel.cpp \
+    src/osmscout/MapManager.cpp \
+    src/osmscout/MapProvider.cpp \
+    src/osmscout/MapWidget.cpp \
+    src/osmscout/OnlineTileProvider.cpp \
+    src/osmscout/OnlineTileProviderModel.cpp \
+    src/osmscout/OSMTile.cpp \
+    src/osmscout/OsmTileDownloader.cpp \
+    src/osmscout/PlaneDBThread.cpp \
+    src/osmscout/RoutingModel.cpp \
+    src/osmscout/SearchLocationModel.cpp \
+    src/osmscout/Settings.cpp \
+    src/osmscout/TileCache.cpp \
+    src/osmscout/TiledDBThread.cpp
+
+
+HEADERS += \
+    include/osmscout/AvailableMapsModel.h \
+    include/osmscout/ClientQtFeatures.h \
+    include/osmscout/DBThread.h \
+    include/osmscout/InputHandler.h \
+    include/osmscout/LocationEntry.h \
+    include/osmscout/LocationInfoModel.h \
+    include/osmscout/MapDownloadsModel.h \
+    include/osmscout/MapManager.h \
+    include/osmscout/MapProvider.h \
+    include/osmscout/MapWidget.h \
+    include/osmscout/OnlineTileProvider.h \
+    include/osmscout/OnlineTileProviderModel.h \
+    include/osmscout/OSMTile.h \
+    include/osmscout/OsmTileDownloader.h \
+    include/osmscout/PersistentCookieJar.h \
+    include/osmscout/PlaneDBThread.h \
+    include/osmscout/RoutingModel.h \
+    include/osmscout/SearchLocationModel.h \
+    include/osmscout/Settings.h \
+    include/osmscout/TileCache.h \
+    include/osmscout/TiledDBThread.h \
+    include/osmscout/private/ClientQtImportExport.h \
+    include/osmscout/private/Config.h
+
+macx {
+    QMAKE_CXXFLAGS = -mmacosx-version-min=10.7 -std=gnu0x -stdlib=libc++
+    CONFIG +=c++11
+}
+
+unix {
+    target.path = /usr/lib
+    INSTALLS += target
+}
+
+windows {
+    DEFINES += WIN32 OSMSCOUTMAPQTDLL DLL_EXPORT
+    CONFIG(debug, debug|release): DESTDIR = ../windows/Debug
+    CONFIG(release, debug|release): DESTDIR = ../windows/Release
+}

--- a/libosmscout-map-qt/libosmscout-map-qt.pro
+++ b/libosmscout-map-qt/libosmscout-map-qt.pro
@@ -1,14 +1,20 @@
 QT       += quick opengl
 
-TARGET = libosmscout-map-qt
+TARGET = osmscout-map-qt
 TEMPLATE = lib
 CONFIG += staticlib
 INCLUDEPATH += include ../libosmscout-map/include ../libosmscout/include
 
 SOURCES += \
-    src/osmscout/MapPainterQt.cpp
+    src/osmscout/MapPainterQt.cpp \
+    src/osmscout/SimplifiedPath.cpp
 
-HEADERS +=
+HEADERS += \
+    include/osmscout/MapPainterQt.h \
+    include/osmscout/MapQtFeatures.h \
+    include/osmscout/SimplifiedPath.h \
+    include/osmscout/private/Config.h \
+    include/osmscout/private/MapQtImportExport.h
 
 macx {
     QMAKE_CXXFLAGS = -mmacosx-version-min=10.7 -std=gnu0x -stdlib=libc++


### PR DESCRIPTION
On Mac OSX using pkconfig with Qt is complicate, allow the build of StyleEditor without it 