### PR TITLE
normalise location name before lookup

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
@@ -72,9 +72,9 @@ namespace osmscout {
   void LocationIndexGenerator::PostalArea::AddLocationObject(const std::string& name,
                                                              const ObjectFileRef& objectRef)
   {
-    std::string locationNameLower=UTF8StringToLower(name);
+    std::string locationNameNorm=UTF8NormForLookup(name);
 
-    RegionLocation& location=locations[locationNameLower];
+    RegionLocation& location=locations[locationNameNorm];
 
     std::unordered_map<std::string,size_t>::iterator nameEntry=location.names.find(name);
 
@@ -1431,9 +1431,9 @@ namespace osmscout {
     // If there is a non-default postal area but the location is in the default postal area => make a copy
     if (foundInDefaultArea &&
         postalAreaEntry!=region.postalAreas.end()) {
-      std::string locationNameLower=UTF8StringToLower(loc->second.GetName());
+      std::string locationNameNorm=UTF8NormForLookup(loc->second.GetName());
 
-      auto newLoc=postalAreaEntry->second.locations.insert(std::make_pair(locationNameLower,
+      auto newLoc=postalAreaEntry->second.locations.insert(std::make_pair(locationNameNorm,
                                                                           loc->second)).first;
 
       newLoc->second.addresses.clear();
@@ -1860,7 +1860,7 @@ namespace osmscout {
                                                                                                               const std::string &locationName)
   {
     std::map<std::string,RegionLocation> &locations=postalArea.locations;
-    std::string                          locationNameSearch=UTF8StringToLower(locationName);
+    std::string                          locationNameSearch=UTF8NormForLookup(locationName);
     auto                                 loc=locations.find(locationNameSearch);
 
     if (loc!=locations.end()) {
@@ -1870,25 +1870,25 @@ namespace osmscout {
 
     // if locationName is same as region.name (or one of its name aliases) add new location entry
     // it is usual case for addresses without street and defined addr:place
-    std::string regionNameLower=UTF8StringToLower(region.name);
+    std::string regionNameNorm=UTF8NormForLookup(region.name);
 
-    if (regionNameLower==locationNameSearch) {
+    if (regionNameNorm==locationNameSearch) {
       postalArea.AddLocationObject(region.name,
                                    region.reference);
 
       progress.Debug(std::string("Create virtual location for region '")+region.name+"'");
-      return locations.find(regionNameLower);
+      return locations.find(regionNameNorm);
     }
 
     for (auto &alias: region.aliases) {
-      std::string regionAliasNameLower=UTF8StringToLower(alias.name);
+      std::string regionAliasNameNorm=UTF8NormForLookup(alias.name);
 
-      if (regionAliasNameLower==locationNameSearch) {
+      if (regionAliasNameNorm==locationNameSearch) {
         postalArea.AddLocationObject(alias.name,
                                      ObjectFileRef(alias.reference,refNode));
 
         progress.Debug(std::string("Create virtual location for '")+alias.name+"' (alias of region "+region.name+")");
-        return locations.find(regionAliasNameLower);
+        return locations.find(regionAliasNameNorm);
       }
     }
 

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -543,6 +543,21 @@ namespace osmscout {
    * @note that a global C++ locale must be set for more than simple ASCII conversions to work.
    */
   extern OSMSCOUT_API std::string UTF8StringToLower(const std::string& text);
+
+  /**
+   * Normalise the given std::string containing a UTF8 character sequence
+   * for tolerant comparison. It may be used for string lookup typed by human,
+   * for example street name, where string are not binary equals,
+   * but are "same" for human - for example "Baker Street" and "Baker  street"
+   *
+   * @param text
+   *    Text to get converted
+   * @return
+   *    Converted text
+   *
+   * @note that a global C++ locale must be set for more than simple ASCII conversions to work.
+   */
+  extern OSMSCOUT_API std::string UTF8NormForLookup(const std::string& text);
 }
 
 #endif

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -725,4 +725,31 @@ namespace osmscout {
 
     return WStringToUTF8String(wstr);
   }
+
+  std::string UTF8NormForLookup(const std::string& text)
+  {
+    std::wstring wstr=UTF8StringToWString(text);
+
+    auto& f=std::use_facet<std::ctype<wchar_t>>(std::locale());
+
+    // convert to lower and replace all whitespaces with simple space
+    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
+                   [&f](wchar_t c) -> wchar_t {
+                     // std::iswspace don't recognize no-break space and others
+                     // so-space characters as space -> we are using switch here...
+                     switch(c){
+                       case ' ':
+                       case L'\u0009': // tabular
+                       case L'\u00A0': // no-break space (&nbsp;)
+                       case L'\u2007': // figure space
+                       case L'\u202F': // narrow no-break space
+                         return ' ';
+                       default:
+                         return f.tolower(c); // to lower
+                     }});
+
+    // TODO: remove multiple following spaces by one
+
+    return WStringToUTF8String(wstr);
+  }
 }


### PR DESCRIPTION
Hi. 

I added location name normalisation for lookup. Main problem was that no-breakable space is sometimes used in street name but it is missing in `addr:street` in address points. This change brings 1881 new address points* to osmscout in Czechia ;-)

`*` ...ok, it is not big issue, it is less than 1% of address points...