### PR TITLE
Fix libosmscout-client-qt not installing import/export header

### DIFF
--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -97,5 +97,5 @@ install(TARGETS osmscout_client_qt
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "private" EXCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "private/Config.h" EXCLUDE)
 install(FILES ${OSMSCOUT_BASE_DIR_BUILD}/include/osmscout/ClientQtFeatures.h DESTINATION include/osmscout)


### PR DESCRIPTION
Install target is excluding `private` folder with `ClientQtImportExport.h` header inside, while other libraries are excluding only `Config.h` file.
See [libosmscout-map-qt/CMakeLists.txt](https://github.com/Framstag/libosmscout/blob/master/libosmscout-map-qt/CMakeLists.txt#L39) for example.