### PR TITLE
Rotation in Qt renderer, input handler

### DIFF
--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -269,10 +269,12 @@ private:
     MapView startMapView;
     QVector2D _move;
     osmscout::Magnification targetMagnification;
+    double targetAngel;
     int animationDuration;
 
     const int MOVE_ANIMATION_DURATION = 1000; // ms
     const int ZOOM_ANIMATION_DURATION = 500; // ms
+    const int ROTATE_ANIMATION_DURATION = 1000; //ms
     const int ANIMATION_TICK = 16;
 
 private slots:

--- a/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
@@ -93,6 +93,10 @@ public:
    */
   virtual bool RenderMap(QPainter& painter,
                          const RenderMapRequest& request);
+
+private:
+  double computeScale(const osmscout::MercatorProjection &previousProjection,
+                      const osmscout::MercatorProjection &currentProjection);
 };
 
 #endif /* PLANEMAPRENDERER_H */

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -169,26 +169,22 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
   osmscout::GeoBox finalImgBoundingBox;
   finalImgProjection.GetDimensions(finalImgBoundingBox);
 
-  finalImgProjection.GetDimensions(finalImgBoundingBox);
-
   // projection bounding box may be smaller than projection dimensions...
-  double srcX1;
-  double srcY1;
-  double srcX2;
-  double srcY2;
+  double srcX;
+  double srcY;
 
-  finalImgProjection.GeoToPixel(finalImgBoundingBox.GetMaxCoord(),srcX2,srcY1); // max coord => right top
-  finalImgProjection.GeoToPixel(finalImgBoundingBox.GetMinCoord(),srcX1,srcY2); // min coord => left bottom
+  finalImgProjection.GeoToPixel(finalImgBoundingBox.GetCenter(),srcX,srcY);
+  srcX-=finalImgProjection.GetWidth()*0.5;
+  srcY-=finalImgProjection.GetHeight()*0.5;
 
-  double x1;
-  double y1;
-  double x2;
-  double y2;
+  double x;
+  double y;
 
-  requestProjection.GeoToPixel(finalImgBoundingBox.GetMaxCoord(),x2,y1); // max coord => right top
-  requestProjection.GeoToPixel(finalImgBoundingBox.GetMinCoord(),x1,y2); // min coord => left bottom
+  requestProjection.GeoToPixel(finalImgBoundingBox.GetCenter(),x,y);
+  x-=requestProjection.GetWidth()*canvasOverrun*0.5;
+  y-=requestProjection.GetHeight()*canvasOverrun*0.5;
 
-  if (x1>0 || y1>0 || x2<request.width || y2<request.height) {
+  if (x>0 || y>0) {
     painter.fillRect(0,
                      0,
                      request.width,
@@ -199,9 +195,17 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
                                       backgroundColor.GetA()));
   }
 
-  // TODO: handle angle
   //qDebug() << "Draw final image to canvas:" << QRectF(x1,y1,x2-x1,y2-y1);
-  painter.drawImage(QRectF(x1,y1,x2-x1,y2-y1),*finishedImage,QRectF(srcX1,srcY1,srcX2-srcX1,srcY2-srcY1));
+
+  painter.drawImage(QRectF(x,
+                           y,
+                           requestProjection.GetWidth()*canvasOverrun,
+                           requestProjection.GetHeight()*canvasOverrun),
+                    *finishedImage,
+                    QRectF(srcX,
+                           srcY,
+                           finalImgProjection.GetWidth(),
+                           finalImgProjection.GetHeight()));
 
   RenderMapRequest extendedRequest=request;
   extendedRequest.width*=canvasOverrun;

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -207,9 +207,11 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
 
   if (finalImgProjection.GetAngle()!=requestProjection.GetAngle()){
     // rotate final image
-    painter.translate(request.width/2.0,request.height/2.0);
+    QPointF rotationCenter(targetRectangle.x()+targetRectangle.width()/2.0,
+                           targetRectangle.y()+targetRectangle.height()/2.0);
+    painter.translate(rotationCenter);
     painter.rotate(qRadiansToDegrees(requestProjection.GetAngle()-finalImgProjection.GetAngle()));
-    painter.translate(request.width/-2.0,request.height/-2.0);
+    painter.translate(rotationCenter*-1.0);
   }
 
   painter.drawImage(targetRectangle,


### PR DESCRIPTION
Hi. Here are patches from Alexander that brings map rotation back to Qt code and OSMScout2 demo (https://github.com/Framstag/libosmscout/issues/478) + my fix that makes animations fluent. 

It works just with plane renderer. Non zero angle with tiled renderer leads to invalid image or even to SIGFPE...