### PR TITLE
move settings in cookiejar to osmscoutqt settings

### DIFF
--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -126,7 +126,7 @@ signals:
   void downloadJobsChanged();
 
 public:
-  MapManager(QStringList databaseLookupDirs);
+  MapManager(QStringList databaseLookupDirs, SettingsRef settings);
   
   virtual ~MapManager();
 

--- a/libosmscout-client-qt/include/osmscout/PersistentCookieJar.h
+++ b/libosmscout-client-qt/include/osmscout/PersistentCookieJar.h
@@ -52,10 +52,11 @@
 #include <QNetworkCookie>
 
 #include <osmscout/private/ClientQtImportExport.h>
+#include <osmscout/OSMScoutQt.h>
 
 class OSMSCOUT_CLIENT_QT_API PersistentCookieJar : public QNetworkCookieJar {
 public:
-    PersistentCookieJar(QObject *parent = Q_NULLPTR) : QNetworkCookieJar(parent) { load(); }
+    PersistentCookieJar(SettingsRef settings, QObject *parent = Q_NULLPTR) : QNetworkCookieJar(parent) { load(settings); }
     virtual ~PersistentCookieJar() { save(); }
 
     virtual QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const
@@ -82,15 +83,14 @@ private:
                 data.append("\n");
             }
         }
-        QSettings settings;
-        settings.setValue("Cookies",data);
+        SettingsRef settings = OSMScoutQt::GetInstance().GetSettings();
+        settings->SetCookieData(data);
     }
 
-    void load()
+    void load(SettingsRef settings)
     {
         QMutexLocker lock(&mutex);
-        QSettings settings;
-        QByteArray data = settings.value("Cookies").toByteArray();
+        const QByteArray data = settings->GetCookieData();
         setAllCookies(QNetworkCookie::parseCookies(data));
     }
 

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -135,7 +135,10 @@ public:
   double GetFontSize() const;
   void SetFontSize(double fontSize);
 
-  const QString GetHttpCacheDir() const;  
+  const QString GetHttpCacheDir() const;
+  
+  const QByteArray GetCookieData() const;
+  void SetCookieData(QByteArray data);
 };
 
 /**

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -58,13 +58,13 @@ int AvailableMapsModelMap::getVersion() const
 
 AvailableMapsModel::AvailableMapsModel()
 {
-  SettingsRef settings=OSMScoutQt::GetInstance().GetSettings();
+  SettingsRef settings = OSMScoutQt::GetInstance().GetSettings();
   mapProviders = settings->GetMapProviders();
 
-  connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT(listDownloaded(QNetworkReply*)));    
+  connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT(listDownloaded(QNetworkReply*)));
   diskCache.setCacheDirectory(settings->GetHttpCacheDir());
   webCtrl.setCache(&diskCache);
-  webCtrl.setCookieJar(new PersistentCookieJar());
+  webCtrl.setCookieJar(new PersistentCookieJar(settings));
 
   QLocale locale;
   for (auto &provider: mapProviders){

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -36,7 +36,7 @@ DBThread::DBThread(QThread *backgroundThread,
                    QString iconDirectory,
                    SettingsRef settings)
   : backgroundThread(backgroundThread),
-    mapManager(std::make_shared<MapManager>(databaseLookupDirs)),
+    mapManager(std::make_shared<MapManager>(databaseLookupDirs, settings)),
     basemapLookupDirectory(basemapLookupDirectory),
     settings(settings),
     mapDpi(-1),

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QDirIterator>
-#include <QTimer>
 #include <QDebug>
 
 #include <osmscout/MapManager.h>

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <QDirIterator>
+#include <QTimer>
 #include <QDebug>
 
 #include <osmscout/MapManager.h>
@@ -128,10 +129,11 @@ QString MapDownloadJob::getDownloadingFile()
   return "";
 }
 
-MapManager::MapManager(QStringList databaseLookupDirs):
+MapManager::MapManager(QStringList databaseLookupDirs, SettingsRef settings):
   databaseLookupDirs(databaseLookupDirs)
 {
-  webCtrl.setCookieJar(new PersistentCookieJar());
+  qDebug() << "MapManager ctor";
+  webCtrl.setCookieJar(new PersistentCookieJar(settings));
   // we don't use disk cache here
 
 }

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -106,7 +106,7 @@ bool OSMScoutQtBuilder::Init()
                                   cacheLocation,
                                   onlineTileCacheSize,
                                   offlineTileCacheSize);
-
+                                  
   return true;
 }
 

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -296,7 +296,6 @@ const QString Settings::GetHttpCacheDir() const
 
 const QByteArray Settings::GetCookieData() const
 {
-  qDebug() << "Settings::GetCookieData";
   return storage->value("OSMScoutLib/General/Cookies").toByteArray();
 }
 

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -294,6 +294,17 @@ const QString Settings::GetHttpCacheDir() const
   return cacheLocation + QDir::separator() + "OSMScoutHttpCache";
 }
 
+const QByteArray Settings::GetCookieData() const
+{
+  qDebug() << "Settings::GetCookieData";
+  return storage->value("OSMScoutLib/General/Cookies").toByteArray();
+}
+
+void Settings::SetCookieData(const QByteArray data)
+{
+  storage->setValue("OSMScoutLib/General/Cookies", data);
+}
+
 QmlSettings::QmlSettings()
 {
     settings=OSMScoutQt::GetInstance().GetSettings();


### PR DESCRIPTION
PersistentCookieJar still had its own QSettings instance resulting in having some loose registry entry on win when using an external setting path.
Since the PersistentCookieJar is created in ctor of MapManager before the OSMScoutQt instance is created i had to hand the settings ref through all ctors into the cookiejar.