### PR TITLE
define user agent at runtime

### DIFF
--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -151,7 +151,8 @@ int main(int argc, char* argv[])
     .WithIconDirectory(iconDirectory)
     .WithMapLookupDirectories(mapLookupDirectories)
     .WithOnlineTileProviders(":/resources/online-tile-providers.json")
-    .WithMapProviders(":/resources/map-providers.json");
+    .WithMapProviders(":/resources/map-providers.json")
+    .WithUserAgent("OSMScout2DemoApp", "v?");
 
   if (!builder.Init()){
     std::cerr << "Cannot initialize OSMScout library" << std::endl;

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -88,7 +88,8 @@ int main(int argc, char* argv[])
   builder
     .WithIconDirectory(iconDirectory)
     .WithMapLookupDirectories(mapLookupDirectories)
-    .WithOnlineTileProviders(":/resources/online-tile-providers.json");
+    .WithOnlineTileProviders(":/resources/online-tile-providers.json")
+    .WithUserAgent("OSMScoutStyleEditor", "v?");
 
   if (!builder.Init()){
     osmscout::log.Error() << "Cannot initialize OSMScout library";

--- a/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
@@ -59,6 +59,9 @@ private:
   QString styleSheetFile;
   bool styleSheetFileConfigured;
 
+  QString appName;
+  QString appVersion;
+
 public:
   OSMScoutQtBuilder();
 
@@ -133,6 +136,13 @@ public:
     return *this;
   }
 
+  inline OSMScoutQtBuilder& WithUserAgent(QString appName,
+                                          QString appVersion){
+    this->appName=appName;
+    this->appVersion=appVersion;
+    return *this;
+  }
+
   bool Init();
 };
 
@@ -194,6 +204,7 @@ private:
   QString       cacheLocation;
   size_t        onlineTileCacheSize;
   size_t        offlineTileCacheSize;
+  QString       userAgent;
 
 private:
   OSMScoutQt(SettingsRef settings,
@@ -202,7 +213,8 @@ private:
              QString iconDirectory,
              QString cacheLocation,
              size_t onlineTileCacheSize,
-             size_t offlineTileCacheSize);
+             size_t offlineTileCacheSize,
+             QString userAgent);
 public:
   virtual ~OSMScoutQt();
 
@@ -215,6 +227,8 @@ public:
   Router* MakeRouter();
   SearchModule *MakeSearchModule();
   StyleModule *MakeStyleModule();
+
+  QString GetUserAgent();
 
   static void RegisterQmlTypes(const char *uri="net.sf.libosmscout.map",
                                int versionMajor=1,

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -31,13 +31,9 @@
 
 #include <osmscout/private/ClientQtImportExport.h>
 
-// these variables should be defined by build system
-#ifndef OSMSCOUT_VERSION_STRING
-#define OSMSCOUT_VERSION_STRING "v?"
-#endif
-
-#ifndef OSMSCOUT_USER_AGENT
-#define OSMSCOUT_USER_AGENT "OSMScout demo app %1"
+// this variable should be defined by build system
+#ifndef LIBOSMSCOUT_VERSION_STRING
+#define LIBOSMSCOUT_VERSION_STRING "v?"
 #endif
 
 /**

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -74,7 +74,7 @@ AvailableMapsModel::AvailableMapsModel()
     QNetworkRequest request(url);
     requests[url]=provider;
     
-    request.setHeader(QNetworkRequest::UserAgentHeader, QString(OSMSCOUT_USER_AGENT).arg(OSMSCOUT_VERSION_STRING));
+    request.setHeader(QNetworkRequest::UserAgentHeader, OSMScoutQt::GetInstance().GetUserAgent());
     //request.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
     webCtrl.get(request);
   }

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -19,6 +19,7 @@
 
 #include <osmscout/FileDownloader.h>
 #include <osmscout/Settings.h>
+#include <osmscout/OSMScoutQt.h>
 
 #include <QUrl>
 #include <QDir>
@@ -123,7 +124,7 @@ void FileDownloader::startDownload()
   // start download
   QNetworkRequest request(m_url);
   request.setHeader(QNetworkRequest::UserAgentHeader,
-                    QString(OSMSCOUT_USER_AGENT).arg(OSMSCOUT_VERSION_STRING));
+                    OSMScoutQt::GetInstance().GetUserAgent());
 
   if (m_downloaded > 0)
     {

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -48,7 +48,9 @@ OSMScoutQtBuilder::OSMScoutQtBuilder():
   onlineTileCacheSize(100),
   offlineTileCacheSize(200),
   styleSheetDirectoryConfigured(false),
-  styleSheetFileConfigured(false)
+  styleSheetFileConfigured(false),
+  appName("UnspecifiedApp"),
+  appVersion("v?")
 {
   QString documentsLocation = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
   mapLookupDirectories << QDir::currentPath();
@@ -103,13 +105,19 @@ bool OSMScoutQtBuilder::Init()
   dbThread->moveToThread(thread);
   thread->start();
 
+  QString userAgent=QString("%1/%2 libosmscout/%3 Qt/%4")
+      .arg(appName).arg(appVersion)
+      .arg(LIBOSMSCOUT_VERSION_STRING)
+      .arg(QT_VERSION_STR);
+
   osmScoutInstance=new OSMScoutQt(settings,
                                   mapManager,
                                   dbThread,
                                   iconDirectory,
                                   cacheLocation,
                                   onlineTileCacheSize,
-                                  offlineTileCacheSize);
+                                  offlineTileCacheSize,
+                                  userAgent);
                                   
   return true;
 }
@@ -178,14 +186,16 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
                        QString iconDirectory,
                        QString cacheLocation,
                        size_t onlineTileCacheSize,
-                       size_t offlineTileCacheSize):
+                       size_t offlineTileCacheSize,
+                       QString userAgent):
         settings(settings),
         mapManager(mapManager),
         dbThread(dbThread),
         iconDirectory(iconDirectory),
         cacheLocation(cacheLocation),
         onlineTileCacheSize(onlineTileCacheSize),
-        offlineTileCacheSize(offlineTileCacheSize)
+        offlineTileCacheSize(offlineTileCacheSize),
+        userAgent(userAgent)
 {
 }
 
@@ -280,4 +290,8 @@ Router* OSMScoutQt::MakeRouter()
   QObject::connect(thread, SIGNAL(finished()),
                    thread, SLOT(deleteLater()));
   return router;
+}
+
+QString OSMScoutQt::GetUserAgent(){
+  return userAgent;
 }

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -85,7 +85,7 @@ void OsmTileDownloader::download(uint32_t zoomLevel, uint32_t x, uint32_t y)
   requests.insert(tileUrl, key);
   
   QNetworkRequest request(tileUrl);
-  request.setHeader(QNetworkRequest::UserAgentHeader, QString(OSMSCOUT_USER_AGENT).arg(OSMSCOUT_VERSION_STRING));
+  request.setHeader(QNetworkRequest::UserAgentHeader, OSMScoutQt::GetInstance().GetUserAgent());
   //request.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
   webCtrl.get(request);
 }


### PR DESCRIPTION
...library may be use by multiple applications, it is not good idea
to define user agent at compile time.
In addition, add Qt version to user agent, it may helps to identify
possible problems from server log.