### PR TITLE
use unsigned OSMId for Area id

### DIFF
--- a/libosmscout-import/src/osmscout/import/MergeAreaData.cpp
+++ b/libosmscout-import/src/osmscout/import/MergeAreaData.cpp
@@ -68,7 +68,7 @@ namespace osmscout {
 
       for (uint32_t current=1; current<=wayDataCount; current++) {
         uint8_t type;
-        Id      id;
+        OSMId   id;
         Area    data;
 
         progress.SetProgress(current,wayDataCount);
@@ -99,7 +99,7 @@ namespace osmscout {
 
       for (uint32_t current=1; current<=relDataCount; current++) {
         uint8_t type;
-        Id      id;
+        OSMId   id;
         Area    data;
 
         progress.SetProgress(current,relDataCount);


### PR DESCRIPTION
ids are written to wayarea.tmp and relarea.tmp as OSMId type (int64_t),
it should be read to identical type
