### PR TITLE
Fix map rendering in Qt library when displayed area is undefined for Mercator projection

### DIFF
--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -258,11 +258,6 @@ void MoveHandler::onTimeout()
     if (!projection.Set(startMapView.center,
                         osmscout::Magnification(startMag + ((targetMag - startMag) * scale) ),
                         dpi, 1000, 1000)) {
-      return;
-    }
-
-    if (!projection.IsValid()) {
-        //TriggerMapRendering();
         return;
     }
 
@@ -358,11 +353,6 @@ bool MoveHandler::moveNow(QVector2D move)
     //qDebug() << "move: " << QString::fromStdString(view.center.GetDisplayText()) << "   by: " << move;
 
     if (!projection.Set(view.center, view.magnification, dpi, 1000, 1000)) {
-      return false;
-    }
-
-    if (!projection.IsValid()) {
-        //TriggerMapRendering();
         return false;
     }
 

--- a/libosmscout/include/osmscout/util/Projection.h
+++ b/libosmscout/include/osmscout/util/Projection.h
@@ -301,8 +301,11 @@ namespace osmscout {
 
     /**
      * Converts a geo coordinate to a pixel coordinate.
+     *
+     * Return true on success,
+     * false if given coordinate is not valid for this projection.
      */
-    virtual void GeoToPixel(const GeoCoord& coord,
+    virtual bool GeoToPixel(const GeoCoord& coord,
                             double& x, double& y) const = 0;
 
   protected:
@@ -414,7 +417,7 @@ namespace osmscout {
     bool PixelToGeo(double x, double y,
                     double& lon, double& lat) const;
 
-    void GeoToPixel(const GeoCoord& coord,
+    bool GeoToPixel(const GeoCoord& coord,
                     double& x, double& y) const;
 
     bool Move(double horizPixel,
@@ -533,7 +536,7 @@ namespace osmscout {
     bool PixelToGeo(double x, double y,
                     double& lon, double& lat) const;
 
-    void GeoToPixel(const GeoCoord& coord,
+    bool GeoToPixel(const GeoCoord& coord,
                     double& x, double& y) const;
 
     inline bool IsLinearInterpolationEnabled()

--- a/libosmscout/src/osmscout/util/Projection.cpp
+++ b/libosmscout/src/osmscout/util/Projection.cpp
@@ -242,7 +242,7 @@ namespace osmscout {
     return IsValidFor(GeoCoord(lat,lon));
   }
 
-  void MercatorProjection::GeoToPixel(const GeoCoord& coord,
+  bool MercatorProjection::GeoToPixel(const GeoCoord& coord,
                                       double& x, double& y) const
   {
     assert(valid);
@@ -268,6 +268,8 @@ namespace osmscout {
     // Transform to canvas coordinate
     y=height/2-y;
     x+=width/2;
+
+    return IsValidFor(coord);
   }
 
   void MercatorProjection::GeoToPixel(const BatchTransformer& /*transformData*/) const
@@ -422,11 +424,12 @@ namespace osmscout {
 
   #ifdef OSMSCOUT_HAVE_SSE2
 
-    void TileProjection::GeoToPixel(const GeoCoord& coord,
+    bool TileProjection::GeoToPixel(const GeoCoord& coord,
                                     double& x, double& y) const
     {
       x=coord.GetLon()*scaleGradtorad-lonOffset;
       y=height-(scale*atanh_sin_pd(coord.GetLat()*gradtorad)-latOffset);
+      return IsValidFor(coord);
     }
 
     //this basically transforms 2 coordinates in 1 call
@@ -445,7 +448,7 @@ namespace osmscout {
 
   #else
 
-    void TileProjection::GeoToPixel(const GeoCoord& coord,
+    bool TileProjection::GeoToPixel(const GeoCoord& coord,
                                     double& x, double& y) const
     {
       x=coord.GetLon()*scaleGradtorad-lonOffset;
@@ -456,6 +459,7 @@ namespace osmscout {
       else {
         y=height-(scale*atanh(sin(coord.GetLat()*gradtorad))-latOffset);
       }
+      return IsValidFor(coord);
     }
 
     void TileProjection::GeoToPixel(const BatchTransformer& /*transformData*/) const


### PR DESCRIPTION
Fixes for https://github.com/Framstag/libosmscout/issues/356

Tim, note that I changed `MercatorProjection::Set` behaviour. See updated documentation:

> Setup projection parameters.
>
> Return true on success,
> false if arguments are not valid for Mercator projection,
> projection parameters are unchnaged in such case.
>
> Note that coord (center) have to be valid coordinate
> in Mercator projection. But it is possible setup dimensions
> (width and height) that projection will cover area bigger
> than the one valid for Mercator projection. Bounding box
> is adjusted then to be valid for projection.
>
> In code:
>
>   projection.GetDimensions(bbox);
>   projection.GeoToPixel(bbox.GetMinCoord(),x,y)
>
> may be x >= 0