### PR TITLE
make map font configurable from QML

### DIFF
--- a/OSMScout2/CMakeLists.txt
+++ b/OSMScout2/CMakeLists.txt
@@ -33,10 +33,12 @@ set(OSMSCOUT_USER_AGENT "OSMScout demo app %1")
 
 set(HEADER_FILES
     src/Theme.h
+    src/AppSettings.h
 )
 
 set(SOURCE_FILES
     src/Theme.cpp
+    src/AppSettings.cpp
     src/OSMScout.cpp
 
     # qml files in CMake sources make it visible in QtCreator

--- a/OSMScout2/OSMScout.pro
+++ b/OSMScout2/OSMScout.pro
@@ -29,9 +29,11 @@ RCC_DIR = $$DESTDIR/
 UI_DIR = $$DESTDIR/
 
 SOURCES = src/OSMScout.cpp \
-          src/Theme.cpp
+          src/Theme.cpp \
+          src/AppSettings.cpp
 
-HEADERS = src/Theme.h
+HEADERS = src/Theme.h \
+          src/AppSettings.h
 
 DISTFILES += \
     qml/custom/MapButton.qml \

--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -100,6 +100,9 @@ Window {
         id: settings
         //mapDPI: 50
     }
+    AppSettings{
+        id: appSettings
+    }
 
     GridLayout {
         id: content
@@ -120,15 +123,15 @@ Window {
 
             function setupInitialPosition(){
                 if (map.databaseLoaded){
-                  if (map.isInDatabaseBoundingBox(settings.mapView.lat, settings.mapView.lon)){
-                    map.view = settings.mapView;
-                    console.log("restore last position: " + settings.mapView.lat + " " + settings.mapView.lon);
+                  if (map.isInDatabaseBoundingBox(appSettings.mapView.lat, appSettings.mapView.lon)){
+                    map.view = appSettings.mapView;
+                    console.log("restore last position: " + appSettings.mapView.lat + " " + appSettings.mapView.lon);
                   }else{
-                    console.log("position " + settings.mapView.lat + " " + settings.mapView.lon + " is outside database, recenter");
+                    console.log("position " + appSettings.mapView.lat + " " + appSettings.mapView.lon + " is outside database, recenter");
                     map.recenter();
                   }
                 }else{
-                  map.view = settings.mapView;
+                  map.view = appSettings.mapView;
                 }
             }
 
@@ -142,7 +145,7 @@ Window {
             }
             onViewChanged: {
                 //console.log("map center "+ map.view.lat + " " + map.view.lon + "");
-                settings.mapView = map.view;
+                appSettings.mapView = map.view;
             }
             Component.onCompleted: {
                 setupInitialPosition();

--- a/OSMScout2/src/AppSettings.cpp
+++ b/OSMScout2/src/AppSettings.cpp
@@ -1,0 +1,74 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <QDebug>
+
+#include <osmscout/InputHandler.h>
+
+#include "AppSettings.h"
+
+AppSettings::AppSettings(): view(NULL)
+{
+}
+
+MapView *AppSettings::GetMapView()
+{
+  if (view == NULL){
+    double lat   = settings.value("settings/map/lat",   0).toDouble();
+    double lon   = settings.value("settings/map/lon",   0).toDouble();
+    double angle = settings.value("settings/map/angle", 0).toDouble();
+    double mag   = settings.value("settings/map/mag",   osmscout::Magnification::magContinent).toDouble();
+    view = new MapView(this,
+              osmscout::GeoCoord(lat, lon),
+              angle,
+              osmscout::Magnification(mag)
+              );
+  }
+  return view;
+}
+
+void AppSettings::SetMapView(QObject *o)
+{
+  MapView *updated = dynamic_cast<MapView*>(o);
+  if (updated == NULL){
+    qWarning() << "Failed to cast " << o << " to MapView*.";
+    return;
+  }
+  bool changed = false;
+  if (view == NULL){
+    view = new MapView(this,
+              osmscout::GeoCoord(updated->GetLat(), updated->GetLon()),
+              updated->GetAngle(),
+              osmscout::Magnification(updated->GetMag())
+              );
+    changed = true;
+  }else{
+    changed = *view != *updated;
+    if (changed){
+        view->operator =( *updated );
+    }
+  }
+  if (changed){
+    settings.setValue("settings/map/lat", view->GetLat());
+    settings.setValue("settings/map/lon", view->GetLon());
+    settings.setValue("settings/map/angle", view->GetAngle());
+    settings.setValue("settings/map/mag", view->GetMag());
+    emit MapViewChanged(view);
+  }
+}

--- a/OSMScout2/src/AppSettings.h
+++ b/OSMScout2/src/AppSettings.h
@@ -1,0 +1,47 @@
+#ifndef APPSETTINGS_H
+#define APPSETTINGS_H
+
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <QSettings>
+
+#include <osmscout/InputHandler.h>
+
+class AppSettings: public QObject{
+  Q_OBJECT
+  Q_PROPERTY(QObject  *mapView  READ GetMapView WRITE SetMapView  NOTIFY MapViewChanged)
+
+signals:
+  void MapViewChanged(MapView *view);
+
+public:
+  AppSettings();
+  inline virtual ~AppSettings(){};
+
+  MapView *GetMapView();
+  void SetMapView(QObject *view);
+
+private:
+  QSettings settings;
+  MapView   *view;
+};
+
+#endif /* APPSETTINGS_H */
+

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -37,6 +37,8 @@
 // Application theming
 #include "Theme.h"
 
+#include "AppSettings.h"
+
 #include <osmscout/util/Logger.h>
 
 Q_DECLARE_METATYPE(osmscout::TileRef)
@@ -74,6 +76,7 @@ int main(int argc, char* argv[])
   qmlRegisterType<RouteStep>("net.sf.libosmscout.map", 1, 0, "RouteStep");
   qmlRegisterType<RoutingListModel>("net.sf.libosmscout.map", 1, 0, "RoutingListModel");
   qmlRegisterType<QmlSettings>("net.sf.libosmscout.map", 1, 0, "Settings");
+  qmlRegisterType<AppSettings>("net.sf.libosmscout.map", 1, 0, "AppSettings");
   qmlRegisterType<AvailableMapsModel>("net.sf.libosmscout.map", 1, 0, "AvailableMapsModel");
   qmlRegisterType<MapDownloadsModel>("net.sf.libosmscout.map", 1, 0, "MapDownloadsModel");
 
@@ -82,10 +85,11 @@ int main(int argc, char* argv[])
   osmscout::log.Debug(false);
   osmscout::log.Info(false);
 
+  SettingsRef settings=std::make_shared<Settings>();
   // load online tile providers
-  Settings::GetInstance()->loadOnlineTileProviders(
+  settings->loadOnlineTileProviders(
     ":/resources/online-tile-providers.json");
-  Settings::GetInstance()->loadMapProviders(
+  settings->loadMapProviders(
     ":/resources/map-providers.json");
 
   QThread thread;
@@ -106,8 +110,8 @@ int main(int argc, char* argv[])
 
   if (cmdLineArgs.size() > 2){
     QFileInfo stylesheetFile(cmdLineArgs.at(2));
-    Settings::GetInstance()->SetStyleSheetDirectory(stylesheetFile.dir().path());
-    Settings::GetInstance()->SetStyleSheetFile(stylesheetFile.fileName());
+    settings->SetStyleSheetDirectory(stylesheetFile.dir().path());
+    settings->SetStyleSheetFile(stylesheetFile.fileName());
   }
 
   QString iconDirectory;
@@ -126,6 +130,7 @@ int main(int argc, char* argv[])
   if (!DBThread::InitializeTiledInstance(
           mapLookupDirectories,
           iconDirectory,
+          renderingSettings,
           cacheLocation + QDir::separator() + "OSMScoutTileCache",
           / onlineTileCacheSize  / 100,
           / offlineTileCacheSize / 200
@@ -136,7 +141,8 @@ int main(int argc, char* argv[])
 */
   if (!DBThread::InitializePlaneInstance(
           mapLookupDirectories,
-          iconDirectory
+          iconDirectory,
+          settings
       )) {
     std::cerr << "Cannot initialize DBThread" << std::endl;
     return 1;
@@ -159,7 +165,6 @@ int main(int argc, char* argv[])
   thread.wait();
 
   DBThread::FreeInstance();
-  Settings::FreeInstance();
 
   return result;
 }

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -65,7 +65,8 @@ int main(int argc, char* argv[])
   QThread thread;
   
   // load online tile providers
-  Settings::GetInstance()->loadOnlineTileProviders(
+  SettingsRef settings=std::make_shared<Settings>();
+  settings->loadOnlineTileProviders(
     ":/resources/online-tile-providers.json");
 
   // setup paths
@@ -83,8 +84,8 @@ int main(int argc, char* argv[])
   
   if (cmdLineArgs.size() > 2){
     QFileInfo stylesheetFile(cmdLineArgs.at(2));
-    Settings::GetInstance()->SetStyleSheetDirectory(stylesheetFile.dir().path());
-    Settings::GetInstance()->SetStyleSheetFile(stylesheetFile.fileName());
+    settings->SetStyleSheetDirectory(stylesheetFile.dir().path());
+    settings->SetStyleSheetFile(stylesheetFile.fileName());
   }
   
   QString iconDirectory;
@@ -101,6 +102,7 @@ int main(int argc, char* argv[])
   if (!DBThread::InitializeTiledInstance(
           mapLookupDirectories,
           iconDirectory,
+          settings,
           cacheLocation + QDir::separator() + "OSMScoutTileCache",
           /* onlineTileCacheSize  */ 100,
           /* offlineTileCacheSize */ 200
@@ -131,7 +133,6 @@ int main(int argc, char* argv[])
   thread.wait();
 
   DBThread::FreeInstance();
-  Settings::FreeInstance();
 
   return result;
 }

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -294,6 +294,7 @@ public slots:
 
 protected:
   MapManagerRef                 mapManager;
+  SettingsRef                   settings;
 
   double                        mapDpi;
   double                        physicalDpi;
@@ -321,7 +322,9 @@ protected:
 
 protected:
   
-  DBThread(QStringList databaseLookupDirectories, QString iconDirectory);
+  DBThread(QStringList databaseLookupDirectories,
+           QString iconDirectory,
+           SettingsRef settings);
 
   virtual ~DBThread();
 
@@ -409,6 +412,11 @@ public:
     return mapManager;
   }
 
+  inline SettingsRef GetSettings() const
+  {
+    return settings;
+  }
+
   inline QString GetStylesheetFilename() const
   {
     return stylesheetFilename;
@@ -426,12 +434,14 @@ public:
   
   static bool InitializeTiledInstance(QStringList databaseDirectory, 
                                       QString iconDirectory,
+                                      SettingsRef settings,
                                       QString tileCacheDirectory,
                                       size_t onlineTileCacheSize = 20, 
                                       size_t offlineTileCacheSize = 50);
 
   static bool InitializePlaneInstance(QStringList databaseDirectory, 
-                                      QString iconDirectory);
+                                      QString iconDirectory,
+                                      SettingsRef settings);
   
   static DBThread* GetInstance();
   static void FreeInstance();

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -269,7 +269,9 @@ public slots:
   void requestLocationDescription(const osmscout::GeoCoord location);
 
   virtual void onMapDPIChange(double dpi);
-  virtual void onRenderSeaChanged(bool);  
+  virtual void onRenderSeaChanged(bool);
+  virtual void onFontNameChanged(const QString);
+  virtual void onFontSizeChanged(double);
 
   /**
    * Start object search by some pattern. 
@@ -313,6 +315,9 @@ protected:
 
   bool                          renderError;
   QList<StyleError>             styleErrors;
+
+  QString                       fontName;
+  double                        fontSize;
 
 protected:
   

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -30,6 +30,8 @@
 #include <osmscout/util/GeoBox.h>
 #include <osmscout/util/Magnification.h>
 
+#include <osmscout/private/ClientQtImportExport.h>
+
 /**
  * \ingroup QtAPI
  *
@@ -48,7 +50,7 @@
  * this tolerance. For double tap, when second tap is farther than this tolerance,
  * double-tap event is not emited.
  */
-class TapRecognizer : public QObject{
+class OSMSCOUT_CLIENT_QT_API TapRecognizer : public QObject{
   Q_OBJECT
 
 private:
@@ -152,7 +154,7 @@ public:
  *
  * Object thats carry information about view center, angle and magnification.
  */
-class MapView: public QObject
+class OSMSCOUT_CLIENT_QT_API MapView: public QObject
 {
   Q_OBJECT
 
@@ -227,7 +229,7 @@ inline bool operator!=(const MapView& a, const MapView& b)
  *
  * Handler also controls map animations.
  */
-class InputHandler : public QObject{
+class OSMSCOUT_CLIENT_QT_API InputHandler : public QObject{
     Q_OBJECT
 public:
     InputHandler(MapView view);
@@ -258,7 +260,7 @@ protected:
  * Handler with support of simple moves and zoom.
  * View changes are animated, so one action may emits many of viewChange signals.
  */
-class MoveHandler : public InputHandler {
+class OSMSCOUT_CLIENT_QT_API MoveHandler : public InputHandler {
     Q_OBJECT
 
 private:
@@ -304,7 +306,7 @@ private:
  *
  * Input handler that animates jumps to target map view.
  */
-class JumpHandler : public InputHandler {
+class OSMSCOUT_CLIENT_QT_API JumpHandler : public InputHandler {
     Q_OBJECT
 
 private:
@@ -332,7 +334,7 @@ public:
  *
  * InputHandler with support of dragg gesture.
  */
-class DragHandler : public MoveHandler {
+class OSMSCOUT_CLIENT_QT_API DragHandler : public MoveHandler {
     Q_OBJECT
 public:
     DragHandler(MapView view, double dpi);
@@ -362,7 +364,7 @@ private:
  * InputHandler with support of multitouch input. It use just first two
  * touch points from touch events.
  */
-class MultitouchHandler : public MoveHandler {
+class OSMSCOUT_CLIENT_QT_API MultitouchHandler : public MoveHandler {
     Q_OBJECT
 public:
     MultitouchHandler(MapView view, double dpi);
@@ -392,7 +394,7 @@ private:
  *
  * Input handler that locks map view to current position.
  */
-class LockHandler : public JumpHandler {
+class OSMSCOUT_CLIENT_QT_API LockHandler : public JumpHandler {
     Q_OBJECT
 protected:
     double dpi;

--- a/libosmscout-client-qt/include/osmscout/OnlineTileProviderModel.h
+++ b/libosmscout-client-qt/include/osmscout/OnlineTileProviderModel.h
@@ -23,8 +23,7 @@
 #include <QAbstractListModel>
 
 #include <osmscout/OnlineTileProvider.h>
-#include <osmscout/Settings.h>
-
+#include <osmscout/DBThread.h>
 
 /**
  * \ingroup QtAPI
@@ -82,7 +81,7 @@ class OSMSCOUT_CLIENT_QT_API OnlineTileProviderModel : public QAbstractListModel
 public:
   inline OnlineTileProviderModel()
   {
-      onlineProviders = Settings::GetInstance()->GetOnlineProviders();
+      onlineProviders = DBThread::GetInstance()->GetSettings()->GetOnlineProviders();
   };
   
   virtual inline ~OnlineTileProviderModel(){};

--- a/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneDBThread.h
@@ -89,7 +89,8 @@ protected:
 
 public:
   PlaneDBThread(QStringList databaseLookupDirs, 
-                QString iconDirectory);
+                QString iconDirectory,
+                SettingsRef renderingSettings);
     
   virtual ~PlaneDBThread();
 

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -43,8 +43,8 @@
 /**
  * \ingroup QtAPI
  * 
- * Settings provide global instance (singleton) that extends Qt's QSettings
- * by properties with signals. It may be accessed via Settings::GetInstance method.
+ * Settings provides central point mutable configuration of OSMScout library.
+ * It uses Qt's QSettings for persistency. It may be accessed from DBThread instance.
  * 
  * List of online tile providers should be initialized at applicaiton start.
  * ```
@@ -58,12 +58,10 @@ class OSMSCOUT_CLIENT_QT_API Settings: public QObject
 {
   Q_OBJECT
   Q_PROPERTY(double   mapDPI      READ GetMapDPI              WRITE SetMapDPI       NOTIFY MapDPIChange)
-  Q_PROPERTY(MapView  *mapView    READ GetMapView             WRITE SetMapView      NOTIFY MapViewChanged)
   Q_PROPERTY(bool     onlineTiles READ GetOnlineTilesEnabled WRITE SetOnlineTilesEnabled NOTIFY OnlineTilesEnabledChanged)
   Q_PROPERTY(QString  onlineTileProviderId READ GetOnlineTileProviderId WRITE SetOnlineTileProviderId NOTIFY OnlineTileProviderIdChanged)
   Q_PROPERTY(bool     offlineMap  READ GetOfflineMap          WRITE SetOfflineMap   NOTIFY OfflineMapChanged)
   Q_PROPERTY(bool     renderSea   READ GetRenderSea           WRITE SetRenderSea    NOTIFY RenderSeaChanged)
-  Q_PROPERTY(QString  gpsFormat   READ GetGpsFormat           WRITE SetGpsFormat    NOTIFY GpsFormatChanged)
   Q_PROPERTY(QString  styleSheetDirectory READ GetStyleSheetDirectory WRITE SetStyleSheetDirectory NOTIFY StyleSheetDirectoryChanged)
   Q_PROPERTY(QString  styleSheetFile      READ GetStyleSheetFile      WRITE SetStyleSheetFile      NOTIFY StyleSheetFileChanged)
   Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
@@ -71,12 +69,10 @@ class OSMSCOUT_CLIENT_QT_API Settings: public QObject
 
 signals:
   void MapDPIChange(double dpi);
-  void MapViewChanged(MapView *view);
   void OnlineTilesEnabledChanged(bool);
   void OnlineTileProviderIdChanged(const QString id);
   void OfflineMapChanged(bool);
   void RenderSeaChanged(bool);
-  void GpsFormatChanged(const QString formatId);
   void StyleSheetDirectoryChanged(const QString dir);
   void StyleSheetFileChanged(const QString file);
   void FontNameChanged(const QString fontName);
@@ -85,7 +81,6 @@ signals:
 private:
   QSettings settings;
   double    physicalDpi;
-  MapView   *view;
   QMap<QString, OnlineTileProvider> onlineProviderMap;
   QList<OnlineTileProvider> onlineProviders;
   QList<MapProvider> mapProviders;
@@ -99,9 +94,6 @@ public:
   void SetMapDPI(double dpi);
   double GetMapDPI() const;
 
-  MapView *GetMapView();
-  void SetMapView(MapView *view);
-  
   osmscout::Vehicle GetRoutingVehicle() const;
   void SetRoutingVehicle(const osmscout::Vehicle& vehicle);
   
@@ -124,9 +116,6 @@ public:
   
   bool GetRenderSea() const;
   void SetRenderSea(bool);
-  
-  const QString GetGpsFormat() const;
-  void SetGpsFormat(const QString formatId);
 
   const QString GetStyleSheetDirectory() const;
   void SetStyleSheetDirectory(const QString dir);
@@ -146,11 +135,13 @@ public:
   double GetFontSize() const;
   void SetFontSize(double fontSize);
 
-  const QString GetHttpCacheDir() const;
-  
-  static Settings* GetInstance();
-  static void FreeInstance();
+  const QString GetHttpCacheDir() const;  
 };
+
+/**
+ * \ingroup QtAPI
+ */
+typedef std::shared_ptr<Settings> SettingsRef;
 
 /**
  * \ingroup QtAPI
@@ -175,23 +166,22 @@ class OSMSCOUT_CLIENT_QT_API QmlSettings: public QObject{
   Q_OBJECT
   Q_PROPERTY(double   physicalDPI READ GetPhysicalDPI CONSTANT)
   Q_PROPERTY(double   mapDPI    READ GetMapDPI  WRITE SetMapDPI   NOTIFY MapDPIChange)
-  Q_PROPERTY(QObject  *mapView  READ GetMapView WRITE SetMapView  NOTIFY MapViewChanged)
   Q_PROPERTY(bool     onlineTiles READ GetOnlineTilesEnabled WRITE SetOnlineTilesEnabled NOTIFY OnlineTilesEnabledChanged)
   Q_PROPERTY(QString  onlineTileProviderId READ GetOnlineTileProviderId WRITE SetOnlineTileProviderId NOTIFY OnlineTileProviderIdChanged)
   Q_PROPERTY(bool     offlineMap READ GetOfflineMap WRITE SetOfflineMap NOTIFY OfflineMapChanged)
   Q_PROPERTY(bool     renderSea  READ GetRenderSea  WRITE SetRenderSea  NOTIFY RenderSeaChanged)
-  Q_PROPERTY(QString  gpsFormat  READ GetGpsFormat  WRITE SetGpsFormat  NOTIFY GpsFormatChanged)
   Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
   Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
 
+private:
+  SettingsRef settings;
+
 signals:
   void MapDPIChange(double dpi);
-  void MapViewChanged(MapView *view);
   void OnlineTilesEnabledChanged(bool enabled);
   void OnlineTileProviderIdChanged(const QString id);
   void OfflineMapChanged(bool);
   void RenderSeaChanged(bool);
-  void GpsFormatChanged(const QString formatId);
   void FontNameChanged(const QString fontName);
   void FontSizeChanged(double fontSize);
 
@@ -205,9 +195,6 @@ public:
   void SetMapDPI(double dpi);
   double GetMapDPI() const;  
     
-  MapView *GetMapView() const;
-  void SetMapView(QObject *view);    
-
   bool GetOnlineTilesEnabled() const;
   void SetOnlineTilesEnabled(bool b);
   
@@ -220,10 +207,7 @@ public:
   void SetOfflineMap(bool);
   
   bool GetRenderSea() const;
-  void SetRenderSea(bool);  
-  
-  const QString GetGpsFormat() const;
-  void SetGpsFormat(const QString formatId);
+  void SetRenderSea(bool);
 
   QString GetFontName() const;
   void SetFontName(const QString fontName);

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -57,15 +57,17 @@
 class OSMSCOUT_CLIENT_QT_API Settings: public QObject
 {
   Q_OBJECT
-  Q_PROPERTY(double   mapDPI     READ GetMapDPI     WRITE SetMapDPI     NOTIFY MapDPIChange)
-  Q_PROPERTY(MapView  *mapView   READ GetMapView    WRITE SetMapView    NOTIFY MapViewChanged)
+  Q_PROPERTY(double   mapDPI      READ GetMapDPI              WRITE SetMapDPI       NOTIFY MapDPIChange)
+  Q_PROPERTY(MapView  *mapView    READ GetMapView             WRITE SetMapView      NOTIFY MapViewChanged)
   Q_PROPERTY(bool     onlineTiles READ GetOnlineTilesEnabled WRITE SetOnlineTilesEnabled NOTIFY OnlineTilesEnabledChanged)
   Q_PROPERTY(QString  onlineTileProviderId READ GetOnlineTileProviderId WRITE SetOnlineTileProviderId NOTIFY OnlineTileProviderIdChanged)
-  Q_PROPERTY(bool     offlineMap READ GetOfflineMap WRITE SetOfflineMap NOTIFY OfflineMapChanged)
-  Q_PROPERTY(bool     renderSea  READ GetRenderSea  WRITE SetRenderSea  NOTIFY RenderSeaChanged)
-  Q_PROPERTY(QString  gpsFormat  READ GetGpsFormat  WRITE SetGpsFormat  NOTIFY GpsFormatChanged)
+  Q_PROPERTY(bool     offlineMap  READ GetOfflineMap          WRITE SetOfflineMap   NOTIFY OfflineMapChanged)
+  Q_PROPERTY(bool     renderSea   READ GetRenderSea           WRITE SetRenderSea    NOTIFY RenderSeaChanged)
+  Q_PROPERTY(QString  gpsFormat   READ GetGpsFormat           WRITE SetGpsFormat    NOTIFY GpsFormatChanged)
   Q_PROPERTY(QString  styleSheetDirectory READ GetStyleSheetDirectory WRITE SetStyleSheetDirectory NOTIFY StyleSheetDirectoryChanged)
   Q_PROPERTY(QString  styleSheetFile      READ GetStyleSheetFile      WRITE SetStyleSheetFile      NOTIFY StyleSheetFileChanged)
+  Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
+  Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
 
 signals:
   void MapDPIChange(double dpi);
@@ -77,6 +79,8 @@ signals:
   void GpsFormatChanged(const QString formatId);
   void StyleSheetDirectoryChanged(const QString dir);
   void StyleSheetFileChanged(const QString file);
+  void FontNameChanged(const QString fontName);
+  void FontSizeChanged(double fontSize);
 
 private:
   QSettings settings;
@@ -136,6 +140,12 @@ public:
   void SetStyleSheetFlags(const QString styleSheetFile, std::unordered_map<std::string,bool> flags);
   void SetStyleSheetFlags(std::unordered_map<std::string,bool> flags);
 
+  QString GetFontName() const;
+  void SetFontName(const QString fontName);
+
+  double GetFontSize() const;
+  void SetFontSize(double fontSize);
+
   const QString GetHttpCacheDir() const;
   
   static Settings* GetInstance();
@@ -171,6 +181,8 @@ class OSMSCOUT_CLIENT_QT_API QmlSettings: public QObject{
   Q_PROPERTY(bool     offlineMap READ GetOfflineMap WRITE SetOfflineMap NOTIFY OfflineMapChanged)
   Q_PROPERTY(bool     renderSea  READ GetRenderSea  WRITE SetRenderSea  NOTIFY RenderSeaChanged)
   Q_PROPERTY(QString  gpsFormat  READ GetGpsFormat  WRITE SetGpsFormat  NOTIFY GpsFormatChanged)
+  Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
+  Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
 
 signals:
   void MapDPIChange(double dpi);
@@ -180,6 +192,8 @@ signals:
   void OfflineMapChanged(bool);
   void RenderSeaChanged(bool);
   void GpsFormatChanged(const QString formatId);
+  void FontNameChanged(const QString fontName);
+  void FontSizeChanged(double fontSize);
 
 public:
   QmlSettings();
@@ -210,6 +224,12 @@ public:
   
   const QString GetGpsFormat() const;
   void SetGpsFormat(const QString formatId);
+
+  QString GetFontName() const;
+  void SetFontName(const QString fontName);
+
+  double GetFontSize() const;
+  void SetFontSize(double fontSize);
 };
 
 #endif

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -79,14 +79,14 @@ signals:
   void FontSizeChanged(double fontSize);
 
 private:
-  QSettings settings;
+  QSettings *storage;
   double    physicalDpi;
   QMap<QString, OnlineTileProvider> onlineProviderMap;
   QList<OnlineTileProvider> onlineProviders;
   QList<MapProvider> mapProviders;
 
 public:
-  Settings();
+  Settings(QSettings *providedStorage=NULL);
   virtual ~Settings();
 
   double GetPhysicalDPI() const;

--- a/libosmscout-client-qt/include/osmscout/TiledDBThread.h
+++ b/libosmscout-client-qt/include/osmscout/TiledDBThread.h
@@ -93,6 +93,7 @@ private:
 public:
   TiledDBThread(QStringList databaseLookupDirectories, 
                 QString iconDirectory,
+                SettingsRef renderingSettings,
                 QString tileCacheDirectory,
                 size_t onlineTileCacheSize = 20, 
                 size_t offlineTileCacheSize = 50);

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -23,6 +23,7 @@
 #include <osmscout/util/String.h>
 #include <osmscout/AvailableMapsModel.h>
 #include <osmscout/PersistentCookieJar.h>
+#include <osmscout/DBThread.h>
 
 MapProvider AvailableMapsModelMap::getProvider() const
 {
@@ -56,10 +57,11 @@ int AvailableMapsModelMap::getVersion() const
 
 AvailableMapsModel::AvailableMapsModel()
 {
-  mapProviders = Settings::GetInstance()->GetMapProviders();
+  SettingsRef settings=DBThread::GetInstance()->GetSettings();
+  mapProviders = settings->GetMapProviders();
 
   connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT(listDownloaded(QNetworkReply*)));    
-  diskCache.setCacheDirectory(Settings::GetInstance()->GetHttpCacheDir());
+  diskCache.setCacheDirectory(settings->GetHttpCacheDir());
   webCtrl.setCache(&diskCache);
   webCtrl.setCookieJar(new PersistentCookieJar());
 

--- a/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
@@ -28,7 +28,7 @@ MapStyleModel::MapStyleModel():
   connect(dbThread,SIGNAL(stylesheetFilenameChanged()),
           this,SIGNAL(styleChanged()));
 
-  Settings* settings = Settings::GetInstance();
+  SettingsRef settings=DBThread::GetInstance()->GetSettings();
 
   QDirIterator dirIt(settings->GetStyleSheetDirectory(), QDirIterator::FollowSymlinks);
   while (dirIt.hasNext()) {
@@ -53,7 +53,7 @@ QString MapStyleModel::getStyle() const
 void MapStyleModel::setStyle(const QString &styleFile) const
 {
   DBThread* dbThread = DBThread::GetInstance();
-  Settings* settings = Settings::GetInstance();
+  SettingsRef settings=dbThread->GetSettings();
 
   settings->SetStyleSheetFile(styleFile);
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -41,9 +41,9 @@ MapWidget::MapWidget(QQuickItem* parent)
     
     DBThread *dbThread=DBThread::GetInstance();
     
-    mapDpi = Settings::GetInstance()->GetMapDPI();
+    mapDpi = dbThread->GetSettings()->GetMapDPI();
 
-    connect(Settings::GetInstance(), SIGNAL(MapDPIChange(double)),
+    connect(dbThread->GetSettings().get(), SIGNAL(MapDPIChange(double)),
             this, SLOT(onMapDPIChange(double)));
   
     tapRecognizer.setPhysicalDpi(dbThread->GetPhysicalDpi());

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -22,7 +22,7 @@
 
 #include <osmscout/OsmTileDownloader.h>
 #include <osmscout/OnlineTileProvider.h>
-#include <osmscout/Settings.h>
+#include <osmscout/DBThread.h>
 
 OsmTileDownloader::OsmTileDownloader(QString diskCacheDir):
   serverNumber(qrand())
@@ -41,11 +41,13 @@ OsmTileDownloader::OsmTileDownloader(QString diskCacheDir):
   
   diskCache.setCacheDirectory(diskCacheDir);
   webCtrl.setCache(&diskCache);
+
+  SettingsRef settings=DBThread::GetInstance()->GetSettings();
   
-  connect(Settings::GetInstance(), SIGNAL(OnlineTileProviderIdChanged(const QString)), 
+  connect(settings.get(), SIGNAL(OnlineTileProviderIdChanged(const QString)),
           this, SLOT(onlineTileProviderChanged()));
   
-  tileProvider = Settings::GetInstance()->GetOnlineTileProvider();
+  tileProvider = settings->GetOnlineTileProvider();
 }
 
 OsmTileDownloader::~OsmTileDownloader() {
@@ -53,7 +55,7 @@ OsmTileDownloader::~OsmTileDownloader() {
 
 void OsmTileDownloader::onlineTileProviderChanged()
 {
-  tileProvider = Settings::GetInstance()->GetOnlineTileProvider();
+  tileProvider = DBThread::GetInstance()->GetSettings()->GetOnlineTileProvider();
   requests.clear();
 }
 

--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -406,6 +406,9 @@ void PlaneDBThread::DrawMap()
     drawParameter.SetRenderUnknowns(false); // it is necessary to disable it with multiple databases
     drawParameter.SetRenderSeaLand(renderSea);
 
+    drawParameter.SetFontName(fontName.toStdString());
+    drawParameter.SetFontSize(fontSize);
+
     drawParameter.SetLabelLineMinCharCount(15);
     drawParameter.SetLabelLineMaxCharCount(30);
     drawParameter.SetLabelLineFitToArea(true);

--- a/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneDBThread.cpp
@@ -39,8 +39,9 @@ static int INITIAL_DATA_RENDERING_TIMEOUT = 10;
 static int UPDATED_DATA_RENDERING_TIMEOUT = 200;
 
 PlaneDBThread::PlaneDBThread(QStringList databaseLookupDirs,
-                             QString iconDirectory)
- : DBThread(databaseLookupDirs, iconDirectory),
+                             QString iconDirectory,
+                             SettingsRef renderingSettings)
+ : DBThread(databaseLookupDirs, iconDirectory, renderingSettings),
    canvasOverrun(1.5),
    pendingRenderingTimer(this),
    currentImage(NULL),

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -314,6 +314,30 @@ void Settings::SetStyleSheetFlags(std::unordered_map<std::string,bool> flags)
   SetStyleSheetFlags(GetStyleSheetFile(), flags);
 }
 
+QString Settings::GetFontName() const
+{
+  return settings.value("settings/map/fontName", "sans-serif").toString();
+}
+void Settings::SetFontName(const QString fontName)
+{
+  if (GetFontName()!=fontName){
+    settings.setValue("settings/map/fontName", fontName);
+    emit FontNameChanged(fontName);
+  }
+}
+
+double Settings::GetFontSize() const
+{
+  return settings.value("settings/map/fontSize", 2.0).toDouble();
+}
+void Settings::SetFontSize(double fontSize)
+{
+  if (GetFontSize()!=fontSize){
+    settings.setValue("settings/map/fontSize", fontSize);
+    emit FontSizeChanged(fontSize);
+  }
+}
+
 const QString Settings::GetHttpCacheDir() const
 {
   QString cacheLocation = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);  
@@ -354,6 +378,10 @@ QmlSettings::QmlSettings()
             this, SIGNAL(RenderSeaChanged(bool)));
     connect(Settings::GetInstance(), SIGNAL(GpsFormatChanged(const QString)),
             this, SIGNAL(GpsFormatChanged(const QString)));
+    connect(Settings::GetInstance(), SIGNAL(FontNameChanged(const QString)),
+            this, SIGNAL(FontNameChanged(const QString)));
+    connect(Settings::GetInstance(), SIGNAL(FontSizeChanged(double)),
+            this, SIGNAL(FontSizeChanged(double)));
 }
 
 double QmlSettings::GetPhysicalDPI() const
@@ -439,4 +467,20 @@ const QString QmlSettings::GetGpsFormat() const
 void QmlSettings::SetGpsFormat(const QString formatId)
 {
     Settings::GetInstance()->SetGpsFormat(formatId);  
+}
+QString QmlSettings::GetFontName() const
+{
+    return Settings::GetInstance()->GetFontName();
+}
+void QmlSettings::SetFontName(const QString fontName)
+{
+    Settings::GetInstance()->SetFontName(fontName);
+}
+double QmlSettings::GetFontSize() const
+{
+    return Settings::GetInstance()->GetFontSize();
+}
+void QmlSettings::SetFontSize(double fontSize)
+{
+    Settings::GetInstance()->SetFontSize(fontSize);
 }

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -60,34 +60,34 @@ double Settings::GetPhysicalDPI() const
 
 void Settings::SetMapDPI(double dpi)
 {
-    settings.setValue("settings/map/dpi", (unsigned int)dpi);
+    settings.setValue("OSMScoutLib/Rendering/DPI", (unsigned int)dpi);
     emit MapDPIChange(dpi);
 }
 
 double Settings::GetMapDPI() const
 {
-  return (size_t)settings.value("settings/map/dpi",physicalDpi).toDouble();
+  return (size_t)settings.value("OSMScoutLib/Rendering/DPI",physicalDpi).toDouble();
 }
 
 osmscout::Vehicle Settings::GetRoutingVehicle() const
 {
-  return (osmscout::Vehicle)settings.value("routing/vehicle",osmscout::vehicleCar).toUInt();
+  return (osmscout::Vehicle)settings.value("OSMScoutLib/Routing/Vehicle",osmscout::vehicleCar).toUInt();
 }
 
 void Settings::SetRoutingVehicle(const osmscout::Vehicle& vehicle)
 {
-  settings.setValue("routing/vehicle", (unsigned int)vehicle);
+  settings.setValue("OSMScoutLib/Routing/Vehicle", (unsigned int)vehicle);
 }
 
 bool Settings::GetOnlineTilesEnabled() const
 {
-  return settings.value("onlineTiles", true).toBool();
+  return settings.value("OSMScoutLib/Rendering/OnlineTiles", true).toBool();
 }
 
 void Settings::SetOnlineTilesEnabled(bool b)
 {
   if (GetOnlineTilesEnabled() != b){
-    settings.setValue("onlineTiles", b);
+    settings.setValue("OSMScoutLib/Rendering/OnlineTiles", b);
     emit OnlineTilesEnabledChanged(b);
   }
 }
@@ -116,12 +116,12 @@ const QString Settings::GetOnlineTileProviderId() const
     if (!onlineProviders.isEmpty()){
         def = onlineProviders.begin()->getId();
     }
-    return settings.value("onlineTileProvider", def).toString();
+    return settings.value("OSMScoutLib/Rendering/OnlineTileProvider", def).toString();
 }
 
 void Settings::SetOnlineTileProviderId(QString id){
     if (GetOnlineTileProviderId() != id){
-        settings.setValue("onlineTileProvider", id);
+        settings.setValue("OSMScoutLib/Rendering/OnlineTileProvider", id);
         emit OnlineTileProviderIdChanged(id);
     }
 }
@@ -184,43 +184,43 @@ bool Settings::loadMapProviders(QString path)
 
 bool Settings::GetOfflineMap() const
 {
-    return settings.value("offlineMap", true).toBool();
+    return settings.value("OSMScoutLib/Rendering/OfflineMap", true).toBool();
 }
 void Settings::SetOfflineMap(bool b)
 {
   if (GetOfflineMap() != b){
-    settings.setValue("offlineMap", b);
+    settings.setValue("OSMScoutLib/Rendering/OfflineMap", b);
     emit OfflineMapChanged(b);
   }
 }
 
 bool Settings::GetRenderSea() const
 {
-  return settings.value("renderSea", true).toBool();
+  return settings.value("OSMScoutLib/Rendering/RenderSea", true).toBool();
 }
 void Settings::SetRenderSea(bool b)
 {
   if (GetRenderSea() != b){
-    settings.setValue("renderSea", b);
+    settings.setValue("OSMScoutLib/Rendering/RenderSea", b);
     emit RenderSeaChanged(b);
   }    
 }
 
 const QString Settings::GetStyleSheetDirectory() const
 {
-  return settings.value("stylesheetDirectory", "stylesheets").toString();
+  return settings.value("OSMScoutLib/Rendering/StylesheetDirectory", "stylesheets").toString();
 }
 void Settings::SetStyleSheetDirectory(const QString dir)
 {
   if (GetStyleSheetDirectory() != dir){
-    settings.setValue("stylesheetDirectory", dir);
+    settings.setValue("OSMScoutLib/Rendering/StylesheetDirectory", dir);
     emit StyleSheetDirectoryChanged(dir);
   }
 }
 
 const QString Settings::GetStyleSheetFile() const
 {
-  return settings.value("stylesheetFile", "standard.oss").toString();
+  return settings.value("OSMScoutLib/Rendering/StylesheetFile", "standard.oss").toString();
 }
 const QString Settings::GetStyleSheetAbsoluteFile() const
 {
@@ -229,7 +229,7 @@ const QString Settings::GetStyleSheetAbsoluteFile() const
 void Settings::SetStyleSheetFile(const QString file)
 {
   if (GetStyleSheetFile() != file){
-    settings.setValue("stylesheetFile", file);
+    settings.setValue("OSMScoutLib/Rendering/StylesheetFile", file);
     emit StyleSheetFileChanged(file);
   }
 }
@@ -237,7 +237,7 @@ void Settings::SetStyleSheetFile(const QString file)
 const std::unordered_map<std::string,bool> Settings::GetStyleSheetFlags(const QString styleSheetFile)
 {
   std::unordered_map<std::string,bool> stylesheetFlags; // TODO: read from config
-  settings.beginGroup("stylesheetFlags/"+styleSheetFile);
+  settings.beginGroup("OSMScoutLib/Rendering/StylesheetFlags/"+styleSheetFile);
   for (const QString key:settings.allKeys()){
     stylesheetFlags[key.toStdString()]=settings.value(key, false).toBool();
   }
@@ -250,7 +250,7 @@ const std::unordered_map<std::string,bool> Settings::GetStyleSheetFlags()
 }
 void Settings::SetStyleSheetFlags(const QString styleSheetFile, std::unordered_map<std::string,bool> flags)
 {
-  settings.beginGroup("stylesheetFlags/"+styleSheetFile);
+  settings.beginGroup("OSMScoutLib/Rendering/StylesheetFlags/"+styleSheetFile);
   for (const auto &entry:flags){
     settings.setValue(QString::fromStdString(entry.first), entry.second);
   }
@@ -263,24 +263,24 @@ void Settings::SetStyleSheetFlags(std::unordered_map<std::string,bool> flags)
 
 QString Settings::GetFontName() const
 {
-  return settings.value("settings/map/fontName", "sans-serif").toString();
+  return settings.value("OSMScoutLib/Rendering/FontName", "sans-serif").toString();
 }
 void Settings::SetFontName(const QString fontName)
 {
   if (GetFontName()!=fontName){
-    settings.setValue("settings/map/fontName", fontName);
+    settings.setValue("OSMScoutLib/Rendering/FontName", fontName);
     emit FontNameChanged(fontName);
   }
 }
 
 double Settings::GetFontSize() const
 {
-  return settings.value("settings/map/fontSize", 2.0).toDouble();
+  return settings.value("OSMScoutLib/Rendering/FontSize", 2.0).toDouble();
 }
 void Settings::SetFontSize(double fontSize)
 {
   if (GetFontSize()!=fontSize){
-    settings.setValue("settings/map/fontSize", fontSize);
+    settings.setValue("OSMScoutLib/Rendering/FontSize", fontSize);
     emit FontSizeChanged(fontSize);
   }
 }

--- a/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
@@ -89,5 +89,6 @@ Q_INVOKABLE void StyleFlagsModel::setFlag(const QString &key, bool value)
   for (const auto &key:updated.keys()){
     flags[key.toStdString()]=updated[key];
   }
-  Settings::GetInstance()->SetStyleSheetFlags(flags);
+  SettingsRef settings=DBThread::GetInstance()->GetSettings();
+  settings->SetStyleSheetFlags(flags);
 }

--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -40,10 +40,11 @@
 // TODO: watch system memory and evict caches when system is under pressure
 TiledDBThread::TiledDBThread(QStringList databaseLookupDirs,
                              QString iconDirectory,
+                             SettingsRef settings,
                              QString tileCacheDirectory,
                              size_t onlineTileCacheSize,
                              size_t offlineTileCacheSize)
- : DBThread(databaseLookupDirs, iconDirectory),
+ : DBThread(databaseLookupDirs, iconDirectory, settings),
    tileCacheDirectory(tileCacheDirectory),
    onlineTileCache(onlineTileCacheSize), // online tiles can be loaded from disk cache easily
    offlineTileCache(offlineTileCacheSize), // render offline tile is expensive
@@ -56,16 +57,16 @@ TiledDBThread::TiledDBThread(QStringList databaseLookupDirs,
   screenHeight=srn->availableSize().height();
 
 
-  onlineTilesEnabled = Settings::GetInstance()->GetOnlineTilesEnabled();
-  offlineTilesEnabled = Settings::GetInstance()->GetOfflineMap();
+  onlineTilesEnabled = settings->GetOnlineTilesEnabled();
+  offlineTilesEnabled = settings->GetOfflineMap();
 
-  connect(Settings::GetInstance(), SIGNAL(OnlineTileProviderIdChanged(const QString)),
+  connect(settings.get(), SIGNAL(OnlineTileProviderIdChanged(const QString)),
           this, SLOT(onlineTileProviderChanged()));
-  connect(Settings::GetInstance(), SIGNAL(OnlineTilesEnabledChanged(bool)),
+  connect(settings.get(), SIGNAL(OnlineTilesEnabledChanged(bool)),
           this, SLOT(onlineTilesEnabledChanged(bool)));
-  connect(Settings::GetInstance(), SIGNAL(OfflineMapChanged(bool)),
+  connect(settings.get(), SIGNAL(OfflineMapChanged(bool)),
           this, SLOT(onOfflineMapChanged(bool)));
-  connect(Settings::GetInstance(), SIGNAL(RenderSeaChanged(bool)),
+  connect(settings.get(), SIGNAL(RenderSeaChanged(bool)),
           this, SLOT(onRenderSeaChanged(bool)));
 
   connect(this, SIGNAL(stylesheetFilenameChanged()),

--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -175,6 +175,9 @@ void TiledDBThread::DrawMap(QPainter &p, const osmscout::GeoCoord center, uint32
     drawParameter.SetRenderUnknowns(false); // it is necessary to disable it with multiple sources
     drawParameter.SetRenderSeaLand(renderSea);
 
+    drawParameter.SetFontName(fontName.toStdString());
+    drawParameter.SetFontSize(fontSize);
+
     drawParameter.SetLabelLineMinCharCount(15);
     drawParameter.SetLabelLineMaxCharCount(30);
     drawParameter.SetLabelLineFitToArea(true);


### PR DESCRIPTION
Map with Comic Sans fonts, configured simply from QML:

```
    Settings {
        fontName: "Comic Sans MS"
    }
```

![comic-sans-map](https://cloud.githubusercontent.com/assets/309458/23116343/6c1d241e-f74a-11e6-89c3-bfdd46f29bd0.png)

Why not :-)