### PR TITLE
add support for parsing geo coordinate string with degrees, minutes and seconds

### DIFF
--- a/Tests/src/GeoCoordParse.cpp
+++ b/Tests/src/GeoCoordParse.cpp
@@ -168,6 +168,16 @@ int main()
     errors++;
   }
 
+  if (!CheckParseSuccess( "50°5'8.860\"N 14°24'37.592\"E",
+                         osmscout::GeoCoord(50.0857944, 14.4104422))) {
+    errors++;
+  }
+
+  if (!CheckParseSuccess("N 50°5.14767' E 14°24.62653'",
+                         osmscout::GeoCoord(50.0857944, 14.4104422))) {
+    errors++;
+  }
+
   if (errors!=0) {
     return 1;
   }

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -207,7 +207,11 @@ namespace osmscout {
      *
      * The text should follow the following expression:
      *
-     * [+|-|N|S] DD[.DDDDD] [N|S] [+|-|W|E] DDD[.DDDDD] [W|E]
+     * [+|-|N|S] <coordinate> [N|S] [+|-|W|E] <coordinate> [W|E]
+     *
+     * coordinate may have one of these formats:
+     *  DDD[.DDDDD]
+     *  DD°[D[.DDD]'[D[.DDD]"]]
      *
      * The means:
      * * You first define the latitude, then the longitude value


### PR DESCRIPTION
Hi. This simple change allows to parse (and use it in search) following coordinate patterns:
```
50°5'8.860"N 14°24'37.592"E
N 50°5.14767' E 14°24.62653'
```

`ScanCoordinate` is not the nicest method, but parsing is straightforward...