### PR TITLE
Optimise place description

### DIFF
--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -514,7 +514,7 @@ namespace osmscout {
                        const double maxDistance=100);
 
     /**
-     * @see LoadNearNodes
+     * @see LoadNearAreas
      */
     bool LoadNearNodes(const GeoCoord& location, const TypeInfoSet &types,
                        std::vector<LocationDescriptionCandicate> &candidates,
@@ -522,15 +522,18 @@ namespace osmscout {
 
     bool DescribeLocationByName(const GeoCoord& location,
                                 LocationDescription& description,
-                                const double lookupDistance=100);
+                                const double lookupDistance=100,
+                                const double sizeFilter=1.0);
 
     bool DescribeLocationByAddress(const GeoCoord& location,
                                    LocationDescription& description,
-                                   const double lookupDistance=100);
+                                   const double lookupDistance=100,
+                                   const double sizeFilter=1.0);
 
     bool DescribeLocationByPOI(const GeoCoord& location,
                                LocationDescription& description,
-                               const double lookupDistance=100);
+                               const double lookupDistance=100,
+                               const double sizeFilter=1.0);
   };
 
   //! \ingroup Service

--- a/libosmscout/include/osmscout/util/GeoBox.h
+++ b/libosmscout/include/osmscout/util/GeoBox.h
@@ -100,8 +100,8 @@ namespace osmscout {
      * @return
      *    True, if there is intersection, else false.
      */
-    inline bool Includes(const GeoCoord& coord,
-                         bool openInterval=true) const
+    template<typename P> inline bool Includes(const P& coord,
+                                              bool openInterval=true) const
     {
       if (openInterval) {
         return minCoord.GetLat()<=coord.GetLat() &&

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -371,15 +371,37 @@ namespace osmscout {
    */
   template<typename N,typename M>
   inline bool IsAreaAtLeastPartlyInArea(const std::vector<N>& a,
-                                        const std::vector<M>& b)
-  {
+                                        const std::vector<M>& b,
+                                        const GeoBox aBox,
+                                        const GeoBox bBox)
+   {
+    if (!aBox.Intersects(bBox)){
+      return false;
+    }
+
     for (const auto& node : a) {
-      if (GetRelationOfPointToArea(node,b)>=0) {
+      if (bBox.Includes(node, /*openInterval*/ false) && GetRelationOfPointToArea(node,b)>=0) {
         return true;
       }
     }
 
     return false;
+  }
+
+  /**
+   * \ingroup Geometry
+   * Return true, if at least one point of area a in within area b
+   */
+  template<typename N,typename M>
+  inline bool IsAreaAtLeastPartlyInArea(const std::vector<N>& a,
+                                        const std::vector<M>& b)
+  {
+    GeoBox aBox;
+    GeoBox bBox;
+    GetBoundingBox(a, aBox);
+    GetBoundingBox(b, bBox);
+
+    return IsAreaAtLeastPartlyInArea(a,b,aBox,bBox);
   }
 
   /**

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -1031,6 +1031,7 @@ namespace osmscout {
     {
       ObjectFileRef         object;
       std::vector<GeoCoord> coords;
+      GeoBox                bbox;
     };
 
   private:
@@ -1101,8 +1102,12 @@ namespace osmscout {
             }
           }
           else {
+            GeoBox ringBBox;
+            area->rings[r].GetBoundingBox(ringBBox);
             if (!IsAreaAtLeastPartlyInArea(entry.coords,
-                                           area->rings[r].nodes)) {
+                                           area->rings[r].nodes,
+                                           entry.bbox,
+                                           ringBBox)) {
               continue;
             }
           }
@@ -1309,6 +1314,7 @@ namespace osmscout {
             AdminRegionReverseLookupVisitor::SearchEntry searchEntry;
 
             searchEntry.object=object;
+            area->rings[r].GetBoundingBox(searchEntry.bbox);
 
             searchEntry.coords.resize(area->rings[r].nodes.size());
 
@@ -1331,6 +1337,7 @@ namespace osmscout {
         AdminRegionReverseLookupVisitor::SearchEntry searchEntry;
 
         searchEntry.object=object;
+        way->GetBoundingBox(searchEntry.bbox);
 
         searchEntry.coords.resize(way->nodes.size());
 

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -1578,7 +1578,8 @@ namespace osmscout {
 
   bool LocationService::DescribeLocationByName(const GeoCoord& location,
                                                LocationDescription& description,
-                                               const double lookupDistance)
+                                               const double lookupDistance,
+                                               const double sizeFilter)
   {
     // search all addressable areas and nodes, sort it by distance, get first with name
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1636,7 +1637,7 @@ namespace osmscout {
     for (const auto &candidate : candidates) {
       std::list<ReverseLookupResult> result;
 
-      if (candidate.GetName().empty()) {
+      if (candidate.GetSize() > sizeFilter || candidate.GetName().empty()) {
         continue;
       }
 
@@ -1691,7 +1692,8 @@ namespace osmscout {
 
   bool LocationService::DescribeLocationByAddress(const GeoCoord& location,
                                                   LocationDescription& description,
-                                                  const double lookupDistance)
+                                                  const double lookupDistance,
+                                                  const double sizeFilter)
   {
     // search all addressable areas and nodes, sort it by distance, get first with address
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1747,8 +1749,11 @@ namespace osmscout {
     std::sort(candidates.begin(),candidates.end(),DistanceComparator);
 
     for (const auto &candidate : candidates) {
-      std::list<ReverseLookupResult> result;
+      if (candidate.GetSize() > sizeFilter){
+        continue;
+      }
 
+      std::list<ReverseLookupResult> result;
       if (!ReverseLookupObject(candidate.GetRef(), result)) {
         return false;
       }
@@ -1776,7 +1781,8 @@ namespace osmscout {
 
   bool LocationService::DescribeLocationByPOI(const GeoCoord& location,
                                               LocationDescription& description,
-                                              const double lookupDistance)
+                                              const double lookupDistance,
+                                              const double sizeFilter)
   {
     // search all addressable areas and nodes, sort it by distance, get first with address
     TypeConfigRef typeConfig=database->GetTypeConfig();
@@ -1831,8 +1837,11 @@ namespace osmscout {
     std::sort(candidates.begin(),candidates.end(),DistanceComparator);
 
     for (const auto &candidate : candidates) {
-      std::list<ReverseLookupResult> result;
+      if (candidate.GetSize() > sizeFilter){
+        continue;
+      }
 
+      std::list<ReverseLookupResult> result;
       if (!ReverseLookupObject(candidate.GetRef(), result)) {
         return false;
       }


### PR DESCRIPTION
Hi. 

I experimented with Italy map with badly detected "leisure_marina" area (issue https://github.com/Framstag/libosmscout/issues/250 ) and find out that location description don't work with it. Marina is defined as POI, and this one has 205547 nodes! `Geometry::IsAreaAtLeastPartlyInArea` method that is used in reverse location lookup is extremely slow for such huge areas. 

I tried it with `LocationDescription` demo, on PC with Intel i7 CPU: 
```time ./Demos/LocationDescription italy 46.50089 11.91746```

With master branch, it was running 10 hours and don't finish!
It tooks 50 minutes after first optimisation https://github.com/Karry/libosmscout/commit/543960ddd2d794002e529a7e4608e1d9e3752491 
```
real    51m26.252s
user    1m14.019s
sys     41m6.028s
```
Then I precompute bounding boxes for both areas https://github.com/Karry/libosmscout/commit/266c8493cc0064fec12ab713a8321ad4784770d7
```
real    32m24.321s
user    0m18.407s
sys     21m12.008s
```
It was better, but still too slow for real usage in applications, so I add size filter https://github.com/Karry/libosmscout/commit/64752206c1d3e9a3f5d49d75df278966dddaa10b to `DescribeLocationBy*` methods. 
When this huge area is filtered out, demo is finished after 10 seconds
```
real    0m10.672s
user    0m0.000s
sys     0m6.200s
```

Please take a look to my changes, especially to `Geometry` methods.