### PR TITLE
always use lower case names to locations lookup

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
@@ -1877,7 +1877,7 @@ namespace osmscout {
                                    region.reference);
 
       progress.Debug(std::string("Create virtual location for region '")+region.name+"'");
-      return locations.find(region.name);
+      return locations.find(regionNameLower);
     }
 
     for (auto &alias: region.aliases) {
@@ -1888,7 +1888,7 @@ namespace osmscout {
                                      ObjectFileRef(alias.reference,refNode));
 
         progress.Debug(std::string("Create virtual location for '")+alias.name+"' (alias of region "+region.name+")");
-        return locations.find(alias.name);
+        return locations.find(regionAliasNameLower);
       }
     }
 


### PR DESCRIPTION
Hi. This bug removes first address from "virtually added" locations. Here is [location_full.diff](https://gist.github.com/Karry/acbf535694eb2ccca87f678efab5ca36) for Czech Republic