### PR TITLE
Discard results if no pattern in LocationListModel

### DIFF
--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -57,6 +57,9 @@ LocationListModel::~LocationListModel()
 void LocationListModel::onSearchResult(const QString searchPattern, 
                                        const QList<LocationEntry> foundLocations)
 {
+  if (this->pattern.isEmpty()) {
+      return; //No search requested
+  }
   if (!searchPattern.contains(this->pattern, Qt::CaseInsensitive)){
     return; // result is not for us
   }


### PR DESCRIPTION
This is a very simple fix for Qt client. It prevents unused LocationListModel to catch all searchFinished signals. 