### PR TITLE
WayWayDataGenerator::GetWays: limit count of loaded ways by its node count

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWayWayDat.cpp
@@ -144,6 +144,7 @@ namespace osmscout {
   {
     uint32_t    wayCount=0;
     size_t      collectedWaysCount=0;
+    size_t      collectedWayNodesCount=0;
     size_t      typesWithWays=0;
     TypeInfoSet currentTypes(types);
 
@@ -174,8 +175,10 @@ namespace osmscout {
       ways[way->GetType()->GetIndex()].push_back(way);
 
       collectedWaysCount++;
+      collectedWayNodesCount+=way->GetNodes().size();
 
-      while (collectedWaysCount>parameter.GetRawWayBlockSize() &&
+      while ((collectedWaysCount>parameter.GetRawWayBlockSize() ||
+              collectedWayNodesCount>parameter.GetRawCoordBlockSize()) &&
              typesWithWays>1) {
         TypeInfoRef victimType;
 
@@ -192,6 +195,9 @@ namespace osmscout {
         assert(victimType);
 
         collectedWaysCount-=ways[victimType->GetIndex()].size();
+        for (auto const &way:ways[victimType->GetIndex()]){
+          collectedWayNodesCount-=way->GetNodes().size();
+        }
         ways[victimType->GetIndex()].clear();
 
         typesWithWays--;


### PR DESCRIPTION
Hi, I am experimenting with contour lines generated from elevation data with 1 degree resolution (I was using 3 deg. resolution until now). Such France import cause out-of-memory state during step 10 (WayWayDataGenerator) on my machine (16 GiB of RAM). Generated contour lines contains too many coordinates...

This patch limit processed ways (types) in one step by sum of required coordinates... Now I am able to run import, it require "just" 11 GiB of ram (`--rawWayBlockSize 4000000 --rawCoordBlockSize 60000000`).

