### PR TITLE
Data object cache

### DIFF
--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -730,7 +730,8 @@ int main(int argc, char* argv[])
 
   osmscout::IndexedDataFile<osmscout::Id,osmscout::RouteNode> routeNodeDataFile("router.dat",
                                                                                 "router.idx",
-                                                                                6000);
+                                                                                6000,
+                                                                                1000);
 
   if (!database.Open(map.c_str())) {
     std::cerr << "Cannot open database" << std::endl;

--- a/Tests/src/MultiDBRouting.cpp
+++ b/Tests/src/MultiDBRouting.cpp
@@ -252,7 +252,8 @@ int main(int argc, char* argv[])
 
   osmscout::IndexedDataFile<osmscout::Id,osmscout::RouteNode> routeNodeFile(std::string(osmscout::RoutingService::DEFAULT_FILENAME_BASE)+".dat",
                                                                             std::string(osmscout::RoutingService::DEFAULT_FILENAME_BASE)+".idx",
-                                                                            12000);
+                                                                            /*indexCacheSize*/12000,
+                                                                            /*dataCacheSize*/1000);
 
   std::cout << "Opening routing database 1..." << std::endl;
 

--- a/libosmscout-import/include/osmscout/import/RawRelIndexedDataFile.h
+++ b/libosmscout-import/include/osmscout/import/RawRelIndexedDataFile.h
@@ -31,7 +31,8 @@ namespace osmscout {
   class RawRelationIndexedDataFile CLASS_FINAL : public IndexedDataFile<OSMId,RawRelation>
   {
   public:
-    RawRelationIndexedDataFile(unsigned long indexCacheSize);
+    RawRelationIndexedDataFile(unsigned long indexCacheSize,
+                               unsigned long dataCacheSize);
   };
 }
 

--- a/libosmscout-import/include/osmscout/import/RawWayIndexedDataFile.h
+++ b/libosmscout-import/include/osmscout/import/RawWayIndexedDataFile.h
@@ -31,7 +31,8 @@ namespace osmscout {
   class RawWayIndexedDataFile CLASS_FINAL : public IndexedDataFile<OSMId,RawWay>
   {
   public:
-    RawWayIndexedDataFile(unsigned long indexCacheSize);
+    RawWayIndexedDataFile(unsigned long indexCacheSize,
+                          unsigned long dataCacheSize);
   };
 }
 

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -1016,9 +1016,9 @@ namespace osmscout {
 
     CoordDataFile              coordDataFile;
 
-    RawWayIndexedDataFile      wayDataFile(parameter.GetRawWayIndexCacheSize());
+    RawWayIndexedDataFile      wayDataFile(parameter.GetRawWayIndexCacheSize(),/*dataCache*/0);
 
-    RawRelationIndexedDataFile relDataFile(parameter.GetRawWayIndexCacheSize());
+    RawRelationIndexedDataFile relDataFile(parameter.GetRawWayIndexCacheSize(),/*dataCache*/0);
     FeatureRef                 featureName(typeConfig->GetFeature(RefFeature::NAME));
 
     if (!coordDataFile.Open(parameter.GetDestinationDirectory(),

--- a/libosmscout-import/src/osmscout/import/RawRelIndexedDataFile.cpp
+++ b/libosmscout-import/src/osmscout/import/RawRelIndexedDataFile.cpp
@@ -21,10 +21,12 @@
 
 namespace osmscout {
 
-  RawRelationIndexedDataFile::RawRelationIndexedDataFile(unsigned long indexCacheSize)
+  RawRelationIndexedDataFile::RawRelationIndexedDataFile(unsigned long indexCacheSize,
+                                                         unsigned long dataCacheSize)
   : IndexedDataFile<OSMId,RawRelation>("rawrels.dat",
                                        "rawrel.idx",
-                                       indexCacheSize)
+                                       indexCacheSize,
+                                       dataCacheSize)
   {
     // no code
   }

--- a/libosmscout-import/src/osmscout/import/RawWayIndexedDataFile.cpp
+++ b/libosmscout-import/src/osmscout/import/RawWayIndexedDataFile.cpp
@@ -21,10 +21,12 @@
 
 namespace osmscout {
 
-  RawWayIndexedDataFile::RawWayIndexedDataFile(unsigned long indexCacheSize)
+  RawWayIndexedDataFile::RawWayIndexedDataFile(unsigned long indexCacheSize,
+                                               unsigned long dataCacheSize)
   : IndexedDataFile<OSMId,RawWay>("rawways.dat",
                                   "rawway.idx",
-                                  indexCacheSize)
+                                  indexCacheSize,
+                                  dataCacheSize)
   {
     // no code
   }

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -177,13 +177,14 @@ namespace osmscout {
 
   private:
     FileOffset        fileOffset;
+    FileOffset        nextFileOffset;
 
   public:
     std::vector<Ring> rings;
 
   public:
     inline Area()
-    : fileOffset(0)
+    : fileOffset(0),nextFileOffset(0)
     {
       // no code
     }
@@ -191,6 +192,11 @@ namespace osmscout {
     inline FileOffset GetFileOffset() const
     {
       return fileOffset;
+    }
+
+    inline FileOffset GetNextFileOffset() const
+    {
+      return nextFileOffset;
     }
 
     inline ObjectFileRef GetObjectFileRef() const

--- a/libosmscout/include/osmscout/AreaDataFile.h
+++ b/libosmscout/include/osmscout/AreaDataFile.h
@@ -37,7 +37,7 @@ namespace osmscout {
     static const char* AREAS_IDMAP;
 
   public:
-    AreaDataFile();
+    AreaDataFile(size_t cacheSize);
   };
 
   typedef std::shared_ptr<AreaDataFile> AreaDataFileRef;

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -150,7 +150,7 @@ namespace osmscout {
   /**
    * Read one data value from the given file offset.
    *
-   * Method is thread-safe.
+   * Method is NOT thread-safe.
    */
   template <class N>
   bool DataFile<N>::ReadData(const TypeConfig& typeConfig,
@@ -158,8 +158,6 @@ namespace osmscout {
                              FileOffset offset,
                              N& data) const
   {
-    std::lock_guard<std::mutex> lock(accessMutex);
-
     try {
       scanner.SetPos(offset);
 
@@ -177,7 +175,7 @@ namespace osmscout {
   /**
    * Read one data value from the current position of the stream
    *
-   * Method is not thread-safe.
+   * Method is NOT thread-safe.
    */
   template <class N>
   bool DataFile<N>::ReadData(const TypeConfig& typeConfig,

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -72,10 +72,16 @@ namespace osmscout {
   {
   public:
     typedef std::shared_ptr<N> ValueType;
+    typedef Cache<FileOffset,std::shared_ptr<N>> ValueCache;
+
+    typedef typename Cache<FileOffset,ValueType>::CacheEntry ValueCacheEntry;
+    typedef typename Cache<FileOffset,ValueType>::CacheRef ValueCacheRef;
 
   private:
     std::string         datafile;        //!< Basename part of the data file name
     std::string         datafilename;    //!< complete filename for data file
+
+    mutable ValueCache  cache;
 
     mutable FileScanner scanner;         //!< File stream to the data file
 
@@ -94,7 +100,7 @@ namespace osmscout {
                   N& data) const;
 
   public:
-    DataFile(const std::string& datafile);
+    DataFile(const std::string& datafile, size_t cacheSize=10000);
 
     virtual ~DataFile();
 
@@ -127,8 +133,8 @@ namespace osmscout {
   };
 
   template <class N>
-  DataFile<N>::DataFile(const std::string& datafile)
-  : datafile(datafile)
+  DataFile<N>::DataFile(const std::string& datafile, size_t cacheSize)
+  : datafile(datafile),cache(cacheSize)
   {
     // no code
   }
@@ -265,17 +271,23 @@ namespace osmscout {
     data.reserve(data.size()+offsets.size());
 
     for (const auto& offset : offsets) {
-      ValueType value=std::make_shared<N>();
+      ValueCacheRef entryRef;
+      if (cache.GetEntry(offset,entryRef)){
+        data.push_back(entryRef->value);
+      }else{
+        ValueType value=std::make_shared<N>();
 
-      if (!ReadData(*typeConfig,
-                    scanner,
-                    offset,
-                    *value)) {
-        log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
-        return false;
+        if (!ReadData(*typeConfig,
+                      scanner,
+                      offset,
+                      *value)) {
+          log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
+          return false;
+        }
+
+        cache.SetEntry(ValueCacheEntry(offset,value));
+        data.push_back(value);
       }
-
-      data.push_back(value);
     }
 
     return true;
@@ -296,12 +308,19 @@ namespace osmscout {
     for (const auto& offset : offsets) {
       ValueType value=std::make_shared<N>();
 
-      if (!ReadData(*typeConfig,
-                    scanner,
-                    offset,
-                    *value)) {
-        log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
-        return false;
+      ValueCacheRef entryRef;
+      if (cache.GetEntry(offset,entryRef)){
+        value=entryRef->value;
+      }else{
+        if (!ReadData(*typeConfig,
+                      scanner,
+                      offset,
+                      *value)) {
+          log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
+          return false;
+        }
+
+        cache.SetEntry(ValueCacheEntry(offset,value));
       }
 
       if (!value->Intersects(boundingBox)) {
@@ -326,18 +345,24 @@ namespace osmscout {
     data.reserve(data.size()+offsets.size());
 
     for (const auto& offset : offsets) {
-      ValueType value=std::make_shared<N>();
+      ValueCacheRef entryRef;
+      if (cache.GetEntry(offset,entryRef)){
+        data.push_back(entryRef->value);
+      }else{
+        ValueType value=std::make_shared<N>();
 
-      if (!ReadData(*typeConfig,
-                    scanner,
-                    offset,
-                    *value)) {
-        log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
-        // TODO: Remove broken entry from cache
-        return false;
+        if (!ReadData(*typeConfig,
+                      scanner,
+                      offset,
+                      *value)) {
+          log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
+          // TODO: Remove broken entry from cache
+          return false;
+        }
+
+        cache.SetEntry(ValueCacheEntry(offset,value));
+        data.push_back(value);
       }
-
-      data.push_back(value);
     }
 
     return true;
@@ -355,18 +380,24 @@ namespace osmscout {
     data.reserve(data.size()+offsets.size());
 
     for (const auto& offset : offsets) {
-      ValueType value=std::make_shared<N>();
+      ValueCacheRef entryRef;
+      if (cache.GetEntry(offset,entryRef)){
+        data.push_back(entryRef->value);
+      }else{
+        ValueType value=std::make_shared<N>();
 
-      if (!ReadData(*typeConfig,
-                    scanner,
-                    offset,
-                    *value)) {
-        log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
-        // TODO: Remove broken entry from cache
-        return false;
+        if (!ReadData(*typeConfig,
+                      scanner,
+                      offset,
+                      *value)) {
+          log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
+          // TODO: Remove broken entry from cache
+          return false;
+        }
+
+        cache.SetEntry(ValueCacheEntry(offset,value));
+        data.push_back(value);
       }
-
-      data.push_back(value);
     }
 
     return true;
@@ -403,18 +434,26 @@ namespace osmscout {
   bool DataFile<N>::GetByOffset(const FileOffset& offset,
                                 ValueType& entry) const
   {
-    ValueType value=std::make_shared<N>();
+    std::lock_guard<std::mutex> lock(accessMutex);
 
-    if (!ReadData(*typeConfig,
-                  scanner,
-                  offset,
-                  *value)) {
-      log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
-      // TODO: Remove broken entry from cache
-      return false;
+    ValueCacheRef entryRef;
+    if (cache.GetEntry(offset,entryRef)){
+      entry=entryRef->value;
+    }else{
+      ValueType value=std::make_shared<N>();
+
+      if (!ReadData(*typeConfig,
+                    scanner,
+                    offset,
+                    *value)) {
+        log.Error() << "Error while reading data from offset " << offset << " of file " << datafilename << "!";
+        // TODO: Remove broken entry from cache
+        return false;
+      }
+
+      cache.SetEntry(ValueCacheEntry(offset,value));
+      entry=value;
     }
-
-    entry=value;
 
     return true;
   }
@@ -426,7 +465,7 @@ namespace osmscout {
    */
   template <class N>
   bool DataFile<N>::GetByBlockSpan(const DataBlockSpan& span,
-                                   std::vector<ValueType>& area) const
+                                   std::vector<ValueType>& data) const
   {
     if (span.count==0) {
       return true;
@@ -435,21 +474,36 @@ namespace osmscout {
     std::lock_guard<std::mutex> lock(accessMutex);
 
     try {
-      scanner.SetPos(span.startOffset);
+      bool offsetSetup=false;
+      FileOffset offset=span.startOffset;
 
-      area.reserve(area.size()+span.count);
+      data.reserve(data.size()+span.count);
 
       for (uint32_t i=1; i<=span.count; i++) {
-        ValueType value=std::make_shared<N>();
+        ValueCacheRef entryRef;
+        if (cache.GetEntry(offset,entryRef)){
+          data.push_back(entryRef->value);
+          offset=entryRef->value->GetNextFileOffset();
+          offsetSetup=false;
+        }else{
+          if (!offsetSetup){
+            scanner.SetPos(offset);
+          }
 
-        if (!ReadData(*typeConfig,
-                      scanner,
-                      *value)) {
-          log.Error() << "Error while reading data #" << i << " starting from offset " << span.startOffset << " of file " << datafilename << "!";
-          return false;
+          ValueType value=std::make_shared<N>();
+
+          if (!ReadData(*typeConfig,
+                        scanner,
+                        *value)) {
+            log.Error() << "Error while reading data #" << i << " starting from offset " << span.startOffset << " of file " << datafilename << "!";
+            return false;
+          }
+
+          cache.SetEntry(ValueCacheEntry(offset,value));
+          offset=value->GetNextFileOffset();
+          offsetSetup=true;
+          data.push_back(value);
         }
-
-        area.push_back(value);
       }
 
       return true;
@@ -485,20 +539,35 @@ namespace osmscout {
 
         std::lock_guard<std::mutex> lock(accessMutex);
 
-        scanner.SetPos(span.startOffset);
+        bool offsetSetup=false;
+        FileOffset offset=span.startOffset;
 
         for (uint32_t i=1; i<=span.count; i++) {
-          ValueType value=std::make_shared<N>();
+          ValueCacheRef entryRef;
+          if (cache.GetEntry(offset,entryRef)){
+            data.push_back(entryRef->value);
+            offset=entryRef->value->GetNextFileOffset();
+            offsetSetup=false;
+          }else{
+            if (!offsetSetup){
+              scanner.SetPos(offset);
+            }
 
-          if (!ReadData(*typeConfig,
-                        scanner,
-                        *value)) {
-            log.Error() << "Error while reading data #" << i << " starting from offset " << span.startOffset <<
-            " of file " << datafilename << "!";
-            return false;
+            ValueType value=std::make_shared<N>();
+
+            if (!ReadData(*typeConfig,
+                          scanner,
+                          *value)) {
+              log.Error() << "Error while reading data #" << i << " starting from offset " << span.startOffset <<
+              " of file " << datafilename << "!";
+              return false;
+            }
+
+            cache.SetEntry(ValueCacheEntry(offset,value));
+            offset=value->GetNextFileOffset();
+            offsetSetup=true;
+            data.push_back(value);
           }
-
-          data.push_back(value);
         }
       }
     }

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -100,7 +100,7 @@ namespace osmscout {
                   N& data) const;
 
   public:
-    DataFile(const std::string& datafile, size_t cacheSize=10000);
+    DataFile(const std::string& datafile, size_t cacheSize);
 
     virtual ~DataFile();
 
@@ -602,7 +602,8 @@ namespace osmscout {
   public:
     IndexedDataFile(const std::string& datafile,
                     const std::string& indexfile,
-                    unsigned long indexCacheSize);
+                    unsigned long indexCacheSize,
+                    unsigned long dataCacheSize);
 
     bool Open(const TypeConfigRef& typeConfig,
               const std::string& path,
@@ -635,8 +636,9 @@ namespace osmscout {
   template <class I, class N>
   IndexedDataFile<I,N>::IndexedDataFile(const std::string& datafile,
                                         const std::string& indexfile,
-                                        unsigned long indexCacheSize)
-  : DataFile<N>(datafile),
+                                        unsigned long indexCacheSize,
+                                        unsigned long dataCacheSize)
+  : DataFile<N>(datafile,dataCacheSize),
     index(indexfile,indexCacheSize)
   {
     // no code

--- a/libosmscout/include/osmscout/Database.h
+++ b/libosmscout/include/osmscout/Database.h
@@ -79,14 +79,27 @@ namespace osmscout {
     unsigned long areaAreaIndexCacheSize;
     unsigned long areaNodeIndexCacheSize;
 
+    unsigned long nodeDataCacheSize;
+    unsigned long wayDataCacheSize;
+    unsigned long areaDataCacheSize;
   public:
     DatabaseParameter();
 
     void SetAreaAreaIndexCacheSize(unsigned long areaAreaIndexCacheSize);
     void SetAreaNodeIndexCacheSize(unsigned long areaNodeIndexCacheSize);
+    void SetNodeDataCacheSize(unsigned long  size);
+    void SetWayDataCacheSize(unsigned long  size);
+    void SetAreaDataCacheSize(unsigned long  size);
+    void SetOptimisedWaysDataCacheSize(unsigned long  size);
+    void SetOptimisedAreasDataCacheSize(unsigned long  size);
 
     unsigned long GetAreaAreaIndexCacheSize() const;
     unsigned long GetAreaNodeIndexCacheSize() const;
+    unsigned long GetNodeDataCacheSize() const;
+    unsigned long GetWayDataCacheSize() const;
+    unsigned long GetAreaDataCacheSize() const;
+    unsigned long GetOptimisedWaysDataCacheSize() const;
+    unsigned long GetOptimisedAreasDataCacheSize() const;
   };
 
   /**

--- a/libosmscout/include/osmscout/Node.h
+++ b/libosmscout/include/osmscout/Node.h
@@ -41,12 +41,13 @@ namespace osmscout {
     FeatureValueBuffer featureValueBuffer; //!< List of features
 
     FileOffset         fileOffset;         //!< File offset in the data file, use as unique id
+    FileOffset         nextFileOffset;     //!< Offset after this node
 
     GeoCoord           coords;             //!< Coordinates of node
 
   public:
     inline Node()
-    : fileOffset(0)
+    : fileOffset(0), nextFileOffset(0)
     {
       // no code
     }
@@ -54,6 +55,11 @@ namespace osmscout {
     inline FileOffset GetFileOffset() const
     {
       return fileOffset;
+    }
+
+    inline FileOffset GetNextFileOffset() const
+    {
+      return nextFileOffset;
     }
 
     inline ObjectFileRef GetObjectFileRef() const

--- a/libosmscout/include/osmscout/NodeDataFile.h
+++ b/libosmscout/include/osmscout/NodeDataFile.h
@@ -37,7 +37,7 @@ namespace osmscout {
     static const char* NODES_IDMAP;
 
   public:
-    NodeDataFile();
+    NodeDataFile(size_t cacheSize);
   };
 
   typedef std::shared_ptr<NodeDataFile> NodeDataFileRef;

--- a/libosmscout/include/osmscout/Way.h
+++ b/libosmscout/include/osmscout/Way.h
@@ -42,7 +42,8 @@ namespace osmscout {
   private:
     FeatureValueBuffer featureValueBuffer; //!< List of features
 
-    FileOffset         fileOffset;         //!< Offset into the data file fo this way
+    FileOffset         fileOffset;         //!< Offset into the data file of this way
+    FileOffset         nextFileOffset;     //!< Offset after this way
 
 
   public:
@@ -50,7 +51,7 @@ namespace osmscout {
 
   public:
     inline Way()
-    : fileOffset(0)
+    : fileOffset(0),nextFileOffset(0)
     {
       // no code
     }
@@ -58,6 +59,11 @@ namespace osmscout {
     inline FileOffset GetFileOffset() const
     {
       return fileOffset;
+    }
+
+    inline FileOffset GetNextFileOffset() const
+    {
+      return nextFileOffset;
     }
 
     inline ObjectFileRef GetObjectFileRef() const

--- a/libosmscout/include/osmscout/WayDataFile.h
+++ b/libosmscout/include/osmscout/WayDataFile.h
@@ -37,7 +37,7 @@ namespace osmscout {
     static const char* WAYS_IDMAP;
 
   public:
-    WayDataFile();
+    WayDataFile(size_t cacheSize);
   };
 
   typedef std::shared_ptr<WayDataFile> WayDataFileRef;

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -227,6 +227,7 @@ namespace osmscout {
                    rings[i].GetType()->GetAreaId()!=typeIgnore &&
                    rings[i].GetType()->CanRoute());
     }
+    nextFileOffset=scanner.GetPos();
   }
 
   /**
@@ -293,6 +294,7 @@ namespace osmscout {
                    rings[i].GetType()->GetAreaId()!=typeIgnore ||
                    rings[i].ring==outerRingId);
     }
+    nextFileOffset=scanner.GetPos();
   }
 
   /**
@@ -358,6 +360,7 @@ namespace osmscout {
       scanner.Read(rings[i].nodes,
                    false);
     }
+    nextFileOffset=scanner.GetPos();
   }
 
   /**

--- a/libosmscout/src/osmscout/AreaDataFile.cpp
+++ b/libosmscout/src/osmscout/AreaDataFile.cpp
@@ -24,8 +24,8 @@ namespace osmscout {
   const char* AreaDataFile::AREAS_DAT="areas.dat";
   const char* AreaDataFile::AREAS_IDMAP="areas.idmap";
 
-  AreaDataFile::AreaDataFile()
-  : DataFile<Area>(AREAS_DAT)
+  AreaDataFile::AreaDataFile(size_t cacheSize)
+  : DataFile<Area>(AREAS_DAT, cacheSize)
   {
     // no code
   }

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -36,7 +36,10 @@ namespace osmscout {
 
   DatabaseParameter::DatabaseParameter()
   : areaAreaIndexCacheSize(5000),
-    areaNodeIndexCacheSize(1000)
+    areaNodeIndexCacheSize(1000),
+    nodeDataCacheSize(5000),
+    wayDataCacheSize(10000),
+    areaDataCacheSize(5000)
   {
     // no code
   }
@@ -51,6 +54,21 @@ namespace osmscout {
     this->areaNodeIndexCacheSize=areaNodeIndexCacheSize;
   }
 
+  void DatabaseParameter::SetNodeDataCacheSize(unsigned long size)
+  {
+    this->nodeDataCacheSize=size;
+  }
+
+  void DatabaseParameter::SetWayDataCacheSize(unsigned long  size)
+  {
+    this->wayDataCacheSize=size;
+  }
+
+  void DatabaseParameter::SetAreaDataCacheSize(unsigned long  size)
+  {
+    this->areaDataCacheSize=size;
+  }
+
   unsigned long DatabaseParameter::GetAreaAreaIndexCacheSize() const
   {
     return areaAreaIndexCacheSize;
@@ -59,6 +77,21 @@ namespace osmscout {
   unsigned long DatabaseParameter::GetAreaNodeIndexCacheSize() const
   {
     return areaNodeIndexCacheSize;
+  }
+
+  unsigned long DatabaseParameter::GetNodeDataCacheSize() const
+  {
+    return nodeDataCacheSize;
+  }
+
+  unsigned long DatabaseParameter::GetWayDataCacheSize() const
+  {
+    return wayDataCacheSize;
+  }
+
+  unsigned long DatabaseParameter::GetAreaDataCacheSize() const
+  {
+    return areaDataCacheSize;
   }
 
   Database::Database(const DatabaseParameter& parameter)
@@ -206,7 +239,7 @@ namespace osmscout {
     }
 
     if (!nodeDataFile) {
-      nodeDataFile=std::make_shared<NodeDataFile>();
+      nodeDataFile=std::make_shared<NodeDataFile>(parameter.GetNodeDataCacheSize());
     }
 
     if (!nodeDataFile->IsOpen()) {
@@ -236,7 +269,7 @@ namespace osmscout {
     }
 
     if (!areaDataFile) {
-      areaDataFile=std::make_shared<AreaDataFile>();
+      areaDataFile=std::make_shared<AreaDataFile>(parameter.GetAreaDataCacheSize());
     }
 
     if (!areaDataFile->IsOpen()) {
@@ -266,7 +299,7 @@ namespace osmscout {
     }
 
     if (!wayDataFile) {
-      wayDataFile=std::make_shared<WayDataFile>();
+      wayDataFile=std::make_shared<WayDataFile>(parameter.GetWayDataCacheSize());
     }
 
     if (!wayDataFile->IsOpen()) {

--- a/libosmscout/src/osmscout/Node.cpp
+++ b/libosmscout/src/osmscout/Node.cpp
@@ -56,6 +56,7 @@ namespace osmscout {
     featureValueBuffer.Read(scanner);
 
     scanner.ReadCoord(coords);
+    nextFileOffset=scanner.GetPos();
   }
 
   /**

--- a/libosmscout/src/osmscout/NodeDataFile.cpp
+++ b/libosmscout/src/osmscout/NodeDataFile.cpp
@@ -24,8 +24,8 @@ namespace osmscout {
   const char* NodeDataFile::NODES_DAT="nodes.dat";
   const char* NodeDataFile::NODES_IDMAP="nodes.idmap";
 
-  NodeDataFile::NodeDataFile()
-  : DataFile<Node>(NODES_DAT)
+  NodeDataFile::NodeDataFile(size_t cacheSize)
+  : DataFile<Node>(NODES_DAT,cacheSize)
   {
     // no code
   }

--- a/libosmscout/src/osmscout/RoutingService.cpp
+++ b/libosmscout/src/osmscout/RoutingService.cpp
@@ -113,10 +113,12 @@ namespace osmscout {
      debugPerformance(parameter.IsDebugPerformance()),
      routeNodeDataFile(GetDataFilename(filenamebase),
                        GetIndexFilename(filenamebase),
-                       12000),
+                       /*indexCacheSize*/ 12000,
+                       /*dataCacheSize*/ 1000),
      junctionDataFile(RoutingService::FILENAME_INTERSECTIONS_DAT,
                       RoutingService::FILENAME_INTERSECTIONS_IDX,
-                      10000)
+                      /*indexCacheSize*/ 10000,
+                      /*dataCacheSize*/ 1000)
   {
     assert(database);
   }

--- a/libosmscout/src/osmscout/Way.cpp
+++ b/libosmscout/src/osmscout/Way.cpp
@@ -95,6 +95,7 @@ namespace osmscout {
 
     scanner.Read(nodes,type->CanRoute() ||
                        type->GetOptimizeLowZoom());
+    nextFileOffset=scanner.GetPos();
   }
 
   /**
@@ -117,6 +118,7 @@ namespace osmscout {
     featureValueBuffer.Read(scanner);
 
     scanner.Read(nodes,false);
+    nextFileOffset=scanner.GetPos();
   }
 
   /**

--- a/libosmscout/src/osmscout/WayDataFile.cpp
+++ b/libosmscout/src/osmscout/WayDataFile.cpp
@@ -24,8 +24,8 @@ namespace osmscout {
   const char* WayDataFile::WAYS_DAT="ways.dat";
   const char* WayDataFile::WAYS_IDMAP="ways.idmap";
 
-  WayDataFile::WayDataFile()
-  : DataFile<Way>(WAYS_DAT)
+  WayDataFile::WayDataFile(size_t cacheSize)
+  : DataFile<Way>(WAYS_DAT,cacheSize)
   {
     // no code
   }


### PR DESCRIPTION
Hi. When one way or area intersects more (cache) tiles, it is loaded twice into memory. Similar situation happens on zoom-out when cache tile can't be prefill. These duplicated loads cost some of cpu and memory. This MR adds cache to data files (map from `FileOffset` to object).

I run some performance tests on phone with armv7 cpu: https://gist.github.com/Karry/184ee8acefc5ff5cc0e1217faaeb5aba

When only a few cache tiles is loaded (zoom level <16), there is measurable overhead of data cache and no memory benefits (performance test don't print how many cache tiles was used). But when more cache tiles have to be loaded, there are benefits - significant memory and load time reduction.