### PR TITLE
Allow ways to have postal code feature

### DIFF
--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -1447,10 +1447,6 @@ namespace osmscout {
                                 const TagMap& tags,
                                 FeatureValueBuffer& buffer) const
   {
-    // ignore ways for now
-    if (object.GetType() == OSMRefType::osmRefWay)
-      return;
-
     auto postalCode=tags.find(tagPostalCode);
     auto addrPostCode=tags.find(tagAddrPostCode);
 


### PR DESCRIPTION
I dont know why i added this restriction back then but it prevents lot of valid postal codes at houses which are only made of a way and dont have a specific postal code node.