### PR TITLE
prevent warning for autoclosing file

### DIFF
--- a/libosmscout/src/osmscout/LocationIndex.cpp
+++ b/libosmscout/src/osmscout/LocationIndex.cpp
@@ -426,9 +426,11 @@ namespace osmscout {
                                   visitor);
 
         if (action==AdminRegionVisitor::error) {
+          scanner.Close();
           return false;
         }
         else if (action==AdminRegionVisitor::stop) {
+          scanner.Close();
           return true;
         }
         else if (action==AdminRegionVisitor::skipChildren) {
@@ -469,6 +471,7 @@ namespace osmscout {
                                       visitor,
                                       recursive,
                                       stopped)) {
+        scanner.Close();
         return false;
       }
 


### PR DESCRIPTION
This avoids the "Automatically closing FileScanner for file " warning during location lookup