### PR TITLE
add FileDownloader to Qt client library

### DIFF
--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HEADER_FILES
     #include/osmscout/private/Config.h
     #include/osmscout/ClientQtFeatures.h
     include/osmscout/DBThread.h
+    include/osmscout/FileDownloader.h
     include/osmscout/InputHandler.h
     include/osmscout/LocationEntry.h
     include/osmscout/LocationInfoModel.h
@@ -46,6 +47,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     src/osmscout/DBThread.cpp
+    src/osmscout/FileDownloader.cpp
     src/osmscout/InputHandler.cpp
     src/osmscout/LocationEntry.cpp
     src/osmscout/LocationInfoModel.cpp

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -1,0 +1,129 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Rinigus
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#ifndef FILEDOWNLOADER_H
+#define FILEDOWNLOADER_H
+
+#include <QObject>
+#include <QString>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QFile>
+#include <QUrl>
+#include <QProcess>
+#include <QByteArray>
+#include <QTime>
+
+#include <osmscout/private/ClientQtImportExport.h>
+
+/// \brief Downloads a file specified by URL
+///
+/// Downloads a file as specified by URL and stores in a given path.
+/// If the required directories do not exist, creates all parent directories
+/// as needed. If specified that the format is BZ2, the downloader pipes
+/// the internet stream through a process running bunzip2.
+class OSMSCOUT_CLIENT_QT_API FileDownloader : public QObject
+{
+  Q_OBJECT
+
+public:
+  enum Type { Plain=0, BZ2=1 };
+
+public:
+  explicit FileDownloader(QNetworkAccessManager *manager, QString url, QString path, const Type mode = Plain, QObject *parent = 0);
+  ~FileDownloader();
+
+  operator bool() const { return m_isok; }
+  QString getFileName() const { return m_path; }
+  uint64_t getBytesDownloaded() const;
+
+signals:
+  void downloadedBytes(uint64_t sz);
+  void writtenBytes(uint64_t sz);
+  void finished(QString path);
+  void error(QString error_text);
+
+public slots:
+  void onNetworkReadyRead();
+  void onDownloaded();
+  void onNetworkError(QNetworkReply::NetworkError code);
+  void startDownload(); ///< called internally, but has to be a slot
+
+protected:
+  void onProcessStarted();
+  void onProcessStopped(int exitCode, QProcess::ExitStatus exitStatus); ///< Called on error while starting or when process has stopped
+  void onProcessStateChanged(QProcess::ProcessState newState); ///< Called when state of the process has changed
+  void onProcessRead();
+  void onProcessReadError();
+
+  void onBytesWritten(qint64);
+
+  void onFinished();
+  void onError(const QString &err);
+
+  bool restartDownload(bool force = false); ///< Restart download if download retries are not used up
+
+  virtual void timerEvent(QTimerEvent *event);
+
+protected:
+  QNetworkAccessManager *m_manager;
+  QUrl m_url;
+  QString m_path;
+
+  QNetworkReply *m_reply{nullptr};
+
+  QProcess *m_process{nullptr};
+  bool m_process_started{false};
+
+  QFile m_file;
+
+  bool m_pipe_to_process{false};
+  bool m_isok{true};
+
+  QByteArray m_cache_safe;
+  QByteArray m_cache_current;
+  bool m_clear_all_caches{false};
+  bool m_pause_network_io{false};
+
+  uint64_t m_downloaded{0};
+  uint64_t m_written{0};
+  uint64_t m_downloaded_gui{0};
+
+  uint64_t m_download_throttle_bytes{0};
+  QTime m_download_throttle_time_start;
+  double m_download_throttle_max_speed{0};
+
+  uint64_t m_downloaded_last_error{0};
+  size_t m_download_retries{0};
+  QTime m_download_last_read_time;
+
+  const size_t const_max_download_retries{5};          ///< Maximal number of download retries before cancelling download
+  const double const_download_retry_sleep_time{30.0};  ///< Time between retries in seconds
+
+  const qint64 const_cache_size_before_swap{1024*1024*1}; ///< Size at which cache is promoted from network to file/process
+  const qint64 const_buffer_size_io{1024*1024*3};         ///< Size of the buffers that should not be significantly exceeded
+  const qint64 const_buffer_network{1024*1024*1};         ///< Size of network ring buffer
+
+  /// \brief Factor determining whether cancel download when network buffer is too large
+  const qint64 const_buffer_network_max_factor_before_cancel{10};
+
+  const int const_download_timeout{60};                ///< Download timeout in seconds
+};
+
+#endif // FILEDOWNLOADER_H

--- a/libosmscout-client-qt/libosmscout-client-qt.pro
+++ b/libosmscout-client-qt/libosmscout-client-qt.pro
@@ -8,6 +8,7 @@ INCLUDEPATH += include ../libosmscout-map/include ../libosmscout-map-qt/include 
 SOURCES += \
     src/osmscout/AvailableMapsModel.cpp \
     src/osmscout/DBThread.cpp \
+    src/osmscout/FileDownloader.cpp \
     src/osmscout/InputHandler.cpp \
     src/osmscout/LocationEntry.cpp \
     src/osmscout/LocationInfoModel.cpp \
@@ -31,6 +32,7 @@ HEADERS += \
     include/osmscout/AvailableMapsModel.h \
     include/osmscout/ClientQtFeatures.h \
     include/osmscout/DBThread.h \
+    include/osmscout/FileDownloader.h \
     include/osmscout/InputHandler.h \
     include/osmscout/LocationEntry.h \
     include/osmscout/LocationInfoModel.h \

--- a/libosmscout-client-qt/src/Makefile.am
+++ b/libosmscout-client-qt/src/Makefile.am
@@ -41,6 +41,8 @@ libosmscoutclientqt_la_SOURCES = osmscout/DBThread.cpp \
                                  osmscout/moc_MapProvider.cpp \
                                  osmscout/AvailableMapsModel.cpp \
                                  osmscout/moc_AvailableMapsModel.cpp \
+                                 osmscout/FileDownloader.cpp \
+                                 osmscout/moc_FileDownloader.cpp \
                                  osmscout/MapManager.cpp \
                                  osmscout/moc_MapManager.cpp \
                                  osmscout/MapDownloadsModel.cpp \

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -1,0 +1,449 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Rinigus
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/FileDownloader.h>
+#include <osmscout/Settings.h>
+
+#include <QUrl>
+#include <QDir>
+#include <QFileInfo>
+#include <QTimer>
+
+#include <QDebug>
+
+#include <algorithm>
+#include <iostream> // for a rarely expected error message
+
+FileDownloader::FileDownloader(QNetworkAccessManager *manager,
+                               QString url, QString path,
+                               const Type mode,
+                               QObject *parent):
+  QObject(parent),
+  m_manager(manager),
+  m_url(url), m_path(path)
+{
+  if (!m_url.isValid())
+    {
+      m_isok = false;
+      return;
+    }
+
+  // check path and open file
+  QFileInfo finfo(m_path);
+  QDir dir;
+  if ( !dir.mkpath(finfo.dir().absolutePath()) )
+    {
+      m_isok = false;
+      return;
+    }
+
+  m_file.setFileName(m_path + ".download");
+  if (!m_file.open(QIODevice::WriteOnly))
+    {
+      m_isok = false;
+      return;
+    }
+
+  connect( &m_file, &QFile::bytesWritten,
+           this, &FileDownloader::onBytesWritten );
+
+  // start data processor if requested
+  QString command;
+  QStringList arguments;
+  if (mode == BZ2)
+    {
+      command = "bunzip2";
+      arguments << "-c";
+    }
+  else if (mode == Plain)
+    {
+      // nothing to do
+    }
+  else
+    {
+      std::cerr << "FileDownloader: unknown mode: " << mode << std::endl;
+      m_isok = false;
+      return;
+    }
+
+  if (!command.isEmpty())
+    {
+      m_pipe_to_process = true;
+      m_process = new QProcess(this);
+
+      connect( m_process, &QProcess::started,
+               this, &FileDownloader::onProcessStarted );
+
+      connect( m_process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+               this, &FileDownloader::onProcessStopped );
+
+      connect( m_process, &QProcess::stateChanged,
+               this, &FileDownloader::onProcessStateChanged );
+
+      connect( m_process, &QProcess::readyReadStandardOutput,
+               this, &FileDownloader::onProcessRead );
+
+      connect( m_process, &QProcess::readyReadStandardError,
+               this, &FileDownloader::onProcessReadError );
+
+      connect( m_process, &QProcess::bytesWritten,
+               this, &FileDownloader::onBytesWritten );
+
+      m_process->start(command, arguments);
+    }
+
+  m_download_last_read_time.start();
+  m_download_throttle_time_start.start();
+
+  // start download
+  // startDownload();
+  startTimer(1000); // used to check for timeouts and in throttling network speed
+}
+
+FileDownloader::~FileDownloader()
+{
+  if (m_reply) m_reply->deleteLater();
+  if (m_process) m_process->deleteLater();
+}
+
+void FileDownloader::startDownload()
+{
+  // qDebug() << "Start or ReStart: " << m_url;
+
+  // start download
+  QNetworkRequest request(m_url);
+  request.setHeader(QNetworkRequest::UserAgentHeader,
+                    QString(OSMSCOUT_USER_AGENT).arg(OSMSCOUT_VERSION_STRING));
+
+  if (m_downloaded > 0)
+    {
+      QByteArray range_header = "bytes=" + QByteArray::number((qulonglong)m_downloaded) + "-";
+      request.setRawHeader("Range",range_header);
+    }
+
+  m_reply = m_manager->get(request);
+  m_reply->setReadBufferSize(const_buffer_network);
+
+  connect(m_reply, SIGNAL(readyRead()),
+          this, SLOT(onNetworkReadyRead()));
+  connect(m_reply, SIGNAL(finished()),
+          this, SLOT(onDownloaded()));
+  connect(m_reply, SIGNAL(error(QNetworkReply::NetworkError)),
+          this, SLOT(onNetworkError(QNetworkReply::NetworkError)));
+
+  m_download_last_read_time.restart();
+  m_download_throttle_time_start.restart();
+  m_download_throttle_bytes = 0;
+}
+
+void FileDownloader::onFinished()
+{
+  m_file.close();
+
+  { // delete the file if it exists already to update it
+    // with a new copy
+    QFile ftmp(m_path);
+    ftmp.remove();
+  }
+
+  m_file.rename(m_path);
+
+  if (m_process)
+    {
+      m_process->deleteLater();
+      m_process = nullptr;
+    }
+
+  if (m_reply)
+    {
+      m_reply->deleteLater();
+      m_reply = nullptr;
+    }
+
+  emit finished(m_path);
+}
+
+void FileDownloader::onError(const QString &err)
+{
+  m_file.close();
+  m_file.remove();
+
+  if (m_process)
+    {
+      m_process->deleteLater();
+      m_process = nullptr;
+    }
+
+  if (m_reply)
+    {
+      m_reply->deleteLater();
+      m_reply = nullptr;
+    }
+
+  m_isok = false;
+  emit error(err);
+}
+
+void FileDownloader::onNetworkReadyRead()
+{
+  m_download_last_read_time.restart();
+
+  if (!m_reply ||
+      (m_pipe_to_process && !m_process_started) ) // too early, haven't started yet
+    return;
+
+  double speed = m_download_throttle_bytes /
+      (m_download_throttle_time_start.elapsed() * 1e-3) / 1024.0;
+
+  //  qDebug() << "Buffers: "
+  //           << m_reply->bytesAvailable() << " [network] / "
+  //           << m_reply->readBufferSize() << " [network max] / "
+  //           << (m_pipe_to_process ? m_process->bytesToWrite() : -1)
+  //           << " [process] / " << m_file.bytesToWrite() << " [file]; "
+  //           << "speed [kb/s]: " << speed
+  //           << " / clear: " << m_clear_all_caches;
+
+  // check if the network has to be throttled due to excessive
+  // non-writen buffers. check is skipped on the last read called
+  // with m_clear_all_caches
+  if (!m_clear_all_caches)
+    {
+      /// It seems that sometimes Qt heavily overshoots the requested network buffer size. In
+      /// particular it has been usual for the first download from start of the server. On the second try,
+      /// it's usually OK (seen on SFOS 2.0 series)
+      if ( m_reply->bytesAvailable() > const_buffer_network_max_factor_before_cancel*const_buffer_network )
+        {
+          restartDownload(true);
+          return;
+        }
+
+      if ( (m_pipe_to_process && m_process->bytesToWrite() > const_buffer_size_io) ||
+           (m_file.bytesToWrite() > const_buffer_size_io) )
+        {
+          m_pause_network_io = true;
+          return;
+        }
+
+      // check if requested speed has been exceeded
+      if (m_download_throttle_max_speed > 0)
+        {
+          if (speed > m_download_throttle_max_speed)
+            {
+              //              qDebug() << "Going too fast: " << speed;
+              m_pause_network_io = true;
+              return;
+            }
+        }
+    }
+
+  m_pause_network_io = false;
+
+  QByteArray data_current;
+  if (m_clear_all_caches) data_current = m_reply->readAll();
+  else data_current = m_reply->read( std::min(const_cache_size_before_swap, const_buffer_network) );
+
+  m_cache_current.append(data_current);
+  m_downloaded_gui += data_current.size();
+  m_download_throttle_bytes += data_current.size();
+
+  emit downloadedBytes(m_downloaded_gui);
+
+  // check if caches are full or whether they have to be
+  // filled before writing to file/process
+  if (!m_clear_all_caches && m_cache_current.size() < const_cache_size_before_swap)
+    return;
+
+  QByteArray data(m_cache_safe);
+  if (m_clear_all_caches)
+    {
+      data.append(m_cache_current);
+      m_cache_current.clear();
+      m_cache_safe.clear();
+    }
+  else
+    {
+      m_cache_safe = m_cache_current;
+      m_cache_current.clear();
+    }
+
+  m_downloaded += data.size();
+
+  if (m_pipe_to_process)
+    {
+      m_process->write(data);
+    }
+  else
+    {
+      m_file.write(data);
+      emit writtenBytes(m_downloaded);
+    }
+}
+
+uint64_t FileDownloader::getBytesDownloaded() const
+{
+  return m_downloaded_gui;
+}
+
+void FileDownloader::onDownloaded()
+{
+  if (!m_reply) return; // happens on error, after error cleanup and initiating retry
+
+  if (m_reply->error() != QNetworkReply::NoError)
+    return;
+
+  if (m_pipe_to_process && !m_process_started)
+    return;
+
+  m_clear_all_caches = true;
+  onNetworkReadyRead(); // update all data if needed
+
+  if (m_pipe_to_process && m_process)
+    m_process->closeWriteChannel();
+
+  if (m_reply) m_reply->deleteLater();
+  m_reply = nullptr;
+
+  if (!m_pipe_to_process) onFinished();
+}
+
+bool FileDownloader::restartDownload(bool force)
+{
+//  qDebug() << QTime::currentTime() << " / Restart called: "
+//           << m_url << " " << m_download_retries << " " << m_download_last_read_time.elapsed();
+
+  // check if we should retry before cancelling all with an error
+  // this check is performed only if we managed to get some data
+  if (m_downloaded_last_error != m_downloaded)
+    m_download_retries = 0;
+
+  if (m_reply &&
+      m_download_retries < const_max_download_retries &&
+      (m_downloaded > 0 || force) )
+    {
+      m_cache_safe.clear();
+      m_cache_current.clear();
+      m_reply->deleteLater();
+      m_reply = nullptr;
+
+      QTimer::singleShot(const_download_retry_sleep_time * 1e3,
+                         this, SLOT(startDownload()));
+
+      m_download_retries++;
+      m_downloaded_gui = m_downloaded;
+      m_downloaded_last_error = m_downloaded;
+      m_download_last_read_time.restart();
+
+      return true;
+    }
+
+  return false;
+}
+
+void FileDownloader::onNetworkError(QNetworkReply::NetworkError /*code*/)
+{
+  if (restartDownload()) return;
+
+  if (m_reply)
+    {
+      QString err = tr("Failed to download") + "<br>" + m_path +
+          "<br><br>" +tr("Error code: %1").arg(QString::number(m_reply->error())) + "<br><blockquote><small>" +
+          m_reply->errorString() +
+          "</small></blockquote>";
+      onError(err);
+    }
+}
+
+void FileDownloader::timerEvent(QTimerEvent * /*event*/)
+{
+  if (m_pause_network_io)
+    onNetworkReadyRead();
+
+  if (m_download_last_read_time.elapsed()*1e-3 > const_download_timeout)
+    {
+      if (restartDownload()) return;
+
+      QString err = tr("Failed to download") + "<br>" + m_path +
+          "<br><br>" +tr("Timeout");
+
+      onError(err);
+    }
+}
+
+void FileDownloader::onBytesWritten(qint64)
+{
+  if (m_pause_network_io)
+    onNetworkReadyRead();
+}
+
+void FileDownloader::onProcessStarted()
+{
+  m_process_started = true;
+  onNetworkReadyRead(); // pipe all data in that has been collected already
+}
+
+void FileDownloader::onProcessRead()
+{
+  m_download_last_read_time.restart();
+
+  if (!m_process) return;
+
+  QByteArray data = m_process->readAllStandardOutput();
+  m_file.write(data);
+  m_written += data.size();
+  emit writtenBytes(m_written);
+}
+
+void FileDownloader::onProcessStopped(int exitCode, QProcess::ExitStatus /*exitStatus*/)
+{
+  if (exitCode != 0)
+    {
+      QString err = tr("Error in processing downloaded data");
+      m_isok = false;
+      emit error(err);
+      return;
+    }
+
+  if (!m_process) return;
+
+  onProcessRead();
+  onFinished();
+}
+
+void FileDownloader::onProcessReadError()
+{
+  if (!m_process) return;
+
+  QByteArray data = m_process->readAllStandardError();
+  if (data.size() > 0)
+    {
+      QString
+          err = tr("Error in processing downloaded data") + ": " +
+          QString(data.data());
+      onError(err);
+    }
+}
+
+void FileDownloader::onProcessStateChanged(QProcess::ProcessState state)
+{
+  if ( !m_process_started && state == QProcess::NotRunning )
+    {
+      QString err = tr("Error in processing downloaded data: could not start the program") + " " + m_process->program();
+      onError(err);
+    }
+}


### PR DESCRIPTION
This PR replaces FileDownloadJob with FileDownloader from OSM Scout Server. It addresses issue #276 as well as offers resuming of downloads and keeps an eye on internal Qt buffers. All in all, it should provide with the working and tested implementation of downloads.

There are few issues regarding this PR:

* I tested the code in OSM Scout Server and it works quite well over there. On OSMScout2, the testing was limited

* Since FileDownloader already includes resumption of downloads, there is no need to have resumption at MapDownloadJob level. In my understanding, MapDownloadJob::onJobFailed should propagate the error message to the user. GUI hooks are out of the scope of this PR and, in my mind, should be dealt on application and not library level.

* Since there is only one download at a time, several functions in MapDownloadJob were simplified. In this way, we have only job[0] which is downloading and its deleted as soon as all is done.

* Coding style follows the style I am using for OSM Scout Server: member variables are prefixed with m_ and since my editor is not configured for table-like variable declarations, I have not done it over here either. FileDownloader though is a separate class and I hope its OK. When changing some other code inside the library, I do try to follow the coding style around it.