### PR TITLE
add tag.html to reports

### DIFF
--- a/libosmscout-import/src/osmscout/import/Import.cpp
+++ b/libosmscout-import/src/osmscout/import/Import.cpp
@@ -1132,6 +1132,7 @@ namespace osmscout {
   std::list<std::string> Importer::GetProvidedReportFiles() const
   {
     std::list<std::string> providedFiles={ImportErrorReporter::FILENAME_INDEX_HTML,
+                                          ImportErrorReporter::FILENAME_TAG_HTML,
                                           ImportErrorReporter::FILENAME_WAY_HTML,
                                           ImportErrorReporter::FILENAME_RELATION_HTML,
                                           ImportErrorReporter::FILENAME_LOCATION_HTML};


### PR DESCRIPTION
File tag.html was left undeleted on imports where reports were asked to be deleted