### PR TITLE
Basemap import fixes

### DIFF
--- a/BasemapImport/src/BasemapImport.cpp
+++ b/BasemapImport/src/BasemapImport.cpp
@@ -301,6 +301,7 @@ static bool ImportCoastlines(const std::string& destinationDirectory,
         if (std::abs(coastline->coast.front().GetLon())>179.999 &&
             std::abs(coastline->coast.front().GetLon()-coastline->coast.back().GetLon())<0.001){
           coastline->isArea=true;
+          coastline->coast.push_back(coastline->coast.front());
         }else if (coastline->coast.front().GetLon()<-179.999 && // reverse direction than OSM data!
                   coastline->coast.back().GetLon()>+179.999 &&
                   coastline->coast.front().GetLat()<-56 &&

--- a/libosmscout-import/include/osmscout/import/GenWaterIndex.h
+++ b/libosmscout-import/include/osmscout/import/GenWaterIndex.h
@@ -52,9 +52,6 @@ namespace osmscout {
                               Progress& progress,
                               std::list<WaterIndexProcessor::CoastRef>& boundingPolygons);
 
-    void MergeCoastlines(Progress& progress,
-                         std::list<WaterIndexProcessor::CoastRef>& coastlines);
-
     bool AssumeLand(const ImportParameter& parameter,
                     Progress& progress,
                     const TypeConfig& typeConfig,

--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -455,6 +455,9 @@ namespace osmscout {
                              Data& data);
 
 public:
+    void MergeCoastlines(Progress& progress,
+                         std::list<WaterIndexProcessor::CoastRef>& coastlines);
+
     void GetCells(const StateMap& stateMap,
                   const std::vector<GeoCoord>& points,
                   std::set<Pixel>& cellIntersections) const;

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -2082,8 +2082,7 @@ namespace osmscout {
       currentCell++;
 
 #if defined(DEBUG_COASTLINE)
-      std::cout << " - cell " << cellEntry.first.x << " " << cellEntry.first.y <<
-        " (level offset " << level.indexEntryOffset << "): " << std::endl;
+      std::cout << " - cell " << cellEntry.first.x << " " << cellEntry.first.y << "): " << std::endl;
 #endif
 
       HandleCoastlineCell(progress,
@@ -2177,6 +2176,99 @@ namespace osmscout {
                  );
 
     coastlines=synthesized;
+  }
+
+  void WaterIndexProcessor::MergeCoastlines(Progress& progress,
+                                            std::list<WaterIndexProcessor::CoastRef>& coastlines)
+  {
+    progress.SetAction("Merging coastlines");
+
+    std::map<Id,WaterIndexProcessor::CoastRef> coastStartMap;
+    std::list<WaterIndexProcessor::CoastRef>   mergedCoastlines;
+    std::set<Id>                               blacklist;
+    size_t                                     wayCoastCount=0;
+    size_t                                     areaCoastCount=0;
+
+    std::list<WaterIndexProcessor::CoastRef>::iterator c=coastlines.begin();
+    while (c!=coastlines.end()) {
+      WaterIndexProcessor::CoastRef coast=*c;
+
+      if (coast->isArea) {
+        areaCoastCount++;
+        mergedCoastlines.push_back(coast);
+
+        c=coastlines.erase(c);
+      }
+      else {
+        coastStartMap.insert(std::make_pair(coast->frontNodeId,coast));
+
+        c++;
+      }
+    }
+
+    bool merged=true;
+
+    while (merged) {
+      merged=false;
+
+      for (const auto& coast : coastlines) {
+        if (blacklist.find(coast->id)!=blacklist.end()) {
+          continue;
+        }
+
+        std::map<Id,WaterIndexProcessor::CoastRef>::iterator other=coastStartMap.find(coast->backNodeId);
+
+        if (other!=coastStartMap.end() &&
+            blacklist.find(other->second->id)==blacklist.end() &&
+            coast->id!=other->second->id) {
+          for (size_t i=1; i<other->second->coast.size(); i++) {
+            coast->coast.push_back(other->second->coast[i]);
+          }
+
+          coast->backNodeId=coast->coast.back().GetId();
+
+          // Immediately reduce memory
+          other->second->coast.clear();
+
+          blacklist.insert(other->second->id);
+          coastStartMap.erase(other);
+
+          merged=true;
+        }
+      }
+    }
+
+    // Gather merged coastlines
+    for (const auto& coastline : coastlines) {
+      if (blacklist.find(coastline->id)!=blacklist.end()) {
+        continue;
+      }
+
+      if (coastline->frontNodeId==coastline->backNodeId) {
+        coastline->isArea=true;
+        coastline->coast.pop_back();
+
+        areaCoastCount++;
+      }
+      else {
+        wayCoastCount++;
+      }
+
+      if ((coastline->isArea && coastline->coast.size()<=2) || coastline->coast.size()<2) {
+        progress.Warning("Dropping to short coastline with id "+NumberToString(coastline->id));
+        continue;
+      }
+
+      //if (!coastline->isArea){
+      //  WriteGpx(coastline->coast, "coastway-"+NumberToString(coastline->id)+".gpx");
+      //}
+
+      mergedCoastlines.push_back(coastline);
+    }
+
+    progress.Info(NumberToString(wayCoastCount)+" way coastline(s), "+NumberToString(areaCoastCount)+" area coastline(s)");
+
+    coastlines=mergedCoastlines;
   }
 
   /**


### PR DESCRIPTION
Some fixes for basemap import https://github.com/Framstag/libosmscout/issues/363:
- it is necessary to merge coastlines, Euro-Asia coastline are splitted in shapefiles from `openstreetmapdata.com`
- then I closed coastline ways that are touching antimeridian + Antartica (it is little bit hack)
- and remove remaining unclosed coastlines

![basemap](https://user-images.githubusercontent.com/309458/27058515-0fc9b00c-4fd2-11e7-8e31-de0d2c3cf657.png)

There are still some artefacts, but I think that it is rendering issue, not importer... 

Tim, I saw that coastlines from shapefile has different direction than is usual in OSM data. This is some rule? I see some "unfilled" islands, it is possible that coastlines in shapefile may be clock-wise and counter-clock-wise? Or it is some different bug?