### PR TITLE
fix island/islet style, these disappears from 'veryClose' magnification

### DIFF
--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -1835,6 +1835,11 @@ STYLE
          place_islet] {
      NODE.TEXT {label: IName; style: emphasize; size: 1.3; priority: @labelPrioIsland;}
      AREA.TEXT { label: IName; style: emphasize; priority: @labelPrioIsland; autoSize: true; }
+   }
+ }
+ [MAG region-] {
+   [TYPE place_island,
+         place_islet] {
      AREA {color: @landColor;}
    }
  }

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -1858,6 +1858,11 @@ STYLE
          place_islet] {
      NODE.TEXT {label: IName; style: emphasize; size: 1.3; priority: @labelPrioIsland;}
      AREA.TEXT { label: IName; style: emphasize; priority: @labelPrioIsland; autoSize: true; }
+   }
+ }
+ [MAG region-] {
+   [TYPE place_island,
+         place_islet] {
      AREA {color: @landColor;}
    }
  }


### PR DESCRIPTION
Hi. Islands and islets was configured to disappear from zoom level 16. It is fine for place labels, but not for areas itself :-)

![paris-15](https://user-images.githubusercontent.com/309458/31704668-9ec96ada-b3e2-11e7-907a-f0baa9b38cdc.png)
![paris-16](https://user-images.githubusercontent.com/309458/31704670-a0bb3922-b3e2-11e7-9bf6-a9663a8f4930.png)
