### PR TITLE
Compiler warnings 2

### DIFF
--- a/libosmscout-import/include/osmscout/import/GenCoordDat.h
+++ b/libosmscout-import/include/osmscout/import/GenCoordDat.h
@@ -29,15 +29,6 @@
 
 namespace osmscout {
 
-/**
- * Some temporary variables used in asserts may be unused
- * on production build, when asserts are wiped out.
- *
- * Usage of this macro for such variables makes production
- * build happy, and avoids unused-variable warning
- */
-#define _unused(x) ((void)(x))
-
   class CoordDataGenerator CLASS_FINAL : public ImportModule
   {
   private:

--- a/libosmscout-import/src/osmscout/import/GenCoordDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenCoordDat.cpp
@@ -28,6 +28,7 @@
 #include <osmscout/import/RawCoord.h>
 
 #include <osmscout/util/String.h>
+#include <osmscout/system/Compiler.h>
 
 namespace osmscout {
 
@@ -119,7 +120,7 @@ namespace osmscout {
             }
 
             assert(currentUpperLimit<oldUpperLimit);
-            _unused(oldUpperLimit);
+            unused(oldUpperLimit);
           }
         }
 
@@ -295,7 +296,7 @@ namespace osmscout {
             }
 
             assert(currentUpperLimit<oldUpperLimit);
-            _unused(oldUpperLimit);
+            unused(oldUpperLimit);
           }
         }
 

--- a/libosmscout/include/osmscout/system/Compiler.h
+++ b/libosmscout/include/osmscout/system/Compiler.h
@@ -26,4 +26,13 @@
   #define CLASS_FINAL final
 #endif
 
+/**
+ * Some temporary variables used in asserts may be unused
+ * on production build, when asserts are wiped out.
+ *
+ * Usage of this macro for such variables makes production
+ * build happy, and avoids unused-variable warning
+ */
+#define unused(x) ((void)(x))
+
 #endif

--- a/libosmscout/src/osmscout/util/FileScanner.cpp
+++ b/libosmscout/src/osmscout/util/FileScanner.cpp
@@ -45,6 +45,7 @@
 #endif
 
 #include <osmscout/system/Assert.h>
+#include <osmscout/system/Compiler.h>
 
 #include <osmscout/util/Exception.h>
 #include <osmscout/util/Logger.h>
@@ -220,6 +221,7 @@ namespace osmscout {
       }
     }
 #elif  defined(__WIN32__) || defined(WIN32)
+    unused(mode);
     if (useMmap && this->size>0) {
       FreeBuffer();
 


### PR DESCRIPTION
 - move `unused` macro to system/Compiler.h
 - mark `mode` parameter in `FileScanner::Open` as unused for windows - suppress compiler warning
