### PR TITLE
WIP: limit usage of mmap on 32 bit systems

### DIFF
--- a/libosmscout/include/osmscout/Database.h
+++ b/libosmscout/include/osmscout/Database.h
@@ -82,6 +82,11 @@ namespace osmscout {
     unsigned long nodeDataCacheSize;
     unsigned long wayDataCacheSize;
     unsigned long areaDataCacheSize;
+
+    bool routerDataMMap;
+    bool nodesDataMMap;
+    bool areasDataMMap;
+    bool waysDataMMap;
   public:
     DatabaseParameter();
 
@@ -93,6 +98,11 @@ namespace osmscout {
     void SetOptimisedWaysDataCacheSize(unsigned long  size);
     void SetOptimisedAreasDataCacheSize(unsigned long  size);
 
+    void SetRouterDataMMap(bool mmap);
+    void SetNodesDataMMap(bool mmap);
+    void SetAreasDataMMap(bool mmap);
+    void SetWaysDataMMap(bool mmap);
+
     unsigned long GetAreaAreaIndexCacheSize() const;
     unsigned long GetAreaNodeIndexCacheSize() const;
     unsigned long GetNodeDataCacheSize() const;
@@ -100,6 +110,11 @@ namespace osmscout {
     unsigned long GetAreaDataCacheSize() const;
     unsigned long GetOptimisedWaysDataCacheSize() const;
     unsigned long GetOptimisedAreasDataCacheSize() const;
+
+    bool GetRouterDataMMap() const;
+    bool GetNodesDataMMap() const;
+    bool GetAreasDataMMap() const;
+    bool GetWaysDataMMap() const;
   };
 
   /**
@@ -166,6 +181,11 @@ namespace osmscout {
 
     std::string GetPath() const;
     TypeConfigRef GetTypeConfig() const;
+
+    inline bool GetRouterDataMMap() const
+    {
+      return parameter.GetRouterDataMMap();
+    };
 
     BoundingBoxDataFileRef GetBoundingBoxDataFile() const;
 

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -39,7 +39,11 @@ namespace osmscout {
     areaNodeIndexCacheSize(1000),
     nodeDataCacheSize(5000),
     wayDataCacheSize(10000),
-    areaDataCacheSize(5000)
+    areaDataCacheSize(5000),
+    routerDataMMap(true),
+    nodesDataMMap(true),
+    areasDataMMap(true),
+    waysDataMMap(true)
   {
     // no code
   }
@@ -69,6 +73,26 @@ namespace osmscout {
     this->areaDataCacheSize=size;
   }
 
+  void DatabaseParameter::SetRouterDataMMap(bool mmap)
+  {
+    routerDataMMap=mmap;
+  }
+
+  void DatabaseParameter::SetNodesDataMMap(bool mmap)
+  {
+    nodesDataMMap=mmap;
+  }
+
+  void DatabaseParameter::SetAreasDataMMap(bool mmap)
+  {
+    areasDataMMap=mmap;
+  }
+
+  void DatabaseParameter::SetWaysDataMMap(bool mmap)
+  {
+    waysDataMMap=mmap;
+  }
+
   unsigned long DatabaseParameter::GetAreaAreaIndexCacheSize() const
   {
     return areaAreaIndexCacheSize;
@@ -92,6 +116,26 @@ namespace osmscout {
   unsigned long DatabaseParameter::GetAreaDataCacheSize() const
   {
     return areaDataCacheSize;
+  }
+
+  bool DatabaseParameter::GetRouterDataMMap() const
+  {
+    return routerDataMMap;
+  }
+
+  bool DatabaseParameter::GetNodesDataMMap() const
+  {
+    return nodesDataMMap;
+  }
+
+  bool DatabaseParameter::GetAreasDataMMap() const
+  {
+    return areasDataMMap;
+  }
+
+  bool DatabaseParameter::GetWaysDataMMap() const
+  {
+    return waysDataMMap;
   }
 
   Database::Database(const DatabaseParameter& parameter)
@@ -247,7 +291,7 @@ namespace osmscout {
 
       if (!nodeDataFile->Open(typeConfig,
                               path,
-                              true)) {
+                              parameter.GetNodesDataMMap())) {
         log.Error() << "Cannot open 'nodes.dat'!";
         return NULL;
       }
@@ -277,7 +321,7 @@ namespace osmscout {
 
       if (!areaDataFile->Open(typeConfig,
                               path,
-                              true)) {
+                              parameter.GetAreasDataMMap())) {
         log.Error() << "Cannot open 'areas.dat'!";
         return NULL;
       }
@@ -307,7 +351,7 @@ namespace osmscout {
 
       if (!wayDataFile->Open(typeConfig,
                              path,
-                             true)) {
+                             parameter.GetWaysDataMMap())) {
         log.Error() << "Cannot open 'ways.dat'!";
         return NULL;
       }

--- a/libosmscout/src/osmscout/RoutingService.cpp
+++ b/libosmscout/src/osmscout/RoutingService.cpp
@@ -173,7 +173,7 @@ namespace osmscout {
     if (!routeNodeDataFile.Open(database->GetTypeConfig(),
                                 path,
                                 true,
-                                true)) {
+                                database->GetRouterDataMMap())) {
       log.Error() << "Cannot open '" <<  path << "'!";
       return false;
     }


### PR DESCRIPTION
Hi. 

My app is crashing randomly on my phone (32 bit ARMv7) with multiple databases. `strace` shows sad true about exhausted memory space:
```
open("/dev/kgsl-3d0", O_RDWR|O_SYNC)    = 6
mmap2(0xbe950000, 1597440, PROT_READ|PROT_WRITE, MAP_SHARED, 6, 0x14e14000) = -1 ENOMEM (Cannot allocate memory)
exit_group(1) 
+++ exited with 1 +++
```
Crashes occurs when mmaped space is around 2 GiB. This MR adds new parameters to `DatabaseParameter` to control if data files can be mapped. Database loading in `DBThread` is extended by nasty code that compute database file sizes and prohibit mmap of data files when mmap-ed size can exceed 1.5 GiB...

Please wait a bit with merging, I will try to use it few days...