### PR TITLE
Add the DrawGroundTiles public method to iOS/OSX driver

### DIFF
--- a/Apple/OSMScoutOSX/OSMScoutOSX/OSMScoutMKTileOverlay.m
+++ b/Apple/OSMScoutOSX/OSMScoutOSX/OSMScoutMKTileOverlay.m
@@ -73,6 +73,10 @@
 #if TARGET_OS_IPHONE
         UIGraphicsBeginImageContextWithOptions(CGSizeMake(kOSMScoutDefaultTileSize, kOSMScoutDefaultTileSize),YES,0);
         CGContextRef cg = UIGraphicsGetCurrentContext();
+        CGFloat contentScale = [UIScreen mainScreen].scale;
+        if(contentScale!=1.0){
+          CGContextScaleCTM(cg, 1/contentScale, 1/contentScale);
+        }
         [_osmScout drawMapTo:cg x:_x y:_y zoom:1<<_zoom width:kOSMScoutDefaultTileSize height:kOSMScoutDefaultTileSize];
         UIImage* img = UIGraphicsGetImageFromCurrentImageContext();
         NSData *imgData = UIImagePNGRepresentation(img);
@@ -83,6 +87,10 @@
         NSGraphicsContext *nsgc = [NSGraphicsContext graphicsContextWithGraphicsPort:bitmapContext flipped:YES];
         [NSGraphicsContext setCurrentContext:nsgc];
         CGContextRef cg = [nsgc graphicsPort];
+        CGFloat contentScale = [UIScreen mainScreen].scale;
+        if(contentScale!=1.0){
+          CGContextScaleCTM(cg, 1/contentScale, 1/contentScale);
+        }
         CGAffineTransform flipVertical = CGAffineTransformMake(1, 0, 0, -1, 0, kOSMScoutDefaultTileSize*_scaleFactor);
         CGContextConcatCTM(cg, flipVertical);
         [_osmScout drawMapTo:cg x:_x y:_y zoom:1<<_zoom width:kOSMScoutDefaultTileSize height:kOSMScoutDefaultTileSize];

--- a/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
+++ b/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
@@ -77,6 +77,11 @@ namespace osmscout {
                      const MapParameter& parameter,
                      const MapData& data,
                      CGContextRef paintCG);
+        
+        void DrawGroundTiles(const Projection& projection,
+                             const MapParameter& parameter,
+                             const std::list<GroundTile>& groundTiles,
+                             CGContextRef paintCG);
     protected:
         bool HasIcon(const StyleConfig& styleConfig,
                      const MapParameter& parameter,

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -70,7 +70,6 @@ namespace osmscout {
         Font *font = [Font fontWithName:[NSString stringWithUTF8String: parameter.GetFontName().c_str()] size:fontSize];
         return fonts.insert(std::pair<size_t,Font *>(fontSize,font)).first->second;
     }
-
     
     /*
      * DrawMap()
@@ -80,17 +79,237 @@ namespace osmscout {
                                const MapParameter& parameter,
                                const MapData& data,
                                CGContextRef paintCG){
-
         cg = paintCG;
-        if(contentScale!=1.0){
-            CGContextScaleCTM(cg, 1/contentScale, 1/contentScale);
-        }
         Draw(projection,
              parameter,
              data);
         return true;
     }
 
+    /*
+     * DrawGroundTiles(const Projection& projection,
+     *                 const MapParameter& parameter,
+     *                 const std::list<GroundTile>& groundTiles,
+     *                 CGContextRef paintCG)
+     */
+    void MapPainterIOS::DrawGroundTiles(const Projection& projection,
+                                        const MapParameter& parameter,
+                                        const std::list<GroundTile>& groundTiles,
+                                        CGContextRef paintCG){
+        cg = paintCG;
+        
+        FillStyleRef      landFill;
+        
+        styleConfig->GetLandFillStyle(projection,
+                                      landFill);
+        
+        if (!landFill) {
+            return;
+        }
+        
+        if (parameter.GetRenderBackground()) {
+            DrawGround(projection,
+                       parameter,
+                       *landFill);
+        }
+        
+        FillStyleRef       seaFill;
+        FillStyleRef       coastFill;
+        FillStyleRef       unknownFill;
+        LineStyleRef       coastlineLine;
+        std::vector<Point> points;
+        size_t             start=0;
+        size_t             end=0;
+        
+        styleConfig->GetSeaFillStyle(projection,
+                                     seaFill);
+        styleConfig->GetCoastFillStyle(projection,
+                                       coastFill);
+        styleConfig->GetUnknownFillStyle(projection,
+                                         unknownFill);
+        styleConfig->GetCoastlineLineStyle(projection,
+                                           coastlineLine);
+        
+        if (!seaFill) {
+            return;
+        }
+        
+        double             errorTolerancePixel=projection.ConvertWidthToPixel(parameter.GetOptimizeErrorToleranceMm());
+        FeatureValueBuffer coastlineSegmentAttributes;
+        
+        for (const auto& tile : groundTiles) {
+            AreaData areaData;
+            
+            if (tile.type==GroundTile::unknown &&
+                !parameter.GetRenderUnknowns()) {
+                continue;
+            }
+            
+            switch (tile.type) {
+                case GroundTile::land:
+                    areaData.fillStyle=landFill;
+                    break;
+                case GroundTile::water:
+                    areaData.fillStyle=seaFill;
+                    break;
+                case GroundTile::coast:
+                    areaData.fillStyle=coastFill;
+                    break;
+                case GroundTile::unknown:
+                    areaData.fillStyle=unknownFill;
+                    break;
+            }
+            if (!areaData.fillStyle){
+                continue;
+            }
+            
+            GeoCoord minCoord(tile.yAbs*tile.cellHeight-90.0,
+                              tile.xAbs*tile.cellWidth-180.0);
+            GeoCoord maxCoord(minCoord.GetLat()+tile.cellHeight,
+                              minCoord.GetLon()+tile.cellWidth);
+            
+            areaData.boundingBox.Set(minCoord,maxCoord);
+            
+            if (tile.coords.empty()) {
+                // Fill the cell completely with the fill for the given cell type
+                points.resize(5);
+                
+                points[0].SetCoord(areaData.boundingBox.GetMinCoord());
+                points[1].SetCoord(GeoCoord(areaData.boundingBox.GetMinCoord().GetLat(),
+                                            areaData.boundingBox.GetMaxCoord().GetLon()));
+                points[2].SetCoord(areaData.boundingBox.GetMaxCoord());
+                points[3].SetCoord(GeoCoord(areaData.boundingBox.GetMaxCoord().GetLat(),
+                                            areaData.boundingBox.GetMinCoord().GetLon()));
+                points[4]=points[0];
+                
+                transBuffer.transPolygon.TransformArea(projection,
+                                                       TransPolygon::none,
+                                                       points,
+                                                       errorTolerancePixel);
+                
+                size_t s=transBuffer.transPolygon.GetStart();
+                
+                start=transBuffer.buffer->PushCoord(floor(transBuffer.transPolygon.points[s+0].x),
+                                                    ceil(transBuffer.transPolygon.points[s+0].y));
+                
+                
+                transBuffer.buffer->PushCoord(ceil(transBuffer.transPolygon.points[s+1].x),
+                                              ceil(transBuffer.transPolygon.points[s+1].y));
+                
+                transBuffer.buffer->PushCoord(ceil(transBuffer.transPolygon.points[s+2].x),
+                                              floor(transBuffer.transPolygon.points[s+2].y));
+                
+                transBuffer.buffer->PushCoord(floor(transBuffer.transPolygon.points[s+3].x),
+                                              floor(transBuffer.transPolygon.points[s+3].y));
+                
+                end=transBuffer.buffer->PushCoord(floor(transBuffer.transPolygon.points[s+4].x),
+                                                  ceil(transBuffer.transPolygon.points[s+4].y));
+            } else {
+                points.resize(tile.coords.size());
+                
+                for (size_t i=0; i<tile.coords.size(); i++) {
+                    double lat;
+                    double lon;
+                    
+                    lat=areaData.boundingBox.GetMinCoord().GetLat()+tile.coords[i].y*tile.cellHeight/GroundTile::Coord::CELL_MAX;
+                    lon=areaData.boundingBox.GetMinCoord().GetLon()+tile.coords[i].x*tile.cellWidth/GroundTile::Coord::CELL_MAX;
+                    
+                    points[i].SetCoord(GeoCoord(lat,lon));
+                }
+                
+                transBuffer.transPolygon.TransformArea(projection,
+                                                       TransPolygon::none,
+                                                       points,
+                                                       errorTolerancePixel);
+                
+                for (size_t i=transBuffer.transPolygon.GetStart(); i<=transBuffer.transPolygon.GetEnd(); i++) {
+                    double x,y;
+                    
+                    if (tile.coords[i].x==0) {
+                        x=floor(transBuffer.transPolygon.points[i].x);
+                    }
+                    else if (tile.coords[i].x==GroundTile::Coord::CELL_MAX) {
+                        x=ceil(transBuffer.transPolygon.points[i].x);
+                    }
+                    else {
+                        x=transBuffer.transPolygon.points[i].x;
+                    }
+                    
+                    if (tile.coords[i].y==0) {
+                        y=ceil(transBuffer.transPolygon.points[i].y);
+                    }
+                    else if (tile.coords[i].y==GroundTile::Coord::CELL_MAX) {
+                        y=floor(transBuffer.transPolygon.points[i].y);
+                    }
+                    else {
+                        y=transBuffer.transPolygon.points[i].y;
+                    }
+                    
+                    size_t idx=transBuffer.buffer->PushCoord(x,y);
+                    
+                    if (i==transBuffer.transPolygon.GetStart()) {
+                        start=idx;
+                    }
+                    else if (i==transBuffer.transPolygon.GetEnd()) {
+                        end=idx;
+                    }
+                }
+                
+                if (coastlineLine) {
+                    size_t lineStart=0;
+                    size_t lineEnd;
+                    
+                    while (lineStart<tile.coords.size()) {
+                        while (lineStart<tile.coords.size() &&
+                               !tile.coords[lineStart].coast) {
+                            lineStart++;
+                        }
+                        
+                        if (lineStart>=tile.coords.size()) {
+                            continue;
+                        }
+                        
+                        lineEnd=lineStart;
+                        
+                        while (lineEnd<tile.coords.size() &&
+                               tile.coords[lineEnd].coast) {
+                            lineEnd++;
+                        }
+                        
+                        if (lineStart!=lineEnd) {
+                            WayData data;
+                            
+                            data.buffer=&coastlineSegmentAttributes;
+                            data.layer=0;
+                            data.lineStyle=coastlineLine;
+                            data.wayPriority=std::numeric_limits<int>::max();
+                            data.transStart=start+lineStart;
+                            data.transEnd=start+lineEnd;
+                            data.lineWidth=GetProjectedWidth(projection,
+                                                             projection.ConvertWidthToPixel(coastlineLine->GetDisplayWidth()),
+                                                             coastlineLine->GetWidth());
+                            data.startIsClosed=false;
+                            data.endIsClosed=false;
+                            
+                            DrawWay(*styleConfig,
+                                    projection,
+                                    parameter,
+                                    data);
+                        }
+                        
+                        lineStart=lineEnd+1;
+                    }
+                }
+            }
+            
+            areaData.ref=ObjectFileRef();
+            areaData.transStart=start;
+            areaData.transEnd=end;
+            
+            DrawArea(projection,parameter,areaData);
+        }
+    }
+    
     /*
      * HasIcon()
      */
@@ -951,5 +1170,4 @@ namespace osmscout {
         }
     }
 
-    
 }


### PR DESCRIPTION
It is useful to draw the base map with the world coastlines.

The graphic context (gc) given to draw methods should now be scaled for retina display, the methods don't do it anymore.