### PR TITLE
Add support for “embankment” tag 

### DIFF
--- a/StyleEditor/src/Highlighter.cpp
+++ b/StyleEditor/src/Highlighter.cpp
@@ -90,7 +90,7 @@ void Highlighter::updateRules()
 
     kwTUNNELBRIDGEFormat.setFontWeight(QFont::Bold);
     kwTUNNELBRIDGEFormat.setForeground(QColor("#25a13b"));
-    rule.pattern = QRegExp("TUNNEL|BRIDGE");
+    rule.pattern = QRegExp("TUNNEL|BRIDGE|EMBANKMENT");
     rule.pattern.setMinimal(true);
     rule.format = kwTUNNELBRIDGEFormat;
     highlightingRules.append(rule);

--- a/libosmscout-client-qt/libosmscout-client-qt.pro
+++ b/libosmscout-client-qt/libosmscout-client-qt.pro
@@ -25,7 +25,10 @@ SOURCES += \
     src/osmscout/SearchLocationModel.cpp \
     src/osmscout/Settings.cpp \
     src/osmscout/TileCache.cpp \
-    src/osmscout/TiledDBThread.cpp
+    src/osmscout/TiledDBThread.cpp \
+    src/osmscout/MapStyleModel.cpp \
+    src/osmscout/StyleFlagsModel.cpp \
+    src/osmscout/MapObjectInfoModel.cpp
 
 
 HEADERS += \
@@ -52,7 +55,10 @@ HEADERS += \
     include/osmscout/TileCache.h \
     include/osmscout/TiledDBThread.h \
     include/osmscout/private/ClientQtImportExport.h \
-    include/osmscout/private/Config.h
+    include/osmscout/private/Config.h \
+    include/osmscout/MapStyleModel.h \
+    include/osmscout/StyleFlagsModel.h \
+    include/osmscout/MapObjectInfoModel.h
 
 macx {
     QMAKE_CXXFLAGS = -mmacosx-version-min=10.7 -std=gnu0x -stdlib=libc++

--- a/libosmscout-import/src/osmscout/import/GenWaterIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWaterIndex.cpp
@@ -633,6 +633,7 @@ namespace osmscout {
 
     BridgeFeatureReader bridgeFeatureRader(typeConfig);
     TunnelFeatureReader tunnelFeatureRader(typeConfig);
+    EmbankmentFeatureReader embankmentFeatureRader(typeConfig);
     FileScanner         scanner;
     uint32_t            wayCount=0;
 
@@ -658,6 +659,7 @@ namespace osmscout {
             !way.GetType()->GetIgnoreSeaLand() &&
             !tunnelFeatureRader.IsSet(way.GetFeatureValueBuffer()) &&
             !bridgeFeatureRader.IsSet(way.GetFeatureValueBuffer()) &&
+            !embankmentFeatureRader.IsSet(way.GetFeatureValueBuffer()) &&
             way.nodes.size()>=2) {
           std::set<Pixel> coords;
 

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -169,6 +169,7 @@ namespace osmscout {
   private:
     BridgeFeatureReader      bridgeReader;
     TunnelFeatureReader      tunnelReader;
+    EmbankmentFeatureReader  embankmentReader;
     AccessFeatureValueReader accessReader;
 
   public:
@@ -182,6 +183,11 @@ namespace osmscout {
     inline bool IsTunnel(const FeatureValueBuffer& buffer) const
     {
       return tunnelReader.IsSet(buffer);
+    }
+
+    inline bool IsEmbankment(const FeatureValueBuffer& buffer) const
+    {
+      return embankmentReader.IsSet(buffer);
     }
 
     bool IsOneway(const FeatureValueBuffer& buffer) const;
@@ -303,6 +309,7 @@ namespace osmscout {
     size_t                maxLevel;
     bool                  bridge;
     bool                  tunnel;
+    bool                  embankment;
     bool                  oneway;
     SizeConditionRef      sizeCondition;
 
@@ -316,6 +323,7 @@ namespace osmscout {
     StyleFilter& SetMaxLevel(size_t level);
     StyleFilter& SetBridge(bool bridge);
     StyleFilter& SetTunnel(bool tunnel);
+    StyleFilter& SetEmbankment(bool embankment);
     StyleFilter& SetOneway(bool oneway);
 
     StyleFilter& SetSizeCondition(const SizeConditionRef& condition);
@@ -350,6 +358,11 @@ namespace osmscout {
       return tunnel;
     }
 
+    inline bool GetEmbankment() const
+    {
+      return embankment;
+    }
+
     inline bool GetOneway() const
     {
       return oneway;
@@ -380,6 +393,7 @@ namespace osmscout {
   private:
     bool             bridge;
     bool             tunnel;
+    bool             embankment;
     bool             oneway;
     SizeConditionRef sizeCondition;
 
@@ -393,9 +407,10 @@ namespace osmscout {
 
     inline bool HasCriteria() const
     {
-      return bridge ||
-             tunnel ||
-             oneway ||
+      return bridge     ||
+             tunnel     ||
+             embankment ||
+             oneway     ||
              sizeCondition;
     }
 
@@ -407,6 +422,11 @@ namespace osmscout {
     inline bool GetTunnel() const
     {
       return tunnel;
+    }
+
+    inline bool GetEmbankment() const
+    {
+      return embankment;
     }
 
     inline bool GetOneway() const

--- a/libosmscout-map/include/osmscout/oss/Parser.h
+++ b/libosmscout-map/include/osmscout/oss/Parser.h
@@ -233,6 +233,7 @@ inline void ToRGBA(const std::string& str, Color& color)
 	void STYLEFILTER_ONEWAY(StyleFilter& filter);
 	void STYLEFILTER_BRIDGE(StyleFilter& filter);
 	void STYLEFILTER_TUNNEL(StyleFilter& filter);
+	void STYLEFILTER_EMBANKMENT(StyleFilter& filter);
 	void STYLEFILTER_SIZE(StyleFilter& filter);
 	void SIZECONDITION(SizeConditionRef& condition);
 	void NODESTYLEDEF(StyleFilter filter, bool state);

--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -625,6 +625,9 @@ PRODUCTIONS
                      STYLEFILTER_TUNNEL<filter>
                    ]
                    [
+                     STYLEFILTER_EMBANKMENT<filter>
+                   ]
+                   [
                      STYLEFILTER_SIZE<filter>
                    ]
                 "]"
@@ -849,6 +852,13 @@ PRODUCTIONS
               = "TUNNEL"
                 (.
                   filter.SetTunnel(true);
+                .)
+                .
+
+  STYLEFILTER_EMBANKMENT<StyleFilter& filter>
+              = "EMBANKMENT"
+                (.
+                  filter.SetEmbankment(true);
                 .)
                 .
 

--- a/libosmscout-map/src/osmscout/StyleConfig.cpp
+++ b/libosmscout-map/src/osmscout/StyleConfig.cpp
@@ -172,6 +172,7 @@ namespace osmscout {
   StyleResolveContext::StyleResolveContext(const TypeConfigRef& typeConfig)
   : bridgeReader(*typeConfig),
     tunnelReader(*typeConfig),
+    embankmentReader(*typeConfig),
     accessReader(*typeConfig)
   {
     // no code
@@ -1528,6 +1529,7 @@ namespace osmscout {
     maxLevel(std::numeric_limits<size_t>::max()),
     bridge(false),
     tunnel(false),
+    embankment(false),
     oneway(false)
   {
     // no code
@@ -1540,6 +1542,7 @@ namespace osmscout {
     this->maxLevel=other.maxLevel;
     this->bridge=other.bridge;
     this->tunnel=other.tunnel;
+    this->embankment=other.embankment;
     this->oneway=other.oneway;
     this->sizeCondition=other.sizeCondition;
   }
@@ -1579,6 +1582,13 @@ namespace osmscout {
     return *this;
   }
 
+  StyleFilter& StyleFilter::SetEmbankment(bool embankment)
+  {
+    this->embankment=embankment;
+
+    return *this;
+  }
+    
   StyleFilter& StyleFilter::SetOneway(bool oneway)
   {
     this->oneway=oneway;
@@ -1596,6 +1606,7 @@ namespace osmscout {
   StyleCriteria::StyleCriteria()
   : bridge(false),
     tunnel(false),
+    embankment(false),
     oneway(false)
   {
     // no code
@@ -1605,6 +1616,7 @@ namespace osmscout {
   {
     this->bridge=other.GetBridge();
     this->tunnel=other.GetTunnel();
+    this->embankment=other.GetEmbankment();
     this->oneway=other.GetOneway();
     this->sizeCondition=other.GetSizeCondition();
   }
@@ -1613,23 +1625,26 @@ namespace osmscout {
   {
     this->bridge=other.bridge;
     this->tunnel=other.tunnel;
+    this->embankment=other.embankment;
     this->oneway=other.oneway;
     this->sizeCondition=other.sizeCondition;
   }
 
   bool StyleCriteria::operator==(const StyleCriteria& other) const
   {
-    return bridge==other.bridge &&
-           tunnel==other.tunnel &&
-           oneway==other.oneway &&
+    return bridge==other.bridge         &&
+           tunnel==other.tunnel         &&
+           embankment==other.embankment &&
+           oneway==other.oneway         &&
            sizeCondition==other.sizeCondition;
   }
 
   bool StyleCriteria::operator!=(const StyleCriteria& other) const
   {
-    return bridge!=other.bridge ||
-           tunnel!=other.tunnel ||
-           oneway!=other.oneway ||
+    return bridge!=other.bridge         ||
+           tunnel!=other.tunnel         ||
+           embankment!=other.embankment ||
+           oneway!=other.oneway         ||
            sizeCondition!=other.sizeCondition;
   }
 
@@ -1644,6 +1659,10 @@ namespace osmscout {
       return false;
     }
 
+    if (embankment) {
+      return false;
+    }
+      
     if (oneway) {
       return false;
     }
@@ -1672,6 +1691,11 @@ namespace osmscout {
       return false;
     }
 
+    if (embankment &&
+       !context.IsEmbankment(buffer)) {
+      return false;
+    }
+      
     if (oneway &&
         !context.IsOneway(buffer)) {
       return false;

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1024,6 +1024,9 @@ void Parser::STYLEFILTER(StyleFilter& filter) {
 		if (la->kind == 42 /* "TUNNE" */) {
 			STYLEFILTER_TUNNEL(filter);
 		}
+		if (la->kind == 999 /* "EMBANKMENT" */) {
+			STYLEFILTER_EMBANKMENT(filter);
+		}
 		if (la->kind == 43 /* "SIZE" */) {
 			STYLEFILTER_SIZE(filter);
 		}
@@ -1239,6 +1242,12 @@ void Parser::STYLEFILTER_BRIDGE(StyleFilter& filter) {
 void Parser::STYLEFILTER_TUNNEL(StyleFilter& filter) {
 		Expect(42 /* "TUNNE" */);
 		filter.SetTunnel(true);
+		
+}
+
+void Parser::STYLEFILTER_EMBANKMENT(StyleFilter& filter) {
+		Expect(999 /* "EMBANKMENT" */);
+		filter.SetEmbankment(true);
 		
 }
 
@@ -2416,6 +2425,7 @@ void Errors::SynErr(int line, int col, int n)
 			case 167: s = coco_string_create("invalid CAPSTYLE"); break;
 			case 168: s = coco_string_create("invalid TEXTLABE"); break;
 			case 169: s = coco_string_create("invalid LABELSTYLE"); break;
+			case 999: s = coco_string_create("\"EMBANKMENT\" expected"); break;
 
     default:
     {

--- a/libosmscout-map/src/osmscout/oss/Scanner.cpp
+++ b/libosmscout-map/src/osmscout/oss/Scanner.cpp
@@ -245,6 +245,7 @@ void Scanner::Init() {
 	keywords.set("emphasize", 87);
 	keywords.set("lighten", 88);
 	keywords.set("darken", 91);
+	keywords.set("EMBANKMENT", 999);
 
 
   tvalLength = 128;

--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -1164,6 +1164,7 @@ namespace osmscout {
     FeatureRef                                  featureGrade;
     FeatureRef                                  featureBridge;
     FeatureRef                                  featureTunnel;
+    FeatureRef                                  featureEmbankment;
     FeatureRef                                  featureRoundabout;
 
   public:

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1182,6 +1182,28 @@ namespace osmscout {
                FeatureValueBuffer& buffer) const;
   };
 
+  class OSMSCOUT_API EmbankmentFeature : public Feature
+  {
+    private:
+      TagId tagEmbankment;
+
+    public:
+        /** Name of this feature */
+        static const char* const NAME;
+
+    public:
+        void Initialize(TypeConfig& typeConfig);
+
+        std::string GetName() const;
+
+        void Parse(Progress& progress,
+                   const TypeConfig& typeConfig,
+                   const FeatureInstance& feature,
+                   const ObjectOSMRef& object,
+                   const TagMap& tags,
+                   FeatureValueBuffer& buffer) const;
+  };
+
   class OSMSCOUT_API RoundaboutFeature : public Feature
   {
   private:
@@ -1644,6 +1666,7 @@ namespace osmscout {
   typedef FeatureReader<AccessRestrictedFeature> AccessRestrictedFeatureReader;
   typedef FeatureReader<BridgeFeature>           BridgeFeatureReader;
   typedef FeatureReader<TunnelFeature>           TunnelFeatureReader;
+  typedef FeatureReader<EmbankmentFeature>       EmbankmentFeatureReader;
   typedef FeatureReader<RoundaboutFeature>       RoundaboutFeatureReader;
 
   /**

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -1063,6 +1063,9 @@ namespace osmscout {
     featureTunnel=std::make_shared<TunnelFeature>();
     RegisterFeature(featureTunnel);
 
+    featureEmbankment=std::make_shared<EmbankmentFeature>();
+    RegisterFeature(featureEmbankment);
+      
     featureRoundabout=std::make_shared<RoundaboutFeature>();
     RegisterFeature(featureRoundabout);
 
@@ -1250,6 +1253,9 @@ namespace osmscout {
       }
       if (!typeInfo->HasFeature(TunnelFeature::NAME)) {
         typeInfo->AddFeature(featureTunnel);
+      }
+      if (!typeInfo->HasFeature(EmbankmentFeature::NAME)) {
+        typeInfo->AddFeature(featureEmbankment);
       }
       if (!typeInfo->HasFeature(RoundaboutFeature::NAME)) {
         typeInfo->AddFeature(featureRoundabout);

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -1721,6 +1721,35 @@ namespace osmscout {
     }
   }
 
+  const char* const EmbankmentFeature::NAME = "Embankment";
+
+  void EmbankmentFeature::Initialize(TypeConfig& typeConfig)
+  {
+        tagEmbankment=typeConfig.RegisterTag("embankment");
+  }
+    
+  std::string EmbankmentFeature::GetName() const
+  {
+        return NAME;
+  }
+    
+  void EmbankmentFeature::Parse(Progress& /*progress*/,
+                            const TypeConfig& /*typeConfig*/,
+                            const FeatureInstance& feature,
+                            const ObjectOSMRef& /*object*/,
+                            const TagMap& tags,
+                            FeatureValueBuffer& buffer) const
+  {
+        auto embankment=tags.find(tagEmbankment);
+
+        if (embankment!=tags.end() &&
+            !(embankment->second=="no" ||
+              embankment->second=="false" ||
+              embankment->second=="0")) {
+                buffer.AllocateValue(feature.GetIndex());
+        }
+  }
+
   const char* const RoundaboutFeature::NAME = "Roundabout";
 
   void RoundaboutFeature::Initialize(TypeConfig& typeConfig)


### PR DESCRIPTION
(https://wiki.openstreetmap.org/wiki/Key:embankment)

Ways with embankment tag set to yes are often used like bridges, when these ways cross some part of seas or oceans the water detection code is confused and classify wrongly the corresponding tiles as ground instead of water.  Of course the EMBANKMENT keyword could also be used to style ways like TUNNEL and BRIDGE.
I modified the scanner and parser code by hands to make some tests because I don’t have the tools to compile the grammar file, could you generate this files properly ?