### PR TITLE
Report broken relations to html report

### DIFF
--- a/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
+++ b/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
@@ -160,6 +160,7 @@ namespace osmscout {
                     Progress& progress,
                     Id id,
                     const std::string& name,
+                    const TypeInfoRef& type,
                     std::list<MultipolygonPart>& parts);
 
     bool ResolveMultipolygon(const TypeConfig& typeConfig,
@@ -167,6 +168,7 @@ namespace osmscout {
                              Progress& progress,
                              Id id,
                              const std::string& name,
+                             const TypeInfoRef& type,
                              std::list<MultipolygonPart>& parts);
 
     bool ComposeAreaMembers(const TypeConfig& typeConfig,

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -146,6 +146,7 @@ namespace osmscout {
                                         Progress& progress,
                                         Id id,
                                         const std::string& name,
+                                        const TypeInfoRef& type,
                                         std::list<MultipolygonPart>& parts)
   {
     std::list<MultipolygonPart>                 rings;
@@ -184,6 +185,11 @@ namespace osmscout {
                        " of way "+NumberToString(entry.second.front()->ways.front()->GetId())+
                        " cannot be joined with any other way of the relation "+
                        NumberToString(id)+" "+name);
+
+        parameter.GetErrorReporter()->ReportRelation(id,
+                                                     type,
+                                                     "Incomplete or broken relation - cannot join path "+
+                                                     NumberToString(entry.second.front()->ways.front()->GetId()));
         return false;
       }
 
@@ -318,6 +324,7 @@ namespace osmscout {
                                                  Progress& progress,
                                                  Id id,
                                                  const std::string& name,
+                                                 const TypeInfoRef& type,
                                                  std::list<MultipolygonPart>& parts)
   {
     std::list<MultipolygonPart> groups;
@@ -331,6 +338,7 @@ namespace osmscout {
                     progress,
                     id,
                     name,
+                    type,
                     parts)) {
       return false;
     }
@@ -459,7 +467,7 @@ namespace osmscout {
 
           part.role.nodes[n].Set(coordEntry->second.GetSerial(),
                                  coordEntry->second.GetCoord());
-        }
+          }
 
         part.ways.push_back(way);
 
@@ -918,6 +926,7 @@ namespace osmscout {
                              progress,
                              rawRelation.GetId(),
                              name,
+                             rawRelation.GetType(),
                              parts)) {
       return false;
     }

--- a/libosmscout/include/osmscout/Coord.h
+++ b/libosmscout/include/osmscout/Coord.h
@@ -45,7 +45,7 @@ namespace osmscout {
   struct OSMSCOUT_API Coord CLASS_FINAL
   {
   private:
-    uint8_t    serial;     //!< Serial id in relation to all coordinates witht he same coord value
+    uint8_t    serial;     //!< Serial id in relation to all coordinates with the same coord value
     GeoCoord   coord;      //!< The geographic coordinate
 
   public:

--- a/libosmscout/include/osmscout/Point.h
+++ b/libosmscout/include/osmscout/Point.h
@@ -87,7 +87,7 @@ namespace osmscout {
     /**
      * Returns a fast calculable unique id for the coordinate under consideration
      * that different OSM nodes with the same coordinate will have different ids if the
-     * identity of the node is important - else th serial id will 0.
+     * identity of the node is important - else the serial id will be 0.
      *
      * The id does not have any semantics regarding sorting. Coordinates with close ids
      * do not need to be close in location.
@@ -125,7 +125,7 @@ namespace osmscout {
 
     /**
      * Compare this and the other point for "sameness". Sameness is defined as having the
-     * same coordinate but not necessarily the same serial id. THis means, that both points
+     * same coordinate but not necessarily the same serial id. This means, that both points
      * have the same location but are not necessarily identical.
      *
      * @param other

--- a/libosmscout/src/osmscout/util/HTMLWriter.cpp
+++ b/libosmscout/src/osmscout/util/HTMLWriter.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <osmscout/util/HTMLWriter.h>
+#include <osmscout/util/String.h>
 
 #include <osmscout/system/Assert.h>
 #include <osmscout/util/Logger.h>
@@ -330,7 +331,7 @@ namespace osmscout {
         break;
       }
 
-      file << "/" << object.GetId() << "\">" << Sanitize(name) << "</a>";
+      file << "/" << NumberToString(object.GetId()) << "\">" << Sanitize(name) << "</a>";
     }
     catch (std::ifstream::failure& e) {
       throw IOException(filename,"Cannot write object link",e);


### PR DESCRIPTION
Hi. I was investigating one missing multipolygon on the map. It was caused by unclosed outer ring, so it was not library bug. I just extend reporting of invalid relations to relation.html...