### PR TITLE
fix osmscout::GetLineIntersection for two different zero size vectors

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -72,6 +72,13 @@ else()
 	message("Skip DrawTextQt test, libosmscout-map-qt is missing.")
 endif()
 
+#---- Geometry
+add_executable(Geometry src/Geometry.cpp)
+set_property(TARGET Geometry PROPERTY CXX_STANDARD 11)
+target_include_directories(Geometry PRIVATE ${OSMSCOUT_BASE_DIR_SOURCE}/libosmscout/include)
+target_link_libraries(Geometry osmscout)
+install(TARGETS Geometry RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+
 #---- WorkQueue
 add_executable(WorkQueue src/WorkQueue.cpp)
 set_property(TARGET WorkQueue PROPERTY CXX_STANDARD 11)

--- a/Tests/src/Geometry.cpp
+++ b/Tests/src/Geometry.cpp
@@ -1,0 +1,41 @@
+/*
+  CachePerformance - a test program for libosmscout
+  Copyright (C) 2017 Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <cstdlib>
+#include <iostream>
+
+#include <osmscout/util/Geometry.h>
+#include <osmscout/GeoCoord.h>
+
+using namespace std;
+
+int main(int /*argc*/, char** /*argv*/)
+{
+  std::cout << "Two different zero size vector can't intersects... ";
+
+  osmscout::GeoCoord a(51,14);
+  osmscout::GeoCoord b(52,15);
+  osmscout::GeoCoord intersection;
+  
+  assert (!osmscout::GetLineIntersection(a,a,
+                                         b,b,
+                                         intersection));
+  std::cout << "OK" << std::endl;
+}
+

--- a/Tests/src/Geometry.cpp
+++ b/Tests/src/Geometry.cpp
@@ -36,6 +36,8 @@ int main(int /*argc*/, char** /*argv*/)
   assert (!osmscout::GetLineIntersection(a,a,
                                          b,b,
                                          intersection));
+  assert (!osmscout::LinesIntersect(a,a,
+                                    b,b));
   std::cout << "OK" << std::endl;
 }
 

--- a/Tests/src/Makefile.am
+++ b/Tests/src/Makefile.am
@@ -6,7 +6,8 @@ bin_PROGRAMS = CachePerformance \
                ThreadedDatabase \
                WorkQueue \
 	       MapRotate \
-               MultiDBRouting
+               MultiDBRouting \
+	       Geometry
 
 AM_CPPFLAGS = $(LIB_CXXFLAGS) \
               -I$(top_srcdir)/include
@@ -46,6 +47,10 @@ MapRotate_LDADD = $(LIBOSMSCOUT_LIBS) $(LIBOSMSCOUTMAP_LIBS)
 MultiDBRouting_SOURCES = MultiDBRouting.cpp
 MultiDBRouting_CXXFLAGS = $(LIBOSMSCOUT_CFLAGS)
 MultiDBRouting_LDADD = $(LIBOSMSCOUT_LIBS)
+
+Geometry_SOURCES = Geometry.cpp
+Geometry_CXXFLAGS = $(LIBOSMSCOUT_CFLAGS)
+Geometry_LDADD = $(LIBOSMSCOUT_LIBS)
 
 if HAVE_LIB_OSMSCOUTMAPQT
 bin_PROGRAMS += DrawTextQt

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -135,6 +135,11 @@ namespace osmscout {
         a2.IsEqual(b2)) {
       return true;
     }
+    if (a1.IsEqual(a2) &&
+        b1.IsEqual(b2)){
+      // two different zero size vectors can't intersects
+      return false;
+    }
 
     double denr=(b2.GetLat()-b1.GetLat())*(a2.GetLon()-a1.GetLon())-
                 (b2.GetLon()-b1.GetLon())*(a2.GetLat()-a1.GetLat());

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -177,10 +177,19 @@ namespace osmscout {
                            N& intersection)
   {
     if (a1.IsEqual(b1) ||
-        a1.IsEqual(b2) ||
-        a2.IsEqual(b1) ||
-        a2.IsEqual(b2)) {
+        a1.IsEqual(b2)){
+      intersection.Set(a1.GetLat(),a1.GetLon());
       return true;
+    }
+    if (a2.IsEqual(b1) ||
+        a2.IsEqual(b2)) {
+      intersection.Set(a2.GetLat(),a2.GetLon());
+      return true;
+    }
+    if (a1.IsEqual(a2) &&
+        b1.IsEqual(b2)){
+      // two different zero size vectors can't intersects
+      return false;
     }
 
     double denr=(b2.GetLat()-b1.GetLat())*(a2.GetLon()-a1.GetLon())-
@@ -195,6 +204,8 @@ namespace osmscout {
       if (ua_numr==0.0 && ub_numr==0.0) {
         // This gives currently false hits because of number resolution problems, if two lines are very
         // close together and for example are part of a very details node curve intersections are detected.
+
+        // FIXME: setup intersection
         return true;
       }
       else {


### PR DESCRIPTION
...such vectors can't intersects, and add simple test for this method

When I was playing with coastlines (https://github.com/Framstag/libosmscout/pull/190) I found two intersecting zero size vectors, one in Italy and second in Greek ;-) I added simple check for that corner case...