### PR TITLE
use lowest possible OpenGL version hint

### DIFF
--- a/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
+++ b/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
@@ -300,8 +300,8 @@ int main(int argc, char *argv[]) {
   glfwSetErrorCallback(ErrorCallback);
   if (!glfwInit())
     return -1;
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 


### PR DESCRIPTION
Hi. I want to fix this issue: https://github.com/Framstag/libosmscout/issues/378 
But I am not sure if setting lower OGL version hint may have some cons. @fannymonori please review it :-)