### PR TITLE
OSMScoutOpenGL: add GLEW include dirs

### DIFF
--- a/OSMScoutOpenGL/CMakeLists.txt
+++ b/OSMScoutOpenGL/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(OSMScoutOpenGL PRIVATE
 		${OSMSCOUT_BASE_DIR_SOURCE}/libosmscout-map/include
 		${OSMSCOUT_BASE_DIR_SOURCE}/libosmscout-map-opengl/include
 		${OPENGL_INCLUDE_DIR}
+		${GLEW_INCLUDE_DIRS}
 		)
 
 if(MSVS OR MSYS OR MINGW)


### PR DESCRIPTION
`OSMScoutOpenGL` should include GLEW headers too... Should fix https://github.com/Framstag/libosmscout/issues/365#issuecomment-309342081