### PR TITLE
Qt overlay way

### DIFF
--- a/OSMScout2/qml/SearchDialog.qml
+++ b/OSMScout2/qml/SearchDialog.qml
@@ -68,6 +68,7 @@ FocusScope {
         routingPopup.parent = desktop
         routingPopup.visible = true
 
+        map.addOverlayWay(0,routingModel.routeWay);
         console.log("Show routing result; dialog height: "+routingBox.height);
     }
 

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -47,6 +47,7 @@ set(HEADER_FILES
     include/osmscout/MapRenderer.h
     include/osmscout/PlaneMapRenderer.h
     include/osmscout/TiledMapRenderer.h
+    include/osmscout/OverlayWay.h
 )
 
 set(SOURCE_FILES
@@ -79,6 +80,7 @@ set(SOURCE_FILES
     src/osmscout/MapRenderer.cpp
     src/osmscout/PlaneMapRenderer.cpp
     src/osmscout/TiledMapRenderer.cpp
+    src/osmscout/OverlayWay.cpp
 )
 
 add_library(osmscout_client_qt ${SOURCE_FILES} ${HEADER_FILES})

--- a/libosmscout-client-qt/include/Makefile.am
+++ b/libosmscout-client-qt/include/Makefile.am
@@ -19,4 +19,6 @@ nobase_include_HEADERS= osmscout/private/Config.h \
                         osmscout/LookupModule.h \
                         osmscout/MapRenderer.h \
                         osmscout/PlaneMapRenderer.h \
-                        osmscout/TiledMapRenderer.h
+                        osmscout/TiledMapRenderer.h \
+                        osmscout/OverlayWay.h
+

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -30,7 +30,8 @@ osmscoutclientqtHeader = [
             'osmscout/LookupModule.h',
             'osmscout/MapRenderer.h',
             'osmscout/PlaneMapRenderer.h',
-            'osmscout/TiledMapRenderer.h'
+            'osmscout/TiledMapRenderer.h',
+            'osmscout/OverlayWay.h'
           ]
 
 install_headers(osmscoutclientqtHeader)

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -34,8 +34,6 @@
 #include <osmscout/Database.h>
 #include <osmscout/LocationService.h>
 #include <osmscout/MapService.h>
-#include <osmscout/routing/SimpleRoutingService.h>
-#include <osmscout/routing/RoutePostprocessor.h>
 #include <osmscout/MapPainterQt.h>
 
 #include <osmscout/Settings.h>

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -33,6 +33,7 @@
 #include <osmscout/SearchLocationModel.h>
 #include <osmscout/InputHandler.h>
 #include <osmscout/OSMScoutQt.h>
+#include <osmscout/OverlayWay.h>
 
 /**
  * \defgroup QtAPI Qt API
@@ -139,9 +140,29 @@ public slots:
   void showLocation(LocationEntry* location);
 
   void locationChanged(bool locationValid, double lat, double lon, bool horizontalAccuracyValid, double horizontalAccuracy);
-  
+
+  /**
+   * Add "mark" (small red circle) on top of map.
+   * It will be rendered in UI thread, count of marks should be limited.
+   */
   void addPositionMark(int id, double lat, double lon);
   void removePositionMark(int id);
+
+  /**
+   * Method for registering map overlay way.
+   * Usage from QML:
+   *
+   *    var way=map.createOverlayWay();
+   *    way.addPoint(50.09180646851823, 14.498789861494872);
+   *    way.addPoint(50.09180646851823, 14.60);
+   *    map.addOverlayWay(0,way);
+   *
+   * @param id
+   * @param o
+   */
+  void addOverlayWay(int id,QObject *o);
+  void removeOverlayWay(int id);
+  OverlayWay *createOverlayWay(QString type="_route");
 
   bool toggleDebug();
   bool toggleInfo();

--- a/libosmscout-client-qt/include/osmscout/OverlayWay.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayWay.h
@@ -22,6 +22,8 @@
  */
 
 #include <QObject>
+#include <QMutex>
+#include <QMutexLocker>
 
 #include <osmscout/Way.h>
 #include <osmscout/util/GeoBox.h>
@@ -43,6 +45,7 @@ private:
   QString                       typeName;
   std::vector<osmscout::Point>  nodes;
   osmscout::GeoBox              box;
+  mutable QMutex                lock;
 
 public slots:
   void clear();
@@ -55,16 +58,19 @@ public:
              QString typeName="_route",
              QObject *parent=Q_NULLPTR);
 
-  OverlayWay(const OverlayWay &other);
   
   virtual ~OverlayWay();
 
+  void set(const OverlayWay &other);
+  
   inline QString getTypeName() const
   {
+    QMutexLocker locker(&lock);
     return typeName;
   }
 
   inline void setTypeName(QString name){
+    QMutexLocker locker(&lock);
     typeName=name;
   }
 
@@ -72,8 +78,8 @@ public:
     return nodes.size();
   }
 
-  bool toWay(osmscout::Way &way,
-             const osmscout::TypeConfig typeConfig) const;
+  bool toWay(osmscout::WayRef &way,
+             const osmscout::TypeConfig &typeConfig) const;
 
   osmscout::GeoBox boundingBox();
 };

--- a/libosmscout-client-qt/include/osmscout/OverlayWay.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayWay.h
@@ -1,0 +1,83 @@
+#ifndef OSMSCOUT_CLIENT_QT_OVERLAYWAY_H
+#define OSMSCOUT_CLIENT_QT_OVERLAYWAY_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+
+ Copyright (C) 2017  Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <QObject>
+
+#include <osmscout/Way.h>
+#include <osmscout/util/GeoBox.h>
+#include <osmscout/private/ClientQtImportExport.h>
+
+/**
+ * \ingroup QtAPI
+ *
+ * Qt abstraction for various objects on map,
+ * used for search and routing
+ */
+class OSMSCOUT_CLIENT_QT_API OverlayWay : public QObject
+{
+  Q_OBJECT
+  Q_PROPERTY(QString type READ getTypeName WRITE setTypeName)
+  Q_PROPERTY(int size READ getSize)
+
+private:
+  QString                       typeName;
+  std::vector<osmscout::Point>  nodes;
+  osmscout::GeoBox              box;
+
+public slots:
+  void clear();
+  void addPoint(double lat, double lon);
+
+public:
+  OverlayWay(QObject *parent=Q_NULLPTR);
+
+  OverlayWay(const std::vector<osmscout::Point> &nodes,
+             QString typeName="_route",
+             QObject *parent=Q_NULLPTR);
+
+  OverlayWay(const OverlayWay &other);
+  
+  virtual ~OverlayWay();
+
+  inline QString getTypeName() const
+  {
+    return typeName;
+  }
+
+  inline void setTypeName(QString name){
+    typeName=name;
+  }
+
+  inline int getSize(){
+    return nodes.size();
+  }
+
+  bool toWay(osmscout::Way &way,
+             const osmscout::TypeConfig typeConfig) const;
+
+  osmscout::GeoBox boundingBox();
+};
+
+typedef std::shared_ptr<OverlayWay> OverlayWayRef;
+
+#endif /* OSMSCOUT_CLIENT_QT_OVERLAYWAY_H */

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -33,6 +33,7 @@
 #include <osmscout/SearchLocationModel.h>
 #include <osmscout/DBThread.h>
 #include <osmscout/Router.h>
+#include <osmscout/OverlayWay.h>
 
 /**
  * \ingroup QtAPI
@@ -42,6 +43,7 @@ class OSMSCOUT_CLIENT_QT_API RoutingListModel : public QAbstractListModel
   Q_OBJECT
   Q_PROPERTY(int count READ rowCount)
   Q_PROPERTY(bool ready READ isReady NOTIFY computingChanged)
+  Q_PROPERTY(QObject *routeWay READ getRouteWay)
 
 signals:
   void routeRequest(LocationEntry* start,
@@ -112,6 +114,11 @@ public:
   inline Q_INVOKABLE LocationEntry* locationEntryFromPosition(double lat, double lon, QString label="")
   {
     return new LocationEntry(label,osmscout::GeoCoord(lat,lon));
+  }
+
+  inline OverlayWay* getRouteWay()
+  {
+    return new OverlayWay(route.routeWay.nodes);
   }
 };
 

--- a/libosmscout-client-qt/src/Makefile.am
+++ b/libosmscout-client-qt/src/Makefile.am
@@ -64,7 +64,9 @@ libosmscoutclientqt_la_SOURCES = osmscout/DBThread.cpp \
                                  osmscout/PlaneMapRenderer.cpp \
                                  osmscout/moc_PlaneMapRenderer.cpp \
                                  osmscout/TiledMapRenderer.cpp \
-                                 osmscout/moc_TiledMapRenderer.cpp
+                                 osmscout/moc_TiledMapRenderer.cpp \
+                                 osmscout/OverlayWay.cpp \
+                                 osmscout/moc_OverlayWay.cpp
 
 osmscout/moc_%.cpp: $(top_srcdir)/include/osmscout/%.h
 	@MOC@ -o$@ $<
@@ -96,4 +98,5 @@ MOSTLYCLEANFILES = osmscout/moc_DBThread.cpp \
                    osmscout/moc_LookupModule.cpp \
                    osmscout/moc_MapRenderer.cpp \
                    osmscout/moc_PlaneMapRenderer.cpp \
-                   osmscout/moc_TiledMapRenderer.cpp
+                   osmscout/moc_TiledMapRenderer.cpp \
+                   osmscout/moc_OverlayWay.cpp

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -27,6 +27,7 @@ osmscoutclientqtSrc = [
             'src/osmscout/LookupModule.cpp',
             'src/osmscout/MapRenderer.cpp',
             'src/osmscout/PlaneMapRenderer.cpp',
-            'src/osmscout/TiledMapRenderer.cpp'
+            'src/osmscout/TiledMapRenderer.cpp',
+            'src/osmscout/OverlayWay.cpp'
           ]
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -557,6 +557,28 @@ void MapWidget::removePositionMark(int id)
     update();
 }
 
+void MapWidget::addOverlayWay(int id,QObject *o)
+{
+    const OverlayWay *way = dynamic_cast<const OverlayWay*>(o);
+    if (way == NULL){
+        qWarning() << "Failed to cast " << o << " to OverlayWay*.";
+        return;
+    }
+    qDebug() << "TODO";
+}
+
+void MapWidget::removeOverlayWay(int id)
+{
+    qDebug() << "TODO";
+}
+
+OverlayWay *MapWidget::createOverlayWay(QString type)
+{
+  OverlayWay *result=new OverlayWay();
+  result->setTypeName(type);
+  return result;
+}
+
 void MapWidget::onTap(const QPoint p)
 {
     qDebug() << "tap " << p;

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -564,12 +564,16 @@ void MapWidget::addOverlayWay(int id,QObject *o)
         qWarning() << "Failed to cast " << o << " to OverlayWay*.";
         return;
     }
-    qDebug() << "TODO";
+
+    // create shared pointer copy
+    OverlayWayRef wo=std::make_shared<OverlayWay>();
+    wo->set(*way);
+    renderer->addOverlayWay(id,wo);
 }
 
 void MapWidget::removeOverlayWay(int id)
 {
-    qDebug() << "TODO";
+    renderer->removeOverlayWay(id);
 }
 
 OverlayWay *MapWidget::createOverlayWay(QString type)
@@ -731,10 +735,14 @@ void MapWidget::SetRenderingType(QString strType)
   }
   if (type!=renderingType){
     renderingType=type;
-    if (renderer!=NULL){
-      renderer->deleteLater();
-    }
+
+    std::map<int,OverlayWayRef> overlayWays=renderer->getOverlayWays();
+    renderer->deleteLater();
+    
     renderer = OSMScoutQt::GetInstance().MakeMapRenderer(renderingType);
+    for (auto &p:overlayWays){
+      renderer->addOverlayWay(p.first,p.second);
+    }
     connect(renderer,SIGNAL(Redraw()),
             this,SLOT(redraw()));
     emit renderingTypeChanged(GetRenderingType());

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -28,6 +28,7 @@
 #include <osmscout/MapWidget.h>
 #include <osmscout/PlaneMapRenderer.h>
 #include <osmscout/TiledMapRenderer.h>
+#include <osmscout/OverlayWay.h>
 
 #include <osmscout/AvailableMapsModel.h>
 #include <osmscout/LocationInfoModel.h>
@@ -135,6 +136,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qmlRegisterType<RouteStep>(uri, versionMajor, versionMinor, "RouteStep");
   qmlRegisterType<RoutingListModel>(uri, versionMajor, versionMinor, "RoutingListModel");
   qmlRegisterType<StyleFlagsModel>(uri, versionMajor, versionMinor, "StyleFlagsModel");
+  qmlRegisterType<OverlayWay>(uri, versionMajor, versionMinor, "OverlayWay");
 }
 
 OSMScoutQtBuilder OSMScoutQt::NewInstance()

--- a/libosmscout-client-qt/src/osmscout/OverlayWay.cpp
+++ b/libosmscout-client-qt/src/osmscout/OverlayWay.cpp
@@ -1,0 +1,79 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+
+ Copyright (C) 2017 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/OverlayWay.h>
+#include <osmscout/util/Geometry.h>
+
+OverlayWay::OverlayWay(QObject *parent):
+  QObject(parent),
+  typeName("_route")
+{
+}
+
+OverlayWay::OverlayWay(const std::vector<osmscout::Point> &nodes,
+                       QString typeName,
+                       QObject *parent):
+  QObject(parent),
+  typeName(typeName),
+  nodes(nodes)
+{
+}
+
+OverlayWay::OverlayWay(const OverlayWay &other):
+  typeName(other.typeName),
+  nodes(other.nodes)
+{
+}
+
+OverlayWay::~OverlayWay()
+{
+}
+
+bool OverlayWay::toWay(osmscout::Way &way,
+                       const osmscout::TypeConfig typeConfig) const
+{
+  osmscout::TypeInfoRef type=typeConfig.GetTypeInfo(typeName.toStdString());
+  if (!type){
+    return false;
+  }
+  way.SetType(type);
+  way.nodes=nodes;
+  return true;
+}
+
+void OverlayWay::clear()
+{
+  nodes.clear();
+  box.Invalidate();
+}
+
+void OverlayWay::addPoint(double lat, double lon)
+{
+  nodes.push_back(osmscout::Point(0,osmscout::GeoCoord(lat,lon)));
+  box.Invalidate();
+}
+
+osmscout::GeoBox OverlayWay::boundingBox()
+{
+  if (!box.IsValid() && !nodes.empty()){
+    osmscout::GetBoundingBox(nodes,box);
+  }
+  return box;
+}

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -302,12 +302,19 @@ void PlaneMapRenderer::DrawMap()
     p.setRenderHint(QPainter::TextAntialiasing);
     p.setRenderHint(QPainter::SmoothPixmapTransform);
 
+    // overlay ways
+    std::vector<OverlayWayRef> overlayWays;
+    osmscout::GeoBox renderBox;
+    projection.GetDimensions(renderBox);
+    getOverlayWays(overlayWays,renderBox);
+
     bool success;
     {
       DBRenderJob job(renderProjection,
                       loadJob->GetAllTiles(),
                       &drawParameter,
                       &p,
+                      overlayWays,
                       /*drawCanvasBackground*/ true);
       dbThread->RunJob(&job);
       success=job.IsSuccess();


### PR DESCRIPTION
This MR adds possibility to define overlay way that will be rendered with database data (I removed this feature months ago with support of rendering multiple databases)... 

Overlay way may be defined from QML JavaScript:
```
var way=map.createOverlayWay();
way.type="_route";
way.addPoint(50.09180646851823, 14.498789861494872);
way.addPoint(50.09180646851823, 14.60);
map.addOverlayWay(0,way);
```

Or pickup from `RoutingListModel`:
```
            RoutingListModel {
                id: routingModel
                onReadyChanged: {
                  map.addOverlayWay(0,routingModel.routeWay);
                }
            }
```

Partially solves https://github.com/Framstag/libosmscout/issues/405, custom points and areas may be added later...