### PR TITLE
Qt font caching

### DIFF
--- a/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledDBThread.cpp
@@ -693,7 +693,7 @@ void TiledDBThread::onStylesheetFilenameChanged(){
 
 void TiledDBThread::InvalidateVisualCache()
 {
-  // invalidate tile cache and emit Redraw
+  // invalidate tile cache
   QMutexLocker locker(&tileCacheMutex);
   offlineTileCache.invalidate();
   offlineTileCache.clearPendingRequests();

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -45,19 +45,37 @@ namespace osmscout {
       size_t nVertex;
       size_t direction;
     };
+    struct FontDescriptor
+    {
+      QString       fontName;
+      size_t        fontSize;
+      QFont::Weight weight;
+      bool          italic;
+
+      bool operator<(const FontDescriptor& other) const
+      {
+        if (fontName!=other.fontName)
+         return fontName<other.fontName;
+        if (fontSize!=other.fontSize)
+         return fontSize<other.fontSize;
+        if (weight!=other.weight)
+         return weight<other.weight;
+        return italic<other.italic;
+      }
+    };
 
   private:
-    CoordBufferImpl<Vertex2D> *coordBuffer;
+    CoordBufferImpl<Vertex2D>  *coordBuffer;
 
-    QPainter                  *painter;
+    QPainter                   *painter;
 
-    std::vector<QImage>       images;        //! vector of QImage for icons
-    std::vector<QImage>       patternImages; //! vector of QImage for fill patterns
-    std::vector<QBrush>       patterns;      //! vector of QBrush for fill patterns
-    std::map<size_t,QFont>    fonts;         //! Cached fonts
-    std::vector<double>       sin;           //! Lookup table for sin calculation
+    std::vector<QImage>        images;        //! vector of QImage for icons
+    std::vector<QImage>        patternImages; //! vector of QImage for fill patterns
+    std::vector<QBrush>        patterns;      //! vector of QBrush for fill patterns
+    QMap<FontDescriptor,QFont> fonts;         //! Cached fonts
+    std::vector<double>        sin;           //! Lookup table for sin calculation
 
-    std::mutex                mutex;         //! Mutex for locking concurrent calls
+    std::mutex                 mutex;         //! Mutex for locking concurrent calls
 
   private:
     QFont GetFont(const Projection& projection,

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include <QPainter>
+#include <QMap>
 
 #include <osmscout/private/MapQtImportExport.h>
 

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -59,23 +59,26 @@ namespace osmscout {
                               const MapParameter& parameter,
                               double fontSize)
   {
-    std::map<size_t,QFont>::const_iterator f;
+    FontDescriptor descriptor;
+    descriptor.fontName=QString::fromStdString(parameter.GetFontName());
+    descriptor.fontSize=fontSize*projection.ConvertWidthToPixel(parameter.GetFontSize());
+    descriptor.weight=QFont::Normal;
+    descriptor.italic=false;
 
-    fontSize=fontSize*projection.ConvertWidthToPixel(parameter.GetFontSize());
-
-    f=fonts.find(fontSize);
-
-    if (f!=fonts.end()) {
-      return f->second;
+    if (fonts.contains(descriptor)) {
+      return fonts.value(descriptor);
     }
 
-    QFont font(parameter.GetFontName().c_str(),QFont::Normal,false);
+    QFont font(descriptor.fontName.toStdString().c_str(),
+               descriptor.weight,
+               descriptor.italic);
 
-    font.setPixelSize(fontSize);
+    font.setPixelSize(descriptor.fontSize);
     font.setStyleStrategy(QFont::PreferAntialias);
     font.setStyleStrategy(QFont::PreferMatch);
 
-    return fonts.insert(std::pair<size_t,QFont>(fontSize,font)).first->second;
+    fonts[descriptor]=font;
+    return font;
   }
 
   bool MapPainterQt::HasIcon(const StyleConfig& /*styleConfig*/,


### PR DESCRIPTION
Fonts should not be cached just by its size, but using other parameters too (font name). It makes possible to change rendering font without creating new `MapPainterQt`.