### PR TITLE
Fixed memory leaks in OpenGLRenderer

### DIFF
--- a/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
+++ b/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
@@ -43,7 +43,13 @@ namespace osmscout {
 
     size_t fromOriginY;
 
+    ~OpenGLTexture(){
+      delete []data;
+    }
+
   };
+
+  typedef std::shared_ptr<OpenGLTexture> OpenGLTextureRef;
 
   class OpenGLMapData {
   private:
@@ -53,7 +59,7 @@ namespace osmscout {
     std::vector<GLuint> Elements;
     std::vector<GLuint> ElementsBuffer;
     unsigned char *Textures;
-    std::vector<OpenGLTexture*> TexturesBuffer;
+    std::vector<OpenGLTextureRef> TexturesBuffer;
     int textureSize;
     int textureSizeBuffer;
     int textureWidth;
@@ -119,6 +125,7 @@ namespace osmscout {
   public:
 
     void SwapData() {
+      delete[] Textures;
       this->Vertices.clear();
       this->Vertices = this->VerticesBuffer;
       this->VerticesBuffer.clear();
@@ -150,6 +157,7 @@ namespace osmscout {
     }
 
     void SwapData(int stride) {
+      delete[] Textures;
       this->Vertices.clear();
       this->Vertices = this->VerticesBuffer;
       this->VerticesBuffer.clear();
@@ -321,13 +329,22 @@ namespace osmscout {
       return this->VerticesBuffer.size();
     }
 
-    void AddNewTexture(OpenGLTexture *texture) {
+    /*void AddNewTexture(OpenGLTexture *texture) {
+      TexturesBuffer.push_back(texture);
+
+      textureWidthBuffer += texture->width;
+
+      textureSizeBuffer++;
+    }*/
+
+    void AddNewTexture(OpenGLTextureRef texture) {
       TexturesBuffer.push_back(texture);
 
       textureWidthBuffer += texture->width;
 
       textureSizeBuffer++;
     }
+
 
     int GetTextureWidth(){
       return textureWidth;

--- a/libosmscout-map-opengl/include/osmscout/PNGLoaderOpenGL.h
+++ b/libosmscout-map-opengl/include/osmscout/PNGLoaderOpenGL.h
@@ -27,7 +27,7 @@
 #include <osmscout/OpenGLMapData.h>
 
 namespace osmscout {
-  OSMSCOUT_MAP_OPENGL_API osmscout::OpenGLTexture* LoadPNGOpenGL(const std::string& filename);
+  OSMSCOUT_MAP_OPENGL_API osmscout::OpenGLTextureRef LoadPNGOpenGL(const std::string& filename);
 }
 
 #endif

--- a/libosmscout-map-opengl/include/osmscout/TextLoader.h
+++ b/libosmscout-map-opengl/include/osmscout/TextLoader.h
@@ -33,7 +33,7 @@ namespace osmscout {
 
   class OSMSCOUT_MAP_OPENGL_API CharacterTexture {
     char32_t character;
-    OpenGLTexture *texture;
+    OpenGLTextureRef texture;
     long baselineY;
     long height;
 
@@ -47,11 +47,11 @@ namespace osmscout {
       this->character = character;
     }
 
-    OpenGLTexture *GetTexture() const {
+    OpenGLTextureRef GetTexture() const {
       return texture;
     }
 
-    void SetTexture(OpenGLTexture *texture) {
+    void SetTexture(OpenGLTextureRef texture) {
       this->texture = texture;
     }
 
@@ -73,6 +73,8 @@ namespace osmscout {
 
   };
 
+  typedef std::shared_ptr<CharacterTexture> CharacterTextureRef;
+
   class OSMSCOUT_MAP_OPENGL_API TextLoader {
   private:
     FT_Library ft;
@@ -84,13 +86,15 @@ namespace osmscout {
     int sumWidth;
 
     std::map<std::pair<char32_t, int>, int> characterIndices;
-    std::vector<osmscout::CharacterTexture *> characters;
+    std::vector<osmscout::CharacterTextureRef> characters;
 
     void LoadFace();
 
     void LoadFace(std::string);
 
   public:
+
+    ~TextLoader();
 
     TextLoader(std::string path, long defaultSize);
 
@@ -104,7 +108,7 @@ namespace osmscout {
 
     void SetDefaultFontSize(long defaultFontSize);
 
-    OpenGLTexture *CreateTexture();
+    OpenGLTextureRef CreateTexture();
 
     std::vector<int> AddCharactersToTextureAtlas(std::string text, double size);
   };

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -927,7 +927,7 @@ namespace osmscout {
       bool hasIcon = false;
       if (iconStyle) {
         //has icon?
-        OpenGLTexture *image;
+        OpenGLTextureRef image;
         int IconIndex = 0;
         for (std::list<std::string>::const_iterator path = parameter.GetIconPaths().begin();
              path != parameter.GetIconPaths().end();
@@ -1150,7 +1150,7 @@ namespace osmscout {
       }
     }
 
-    OpenGLTexture *t = Textloader.CreateTexture();
+    OpenGLTextureRef t = Textloader.CreateTexture();
     TextRenderer.AddNewTexture(t);
 
   }

--- a/libosmscout-map-opengl/src/osmscout/PNGLoaderOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/PNGLoaderOpenGL.cpp
@@ -32,7 +32,7 @@ namespace osmscout {
     return bytes[0]!=0;
   }
 
-  osmscout::OpenGLTexture* LoadPNGOpenGL(const std::string& filename){
+  osmscout::OpenGLTextureRef LoadPNGOpenGL(const std::string& filename){
     std::FILE       *file;
     png_structp     png_ptr;
     png_infop       info_ptr;
@@ -212,7 +212,7 @@ namespace osmscout {
     free(image_data);
     std::fclose(file);
 
-    osmscout::OpenGLTexture *texture = new osmscout::OpenGLTexture();
+    osmscout::OpenGLTextureRef texture(new osmscout::OpenGLTexture());
     texture->width = width;
     texture->height = height;
     texture->data = data;

--- a/libosmscout-map-opengl/src/osmscout/Triangulate.cpp
+++ b/libosmscout-map-opengl/src/osmscout/Triangulate.cpp
@@ -35,9 +35,9 @@ namespace osmscout {
     std::vector<p2t::Triangle *> triangles;
     triangles = cdt->GetTriangles();
     for (int i = 0; i < triangles.size(); i++) {
-      p2t::Point &a = *triangles[i]->GetPoint(0);
-      p2t::Point &b = *triangles[i]->GetPoint(1);
-      p2t::Point &c = *triangles[i]->GetPoint(2);
+      p2t::Point a = *triangles[i]->GetPoint(0);
+      p2t::Point b = *triangles[i]->GetPoint(1);
+      p2t::Point c = *triangles[i]->GetPoint(2);
       result.emplace_back(a.x);
       result.emplace_back(a.y);
       result.emplace_back(b.x);
@@ -45,6 +45,10 @@ namespace osmscout {
       result.emplace_back(c.x);
       result.emplace_back(c.y);
     }
+
+    std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
+    delete cdt;
+    cdt = NULL;
 
     return result;
 
@@ -61,9 +65,9 @@ namespace osmscout {
     std::vector<p2t::Triangle *> triangles;
     triangles = cdt->GetTriangles();
     for (int i = 0; i < triangles.size(); i++) {
-      p2t::Point &a = *triangles[i]->GetPoint(0);
-      p2t::Point &b = *triangles[i]->GetPoint(1);
-      p2t::Point &c = *triangles[i]->GetPoint(2);
+      p2t::Point a = *triangles[i]->GetPoint(0);
+      p2t::Point b = *triangles[i]->GetPoint(1);
+      p2t::Point c = *triangles[i]->GetPoint(2);
       result.emplace_back(a.x);
       result.emplace_back(a.y);
       result.emplace_back(b.x);
@@ -71,6 +75,10 @@ namespace osmscout {
       result.emplace_back(c.x);
       result.emplace_back(c.y);
     }
+
+    std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
+    delete cdt;
+    cdt = NULL;
 
     return result;
 
@@ -87,9 +95,9 @@ namespace osmscout {
     std::vector<p2t::Triangle *> triangles;
     triangles = cdt->GetTriangles();
     for (int i = 0; i < triangles.size(); i++) {
-      p2t::Point &a = *triangles[i]->GetPoint(0);
-      p2t::Point &b = *triangles[i]->GetPoint(1);
-      p2t::Point &c = *triangles[i]->GetPoint(2);
+      p2t::Point a = *triangles[i]->GetPoint(0);
+      p2t::Point b = *triangles[i]->GetPoint(1);
+      p2t::Point c = *triangles[i]->GetPoint(2);
       result.emplace_back(a.x);
       result.emplace_back(a.y);
       result.emplace_back(b.x);
@@ -97,6 +105,10 @@ namespace osmscout {
       result.emplace_back(c.x);
       result.emplace_back(c.y);
     }
+
+    std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
+    delete cdt;
+    cdt = NULL;
 
     return result;
 
@@ -109,20 +121,25 @@ namespace osmscout {
                   [&polyline](osmscout::Point p) { polyline.push_back(new p2t::Point(p.GetLon(), p.GetLat())); });
     p2t::CDT *cdt = new p2t::CDT(polyline);
 
+    std::vector<std::vector<p2t::Point *>> holes;
+
     for (int i = 1; i < points.size(); i++) {
       std::vector<p2t::Point *> hole;
       std::for_each(points[i].begin(), points[i].end(),
                     [&hole](osmscout::Point p) { hole.push_back(new p2t::Point(p.GetLon(), p.GetLat())); });
-      cdt->AddHole(hole);
+      holes.push_back(hole);
     }
+
+    for (const auto& hole: holes)
+      cdt->AddHole(hole);
 
     cdt->Triangulate();
     std::vector<p2t::Triangle *> triangles;
     triangles = cdt->GetTriangles();
     for (int i = 0; i < triangles.size(); i++) {
-      p2t::Point &a = *triangles[i]->GetPoint(0);
-      p2t::Point &b = *triangles[i]->GetPoint(1);
-      p2t::Point &c = *triangles[i]->GetPoint(2);
+      p2t::Point a = *triangles[i]->GetPoint(0);
+      p2t::Point b = *triangles[i]->GetPoint(1);
+      p2t::Point c = *triangles[i]->GetPoint(2);
       result.emplace_back(a.x);
       result.emplace_back(a.y);
       result.emplace_back(b.x);
@@ -130,6 +147,15 @@ namespace osmscout {
       result.emplace_back(c.x);
       result.emplace_back(c.y);
     }
+
+    std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
+
+    for(int i = 0; i < holes.size(); i++){
+      std::for_each(holes[i].begin(), holes[i].end(), [](p2t::Point *p){delete p;});
+    }
+
+    delete cdt;
+    cdt = NULL;
 
     return result;
 


### PR DESCRIPTION
I checked the program with valgrind, and fixed the memory leaks.
Now the leak summary seems ok:
==9832== LEAK SUMMARY:
==9832==    definitely lost: 0 bytes in 0 blocks
==9832==    indirectly lost: 0 bytes in 0 blocks
==9832==      possibly lost: 0 bytes in 0 blocks
==9832==    still reachable: 35,833,399 bytes in 1,259 blocks
==9832==         suppressed: 0 bytes in 0 blocks
