### PR TITLE
create MapWidget::screenPosition(lat, lon) method, expose it to QML

### DIFF
--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -270,6 +270,7 @@ public:
   
   bool isDatabaseLoaded();
   Q_INVOKABLE bool isInDatabaseBoundingBox(double lat, double lon);
+  Q_INVOKABLE QPointF screenPosition(double lat, double lon);
 };
 
 #endif

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -315,6 +315,14 @@ bool MapWidget::isInDatabaseBoundingBox(double lat, double lon)
   return resp.boundingBox.Includes(coord);
 }
 
+QPointF MapWidget::screenPosition(double lat, double lon)
+{
+    double x;
+    double y;
+    getProjection().GeoToPixel(osmscout::GeoCoord(lat, lon), x, y);
+    return QPointF(x, y);
+}
+
 void MapWidget::zoom(double zoomFactor)
 {
     zoom(zoomFactor, QPoint(width()/2, height()/2));


### PR DESCRIPTION
Hi. I am adding "debug page" with list of objects near some place (based on `MapObjectInfoModel`). I need to convert coordinates to screen position in QML...