### PR TITLE
Map object info

### DIFF
--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -133,11 +133,11 @@ Window {
             }
 
             onTap: {
-                console.log("tap: " + sceenX + "x" + screenY + " @ " + lat + " " + lon + " (map center "+ map.view.lat + " " + map.view.lon + ")");
+                console.log("tap: " + screenX + "x" + screenY + " @ " + lat + " " + lon + " (map center "+ map.view.lat + " " + map.view.lon + ")");
                 map.focus=true;
             }
             onLongTap: {
-                console.log("long tap: " + sceenX + "x" + screenY + " @ " + lat + " " + lon);
+                console.log("long tap: " + screenX + "x" + screenY + " @ " + lat + " " + lon);
                 map.focus=true;
             }
             onViewChanged: {

--- a/StyleEditor/qml/MapControl.qml
+++ b/StyleEditor/qml/MapControl.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.2
+import QtQuick 2.6
 
 import "custom"
 import net.sf.libosmscout.map 1.0
@@ -33,6 +33,51 @@ Rectangle {
         id: mapObjectInfo
     }
 
+    Rectangle {
+        id: mapObjectInfoPopup
+        visible: false
+        z: 2
+        height: mapObjectInfoView.contentHeight
+        // contentWidth seems don't work...
+        width: Math.max(500, mapObjectInfoView.contentWidth)
+        color: "#ffffff"
+
+        border.width : 1
+        border.color : "#808080"
+
+        ListView {
+            id: mapObjectInfoView
+            model: mapObjectInfo
+            anchors.fill: parent
+            delegate: Row{
+                padding: 2
+                spacing: 5
+                Text {
+                    id: typeLabel
+                    text: (typeof type=="undefined")?"":type
+                }
+                Text {
+                    id: labelLabel
+                    text: (typeof label=="undefined")?"":label
+                }
+                Text {
+                    id: idLabel
+                    text: id+""
+                }
+                Text {
+                    id: nameLabel
+                    text: {
+                      if (typeof name=="undefined"){
+                        return "";
+                      }else{
+                        return "\""+name+"\"";
+                      }
+                    }
+                }
+            }
+        }
+    }
+
     Map {
         id: mapView
         anchors.fill: parent
@@ -42,10 +87,15 @@ Rectangle {
 
         onMouseMove: {
           if (modifiers & Qt.ControlModifier){
-            //console.log("mouse move");
+            //console.log("popup "+mapObjectInfo.rowCount());
             mapObjectInfo.setPosition(mapView.view, 
                                       mapView.width, mapView.height,
                                       screenX, screenY);
+            mapObjectInfoPopup.visible=true;
+            mapObjectInfoPopup.x=screenX;
+            mapObjectInfoPopup.y=screenY;
+          }else{
+            mapObjectInfoPopup.visible=false;
           }
         }
 

--- a/StyleEditor/qml/MapControl.qml
+++ b/StyleEditor/qml/MapControl.qml
@@ -29,13 +29,25 @@ Rectangle {
         mapView.reloadTmpStyle()
     }
 
+    MapObjectInfoModel{
+        id: mapObjectInfo
+    }
 
     Map {
         id: mapView
         anchors.fill: parent
 
         focus: true
-/*
+        property bool shift: false;
+
+        onMouseMove: {
+          if (modifiers & Qt.ControlModifier){
+            console.log("mouse move");
+            mapObjectInfo.setPosition(mapView.view, screenX, screenY);
+          }
+        }
+
+        /*
         Keys.onPressed: {
             if (event.key === Qt.Key_Plus) {
                 mapView.zoomIn(2.0)
@@ -56,7 +68,7 @@ Rectangle {
                 mapView.right()
             }
         }
-*/
+        */
         // Use PinchArea for multipoint zoom in/out?
     }
 

--- a/StyleEditor/qml/MapControl.qml
+++ b/StyleEditor/qml/MapControl.qml
@@ -42,8 +42,10 @@ Rectangle {
 
         onMouseMove: {
           if (modifiers & Qt.ControlModifier){
-            console.log("mouse move");
-            mapObjectInfo.setPosition(mapView.view, screenX, screenY);
+            //console.log("mouse move");
+            mapObjectInfo.setPosition(mapView.view, 
+                                      mapView.width, mapView.height,
+                                      screenX, screenY);
           }
         }
 

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -25,6 +25,7 @@
 // Custom QML objects
 #include "osmscout/MapWidget.h"
 #include "osmscout/SearchLocationModel.h"
+#include "osmscout/MapObjectInfoModel.h"
 #include "FileIO.h"
 
 // Application settings
@@ -57,6 +58,7 @@ int main(int argc, char* argv[])
   qmlRegisterType<MapWidget>("net.sf.libosmscout.map", 1, 0, "Map");
   qmlRegisterType<LocationEntry>("net.sf.libosmscout.map", 1, 0, "Location");
   qmlRegisterType<LocationListModel>("net.sf.libosmscout.map", 1, 0, "LocationListModel");
+  qmlRegisterType<MapObjectInfoModel>("net.sf.libosmscout.map", 1, 0, "MapObjectInfoModel");
   qmlRegisterType<FileIO, 1>("FileIO", 1, 0, "FileIO");
   qmlRegisterType<QmlSettings>("net.sf.libosmscout.map", 1, 0, "Settings");
 

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADER_FILES
     include/osmscout/PersistentCookieJar.h
     include/osmscout/MapManager.h
     include/osmscout/MapDownloadsModel.h
+    include/osmscout/MapObjectInfoModel.h
 )
 
 set(SOURCE_FILES
@@ -61,6 +62,7 @@ set(SOURCE_FILES
     src/osmscout/AvailableMapsModel.cpp
     src/osmscout/MapManager.cpp
     src/osmscout/MapDownloadsModel.cpp
+    src/osmscout/MapObjectInfoModel.cpp
 )
 
 add_library(osmscout_client_qt ${SOURCE_FILES} ${HEADER_FILES})

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -242,6 +242,8 @@ signals:
 
   void searchFinished(const QString searchPattern, bool error);
 
+  void viewObjectsLoaded(const RenderMapRequest&, const osmscout::MapData&);
+
 public slots:
   void ToggleDaylight();
   void ReloadStyle(const QString &suffix="");
@@ -284,7 +286,9 @@ public slots:
    * @param limit - suggested limit for count of retrieved entries from one database
    */
   void SearchForLocations(const QString searchPattern, int limit);
-  
+
+  void requestObjectsOnView(const RenderMapRequest&);
+
 protected:
   MapManagerRef                 mapManager;
 

--- a/libosmscout-client-qt/include/osmscout/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/LocationInfoModel.h
@@ -42,7 +42,7 @@ Q_DECLARE_METATYPE(ObjectKey)
 /**
  * \ingroup QtAPI
  */
-class LocationInfoModel : public QAbstractListModel
+class OSMSCOUT_CLIENT_QT_API LocationInfoModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(bool ready READ isReady NOTIFY readyChange)

--- a/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
@@ -65,19 +65,19 @@ private:
 
   template<class T> void fillObjectInfo(QString type, const T &o)
   {
-    std::cout << " - "<<type.toStdString()<<": " << o->GetType()->GetName() << " " << o->GetObjectFileRef().GetFileOffset();
+    //std::cout << " - "<<type.toStdString()<<": " << o->GetType()->GetName() << " " << o->GetObjectFileRef().GetFileOffset();
     QMap<int, QVariant> info;
     info[LabelRole]=QString::fromStdString(o->GetType()->GetName());
-    info[TypeRole]="node";
+    info[TypeRole]=type;
     info[IdRole]=QVariant::fromValue<uint64_t>(o->GetObjectFileRef().GetFileOffset());
 
     const osmscout::FeatureValueBuffer &features=o->GetFeatureValueBuffer();
     const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
     if (name!=NULL){
       info[NameRole]=QString::fromStdString(name->GetLabel());
-      std::cout << " \"" << name->GetLabel() << "\"";
+      //std::cout << " \"" << name->GetLabel() << "\"";
     }
-    std::cout << std::endl;
+    //std::cout << std::endl;
     model << info;
   }
 

--- a/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
@@ -1,0 +1,115 @@
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2016  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+
+#ifndef MAPOBJECTINFOMODEL_H
+#define MAPOBJECTINFOMODEL_H
+
+#include <QObject>
+#include <QAbstractListModel>
+
+#include <osmscout/GeoCoord.h>
+#include <osmscout/util/GeoBox.h>
+
+#include <osmscout/DBThread.h>
+
+#include <osmscout/LocationInfoModel.h>
+#include <osmscout/private/ClientQtImportExport.h>
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API MapObjectInfoModel: public QAbstractListModel
+{
+  Q_OBJECT
+  Q_PROPERTY(bool ready READ isReady NOTIFY readyChange)
+
+public:
+  enum Roles {
+      LabelRole = Qt::UserRole,
+      TypeRole  = Qt::UserRole+1,
+      IdRole    = Qt::UserRole+2,
+      NameRole  = Qt::UserRole+3,
+  };
+
+signals:
+  void readyChange(bool ready);
+  void objectsRequested(const RenderMapRequest &view);
+
+public slots:
+  void dbInitialized(const DatabaseLoadedResponse&);
+  void setPosition(QObject *mapView,
+                   const int width, const int height,
+                   const int screenX, const int screenY);
+  void onViewObjectsLoaded(const RenderMapRequest&, const osmscout::MapData&);
+
+private:
+  void update();
+
+  template<class T> void fillObjectInfo(QString type, const T &o)
+  {
+    std::cout << " - "<<type.toStdString()<<": " << o->GetType()->GetName() << " " << o->GetObjectFileRef().GetFileOffset();
+    QMap<int, QVariant> info;
+    info[LabelRole]=QString::fromStdString(o->GetType()->GetName());
+    info[TypeRole]="node";
+    info[IdRole]=QVariant::fromValue<uint64_t>(o->GetObjectFileRef().GetFileOffset());
+
+    const osmscout::FeatureValueBuffer &features=o->GetFeatureValueBuffer();
+    const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
+    if (name!=NULL){
+      info[NameRole]=QString::fromStdString(name->GetLabel());
+      std::cout << " \"" << name->GetLabel() << "\"";
+    }
+    std::cout << std::endl;
+    model << info;
+  }
+
+public:
+  MapObjectInfoModel();
+  virtual inline ~MapObjectInfoModel(){};
+
+  Q_INVOKABLE virtual int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const
+  {
+      return model.size();
+  };
+
+  bool inline isReady() const
+  {
+      return ready;
+  };
+
+  Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;
+  virtual QHash<int, QByteArray> roleNames() const;
+  Q_INVOKABLE virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+
+private:
+  bool ready;
+  bool setup;
+  QList<ObjectKey> objectSet; // set of objects already inserted to model
+  QList<QMap<int, QVariant>> model;
+  RenderMapRequest view;
+  int screenX;
+  int screenY;
+  QList<osmscout::MapData> mapData;
+  double mapDpi;
+};
+
+#endif /* MAPOBJECTINFOMODEL_H */
+

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -89,11 +89,12 @@ signals:
   void viewChanged();
   void lockToPossitionChanged();
   void finishedChanged(bool finished);
-  
-  void tap(const int sceenX, const int screenY, const double lat, const double lon);
-  void doubleTap(const int sceenX, const int screenY, const double lat, const double lon);
-  void longTap(const int sceenX, const int screenY, const double lat, const double lon);
-  void tapLongTap(const int sceenX, const int screenY, const double lat, const double lon);
+
+  void mouseMove(const int screenX, const int screenY, const double lat, const double lon, const Qt::KeyboardModifiers modifiers);
+  void tap(const int screenX, const int screenY, const double lat, const double lon);
+  void doubleTap(const int screenX, const int screenY, const double lat, const double lon);
+  void longTap(const int screenX, const int screenY, const double lat, const double lon);
+  void tapLongTap(const int screenX, const int screenY, const double lat, const double lon);
 
   void stylesheetFilenameChanged();
   void styleErrorsChanged();
@@ -258,6 +259,7 @@ public:
   void mousePressEvent(QMouseEvent* event);
   void mouseMoveEvent(QMouseEvent* event);
   void mouseReleaseEvent(QMouseEvent* event);
+  void hoverMoveEvent(QHoverEvent* event);
   
   void paint(QPainter *painter);
   

--- a/libosmscout-client-qt/src/Makefile.am
+++ b/libosmscout-client-qt/src/Makefile.am
@@ -44,7 +44,9 @@ libosmscoutclientqt_la_SOURCES = osmscout/DBThread.cpp \
                                  osmscout/MapManager.cpp \
                                  osmscout/moc_MapManager.cpp \
                                  osmscout/MapDownloadsModel.cpp \
-                                 osmscout/moc_MapDownloadsModel.cpp
+                                 osmscout/moc_MapDownloadsModel.cpp \
+                                 osmscout/MapObjectInfoModel.cpp \
+                                 osmscout/moc_MapObjectInfoModel.cpp
 
 osmscout/moc_%.cpp: $(top_srcdir)/include/osmscout/%.h
 	@MOC@ -o$@ $<

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -770,6 +770,53 @@ void DBThread::SearchForLocations(const QString searchPattern, int limit)
   emit searchFinished(searchPattern, /*error*/ false);
 }
 
+void DBThread::requestObjectsOnView(const RenderMapRequest &view)
+{
+  QMutexLocker locker(&mutex);
+  if (!isInitializedInternal()){
+      return; // ignore request if db is not initialized
+  }
+
+  // setup projection for data lookup
+  osmscout::MercatorProjection lookupProjection;
+  lookupProjection.Set(view.coord, /* angle */ 0, view.magnification, mapDpi, view.width*1.5, view.height*1.5);
+  lookupProjection.SetLinearInterpolationUsage(view.magnification.GetLevel() >= 10);
+
+  osmscout::AreaSearchParameter searchParameter;
+  // https://github.com/Framstag/libosmscout/blob/master/Documentation/RenderTuning.txt
+  if (view.magnification.GetLevel() >= 15) {
+    searchParameter.SetMaximumAreaLevel(6);
+  }
+  else {
+    searchParameter.SetMaximumAreaLevel(4);
+  }
+  searchParameter.SetUseMultithreading(true);
+  searchParameter.SetUseLowZoomOptimization(true);
+
+  for (auto &db:databases){
+    if (!db->database->IsOpen() || (!db->styleConfig)) {
+      continue;
+    }
+    std::list<osmscout::TileRef>  tiles;
+    osmscout::MapData             data;
+
+    osmscout::GeoBox dbBox;
+    db->database->GetBoundingBox(dbBox);
+    osmscout::GeoBox lookupBox;
+    lookupProjection.GetDimensions(lookupBox);
+    if (!dbBox.Intersects(lookupBox)){
+      std::cout << "Skip database" << db->path.toStdString() << std::endl;
+      continue;
+    }
+    db->mapService->LookupTiles(lookupProjection,tiles);
+    // load tiles synchronous
+    db->mapService->LoadMissingTileData(searchParameter,*db->styleConfig,tiles);
+    db->mapService->AddTileDataToMapData(tiles,data);
+
+    emit viewObjectsLoaded(view, data);
+  }
+}
+
 bool DBThread::CalculateRoute(const QString databasePath,
                               const osmscout::RoutingProfile& routingProfile,
                               const osmscout::RoutePosition& start,

--- a/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
@@ -1,0 +1,179 @@
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2016  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <QtCore/qabstractitemmodel.h>
+
+#include <osmscout/MapObjectInfoModel.h>
+
+MapObjectInfoModel::MapObjectInfoModel():
+ready(false), setup(false), view()
+{
+  DBThread *dbThread = DBThread::GetInstance();
+  this->mapDpi=dbThread->GetMapDpi();
+
+  qRegisterMetaType<osmscout::MapData>("osmscout::MapData");
+
+  connect(dbThread, SIGNAL(InitialisationFinished(const DatabaseLoadedResponse&)),
+          this, SLOT(dbInitialized(const DatabaseLoadedResponse&)),
+          Qt::QueuedConnection);
+
+  connect(this, SIGNAL(objectsRequested(const RenderMapRequest &)),
+          dbThread, SLOT(requestObjectsOnView(const RenderMapRequest&)),
+          Qt::QueuedConnection);
+
+  connect(dbThread, SIGNAL(viewObjectsLoaded(const RenderMapRequest&, const osmscout::MapData&)),
+          this, SLOT(onViewObjectsLoaded(const RenderMapRequest&, const osmscout::MapData&)),
+          Qt::QueuedConnection);
+}
+
+void MapObjectInfoModel::dbInitialized(const DatabaseLoadedResponse&)
+{
+  if (setup){
+    emit objectsRequested(view);
+  }
+}
+
+Qt::ItemFlags MapObjectInfoModel::flags(const QModelIndex &index) const
+{
+  if(!index.isValid()) {
+      return Qt::ItemIsEnabled;
+  }
+
+  return QAbstractListModel::flags(index) | Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+}
+
+QHash<int, QByteArray> MapObjectInfoModel::roleNames() const
+{
+  QHash<int, QByteArray> roles=QAbstractListModel::roleNames();
+
+  roles[LabelRole]="label";
+  roles[TypeRole] ="type";
+  
+  return roles;
+}
+
+QVariant MapObjectInfoModel::data(const QModelIndex &index, int role) const
+{
+  qDebug() << "Get data" << index.row() << " role: " << role << " (label: " << LabelRole<< ")";
+
+  if(index.row() < 0 || index.row() >= model.size()) {
+    return QVariant();
+  }
+  QMap<int, QVariant> obj = model.at(index.row());
+  if (!obj.contains(role)){
+    return QVariant();
+  }
+  return obj[role];
+}
+
+void MapObjectInfoModel::setPosition(QObject *o,
+                                     const int width, const int height,
+                                     const int screenX, const int screenY)
+{
+  MapView *mapView = dynamic_cast<MapView*>(o);
+  if (mapView == NULL){
+      qWarning() << "Failed to cast " << o << " to MapView*.";
+      return;
+  }
+  RenderMapRequest r;
+  r.angle=mapView->angle;
+  r.coord=mapView->center;
+  r.width=width;
+  r.height=height;
+  r.magnification=mapView->magnification;
+
+  this->screenX=screenX;
+  this->screenY=screenY;
+
+  if (this->view!=r){
+    this->view=r;
+    beginResetModel();
+    model.clear();
+    mapData.clear();
+    endResetModel();
+    emit objectsRequested(view);
+  }else{
+    update();
+  }
+  setup=true;
+}
+
+void MapObjectInfoModel::onViewObjectsLoaded(const RenderMapRequest &view,
+                                             const osmscout::MapData &data)
+{
+  if (this->view!=view){
+    return;
+  }
+  mapData << data;
+  update();
+}
+
+void MapObjectInfoModel::update()
+{
+  osmscout::MercatorProjection projection;
+  projection.Set(view.coord, /* angle */ 0, view.magnification, mapDpi, view.width, view.height);
+  projection.SetLinearInterpolationUsage(view.magnification.GetLevel() >= 10);
+
+  beginResetModel();
+
+  std::cout << "object near " << this->screenX << " " << this->screenY << ":" << std::endl;
+
+  double x;
+  double y;
+  double x2;
+  double y2;
+  double tolerance=mapDpi/4;
+  QRectF rectangle(this->screenX-tolerance, this->screenY-tolerance, tolerance*2, tolerance*2);
+  for (auto const &d:mapData){
+
+    //std::cout << "nodes: " << d.nodes.size() << std::endl;
+    for (auto const &n:d.nodes){
+      projection.GeoToPixel(n->GetCoords(),x,y);
+      if (rectangle.contains(x,y)){
+        fillObjectInfo("node",n);
+      }
+    }
+
+    std::cout << "ways:  " << d.ways.size() << std::endl;
+    for (auto const &w:d.ways){
+      // TODO: better detection
+      osmscout::GeoBox bbox;
+      w->GetBoundingBox(bbox);
+      projection.GeoToPixel(bbox.GetMinCoord(),x,y);
+      projection.GeoToPixel(bbox.GetMaxCoord(),x2,y2);
+      if (rectangle.intersects(QRectF(QPointF(x,y),QPointF(x2,y2)))){
+        fillObjectInfo("way",w);
+      }
+    }
+
+    std::cout << "areas: " << d.areas.size() << std::endl;
+    for (auto const &a:d.areas){
+      // TODO: better detection
+      osmscout::GeoBox bbox;
+      a->GetBoundingBox(bbox);
+      projection.GeoToPixel(bbox.GetMinCoord(),x,y);
+      projection.GeoToPixel(bbox.GetMaxCoord(),x2,y2);
+      if (rectangle.intersects(QRectF(QPointF(x,y),QPointF(x2,y2)))){
+        fillObjectInfo("area",a);
+      }
+    }
+  }
+  endResetModel();
+}

--- a/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
@@ -65,19 +65,23 @@ QHash<int, QByteArray> MapObjectInfoModel::roleNames() const
 
   roles[LabelRole]="label";
   roles[TypeRole] ="type";
+  roles[IdRole]   ="id";
+  roles[NameRole] ="name";
   
   return roles;
 }
 
 QVariant MapObjectInfoModel::data(const QModelIndex &index, int role) const
 {
-  qDebug() << "Get data" << index.row() << " role: " << role << " (label: " << LabelRole<< ")";
+  //qDebug() << "Get data" << index.row() << " role: " << role;
 
   if(index.row() < 0 || index.row() >= model.size()) {
+    qDebug() << "Undefined row" << index.row();
     return QVariant();
   }
   QMap<int, QVariant> obj = model.at(index.row());
   if (!obj.contains(role)){
+    //qDebug() << "Undefined role" << role << "("<<LabelRole<<"..."<<NameRole<<")";
     return QVariant();
   }
   return obj[role];
@@ -132,8 +136,8 @@ void MapObjectInfoModel::update()
   projection.SetLinearInterpolationUsage(view.magnification.GetLevel() >= 10);
 
   beginResetModel();
-
-  std::cout << "object near " << this->screenX << " " << this->screenY << ":" << std::endl;
+  model.clear();
+  //std::cout << "object near " << this->screenX << " " << this->screenY << ":" << std::endl;
 
   double x;
   double y;
@@ -151,7 +155,7 @@ void MapObjectInfoModel::update()
       }
     }
 
-    std::cout << "ways:  " << d.ways.size() << std::endl;
+    //std::cout << "ways:  " << d.ways.size() << std::endl;
     for (auto const &w:d.ways){
       // TODO: better detection
       osmscout::GeoBox bbox;
@@ -163,7 +167,7 @@ void MapObjectInfoModel::update()
       }
     }
 
-    std::cout << "areas: " << d.areas.size() << std::endl;
+    //std::cout << "areas: " << d.areas.size() << std::endl;
     for (auto const &a:d.areas){
       // TODO: better detection
       osmscout::GeoBox bbox;
@@ -175,5 +179,6 @@ void MapObjectInfoModel::update()
       }
     }
   }
+  //std::cout << "count: "<< model.size() << std::endl;
   endResetModel();
 }

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -37,6 +37,7 @@ MapWidget::MapWidget(QQuickItem* parent)
 {
     setOpaquePainting(true);
     setAcceptedMouseButtons(Qt::LeftButton);
+    setAcceptHoverEvents(true);
     
     DBThread *dbThread=DBThread::GetInstance();
     
@@ -103,6 +104,14 @@ void MapWidget::mousePressEvent(QMouseEvent* event)
 void MapWidget::mouseMoveEvent(QMouseEvent* event)
 {
     translateToTouch(event, Qt::TouchPointMoved);
+}
+void MapWidget::hoverMoveEvent(QHoverEvent* event) {
+    QQuickPaintedItem::hoverMoveEvent(event);
+
+    double lat;
+    double lon;
+    getProjection().PixelToGeo(event->pos().x(), event->pos().y(), lon, lat);
+    emit mouseMove(event->pos().x(), event->pos().y(), lat, lon, event->modifiers());
 }
 void MapWidget::mouseReleaseEvent(QMouseEvent* event)
 {


### PR DESCRIPTION
Hi. I wanted to investigate what "marina" area covers Italy... I was adding some prints to code and try to guess what object it is usually. But it is not friendly way for new user. So I created popup to StyleEditor that shows details for objects on the map when Ctrl key is pressed and mouse is moving:

![map-object-info-popup](https://cloud.githubusercontent.com/assets/309458/22820879/ef092bfe-ef78-11e6-8f29-389ba8305e98.png)
