### PR TITLE
CMake adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,11 @@ include(features)
 set(OSMSCOUT_BUILD_CORE OFF CACHE INTERNAL "" FORCE)
 add_subdirectory(libosmscout)
 
-set(OSMSCOUT_BUILD_IMPORT OFF CACHE INTERNAL "" FORCE)
-add_subdirectory(libosmscout-import)
+option(OSMSCOUT_BUILD_IMPORT "Enable build of import library" ON)
+if(OSMSCOUT_BUILD_IMPORT)
+   set(OSMSCOUT_BUILD_IMPORT OFF CACHE INTERNAL "" FORCE)
+   add_subdirectory(libosmscout-import)
+endif()
 
 set(OSMSCOUT_BUILD_MAP OFF CACHE INTERNAL "" FORCE)
 add_subdirectory(libosmscout-map)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if((CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_G
       endif()
     endif()
   endif()
-  if(OSMSCOUT_PLATFORM_X64 AND NOT APPLE)
+  if(NOT APPLE)
     add_definitions(-fPIC)
   endif()
 endif()


### PR DESCRIPTION
This adds -fPIC for builds on SFOS and allows optional build of -import lib. I hope it didn't break anything else