### PR TITLE
make RoutePostprocessor working without defined types

### DIFF
--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -334,9 +334,9 @@ namespace osmscout {
                                      std::map<DatabaseId,RoutingProfileRef> &profiles,
                                      std::map<DatabaseId,DatabaseRef>& databases,
                                      std::list<PostprocessorRef> processors,
-                                     std::set<std::string> motorwayTypeNames,
-                                     std::set<std::string> motorwayLinkTypeNames,
-                                     std::set<std::string> junctionTypeNames);
+                                     std::set<std::string> motorwayTypeNames=std::set<std::string>(),
+                                     std::set<std::string> motorwayLinkTypeNames=std::set<std::string>(),
+                                     std::set<std::string> junctionTypeNames=std::set<std::string>());
   };
 }
 

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1616,14 +1616,19 @@ namespace osmscout {
       maxSpeedReaders[dbId]=new MaxSpeedFeatureValueReader(*typeConfig);
 
       // init types
+      motorwayTypes[dbId]; // insert empty TypeInfoSet
       for (const std::string &typeName:motorwayTypeNames){
         TypeInfoRef type=typeConfig->GetTypeInfo(typeName);
         motorwayTypes[dbId].Set(type);
       }
+
+      motorwayLinkTypes[dbId]; // insert empty TypeInfoSet
       for (const std::string &typeName:motorwayLinkTypeNames){
         TypeInfoRef type=typeConfig->GetTypeInfo(typeName);
         motorwayLinkTypes[dbId].Set(type);
       }
+      
+      junctionTypes[dbId]; // insert empty TypeInfoSet
       for (const std::string &typeName:junctionTypeNames){
         TypeInfoRef type=typeConfig->GetTypeInfo(typeName);
         junctionTypes[dbId].Set(type);


### PR DESCRIPTION
Hi. This is fix for https://github.com/Framstag/libosmscout/issues/429
...it makes possible to run `RoutePostprocessor` without define any type. But description may be incomplete then - `MotorwayJunctionPostprocessor` don't work then...