### PR TITLE
Write tag errors to new html report

### DIFF
--- a/Tests/src/AccessParse.cpp
+++ b/Tests/src/AccessParse.cpp
@@ -99,7 +99,7 @@ bool CheckParseSuccess(bool canFoot,
                        uint8_t expectedAccessValue,
                        const std::unordered_map<std::string,std::string>& stringTags)
 {
-  osmscout::SilentProgress                        progress;
+  osmscout::SilentTagErrorReporter                reporter;
   osmscout::TypeConfig                            typeConfig;
   osmscout::TypeInfoRef                           testType=std::make_shared<osmscout::TypeInfo>("TestType");
   osmscout::FeatureRef                            accessFeature;
@@ -134,7 +134,7 @@ bool CheckParseSuccess(bool canFoot,
 
   buffer.SetType(testType);
 
-  accessFeature->Parse(progress,
+  accessFeature->Parse(reporter,
                        typeConfig,
                        featureInstance,
                        osmscout::ObjectOSMRef(1,osmscout::osmRefWay),

--- a/Tests/src/AccessParse.cpp
+++ b/Tests/src/AccessParse.cpp
@@ -4,6 +4,7 @@
 
 #include <osmscout/TypeConfig.h>
 #include <osmscout/TypeFeatures.h>
+#include <osmscout/util/TagErrorReporter.h>
 
 std::string AccessToString(uint8_t access)
 {

--- a/libosmscout-import/include/osmscout/import/ImportErrorReporter.h
+++ b/libosmscout-import/include/osmscout/import/ImportErrorReporter.h
@@ -29,6 +29,7 @@
 #include <osmscout/TypeConfig.h>
 
 #include <osmscout/util/HTMLWriter.h>
+#include <osmscout/util/TagErrorReporter.h>
 
 #include <osmscout/system/Compiler.h>
 
@@ -38,10 +39,11 @@ namespace osmscout {
    * Class to report OSM data problems during import against.
    * Based on the reported errors various HTML bases error reporting pages are generated.
    */
-  class OSMSCOUT_IMPORT_API ImportErrorReporter CLASS_FINAL
+  class OSMSCOUT_IMPORT_API ImportErrorReporter CLASS_FINAL: public TagErrorReporter
   {
   public:
     static const char* const FILENAME_INDEX_HTML;
+    static const char* const FILENAME_TAG_HTML;
     static const char* const FILENAME_WAY_HTML;
     static const char* const FILENAME_RELATION_HTML;
     static const char* const FILENAME_LOCATION_HTML;
@@ -80,6 +82,9 @@ namespace osmscout {
 
     std::list<ReportError> errors;
 
+    HTMLWriter             tagReport;
+    size_t                 tagErrorCount;
+
     HTMLWriter             wayReport;
     size_t                 wayErrorCount;
 
@@ -102,6 +107,10 @@ namespace osmscout {
                         const TypeConfigRef& typeConfig,
                         const std::string& destinationDirectory);
     virtual ~ImportErrorReporter();
+
+    virtual void ReportTag(const ObjectOSMRef &object,
+                           const TagMap& tags,
+                           const std::string& error);
 
     void ReportWay(OSMId id,
                    const TagMap& tags,

--- a/libosmscout-import/include/osmscout/import/RawNode.h
+++ b/libosmscout-import/include/osmscout/import/RawNode.h
@@ -118,7 +118,7 @@ namespace osmscout {
 
     void UnsetFeature(size_t idx);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& errorReporter,
                const TypeConfig& typeConfig,
                const TagMap& tags);
     void Read(const TypeConfig& typeConfig,

--- a/libosmscout-import/include/osmscout/import/RawRelation.h
+++ b/libosmscout-import/include/osmscout/import/RawRelation.h
@@ -28,6 +28,7 @@
 
 #include <osmscout/util/FileScanner.h>
 #include <osmscout/util/FileWriter.h>
+#include <osmscout/util/TagErrorReporter.h>
 
 #include <osmscout/system/Compiler.h>
 
@@ -101,7 +102,7 @@ namespace osmscout {
     void SetId(OSMId id);
     void SetType(const TypeInfoRef& type);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& errorReporter,
                const TypeConfig& typeConfig,
                const TagMap& tags);
     void Read(const TypeConfig& typeConfig,

--- a/libosmscout-import/include/osmscout/import/RawWay.h
+++ b/libosmscout-import/include/osmscout/import/RawWay.h
@@ -134,7 +134,7 @@ namespace osmscout {
       nodes.assign(first,end);
     }
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& errorReporter,
                const TypeConfig& typeConfig,
                const TagMap& tags);
     void Read(const TypeConfig& typeConfig,

--- a/libosmscout-import/src/osmscout/import/ImportErrorReporter.cpp
+++ b/libosmscout-import/src/osmscout/import/ImportErrorReporter.cpp
@@ -29,6 +29,7 @@
 namespace osmscout {
 
   const char* const ImportErrorReporter::FILENAME_INDEX_HTML    = "index.html";
+  const char* const ImportErrorReporter::FILENAME_TAG_HTML      = "tag.html";
   const char* const ImportErrorReporter::FILENAME_WAY_HTML      = "way.html";
   const char* const ImportErrorReporter::FILENAME_RELATION_HTML = "relation.html";
   const char* const ImportErrorReporter::FILENAME_LOCATION_HTML = "location.html";
@@ -44,6 +45,12 @@ namespace osmscout {
       locationErrorCount(0)
   {
     nameTagId=typeConfig->GetTagId("name");
+
+    tagReport.Open(AppendFileToDir(destinationDirectory,FILENAME_TAG_HTML));
+    tagReport.WriteDocumentStart();
+    tagReport.WriteHeader("Tag value errors","Import errors related to tags","","..stylesheet.css");
+    tagReport.WriteBodyStart();
+    tagReport.WriteListStart();
 
     wayReport.Open(AppendFileToDir(destinationDirectory,FILENAME_WAY_HTML));
     wayReport.WriteDocumentStart();
@@ -68,6 +75,10 @@ namespace osmscout {
     index.WriteHeader("Index","Index of all reports","","..stylesheet.css");
     index.WriteBodyStart();
     index.WriteListStart();
+
+    index.WriteListEntryStart();
+    index.WriteLink("tag.html","List of tag import errors");
+    index.WriteListEntryEnd();
 
     index.WriteListEntryStart();
     index.WriteLink("way.html","List of way import errors");
@@ -109,6 +120,13 @@ namespace osmscout {
     wayReport.WriteDocumentEnd();
 
     wayReport.CloseFailsafe();
+
+    tagReport.WriteListEnd();
+    tagReport.WriteText(NumberToString(tagErrorCount)+" errors");
+    tagReport.WriteBodyEnd();
+    tagReport.WriteDocumentEnd();
+
+    tagReport.CloseFailsafe();
   }
 
   std::string ImportErrorReporter::GetName(const ObjectOSMRef& object,
@@ -127,6 +145,25 @@ namespace osmscout {
     }
 
     return buffer.str();
+  }
+
+  void ImportErrorReporter::ReportTag(const ObjectOSMRef& object,
+                                      const TagMap& tags,
+                                      const std::string& error)
+  {
+    std::unique_lock <std::mutex> lock(mutex);
+
+    std::string name(GetName(object,tags));
+
+    progress.Warning(name+" - "+error);
+
+    tagReport.WriteListEntryStart();
+    tagReport.WriteOSMObjectLink(object,name);
+    tagReport.WriteText(" - ");
+    tagReport.WriteText(error);
+    tagReport.WriteListEntryEnd();
+
+    tagErrorCount++;
   }
 
   void ImportErrorReporter::ReportWay(OSMId id,

--- a/libosmscout-import/src/osmscout/import/Preprocess.cpp
+++ b/libosmscout-import/src/osmscout/import/Preprocess.cpp
@@ -239,7 +239,7 @@ namespace osmscout {
       node.SetType(type);
       node.SetCoord(data.coord);
 
-      node.Parse(progress,
+      node.Parse(*parameter.GetErrorReporter(),
                  *typeConfig,
                  data.tags);
 
@@ -381,7 +381,7 @@ namespace osmscout {
       assert(false);
     }
 
-    way.Parse(progress,
+    way.Parse(*parameter.GetErrorReporter(),
               *typeConfig,
               data.tags);
 
@@ -470,7 +470,7 @@ namespace osmscout {
 
     relation.members=members;
 
-    relation.Parse(progress,
+    relation.Parse(*parameter.GetErrorReporter(),
                    *typeConfig,
                    tags);
 

--- a/libosmscout-import/src/osmscout/import/RawNode.cpp
+++ b/libosmscout-import/src/osmscout/import/RawNode.cpp
@@ -51,14 +51,14 @@ namespace osmscout {
     featureValueBuffer.FreeValue(idx);
   }
 
-  void RawNode::Parse(Progress& progress,
+  void RawNode::Parse(TagErrorReporter& errorReporter,
                       const TypeConfig& typeConfig,
                       const TagMap& tags)
   {
     ObjectOSMRef object(id,
                         osmRefNode);
 
-    featureValueBuffer.Parse(progress,
+    featureValueBuffer.Parse(errorReporter,
                              typeConfig,
                              object,
                              tags);

--- a/libosmscout-import/src/osmscout/import/RawRelation.cpp
+++ b/libosmscout-import/src/osmscout/import/RawRelation.cpp
@@ -34,14 +34,14 @@ namespace osmscout {
     featureValueBuffer.SetType(type);
   }
 
-  void RawRelation::Parse(Progress& progress,
+  void RawRelation::Parse(TagErrorReporter& errorReporter,
                           const TypeConfig& typeConfig,
                           const TagMap& tags)
   {
     ObjectOSMRef object(id,
                         osmRefRelation);
 
-    featureValueBuffer.Parse(progress,
+    featureValueBuffer.Parse(errorReporter,
                              typeConfig,
                              object,
                              tags);

--- a/libosmscout-import/src/osmscout/import/RawWay.cpp
+++ b/libosmscout-import/src/osmscout/import/RawWay.cpp
@@ -61,14 +61,14 @@ namespace osmscout {
     this->nodes=nodes;
   }
 
-  void RawWay::Parse(Progress& progress,
+  void RawWay::Parse(TagErrorReporter& errorReporter,
                      const TypeConfig& typeConfig,
                      const TagMap& tags)
   {
     ObjectOSMRef object(id,
                         osmRefWay);
 
-    featureValueBuffer.Parse(progress,
+    featureValueBuffer.Parse(errorReporter,
                              typeConfig,
                              object,
                              tags);

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADER_FILES
     include/osmscout/util/Tiling.h
     include/osmscout/util/Transformation.h
     include/osmscout/util/WorkQueue.h
+    include/osmscout/util/TagErrorReporter.h
     include/osmscout/Area.h
     include/osmscout/AreaAreaIndex.h
     include/osmscout/AreaDataFile.h
@@ -113,6 +114,7 @@ set(SOURCE_FILES
     src/osmscout/util/Tiling.cpp
     src/osmscout/util/Transformation.cpp
     src/osmscout/util/WorkQueue.cpp
+    src/osmscout/util/TagErrorReporter.cpp
     src/osmscout/Area.cpp
     src/osmscout/AreaDataFile.cpp
     src/osmscout/AreaAreaIndex.cpp

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -36,7 +36,6 @@ set(HEADER_FILES
     include/osmscout/util/Tiling.h
     include/osmscout/util/Transformation.h
     include/osmscout/util/WorkQueue.h
-    include/osmscout/util/TagErrorReporter.h
     include/osmscout/Area.h
     include/osmscout/AreaAreaIndex.h
     include/osmscout/AreaDataFile.h

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -32,6 +32,7 @@ set(HEADER_FILES
     include/osmscout/util/Projection.h
     include/osmscout/util/StopClock.h
     include/osmscout/util/String.h
+    include/osmscout/util/TagErrorReporter.h
     include/osmscout/util/Tiling.h
     include/osmscout/util/Transformation.h
     include/osmscout/util/WorkQueue.h

--- a/libosmscout/include/osmscout/TypeConfig.h
+++ b/libosmscout/include/osmscout/TypeConfig.h
@@ -39,6 +39,7 @@
 #include <osmscout/util/FileScanner.h>
 #include <osmscout/util/FileWriter.h>
 #include <osmscout/util/Progress.h>
+#include <osmscout/util/TagErrorReporter.h>
 
 #include <osmscout/system/Assert.h>
 
@@ -166,7 +167,7 @@ namespace osmscout {
 
     virtual FeatureValue* AllocateValue(void* buffer);
 
-    virtual void Parse(Progress& progress,
+    virtual void Parse(TagErrorReporter& reporter,
                        const TypeConfig& typeConfig,
                        const FeatureInstance& feature,
                        const ObjectOSMRef& object,
@@ -1057,7 +1058,7 @@ namespace osmscout {
     FeatureValue* AllocateValue(size_t idx);
     void FreeValue(size_t idx);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& errorReporter,
                const TypeConfig& typeConfig,
                const ObjectOSMRef& object,
                const TagMap& tags);

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -88,7 +88,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -156,7 +156,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -225,7 +225,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -291,7 +291,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -364,7 +364,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -612,7 +612,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -747,7 +747,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -807,7 +807,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -867,7 +867,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -927,7 +927,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -988,7 +988,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1062,7 +1062,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1130,7 +1130,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1152,7 +1152,7 @@ namespace osmscout {
 
     std::string GetName() const;
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1174,7 +1174,7 @@ namespace osmscout {
 
     std::string GetName() const;
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1196,7 +1196,7 @@ namespace osmscout {
 
         std::string GetName() const;
 
-        void Parse(Progress& progress,
+        void Parse(TagErrorReporter& reporter,
                    const TypeConfig& typeConfig,
                    const FeatureInstance& feature,
                    const ObjectOSMRef& object,
@@ -1218,7 +1218,7 @@ namespace osmscout {
 
     std::string GetName() const;
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1290,7 +1290,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1361,7 +1361,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1383,7 +1383,7 @@ namespace osmscout {
 
     std::string GetName() const;
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1451,7 +1451,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1517,7 +1517,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,
@@ -1576,7 +1576,7 @@ namespace osmscout {
     size_t GetValueSize() const;
     FeatureValue* AllocateValue(void* buffer);
 
-    void Parse(Progress& progress,
+    void Parse(TagErrorReporter& reporter,
                const TypeConfig& typeConfig,
                const FeatureInstance& feature,
                const ObjectOSMRef& object,

--- a/libosmscout/include/osmscout/util/TagErrorReporter.h
+++ b/libosmscout/include/osmscout/util/TagErrorReporter.h
@@ -31,6 +31,9 @@ namespace osmscout {
 
   class OSMSCOUT_API TagErrorReporter
   {
+  protected:
+    inline TagErrorReporter(){};
+
   public:
     virtual inline ~TagErrorReporter(){};
 
@@ -42,13 +45,13 @@ namespace osmscout {
   class OSMSCOUT_API SilentTagErrorReporter: public TagErrorReporter
   {
   public:
-    inline SilentTagErrorReporter(){}
+    inline SilentTagErrorReporter(){};
 
-    virtual inline ~SilentTagErrorReporter(){}
+    virtual inline ~SilentTagErrorReporter(){};
 
     virtual inline void ReportTag(const ObjectOSMRef& /*object*/,
                                   const TagMap& /*tags*/,
-                                  const std::string& /*error*/){}
+                                  const std::string& /*error*/){};
   };
 }
 

--- a/libosmscout/include/osmscout/util/TagErrorReporter.h
+++ b/libosmscout/include/osmscout/util/TagErrorReporter.h
@@ -26,7 +26,7 @@ namespace osmscout {
   class OSMSCOUT_API TagErrorReporter
   {
   public:
-    virtual ~TagErrorReporter(){};
+    virtual inline ~TagErrorReporter(){};
 
     virtual void ReportTag(const ObjectOSMRef& object,
                            const TagMap& tags,

--- a/libosmscout/include/osmscout/util/TagErrorReporter.h
+++ b/libosmscout/include/osmscout/util/TagErrorReporter.h
@@ -1,3 +1,6 @@
+#ifndef TAGERRORREPORTER_H
+#define TAGERRORREPORTER_H
+
 /*
   This source is part of the libosmscout library
   Copyright (C) 2017 Lukas Karas
@@ -17,9 +20,12 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
-#ifndef TAGERRORREPORTER_H
-#define TAGERRORREPORTER_H
+#include <string>
 
+#include <osmscout/ObjectRef.h>
+#include <osmscout/Tag.h>
+
+#include <osmscout/private/CoreImportExport.h>
 
 namespace osmscout {
 

--- a/libosmscout/include/osmscout/util/TagErrorReporter.h
+++ b/libosmscout/include/osmscout/util/TagErrorReporter.h
@@ -1,0 +1,50 @@
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2017 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#ifndef TAGERRORREPORTER_H
+#define TAGERRORREPORTER_H
+
+
+namespace osmscout {
+
+  class OSMSCOUT_API TagErrorReporter
+  {
+  public:
+    virtual ~TagErrorReporter(){};
+
+    virtual void ReportTag(const ObjectOSMRef& object,
+                           const TagMap& tags,
+                           const std::string& error) = 0;
+  };
+
+  class OSMSCOUT_API SilentTagErrorReporter: public TagErrorReporter
+  {
+  public:
+    inline SilentTagErrorReporter(){}
+
+    virtual inline ~SilentTagErrorReporter(){}
+
+    virtual inline void ReportTag(const ObjectOSMRef& /*object*/,
+                                  const TagMap& /*tags*/,
+                                  const std::string& /*error*/){}
+  };
+}
+
+#endif /* TAGERRORREPORTER_H */
+

--- a/libosmscout/src/Makefile.am
+++ b/libosmscout/src/Makefile.am
@@ -37,6 +37,7 @@ libosmscout_la_SOURCES= osmscout/util/Breaker.cpp \
                         osmscout/util/Tiling.cpp \
                         osmscout/util/Transformation.cpp \
                         osmscout/util/WorkQueue.cpp \
+                        osmscout/util/TagErrorReporter.cpp \
                         osmscout/Types.cpp \
                         osmscout/TypeConfig.cpp \
                         osmscout/TypeFeatures.cpp \

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -272,13 +272,13 @@ namespace osmscout {
     }
   }
 
-  void FeatureValueBuffer::Parse(Progress& progress,
+  void FeatureValueBuffer::Parse(TagErrorReporter& errorReporter,
                                  const TypeConfig& typeConfig,
                                  const ObjectOSMRef& object,
                                  const TagMap& tags)
   {
     for (const auto &feature : type->GetFeatures()) {
-      feature.GetFeature()->Parse(progress,
+      feature.GetFeature()->Parse(errorReporter,
                                   typeConfig,
                                   feature,
                                   object,

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -88,7 +88,7 @@ namespace osmscout {
     return new (buffer) NameFeatureValue();
   }
 
-  void NameFeature::Parse(Progress& /*progress*/,
+  void NameFeature::Parse(TagErrorReporter& /*errorReporter*/,
                           const TypeConfig& typeConfig,
                           const FeatureInstance& feature,
                           const ObjectOSMRef& /*object*/,
@@ -174,7 +174,7 @@ namespace osmscout {
     return new (buffer) NameAltFeatureValue();
   }
 
-  void NameAltFeature::Parse(Progress& /*progress*/,
+  void NameAltFeature::Parse(TagErrorReporter& /*errorReporter*/,
                              const TypeConfig& typeConfig,
                              const FeatureInstance& feature,
                              const ObjectOSMRef& /*object*/,
@@ -261,7 +261,7 @@ namespace osmscout {
     return new (buffer) RefFeatureValue();
   }
 
-  void RefFeature::Parse(Progress& /*progress*/,
+  void RefFeature::Parse(TagErrorReporter& /*errorReporter*/,
                          const TypeConfig& /*typeConfig*/,
                          const FeatureInstance& feature,
                          const ObjectOSMRef& /*object*/,
@@ -330,7 +330,7 @@ namespace osmscout {
     return new (buffer) LocationFeatureValue();
   }
 
-  void LocationFeature::Parse(Progress& /*progress*/,
+  void LocationFeature::Parse(TagErrorReporter& /*errorReporter*/,
                               const TypeConfig& /*typeConfig*/,
                               const FeatureInstance& feature,
                               const ObjectOSMRef& /*object*/,
@@ -426,7 +426,7 @@ namespace osmscout {
     return new (buffer) AddressFeatureValue();
   }
 
-  void AddressFeature::Parse(Progress& /*progress*/,
+  void AddressFeature::Parse(TagErrorReporter& /*errorReporter*/,
                              const TypeConfig& /*typeConfig*/,
                              const FeatureInstance& feature,
                              const ObjectOSMRef& /*object*/,
@@ -529,7 +529,7 @@ namespace osmscout {
     return new (buffer) AccessFeatureValue();
   }
 
-  void AccessFeature::Parse(Progress& /*progress*/,
+  void AccessFeature::Parse(TagErrorReporter& /*errorReporter*/,
                             const TypeConfig& /*typeConfig*/,
                             const FeatureInstance& feature,
                             const ObjectOSMRef& /*object*/,
@@ -791,7 +791,7 @@ namespace osmscout {
     return new (buffer) AccessRestrictedFeatureValue();
   }
 
-  void AccessRestrictedFeature::Parse(Progress& /*progress*/,
+  void AccessRestrictedFeature::Parse(TagErrorReporter& /*errorReporter*/,
                                       const TypeConfig& /*typeConfig*/,
                                       const FeatureInstance& feature,
                                       const ObjectOSMRef& /*object*/,
@@ -908,7 +908,7 @@ namespace osmscout {
     return new (buffer) LayerFeatureValue();
   }
 
-  void LayerFeature::Parse(Progress& progress,
+  void LayerFeature::Parse(TagErrorReporter& errorReporter,
                            const TypeConfig& /*typeConfig*/,
                            const FeatureInstance& feature,
                            const ObjectOSMRef& object,
@@ -928,7 +928,7 @@ namespace osmscout {
         }
       }
       else {
-        progress.Warning(std::string("Layer tag value '")+layer->second+"' for "+object.GetName()+" is not numeric!");
+        errorReporter.ReportTag(object,tags,std::string("Layer tag value '")+layer->second+"' is not numeric!");
       }
     }
   }
@@ -983,7 +983,7 @@ namespace osmscout {
     return new (buffer) WidthFeatureValue();
   }
 
-  void WidthFeature::Parse(Progress& progress,
+  void WidthFeature::Parse(TagErrorReporter& errorReporter,
                            const TypeConfig& /*typeConfig*/,
                            const FeatureInstance& feature,
                            const ObjectOSMRef& object,
@@ -1031,10 +1031,10 @@ namespace osmscout {
     }
 
     if (!StringToNumber(widthString,w)) {
-      progress.Warning(std::string("Width tag value '")+width->second+"' for "+object.GetName()+" is no double!");
+      errorReporter.ReportTag(object,tags,std::string("Width tag value '")+width->second+"' is no double!");
     }
     else if (w<0 && w>255.5) {
-      progress.Warning(std::string("Width tag value '")+width->second+"' for "+object.GetName()+" value is too small or too big!");
+      errorReporter.ReportTag(object,tags,std::string("Width tag value '")+width->second+"' value is too small or too big!");
     }
     else {
       WidthFeatureValue* value=static_cast<WidthFeatureValue*>(buffer.AllocateValue(feature.GetIndex()));
@@ -1093,7 +1093,7 @@ namespace osmscout {
     return new (buffer) MaxSpeedFeatureValue();
   }
 
-  void MaxSpeedFeature::Parse(Progress& progress,
+  void MaxSpeedFeature::Parse(TagErrorReporter& errorReporter,
                               const TypeConfig& typeConfig,
                               const FeatureInstance& feature,
                               const ObjectOSMRef& object,
@@ -1156,7 +1156,7 @@ namespace osmscout {
         valueNumeric=maxSpeedValue;
       }
       else {
-        progress.Warning(std::string("Max speed tag value '")+maxSpeed->second+"' for "+object.GetName()+" is not numeric!");
+        errorReporter.ReportTag(object,tags,std::string("Max speed tag value '")+maxSpeed->second+"' is not numeric!");
         return;
       }
     }
@@ -1233,7 +1233,7 @@ namespace osmscout {
     return new (buffer) GradeFeatureValue();
   }
 
-  void GradeFeature::Parse(Progress& progress,
+  void GradeFeature::Parse(TagErrorReporter& errorReporter,
                            const TypeConfig& typeConfig,
                            const FeatureInstance& feature,
                            const ObjectOSMRef& object,
@@ -1279,7 +1279,7 @@ namespace osmscout {
         return;
       }
       else {
-        progress.Warning(std::string("Unsupported tracktype value '")+tracktype->second+"' for "+object.GetName());
+        errorReporter.ReportTag(object,tags,std::string("Unsupported tracktype value '")+tracktype->second+"'");
       }
     }
 
@@ -1295,7 +1295,7 @@ namespace osmscout {
         value->SetGrade((uint8_t)grade);
       }
       else {
-        progress.Warning(std::string("Unknown surface type '")+surface->second+"' for "+object.GetName()+"!");
+        errorReporter.ReportTag(object,tags,std::string("Unknown surface type '")+surface->second+"' !");
       }
     }
   }
@@ -1354,7 +1354,7 @@ namespace osmscout {
     return new (buffer) AdminLevelFeatureValue();
   }
 
-  void AdminLevelFeature::Parse(Progress& progress,
+  void AdminLevelFeature::Parse(TagErrorReporter& errorReporter,
                                 const TypeConfig& /*typeConfig*/,
                                 const FeatureInstance& feature,
                                 const ObjectOSMRef& object,
@@ -1379,7 +1379,7 @@ namespace osmscout {
         }
       }
       else {
-        progress.Warning(std::string("Admin level is not numeric '")+adminLevel->second+"' for "+object.GetName()+"!");
+        errorReporter.ReportTag(object,tags,std::string("Admin level is not numeric '")+adminLevel->second+"'!");
       }
     }
   }
@@ -1440,7 +1440,7 @@ namespace osmscout {
     return new (buffer) PostalCodeFeatureValue();
   }
 
-  void PostalCodeFeature::Parse(Progress& progress,
+  void PostalCodeFeature::Parse(TagErrorReporter& errorReporter,
                                 const TypeConfig& /*typeConfig*/,
                                 const FeatureInstance& feature,
                                 const ObjectOSMRef& object,
@@ -1471,11 +1471,10 @@ namespace osmscout {
         PostalCodeFeatureValue* value=static_cast<PostalCodeFeatureValue*>(fv);
 
         value->SetPostalCode(postalCodeValue);
-        //progress.Info(std::string("Found postal code ")+postalCodeValue+" for "+object.GetName());
       }
     }
     catch (const std::exception &e) {
-      progress.Error(std::string("PostalCodeFeature::Parse Exception ")+e.what());
+      errorReporter.ReportTag(object,tags,std::string("Postal code parse exception: ")+e.what());
     }
   }
 
@@ -1534,12 +1533,12 @@ namespace osmscout {
     return new (buffer) WebsiteFeatureValue();
   }
 
-  void WebsiteFeature::Parse(Progress& progress,
-                                const TypeConfig& /*typeConfig*/,
-                                const FeatureInstance& feature,
-                                const ObjectOSMRef& object,
-                                const TagMap& tags,
-                                FeatureValueBuffer& buffer) const
+  void WebsiteFeature::Parse(TagErrorReporter& errorReporter,
+                             const TypeConfig& /*typeConfig*/,
+                             const FeatureInstance& feature,
+                             const ObjectOSMRef& object,
+                             const TagMap& tags,
+                             FeatureValueBuffer& buffer) const
   {
     // ignore ways for now
     if (object.GetType() == OSMRefType::osmRefWay)
@@ -1560,11 +1559,10 @@ namespace osmscout {
         WebsiteFeatureValue* value=static_cast<WebsiteFeatureValue*>(fv);
 
         value->SetWebsite(strValue);
-        //progress.Info(std::string("Found website ")+strValue+" for "+object.GetName());
       }
     }
     catch (const std::exception &e) {
-      progress.Error(std::string("WebsiteFeature::Parse Exception ")+e.what());
+      errorReporter.ReportTag(object,tags,std::string("Website parse exception: ")+e.what());
     }
   }
 
@@ -1623,12 +1621,12 @@ namespace osmscout {
     return new (buffer) PhoneFeatureValue();
   }
 
-  void PhoneFeature::Parse(Progress& progress,
-                                const TypeConfig& /*typeConfig*/,
-                                const FeatureInstance& feature,
-                                const ObjectOSMRef& object,
-                                const TagMap& tags,
-                                FeatureValueBuffer& buffer) const
+  void PhoneFeature::Parse(TagErrorReporter& errorReporter,
+                           const TypeConfig& /*typeConfig*/,
+                           const FeatureInstance& feature,
+                           const ObjectOSMRef& object,
+                           const TagMap& tags,
+                           FeatureValueBuffer& buffer) const
   {
     // ignore ways for now
     if (object.GetType() == OSMRefType::osmRefWay)
@@ -1655,11 +1653,10 @@ namespace osmscout {
         PhoneFeatureValue* value=static_cast<PhoneFeatureValue*>(fv);
 
         value->SetPhone(strValue);
-        //progress.Info(std::string("Found phone ")+strValue+" for "+object.GetName());
       }
     }
     catch (const std::exception &e) {
-      progress.Error(std::string("PhoneFeature::Parse Exception ")+e.what());
+      errorReporter.ReportTag(object,tags,std::string("Phone parse exception: ")+e.what());
     }
   }
 
@@ -1675,7 +1672,7 @@ namespace osmscout {
     return NAME;
   }
 
-  void BridgeFeature::Parse(Progress& /*progress*/,
+  void BridgeFeature::Parse(TagErrorReporter& /*errorReporter*/,
                             const TypeConfig& /*typeConfig*/,
                             const FeatureInstance& feature,
                             const ObjectOSMRef& /*object*/,
@@ -1704,7 +1701,7 @@ namespace osmscout {
     return NAME;
   }
 
-  void TunnelFeature::Parse(Progress& /*progress*/,
+  void TunnelFeature::Parse(TagErrorReporter& /*errorReporter*/,
                             const TypeConfig& /*typeConfig*/,
                             const FeatureInstance& feature,
                             const ObjectOSMRef& /*object*/,
@@ -1733,12 +1730,12 @@ namespace osmscout {
         return NAME;
   }
 
-  void EmbankmentFeature::Parse(Progress& /*progress*/,
-                            const TypeConfig& /*typeConfig*/,
-                            const FeatureInstance& feature,
-                            const ObjectOSMRef& /*object*/,
-                            const TagMap& tags,
-                            FeatureValueBuffer& buffer) const
+  void EmbankmentFeature::Parse(TagErrorReporter& /*errorReporter*/,
+                                const TypeConfig& /*typeConfig*/,
+                                const FeatureInstance& feature,
+                                const ObjectOSMRef& /*object*/,
+                                const TagMap& tags,
+                                FeatureValueBuffer& buffer) const
   {
         auto embankment=tags.find(tagEmbankment);
 
@@ -1762,7 +1759,7 @@ namespace osmscout {
     return NAME;
   }
 
-  void RoundaboutFeature::Parse(Progress& /*progress*/,
+  void RoundaboutFeature::Parse(TagErrorReporter& /*errorReporter*/,
                                 const TypeConfig& /*typeConfig*/,
                                 const FeatureInstance& feature,
                                 const ObjectOSMRef& /*object*/,
@@ -1836,7 +1833,7 @@ namespace osmscout {
     return new (buffer) EleFeatureValue();
   }
 
-  void EleFeature::Parse(Progress& progress,
+  void EleFeature::Parse(TagErrorReporter& errorReporter,
                          const TypeConfig& /*typeConfig*/,
                          const FeatureInstance& feature,
                          const ObjectOSMRef& object,
@@ -1884,10 +1881,10 @@ namespace osmscout {
     }
 
     if (!StringToNumber(eleString,e)) {
-      progress.Warning(std::string("Ele tag value '")+ele->second+"' for "+object.GetName()+" is no double!");
+      errorReporter.ReportTag(object,tags,std::string("Ele tag value '")+ele->second+"' is no double!");
     }
     else if (e<0 && e>std::numeric_limits<uint32_t>::max()) {
-      progress.Warning(std::string("Ele tag value '")+ele->second+"' for "+object.GetName()+" value is too small or too big!");
+      errorReporter.ReportTag(object,tags,std::string("Ele tag value '")+ele->second+"' value is too small or too big!");
     }
     else {
       EleFeatureValue* value=static_cast<EleFeatureValue*>(buffer.AllocateValue(feature.GetIndex()));
@@ -1955,7 +1952,7 @@ namespace osmscout {
     return new (buffer) DestinationFeatureValue();
   }
 
-  void DestinationFeature::Parse(Progress& /*progress*/,
+  void DestinationFeature::Parse(TagErrorReporter& /*errorReporter*/,
                                  const TypeConfig& /*typeConfig*/,
                                  const FeatureInstance& feature,
                                  const ObjectOSMRef& /*object*/,
@@ -1987,7 +1984,7 @@ namespace osmscout {
     return NAME;
   }
 
-  void BuildingFeature::Parse(Progress& /*progress*/,
+  void BuildingFeature::Parse(TagErrorReporter& /*errorReporter*/,
                             const TypeConfig& /*typeConfig*/,
                             const FeatureInstance& feature,
                             const ObjectOSMRef& /*object*/,
@@ -2054,7 +2051,7 @@ namespace osmscout {
     return new (buffer) IsInFeatureValue();
   }
 
-  void IsInFeature::Parse(Progress& /*progress*/,
+  void IsInFeature::Parse(TagErrorReporter& /*errorReporter*/,
                           const TypeConfig& /*typeConfig*/,
                           const FeatureInstance& feature,
                           const ObjectOSMRef& /*object*/,

--- a/libosmscout/src/osmscout/util/TagErrorReporter.cpp
+++ b/libosmscout/src/osmscout/util/TagErrorReporter.cpp
@@ -1,6 +1,3 @@
-#ifndef TAGERRORREPORTER_H
-#define TAGERRORREPORTER_H
-
 /*
   This source is part of the libosmscout library
   Copyright (C) 2017 Lukas Karas
@@ -20,40 +17,21 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
-#include <string>
-
-#include <osmscout/ObjectRef.h>
-#include <osmscout/Tag.h>
-
-#include <osmscout/private/CoreImportExport.h>
+#include <osmscout/util/TagErrorReporter.h>
 
 namespace osmscout {
 
-  class OSMSCOUT_API TagErrorReporter
+  TagErrorReporter::TagErrorReporter()
   {
-  protected:
-    TagErrorReporter();
+  }
 
-  public:
-    virtual inline ~TagErrorReporter(){};
-
-    virtual void ReportTag(const ObjectOSMRef& object,
-                           const TagMap& tags,
-                           const std::string& error) = 0;
-  };
-
-  class OSMSCOUT_API SilentTagErrorReporter: public TagErrorReporter
+  SilentTagErrorReporter::SilentTagErrorReporter()
   {
-  public:
-    SilentTagErrorReporter();
+  }
 
-    virtual inline ~SilentTagErrorReporter(){};
-
-    virtual void ReportTag(const ObjectOSMRef& object,
-                           const TagMap& tags,
-                           const std::string& error);
-  };
+  void SilentTagErrorReporter::ReportTag(const ObjectOSMRef& /*object*/,
+                                         const TagMap& /*tags*/,
+                                         const std::string& /*error*/)
+  {
+  }
 }
-
-#endif /* TAGERRORREPORTER_H */
-


### PR DESCRIPTION
Example of such errors:
 - unknown surface type
 - width or ele is not double
 - layer or max speed is not number

See output for France:
https://osmscout.karry.cz/europe/france-12-20170426-0817/tag.html