### PR TITLE
fix qt warning

### DIFF
--- a/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
@@ -49,10 +49,8 @@ class OSMSCOUT_CLIENT_QT_API PlaneDBThread : public DBThread
   Q_OBJECT
   
 signals:
-  void TriggerDrawMap();
   void TileStatusChanged(const osmscout::TileRef& tile);
   void TriggerMapRenderingSignal(const RenderMapRequest& request);
-  void TriggerInitialRendering();
   
 public slots:
   void DrawMap();


### PR DESCRIPTION
dont overload signals