### PR TITLE
Small refactoring and fixes for FileDownloader

### DIFF
--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -53,6 +53,25 @@ static QObject *ThemeProvider(QQmlEngine *engine, QJSEngine *scriptEngine)
     return theme;
 }
 
+#define DEBUG   4
+#define INFO    3
+#define WARNING 2
+#define ERROR   1
+
+static int LogEnv(QString env)
+{
+  if (env.toUpper()=="DEBUG"){
+    return DEBUG;
+  }
+  if (env.toUpper()=="INFO"){
+    return INFO;
+  }
+  if (env.toUpper()=="ERROR"){
+    return ERROR;
+  }
+  return WARNING;
+}
+
 int main(int argc, char* argv[])
 {
 #ifdef Q_WS_X11
@@ -82,8 +101,12 @@ int main(int argc, char* argv[])
 
   qmlRegisterSingletonType<Theme>("net.sf.libosmscout.map", 1, 0, "Theme", ThemeProvider);
 
-  osmscout::log.Debug(false);
-  osmscout::log.Info(false);
+  // init logger by system system variable
+  int logEnv=LogEnv(QProcessEnvironment::systemEnvironment().value("OSMSCOUT_LOG", "WARNING"));
+  osmscout::log.Debug(logEnv>=DEBUG);
+  osmscout::log.Info(logEnv>=INFO);
+  osmscout::log.Warn(logEnv>=WARNING);
+  osmscout::log.Error(logEnv>=ERROR);
 
   SettingsRef settings=std::make_shared<Settings>();
   // load online tile providers

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -116,6 +116,7 @@ protected:
   uint64_t m_downloaded_last_error{0};
   size_t m_download_retries{0};
   QTime m_download_last_read_time;
+  int m_timeout_timer_id{-1};
 
   const size_t const_max_download_retries{5};          ///< Maximal number of download retries before cancelling download
   const double const_download_retry_sleep_time{30.0};  ///< Time between retries in seconds

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -62,19 +62,21 @@ signals:
   void error(QString error_text);
 
 public slots:
+  void startDownload();
+
+protected slots:
   void onNetworkReadyRead();
   void onDownloaded();
   void onNetworkError(QNetworkReply::NetworkError code);
-  void startDownload(); ///< called internally, but has to be a slot
+
+  void onProcessStarted();
+  void onProcessRead();
+  void onProcessStopped(int exitCode); ///< Called on error while starting or when process has stopped
+  void onBytesWritten(qint64);
 
 protected:
-  void onProcessStarted();
-  void onProcessStopped(int exitCode, QProcess::ExitStatus exitStatus); ///< Called on error while starting or when process has stopped
   void onProcessStateChanged(QProcess::ProcessState newState); ///< Called when state of the process has changed
-  void onProcessRead();
   void onProcessReadError();
-
-  void onBytesWritten(qint64);
 
   void onFinished();
   void onError(const QString &err);

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -110,8 +110,6 @@ FileDownloader::FileDownloader(QNetworkAccessManager *manager,
 
   m_download_last_read_time.start();
   m_download_throttle_time_start.start();
-
-  startTimer(1000); // used to check for timeouts and in throttling network speed
 }
 
 FileDownloader::~FileDownloader()
@@ -129,6 +127,7 @@ void FileDownloader::startDownload()
 
   if (m_downloaded > 0)
     {
+      // TODO: Range header don't have to be supported by server, we should handle such case
       QByteArray range_header = "bytes=" + QByteArray::number((qulonglong)m_downloaded) + "-";
       request.setRawHeader("Range",range_header);
     }
@@ -146,6 +145,8 @@ void FileDownloader::startDownload()
   m_download_last_read_time.restart();
   m_download_throttle_time_start.restart();
   m_download_throttle_bytes = 0;
+
+  m_timeout_timer_id=startTimer(1000); // used to check for timeouts and in throttling network speed
 }
 
 void FileDownloader::onFinished()
@@ -320,6 +321,7 @@ void FileDownloader::onDownloaded()
 
 bool FileDownloader::restartDownload(bool force)
 {
+  killTimer(m_timeout_timer_id);
 //  qDebug() << QTime::currentTime() << " / Restart called: "
 //           << m_url << " " << m_download_retries << " " << m_download_last_read_time.elapsed();
 

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -81,8 +81,10 @@ void MapDownloadJob::start()
 
 void MapDownloadJob::onJobFailed(QString error_text){
   osmscout::log.Debug() << "Download failed with the error: " << error_text.toStdString();
-  // application should be connected to MapDownloadsModel::mapDownloadFails(QString) signal
-  // and propagate error message to user
+
+  // TODO: add some flag if this failure is temprary and downloading will be
+  //       retried. If it is final, unrecoverable failure, emit mapDownloadFails
+  // TODO: Report file these failures to UI (via MapDownloadsModel?)
 }
 
 void MapDownloadJob::onJobFinished()

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -89,8 +89,8 @@ void MapDownloadJob::onJobFinished()
 {
   if (!jobs.isEmpty())
     {
-      jobs[0]->deleteLater();
-      downloadedBytes += jobs[0]->getBytesDownloaded();
+      jobs.first()->deleteLater();
+      downloadedBytes += jobs.first()->getBytesDownloaded();
       jobs.pop_front();      
     }
   
@@ -100,7 +100,7 @@ void MapDownloadJob::onJobFinished()
 void MapDownloadJob::downloadNextFile()
 {
   if (!jobs.isEmpty())
-    jobs[0]->startDownload();
+    jobs.first()->startDownload();
   else
     done=true;
   
@@ -122,7 +122,7 @@ double MapDownloadJob::getProgress()
 QString MapDownloadJob::getDownloadingFile()
 {
   if (!jobs.isEmpty())
-    return jobs[0]->getFileName();
+    return jobs.first()->getFileName();
   return "";
 }
 


### PR DESCRIPTION
Hi. 

This MR should fixes https://github.com/Framstag/libosmscout/issues/276 I will test it on phone today...

The main problem was that timeout timer was started on downloader constructor, but it have to be started when real download is started...

Beside this fix, I rewrite usage of Qt signals and initialise osmscout logger by system environment variable in OSMScout2...

@Framstag , @rinigus , please review it
