### PR TITLE
parse railway=preserved type as railway_narrow_gauge

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -527,7 +527,7 @@ TYPES
       {Bridge, Tunnel, Width}
 
   TYPE railway_narrow_gauge
-    = WAY ("railway"=="narrow_gauge")
+    = WAY ("railway"=="narrow_gauge" OR "railway"=="preserved")
       PATH
 
   TYPE railway_monorail


### PR DESCRIPTION
usage of this railway type is not recommended
https://wiki.openstreetmap.org/wiki/Tag:railway%3Dpreserved
but it is still widely used
https://taginfo.openstreetmap.org/tags/?key=railway&value=preserved#overview