### PR TITLE
Routing improvements (mostly Qt)

### DIFF
--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -89,4 +89,7 @@ public:
     const QList<osmscout::ObjectFileRef>& getReferences() const;
 };
 
+typedef std::shared_ptr<LocationEntry> LocationEntryRef;
+Q_DECLARE_METATYPE(LocationEntryRef)
+
 #endif

--- a/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
@@ -32,6 +32,7 @@
 
 class OSMScoutQt;
 Q_DECLARE_METATYPE(osmscout::TileRef)
+Q_DECLARE_METATYPE(osmscout::BreakerRef)
 
 /**
  * \ingroup QtAPI

--- a/libosmscout-client-qt/include/osmscout/Router.h
+++ b/libosmscout-client-qt/include/osmscout/Router.h
@@ -21,6 +21,8 @@
 #ifndef ROUTER_H
 #define ROUTER_H
 
+#include <memory>
+
 #include <QObject>
 #include <QSettings>
 
@@ -97,6 +99,8 @@ struct RouteSelection
   osmscout::Way              routeWay;
 };
 
+typedef std::shared_ptr<RouteSelection> RouteSelectionRef;
+
 Q_DECLARE_METATYPE(RouteSelection)
 
 /**
@@ -111,8 +115,7 @@ private:
   DBThreadRef dbThread;
   QMutex      lock;
 
-  osmscout::RouterParameter           routerParameter;
-  //osmscout::RoutePostprocessor        routePostprocessor;
+  osmscout::RouterParameter routerParameter;
 
 public slots:
   void Initialize();
@@ -136,7 +139,7 @@ public slots:
                       osmscout::Vehicle vehicle,
                       int requestId);
 signals:
-  void routeComputed(RouteSelection route,
+  void routeComputed(RouteSelectionRef route,
                      int requestId);
 
   void routeFailed(QString reason,

--- a/libosmscout-client-qt/include/osmscout/Router.h
+++ b/libosmscout-client-qt/include/osmscout/Router.h
@@ -156,7 +156,6 @@ private:
   QThread     *thread;
   SettingsRef settings;
   DBThreadRef dbThread;
-  QMutex      lock;
 
   osmscout::RouterParameter routerParameter;
 
@@ -176,17 +175,21 @@ public slots:
    * @param target - end position for route computation
    * @param vehicle - used vehicle for route
    * @param requestId - id used later in routeComputed/routeFailed signals
+   * @param breaker - breaker that may be used for cancel routing computation
    */
   void onRouteRequest(LocationEntry* start,
                       LocationEntry* target,
                       osmscout::Vehicle vehicle,
-                      int requestId);
+                      int requestId,
+                      osmscout::BreakerRef breaker);
 signals:
   void routeComputed(RouteSelectionRef route,
                      int requestId);
 
   void routeFailed(QString reason,
                    int requestId);
+
+  void routeCanceled(int requestId);
 
   void routingProgress(int percent,
                        int requestId);
@@ -236,13 +239,15 @@ private:
                            LocationEntry* start,
                            LocationEntry* target,
                            osmscout::Vehicle vehicle,
-                           int requestId);
+                           int requestId,
+                           const osmscout::BreakerRef &breaker);
 
   bool CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
                       const osmscout::RoutePosition& start,
                       const osmscout::RoutePosition& target,
                       osmscout::RouteData& route,
-                      int requestId);
+                      int requestId,
+                      const osmscout::BreakerRef &breaker);
 
   bool TransformRouteDataToRouteDescription(osmscout::MultiDBRoutingServiceRef &routingService,
                                             const osmscout::RouteData& data,

--- a/libosmscout-client-qt/include/osmscout/Router.h
+++ b/libosmscout-client-qt/include/osmscout/Router.h
@@ -177,8 +177,8 @@ public slots:
    * @param requestId - id used later in routeComputed/routeFailed signals
    * @param breaker - breaker that may be used for cancel routing computation
    */
-  void onRouteRequest(LocationEntry* start,
-                      LocationEntry* target,
+  void onRouteRequest(LocationEntryRef start,
+                      LocationEntryRef target,
                       osmscout::Vehicle vehicle,
                       int requestId,
                       osmscout::BreakerRef breaker);
@@ -236,8 +236,8 @@ private:
   void GenerateRouteSteps(RouteSelection &route);
 
   void ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingService,
-                           LocationEntry* start,
-                           LocationEntry* target,
+                           const LocationEntryRef &start,
+                           const LocationEntryRef &target,
                            osmscout::Vehicle vehicle,
                            int requestId,
                            const osmscout::BreakerRef &breaker);

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -62,17 +62,17 @@ public slots:
 
   void clear();
 
-  void onRouteComputed(RouteSelection route,
+  void onRouteComputed(RouteSelectionRef route,
                        int requestId);
 
   void onRouteFailed(QString reason,
                      int requestId);
 
 private:
-  Router          *router;
-  RouteSelection  route;
-  int             requestId;
-  bool            computing;
+  Router            *router;
+  RouteSelectionRef route;
+  int               requestId;
+  bool              computing;
 
 public:
   enum Roles {
@@ -118,7 +118,7 @@ public:
 
   inline OverlayWay* getRouteWay()
   {
-    return new OverlayWay(route.routeWay.nodes);
+    return new OverlayWay(route->routeWay.nodes);
   }
 };
 

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -55,6 +55,8 @@ signals:
 
   void routeFailed(QString reason);
 
+  void routingProgress(int percent);
+
 public slots:
   void setStartAndTarget(LocationEntry* start,
                          LocationEntry* target,
@@ -67,6 +69,9 @@ public slots:
 
   void onRouteFailed(QString reason,
                      int requestId);
+
+  void onRoutingProgress(int percent,
+                         int requestId);
 
 private:
   Router            *router;
@@ -118,6 +123,9 @@ public:
 
   inline OverlayWay* getRouteWay()
   {
+    if (!route){
+      return NULL;
+    }
     return new OverlayWay(route->routeWay.nodes);
   }
 };

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -47,8 +47,8 @@ class OSMSCOUT_CLIENT_QT_API RoutingListModel : public QAbstractListModel
   Q_PROPERTY(QObject *routeWay READ getRouteWay)
 
 signals:
-  void routeRequest(LocationEntry* start,
-                    LocationEntry* target,
+  void routeRequest(LocationEntryRef start,
+                    LocationEntryRef target,
                     osmscout::Vehicle vehicle,
                     int requestId,
                     osmscout::BreakerRef breaker);

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -26,6 +26,7 @@
 #include <QAbstractListModel>
 
 #include <osmscout/Location.h>
+#include <osmscout/util/Breaker.h>
 #include <osmscout/routing/Route.h>
 
 #include <osmscout/private/ClientQtImportExport.h>
@@ -49,7 +50,8 @@ signals:
   void routeRequest(LocationEntry* start,
                     LocationEntry* target,
                     osmscout::Vehicle vehicle,
-                    int requestId);
+                    int requestId,
+                    osmscout::BreakerRef breaker);
 
   void computingChanged();
 
@@ -64,6 +66,8 @@ public slots:
 
   void clear();
 
+  void cancel();
+
   void onRouteComputed(RouteSelectionRef route,
                        int requestId);
 
@@ -74,10 +78,11 @@ public slots:
                          int requestId);
 
 private:
-  Router            *router;
-  RouteSelectionRef route;
-  int               requestId;
-  bool              computing;
+  Router                *router;
+  RouteSelectionRef     route;
+  int                   requestId;
+  bool                  computing;
+  osmscout::BreakerRef  breaker;
 
 public:
   enum Roles {

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -120,6 +120,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<DatabaseLoadedResponse>();
   qRegisterMetaType<osmscout::TileRef>();
   qRegisterMetaType<osmscout::Vehicle>();
+  qRegisterMetaType<osmscout::BreakerRef>();
   qRegisterMetaType<RouteSelection>();
   qRegisterMetaType<RouteSelectionRef>();
 

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -123,6 +123,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<osmscout::BreakerRef>();
   qRegisterMetaType<RouteSelection>();
   qRegisterMetaType<RouteSelectionRef>();
+  qRegisterMetaType<LocationEntryRef>();
 
   // regiester osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -121,6 +121,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<osmscout::TileRef>();
   qRegisterMetaType<osmscout::Vehicle>();
   qRegisterMetaType<RouteSelection>();
+  qRegisterMetaType<RouteSelectionRef>();
 
   // regiester osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -727,11 +727,11 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
     return;
   }
 
-  RouteSelection route;
+  RouteSelectionRef route=std::make_shared<RouteSelection>();
   if (!CalculateRoute(routingService,
                       startNode,
                       targetNode,
-                      route.routeData)) {
+                      route->routeData)) {
     emit routeFailed("There was an error while routing!",requestId);
     return;
   }
@@ -739,16 +739,16 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
   osmscout::log.Debug() << "Route calculated";
 
   TransformRouteDataToRouteDescription(routingService,
-                                       route.routeData,
-                                       route.routeDescription,
+                                       route->routeData,
+                                       route->routeDescription,
                                        start->getLabel().toUtf8().constData(),
                                        target->getLabel().toUtf8().constData());
 
   osmscout::log.Debug() << "Route transformed";
 
-  GenerateRouteSteps(route);
+  GenerateRouteSteps(*route);
 
-  if (!routingService->TransformRouteDataToWay(route.routeData,route.routeWay)) {
+  if (!routingService->TransformRouteDataToWay(route->routeData,route->routeWay)) {
     emit routeFailed("Error while transforming route",requestId);
     return;
   }

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -470,7 +470,7 @@ bool Router::CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
                             int requestId)
 {
   osmscout::RoutingResult    result;
-  // TODO: report progress
+  // TODO: make routing computation cancelable
   osmscout::RoutingParameter parameter;
 
   parameter.SetProgress(std::make_shared<QtRoutingProgress>(

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -466,11 +466,18 @@ osmscout::MultiDBRoutingServiceRef Router::MakeRoutingService(const std::list<DB
 bool Router::CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
                             const osmscout::RoutePosition& start,
                             const osmscout::RoutePosition& target,
-                            osmscout::RouteData& route)
+                            osmscout::RouteData& route,
+                            int requestId)
 {
   osmscout::RoutingResult    result;
   // TODO: report progress
   osmscout::RoutingParameter parameter;
+
+  parameter.SetProgress(std::make_shared<QtRoutingProgress>(
+    [this,requestId](size_t percent){
+      emit routingProgress(percent,requestId);
+    }
+  ));
 
   result=routingService->CalculateRoute(start,
                                         target,
@@ -731,7 +738,8 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
   if (!CalculateRoute(routingService,
                       startNode,
                       targetNode,
-                      route->routeData)) {
+                      route->routeData,
+                      requestId)) {
     emit routeFailed("There was an error while routing!",requestId);
     return;
   }

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -709,8 +709,8 @@ std::string vehicleStr(osmscout::Vehicle vehicle){
 }
 
 void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingService,
-                                 LocationEntry* start,
-                                 LocationEntry* target,
+                                 const LocationEntryRef &start,
+                                 const LocationEntryRef &target,
                                  osmscout::Vehicle /*vehicle*/,
                                  int requestId,
                                  const osmscout::BreakerRef &breaker)
@@ -774,8 +774,8 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
   emit routeComputed(route,requestId);
 }
 
-void Router::onRouteRequest(LocationEntry* start,
-                            LocationEntry* target,
+void Router::onRouteRequest(LocationEntryRef start,
+                            LocationEntryRef target,
                             osmscout::Vehicle vehicle,
                             int requestId,
                             osmscout::BreakerRef breaker)

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -26,8 +26,8 @@ RoutingListModel::RoutingListModel(QObject* parent)
 {
   router=OSMScoutQt::GetInstance().MakeRouter();
 
-  connect(this,SIGNAL(routeRequest(LocationEntry*,LocationEntry*,osmscout::Vehicle,int,osmscout::BreakerRef)),
-          router,SLOT(onRouteRequest(LocationEntry*,LocationEntry*,osmscout::Vehicle,int,osmscout::BreakerRef)),
+  connect(this,SIGNAL(routeRequest(LocationEntryRef,LocationEntryRef,osmscout::Vehicle,int,osmscout::BreakerRef)),
+          router,SLOT(onRouteRequest(LocationEntryRef,LocationEntryRef,osmscout::Vehicle,int,osmscout::BreakerRef)),
           Qt::QueuedConnection);
 
   connect(router,SIGNAL(routeComputed(RouteSelectionRef,int)),
@@ -66,7 +66,14 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   computing=true;
   breaker=std::make_shared<osmscout::ThreadedBreaker>();
   emit computingChanged();
-  emit routeRequest(start,target,vehicle,++requestId,breaker);
+
+  // make copy to shared ptr, remove owhership
+  LocationEntryRef startRef=std::make_shared<LocationEntry>(*start);
+  startRef->setParent(Q_NULLPTR);
+  LocationEntryRef targetRef=std::make_shared<LocationEntry>(*target);
+  targetRef->setParent(Q_NULLPTR);
+
+  emit routeRequest(startRef,targetRef,vehicle,++requestId,breaker);
 }
 
 void RoutingListModel::onRouteComputed(RouteSelectionRef route,

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -30,8 +30,8 @@ RoutingListModel::RoutingListModel(QObject* parent)
           router,SLOT(onRouteRequest(LocationEntry*,LocationEntry*,osmscout::Vehicle,int)),
           Qt::QueuedConnection);
 
-  connect(router,SIGNAL(routeComputed(RouteSelection,int)),
-          this,SLOT(onRouteComputed(RouteSelection,int)),
+  connect(router,SIGNAL(routeComputed(RouteSelectionRef,int)),
+          this,SLOT(onRouteComputed(RouteSelectionRef,int)),
           Qt::QueuedConnection);
   connect(router,SIGNAL(routeFailed(QString,int)),
           this,SLOT(onRouteFailed(QString,int)),
@@ -40,7 +40,7 @@ RoutingListModel::RoutingListModel(QObject* parent)
 
 RoutingListModel::~RoutingListModel()
 {
-  route.routeSteps.clear();
+  route->routeSteps.clear();
   if (router!=NULL){
     router->deleteLater();
     router=NULL;
@@ -63,7 +63,7 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   emit routeRequest(start,target,vehicle,++requestId);
 }
 
-void RoutingListModel::onRouteComputed(RouteSelection route,
+void RoutingListModel::onRouteComputed(RouteSelectionRef route,
                                        int requestId)
 {
   if (requestId!=this->requestId){
@@ -97,23 +97,23 @@ void RoutingListModel::clear()
   beginResetModel();
 
   ++requestId;
-  route.routeSteps.clear();
+  route->routeSteps.clear();
 
   endResetModel();
 }
 
 int RoutingListModel::rowCount(const QModelIndex& ) const
 {
-    return route.routeSteps.size();
+    return route->routeSteps.size();
 }
 
 QVariant RoutingListModel::data(const QModelIndex &index, int role) const
 {
-    if(index.row() < 0 || index.row() >= route.routeSteps.size()) {
+    if(index.row() < 0 || index.row() >= route->routeSteps.size()) {
         return QVariant();
     }
 
-    RouteStep step=route.routeSteps.at(index.row());
+    RouteStep step=route->routeSteps.at(index.row());
 
     switch (role) {
     case Qt::DisplayRole:
@@ -146,11 +146,11 @@ QHash<int, QByteArray> RoutingListModel::roleNames() const
 
 RouteStep* RoutingListModel::get(int row) const
 {
-    if(row < 0 || row >= route.routeSteps.size()) {
+    if(row < 0 || row >= route->routeSteps.size()) {
         return NULL;
     }
 
-    RouteStep step=route.routeSteps.at(row);
+    RouteStep step=route->routeSteps.at(row);
 
     return new RouteStep(step);
 }

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -493,7 +493,7 @@ namespace osmscout {
                                                                   RouteDescription& description)
   {
      ObjectFileRef           prevObject;
-     DatabaseId              prevDatabase;
+     DatabaseId              prevDatabase=0;
      ObjectFileRef           curObject;
      DatabaseId              curDatabase;
      
@@ -567,7 +567,7 @@ namespace osmscout {
   {
     std::list<RouteDescription::Node>::iterator lastJunction=description.Nodes().end();
     ObjectFileRef                               prevObject;
-    DatabaseId                                  prevDb;
+    DatabaseId                                  prevDb=0;
     ObjectFileRef                               curObject;
     DatabaseId                                  curDb;
 
@@ -606,7 +606,7 @@ namespace osmscout {
                                                           RouteDescription& description)
   {
     ObjectFileRef              prevObject;
-    DatabaseId                 prevDb;
+    DatabaseId                 prevDb=0;
     ObjectFileRef              curObject;
     DatabaseId                 curDb;
 


### PR DESCRIPTION
 - fix maybe-uninitialized warning
 - sending struct via queued Qt's connection create its copy - use shared ptr to RouteSelection to avoid this
 - report routing progress via routing model to qml
 - make routing cancelable from QML
 - avoid to use raw LocationEntry pointer owned by QML in queued signal, use copy in shared pointer instead
