### PR TITLE
Qt: Setup search center and use it for sorting databases

### DIFF
--- a/OSMScout2/qml/SearchDialog.qml
+++ b/OSMScout2/qml/SearchDialog.qml
@@ -9,6 +9,8 @@ FocusScope {
     id: searchDialog
 
     property Item desktop;
+    property double searchCenterLat;
+    property double searchCenterLon;
 
     property alias startLocation: searchEdit.location;
     property alias destinationLocation: destinationEdit.location;
@@ -90,6 +92,9 @@ FocusScope {
             LocationSearch {
                 id: searchEdit;
 
+                searchCenterLat: searchDialog.searchCenterLat
+                searchCenterLon: searchDialog.searchCenterLon
+
                 focus: true
 
                 Layout.column: 1
@@ -149,6 +154,9 @@ FocusScope {
 
             LocationSearch {
                 id: destinationEdit;
+
+                searchCenterLat: searchDialog.searchCenterLat
+                searchCenterLon: searchDialog.searchCenterLon
 
                 visible: false
 

--- a/OSMScout2/qml/custom/LocationSearch.qml
+++ b/OSMScout2/qml/custom/LocationSearch.qml
@@ -8,6 +8,8 @@ LineEdit {
 
     property Item desktop;
     property LocationEntry location;
+    property double searchCenterLat;
+    property double searchCenterLon;
 
     // Internal constant
     property int listCellHeight: Theme.textFontSize*2+4
@@ -21,6 +23,7 @@ LineEdit {
             return;
         }
 
+        setupSearchCenter();
         suggestionModel.setPattern(searchEdit.text)
 
         if (suggestionModel.count>=1) {
@@ -39,7 +42,13 @@ LineEdit {
 
     // Private
 
+    function setupSearchCenter() {
+        suggestionModel.lat=searchCenterLat;
+        suggestionModel.lon=searchCenterLon;
+    }
+
     function updateSuggestions() {
+        setupSearchCenter();
         suggestionModel.setPattern(searchEdit.text)
 
         if (suggestionModel.count>=1 &&
@@ -89,6 +98,7 @@ LineEdit {
 
         hidePopup()
 
+        setupSearchCenter();
         suggestionModel.setPattern(searchEdit.text)
     }
 
@@ -219,6 +229,7 @@ LineEdit {
 
     LocationListModel {
         id: suggestionModel
+
         onCountChanged:{
             if (focus){
               updatePopup();

--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -235,6 +235,8 @@ Window {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 desktop: map
+                searchCenterLat: map.lat
+                searchCenterLon: map.lon
 
                 onShowLocation: {
                     console.log("location: "+location);

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -36,55 +36,84 @@
  */
 class OSMSCOUT_CLIENT_QT_API LocationListModel : public QAbstractListModel
 {
-    Q_OBJECT
-    Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
-    Q_PROPERTY(bool searching READ isSearching NOTIFY SearchingChanged)
+  Q_OBJECT
+  Q_PROPERTY(int     count       READ rowCount    NOTIFY countChanged)
+  Q_PROPERTY(bool    searching   READ isSearching NOTIFY SearchingChanged)
+  Q_PROPERTY(double  lat         READ GetLat      WRITE SetLat)
+  Q_PROPERTY(double  lon         READ GetLon      WRITE SetLon)
+  Q_PROPERTY(int     resultLimit READ GetResultLimit WRITE SetResultLimit)
 
 signals:
-    void SearchRequested(const QString searchPattern, int limit);
-    void SearchingChanged(bool);
-    void countChanged(int);
+  void SearchRequested(const QString searchPattern, int limit, osmscout::GeoCoord searchCenter);
+  void SearchingChanged(bool);
+  void countChanged(int);
 
 public slots:
-    void setPattern(const QString& pattern);
-    void onSearchResult(const QString searchPattern, 
-                        const QList<LocationEntry>);
-    void onSearchFinished(const QString searchPattern, bool error);
+  void setPattern(const QString& pattern);
+  void onSearchResult(const QString searchPattern,
+                      const QList<LocationEntry>);
+  void onSearchFinished(const QString searchPattern, bool error);
   
 private:
-    QString pattern;
-    QString lastRequestPattern;
-    QList<LocationEntry*> locations;
-    bool searching;
-    SearchModule* searchModule;
+  QString pattern;
+  QString lastRequestPattern;
+  QList<LocationEntry*> locations;
+  bool searching;
+  SearchModule* searchModule;
+  osmscout::GeoCoord searchCenter;
+  int resultLimit;
 
 public:
-    enum Roles {
-        LabelRole = Qt::UserRole,
-        TypeRole = Qt::UserRole +1,
-        RegionRole = Qt::UserRole +2,
-        LatRole = Qt::UserRole +3,
-        LonRole = Qt::UserRole +4
-    };
+  enum Roles {
+    LabelRole = Qt::UserRole,
+    TypeRole = Qt::UserRole +1,
+    RegionRole = Qt::UserRole +2,
+    LatRole = Qt::UserRole +3,
+    LonRole = Qt::UserRole +4
+  };
 
 public:
-    LocationListModel(QObject* parent = 0);
-    virtual ~LocationListModel();
+  LocationListModel(QObject* parent = 0);
+  virtual ~LocationListModel();
 
-    Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;
+  Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;
 
-    Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
+  Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 
-    Q_INVOKABLE virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+  Q_INVOKABLE virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 
-    virtual QHash<int, QByteArray> roleNames() const;
+  virtual QHash<int, QByteArray> roleNames() const;
 
-    Q_INVOKABLE LocationEntry* get(int row) const;
-    
-    inline bool isSearching() const
-    {
-      return searching;
-    }
+  Q_INVOKABLE LocationEntry* get(int row) const;
+
+  inline bool isSearching() const
+  {
+    return searching;
+  }
+
+  inline double GetLat() const {
+    return searchCenter.GetLat();
+  }
+
+  inline double GetLon() const {
+    return searchCenter.GetLon();
+  }
+
+  inline void SetLat(double lat){
+    searchCenter.Set(lat,searchCenter.GetLon());
+  }
+
+  inline void SetLon(double lon){
+    searchCenter.Set(searchCenter.GetLat(),lon);
+  }
+
+  inline int GetResultLimit() const {
+    return resultLimit;
+  }
+
+  inline void SetResultLimit(int limit){
+    resultLimit=limit;
+  }
 };
 
 #endif

--- a/libosmscout-client-qt/include/osmscout/SearchModule.h
+++ b/libosmscout-client-qt/include/osmscout/SearchModule.h
@@ -65,7 +65,7 @@ public slots:
    * @param searchPattern
    * @param limit - suggested limit for count of retrieved entries from one database
    */
-  void SearchForLocations(const QString searchPattern,int limit);
+  void SearchForLocations(const QString searchPattern,int limit,osmscout::GeoCoord);
 
 public:
   SearchModule(QThread *thread,DBThreadRef dbThread,LookupModule *lookupModule);

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -25,12 +25,12 @@
 #include <osmscout/OSMScoutQt.h>
     
 LocationListModel::LocationListModel(QObject* parent)
-: QAbstractListModel(parent), searching(false)
+: QAbstractListModel(parent), searching(false), searchCenter(0,0), resultLimit(50)
 {
     searchModule=OSMScoutQt::GetInstance().MakeSearchModule();
 
-    connect(this, SIGNAL(SearchRequested(const QString, int)), 
-            searchModule, SLOT(SearchForLocations(const QString, int)),
+    connect(this, SIGNAL(SearchRequested(const QString, int, osmscout::GeoCoord)),
+            searchModule, SLOT(SearchForLocations(const QString, int, osmscout::GeoCoord)),
             Qt::QueuedConnection);
     
     connect(searchModule, SIGNAL(searchResult(const QString, const QList<LocationEntry>)),
@@ -81,7 +81,7 @@ void LocationListModel::onSearchFinished(const QString searchPattern, bool /*err
   if (lastRequestPattern!=pattern){
     qDebug() << "Search postponed" << pattern;
     lastRequestPattern=pattern;
-    emit SearchRequested(pattern, 50);
+    emit SearchRequested(pattern, resultLimit, searchCenter);
   }else{
     searching = false;
     emit SearchingChanged(false);
@@ -130,7 +130,7 @@ void LocationListModel::setPattern(const QString& pattern)
   searching = true;
   lastRequestPattern = pattern;
   emit SearchingChanged(true);
-  emit SearchRequested(pattern, 50);
+  emit SearchRequested(pattern, resultLimit, searchCenter);
 }
 
 int LocationListModel::rowCount(const QModelIndex& ) const


### PR DESCRIPTION
Setup search center and use it for sorting databases to provide nearest results first.
Goal is to use this location for lookup default admin area in future.