### PR TITLE
fix test if glyph can be visible, add animation to DrawTextQt test

### DIFF
--- a/Tests/include/DrawWindow.h
+++ b/Tests/include/DrawWindow.h
@@ -56,6 +56,9 @@ protected:
   int                       sinCount;
   int                       cnt;
   QTime                     timer;
+  QTime                     animTimer;
+  int                       startOffset;
+  double                    moveOffset;
 };
 
 #endif /* TEST_DRAWWINDOW_H */

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -540,8 +540,8 @@ namespace osmscout {
           QPointF point=p.PointAtLength(glyphOffset);
           // check if current glyph can be visible
           qreal diagonal=boundingRect.width()+boundingRect.height(); // it is little bit longer than correct sqrt(w^2+h^2)
-          if (!painter->viewport().intersects(QRect(point.x()-diagonal, point.y()-diagonal,
-                                                    point.x()+diagonal, point.y()+diagonal))){
+          if (!painter->viewport().intersects(QRect(QPoint(point.x()-diagonal, point.y()-diagonal),
+                                                    QPoint(point.x()+diagonal, point.y()+diagonal)))){
             continue;
           }
           qreal angle=p.AngleAtLengthDeg(glyphOffset);


### PR DESCRIPTION
Hi, I was investigating why some glyphs on tile boundary are not rendered and find out that glyph visibility test is just wrong... Here is fix. Second commit add simple animation to DrawTextQt test visibility :)

![screenshot_20170202_001](https://cloud.githubusercontent.com/assets/309458/22543185/d827b0ee-e92f-11e6-9bbc-7e825116a2a9.png)
