### PR TITLE
Qt search result merging and sorting

### DIFF
--- a/OSMScout2/qml/custom/LocationSearch.qml
+++ b/OSMScout2/qml/custom/LocationSearch.qml
@@ -238,11 +238,15 @@ LineEdit {
             } else if (loc.type=="object"){
                 var rank=1;
 
-                if (loc.objectType=="boundary_administrative"){
+                if (loc.objectType=="boundary_country"){
+                    rank*=1;
+                }else if (loc.objectType=="boundary_state"){
+                    rank*=0.93;
+                } else if (loc.objectType=="boundary_administrative" ||
+                           loc.objectType=="place_town"){
                     rank*=0.9;
                 } else if (loc.objectType=="highway_residential" ||
-                           loc.objectType=="address"
-                           ){
+                           loc.objectType=="address"){
                     rank*=0.8;
                 } else if (loc.objectType=="railway_station" ||
                            loc.objectType=="railway_tram_stop" ||
@@ -256,7 +260,7 @@ LineEdit {
                 var distance=loc.distanceTo(searchCenterLat, searchCenterLon);
                 rank*= 1 / Math.log( (distance/1000) + Math.E);
 
-                // console.log("rank " + loc.label + ": " + rank + "");
+                //console.log("rank " + loc.label + ": " + rank + "");
                 return rank;
             }
 

--- a/OSMScout2/qml/custom/LocationSearch.qml
+++ b/OSMScout2/qml/custom/LocationSearch.qml
@@ -230,6 +230,55 @@ LineEdit {
     LocationListModel {
         id: suggestionModel
 
+        // compute rank for location, it should be in range 0~1
+        function locationRank(loc){
+
+            if (loc.type=="coordinate"){
+                return 1;
+            } else if (loc.type=="object"){
+                var rank=1;
+
+                if (loc.objectType=="boundary_administrative"){
+                    rank*=0.9;
+                } else if (loc.objectType=="highway_residential" ||
+                           loc.objectType=="address"
+                           ){
+                    rank*=0.8;
+                } else if (loc.objectType=="railway_station" ||
+                           loc.objectType=="railway_tram_stop" ||
+                           loc.objectType=="railway_subway_entrance" ||
+                           loc.objectType=="highway_bus_stop"
+                          ){
+                    rank*=0.7;
+                }else{
+                    rank*=0.5;
+                }
+                var distance=loc.distanceTo(searchCenterLat, searchCenterLon);
+                rank*= 1 / Math.log( (distance/1000) + Math.E);
+
+                // console.log("rank " + loc.label + ": " + rank + "");
+                return rank;
+            }
+
+            return 0;
+        }
+
+        compare: function(a, b){
+            // console.log("compare " + a.label + " ("+locationRank(a)+") <> " + b.label + " ("+locationRank(b)+")");
+            return locationRank(b) - locationRank(a);
+        }
+
+        equals: function(a, b){
+            if (a.objectType == b.objectType &&
+                a.distanceTo(b.lat, b.lon) < 300 &&
+                a.distanceTo(searchCenterLat, searchCenterLon) > 3000
+                ){
+                // console.log("equals " + a.label + " <> " + b.label + ", " + a.objectType + " <> " + b.objectType + " distance: " + a.distanceTo(b.lat, b.lon));
+                return true;
+            }
+            return false;
+        }
+
         onCountChanged:{
             if (focus){
               updatePopup();

--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -38,55 +38,67 @@
  */
 class OSMSCOUT_CLIENT_QT_API LocationEntry : public QObject
 {
-    Q_OBJECT
-    Q_PROPERTY(QString label READ getLabel)
+  Q_OBJECT
+  Q_PROPERTY(QString label      READ getLabel)
+  Q_PROPERTY(QString type       READ getTypeString)
+  Q_PROPERTY(QString objectType READ getObjectType)
+  Q_PROPERTY(double  lat        READ getLat)
+  Q_PROPERTY(double  lon        READ getLon)
+
 public:
-    enum Type {
-        typeNone,
-        typeObject,
-        typeCoordinate
-    };
+  enum Type {
+    typeNone,
+    typeObject,
+    typeCoordinate
+  };
 
 private:
-    Type                           type;
-    QString                        label;
-    QString                        objectType;
-    QStringList                    adminRegionList;
-    QString                        database;
-    QList<osmscout::ObjectFileRef> references;
-    osmscout::GeoCoord             coord;
-    osmscout::GeoBox               bbox;
+  Type                           type;
+  QString                        label;
+  QString                        objectType;
+  QStringList                    adminRegionList;
+  QString                        database;
+  QList<osmscout::ObjectFileRef> references;
+  osmscout::GeoCoord             coord;
+  osmscout::GeoBox               bbox;
 
 public:
-    LocationEntry(Type type,
-                  const QString& label,
-                  const QString& objectType,
-                  const QStringList& adminRegionList,
-                  const QString database,
-                  const osmscout::GeoCoord coord,
-                  const osmscout::GeoBox bbox,
-                  QObject* parent = 0);
+  LocationEntry(Type type,
+                const QString& label,
+                const QString& objectType,
+                const QStringList& adminRegionList,
+                const QString database,
+                const osmscout::GeoCoord coord,
+                const osmscout::GeoBox bbox,
+                QObject* parent = 0);
 
-    LocationEntry(const QString& label,
-                  const osmscout::GeoCoord& coord,
-                  QObject* parent = 0);
+  LocationEntry(const QString& label,
+                const osmscout::GeoCoord& coord,
+                QObject* parent = 0);
 
-    LocationEntry(QObject* parent = 0);
-    LocationEntry(const LocationEntry& other);
-    virtual ~LocationEntry();
+  LocationEntry(QObject* parent = 0);
+  LocationEntry(const LocationEntry& other);
+  virtual ~LocationEntry();
 
-    void operator=(const LocationEntry&);
-    
-    void addReference(const osmscout::ObjectFileRef reference);
+  void operator=(const LocationEntry&);
 
-    Type getType() const;
-    QString getObjectType() const;
-    QString getLabel() const;
-    QStringList getAdminRegionList() const;
-    QString getDatabase() const;
-    osmscout::GeoCoord getCoord() const;
-    osmscout::GeoBox getBBox() const;
-    const QList<osmscout::ObjectFileRef>& getReferences() const;
+  void addReference(const osmscout::ObjectFileRef reference);
+
+  void mergeWith(const LocationEntry &location);
+
+  Q_INVOKABLE double distanceTo(double lat, double lon) const;
+
+  Type getType() const;
+  QString getTypeString() const;
+  QString getObjectType() const;
+  QString getLabel() const;
+  QStringList getAdminRegionList() const;
+  QString getDatabase() const;
+  osmscout::GeoCoord getCoord() const;
+  osmscout::GeoBox getBBox() const;
+  const QList<osmscout::ObjectFileRef>& getReferences() const;
+  double getLat() const;
+  double getLon() const;
 };
 
 typedef std::shared_ptr<LocationEntry> LocationEntryRef;

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QAbstractListModel>
+#include <QJSValue>
 
 #include <osmscout/GeoCoord.h>
 #include <osmscout/LocationEntry.h>
@@ -43,6 +44,8 @@ class OSMSCOUT_CLIENT_QT_API LocationListModel : public QAbstractListModel
   Q_PROPERTY(double  lon         READ GetLon      WRITE SetLon)
   Q_PROPERTY(int     resultLimit READ GetResultLimit WRITE SetResultLimit)
   Q_PROPERTY(QString pattern     READ getPattern  WRITE setPattern)
+  Q_PROPERTY(QJSValue compare    READ getCompare  WRITE setCompare)
+  Q_PROPERTY(QJSValue equals     READ getEquals   WRITE setEquals)
 
 signals:
   void SearchRequested(const QString searchPattern,
@@ -75,6 +78,8 @@ private:
   osmscout::BreakerRef breaker;
   AdminRegionInfoRef defaultRegion;
   AdminRegionInfoRef lastRequestDefaultRegion;
+  QJSValue compareFn;
+  QJSValue equalsFn;
 
 public:
   enum Roles {
@@ -82,12 +87,31 @@ public:
     TypeRole = Qt::UserRole +1,
     RegionRole = Qt::UserRole +2,
     LatRole = Qt::UserRole +3,
-    LonRole = Qt::UserRole +4
+    LonRole = Qt::UserRole +4,
+    DistanceRole = Qt::UserRole +5,
+    BearingRole = Qt::UserRole +6,
+    LocationObjectRole = Qt::UserRole +7
   };
 
 public:
   LocationListModel(QObject* parent = 0);
   virtual ~LocationListModel();
+
+  QJSValue getCompare() const {
+    return compareFn;
+  }
+
+  void setCompare(const QJSValue &fn){
+    compareFn=fn;
+  }
+
+  QJSValue getEquals() const{
+    return equalsFn;
+  }
+
+  void setEquals(const QJSValue &fn){
+    equalsFn=fn;
+  }
 
   Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;
 
@@ -99,8 +123,7 @@ public:
 
   Q_INVOKABLE LocationEntry* get(int row) const;
 
-  inline bool isSearching() const
-  {
+  inline bool isSearching() const {
     return searching;
   }
 

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -33,19 +33,92 @@
 #include <osmscout/private/ClientQtImportExport.h>
 
 /**
+ * Model for searching objects in osmscout databases by pattern written by human.
+ *
  * \ingroup QtAPI
  */
 class OSMSCOUT_CLIENT_QT_API LocationListModel : public QAbstractListModel
 {
   Q_OBJECT
-  Q_PROPERTY(int     count       READ rowCount    NOTIFY countChanged)
-  Q_PROPERTY(bool    searching   READ isSearching NOTIFY SearchingChanged)
-  Q_PROPERTY(double  lat         READ GetLat      WRITE SetLat)
-  Q_PROPERTY(double  lon         READ GetLon      WRITE SetLon)
-  Q_PROPERTY(int     resultLimit READ GetResultLimit WRITE SetResultLimit)
-  Q_PROPERTY(QString pattern     READ getPattern  WRITE setPattern)
-  Q_PROPERTY(QJSValue compare    READ getCompare  WRITE setCompare)
-  Q_PROPERTY(QJSValue equals     READ getEquals   WRITE setEquals)
+
+  /**
+   * Count of rows in model - count of search results
+   */
+  Q_PROPERTY(int      count       READ rowCount    NOTIFY countChanged)
+
+  /**
+   * True if searching is in progress
+   */
+  Q_PROPERTY(bool     searching   READ isSearching NOTIFY SearchingChanged)
+
+  /**
+   * Lat and lon properties control where is logical search center.
+   * Local admin region is used as default region,
+   * databases used for search are sorted by distance from this point
+   * (local results should be available faster).
+   */
+  Q_PROPERTY(double   lat         READ GetLat      WRITE SetLat)
+
+  /**
+   * \see lat property
+   */
+  Q_PROPERTY(double   lon         READ GetLon      WRITE SetLon)
+
+  /**
+   * Limit of results for each database.
+   */
+  Q_PROPERTY(int      resultLimit READ GetResultLimit WRITE SetResultLimit)
+
+  /**
+   * Searched pattern
+   */
+  Q_PROPERTY(QString  pattern     READ getPattern  WRITE setPattern)
+
+  /**
+   * JavaScript function used for sorting search results.
+   * Compare function will receive two locations arguments,
+   * A and B, where A < B (A should be shown before B),
+   * compare function should return number < 0.
+   *
+   * For sorting results alphabetically:
+   * ```
+   * LocationListModel{
+   *   compare: function(a, b){
+   *     if (a.label < b.label){
+   *        return -1;
+   *     }
+   *     return +1;
+   *   }
+   * }
+   * ```
+   */
+  Q_PROPERTY(QJSValue compare     READ getCompare  WRITE setCompare)
+
+  /**
+   * JavaScript function used for check location equality.
+   * It is possible that model will returns one physical location multiple
+   * times, for example one from location index and second from fulltext
+   * search, or two database segments for one real street...
+   *
+   * Such results may be merged in model.
+   * Function will receive two locations (only locations with same label
+   * will be checked) and should return boolean result.
+   *
+   * For example, merge near objects with same label and type:
+   * ```
+   * LocationListModel{
+   *   equals: function(a, b){
+   *     if (a.objectType == b.objectType &&
+   *         a.distanceTo(b.lat, b.lon) < 300 &&
+   *         a.distanceTo(searchCenterLat, searchCenterLon) > 3000 ){
+   *           return true;
+   *     }
+   *     return false;
+   *   }
+   * }
+   * ```
+   */
+  Q_PROPERTY(QJSValue equals      READ getEquals   WRITE setEquals)
 
 signals:
   void SearchRequested(const QString searchPattern,

--- a/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <osmscout/LocationEntry.h>
+#include <osmscout/util/Geometry.h>
 
 #include <iostream>
 
@@ -97,9 +98,38 @@ void LocationEntry::addReference(const osmscout::ObjectFileRef reference)
     references.push_back(reference);
 }
 
+void LocationEntry::mergeWith(const LocationEntry &location)
+{
+  assert(type==typeObject);
+  assert(location.type==typeObject);
+
+  bbox.Include(location.bbox);
+  for (auto &ref:location.getReferences()) {
+    addReference(ref);
+  }
+  coord=bbox.GetCenter();
+}
+
+Q_INVOKABLE double LocationEntry::distanceTo(double lat, double lon) const
+{
+  return osmscout::GetSphericalDistance(coord, osmscout::GeoCoord(lat, lon)) * 1000;
+}
+
 LocationEntry::Type LocationEntry::getType() const
 {
     return type;
+}
+
+QString LocationEntry::getTypeString() const
+{
+  switch (type){
+    case typeObject:
+      return "object";
+    case typeCoordinate:
+      return "coordinate";
+    default:
+      return "none";
+  }
 }
 
 QString LocationEntry::getObjectType() const
@@ -135,4 +165,14 @@ osmscout::GeoBox LocationEntry::getBBox() const
 const QList<osmscout::ObjectFileRef>& LocationEntry::getReferences() const
 {
     return references;
+}
+
+double LocationEntry::getLat() const
+{
+  return coord.GetLat();
+}
+
+double LocationEntry::getLon() const
+{
+  return coord.GetLon();
 }

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -18,11 +18,13 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  */
 
-#include <iostream>
-
 #include <osmscout/DBThread.h>
 #include <osmscout/SearchLocationModel.h>
 #include <osmscout/OSMScoutQt.h>
+
+#include <QtQml/QQmlEngine>
+
+#include <iostream>
 
 #define INVALID_COORD -1000.0
 
@@ -85,20 +87,79 @@ void LocationListModel::onSearchResult(const QString searchPattern,
                                        const QList<LocationEntry> foundLocations)
 {
   if (this->pattern.isEmpty()) {
-      return; //No search requested
+    return; //No search requested
   }
   if (!searchPattern.contains(this->pattern, Qt::CaseInsensitive)){
     return; // result is not for us
   }
-  
+
+  QTime timer;
+  timer.start();
+
+  QQmlEngine *engine = qmlEngine(this);
   for (auto &location : foundLocations) {
-    // TODO: deduplicate, sort by relevance
-    emit beginInsertRows(QModelIndex(), locations.size(), locations.size());
-    locations.append(new LocationEntry(location));
+
+    if (equalsFn.isCallable()){
+      // try to merge locations that are equals
+      bool merge=false;
+      for (LocationEntry* secondLocation:locations) {
+        if (secondLocation->getLabel()==location.getLabel() &&
+            secondLocation->getDatabase()==location.getDatabase() &&
+            secondLocation->getType()==LocationEntry::typeObject &&
+            location.getType()==LocationEntry::typeObject){
+
+          QJSValueList args;
+          args << engine->newQObject(new LocationEntry(location));
+          args << engine->newQObject(new LocationEntry(*secondLocation));
+          QJSValue result = equalsFn.call(args);
+          if (result.isBool() && result.toBool()){
+
+            // qDebug() << "Merge " << location.getLabel() << " to location " << secondLocation->getLabel();
+            secondLocation->mergeWith(location);
+
+            // emit data change
+            int index=locations.indexOf(secondLocation);
+            if (index>=0) {
+              QVector<int> roles;
+              roles << LatRole << LonRole << DistanceRole << BearingRole;
+              emit dataChanged(createIndex(index, 0), createIndex(index, 0), roles);
+            }
+
+            merge=true;
+            break;
+          }
+        }
+      }
+      if (merge){
+        continue;
+      }
+    }
+
+    // evaluate final position of location
+    int position=locations.size();
+    if (compareFn.isCallable()) {
+      position=0;
+      for (LocationEntry* secondLocation:locations){
+        QJSValueList args;
+        args << engine->newQObject(new LocationEntry(location));
+        args << engine->newQObject(new LocationEntry(*secondLocation));
+        QJSValue result = compareFn.call(args);
+        if (result.isNumber() && result.toNumber() <= 0){
+          break;
+        }
+        position++;
+      }
+    }
+
+    emit beginInsertRows(QModelIndex(), position, position);
+    locations.insert(position, new LocationEntry(location));
+
+    // qDebug() << "Put " << location.getLabel() << " to position: " << position;
+
     emit endInsertRows();
   }  
   emit countChanged(locations.size());
-  qDebug() << "added " << foundLocations.size() << ", model size" << locations.size();
+  qDebug() << "added " << foundLocations.size() << " (in " << timer.elapsed() << " ms), model size" << locations.size();
 }
 
 void LocationListModel::onLocationAdminRegions(const osmscout::GeoCoord location,
@@ -171,7 +232,7 @@ void LocationListModel::setPattern(const QString& pattern)
 
       LocationEntry *location=new LocationEntry(label, coord);
       beginInsertRows(QModelIndex(), locations.size(), locations.size());
-      locations.append(location);
+      locations.insert(0, location);
       endInsertRows();
   }
   emit countChanged(locations.size());
@@ -202,54 +263,74 @@ int LocationListModel::rowCount(const QModelIndex& ) const
 
 QVariant LocationListModel::data(const QModelIndex &index, int role) const
 {
-    if(index.row() < 0 || index.row() >= locations.size()) {
-        return QVariant();
-    }
-
-    LocationEntry* location=locations.at(index.row());
-
-    switch (role) {
-    case Qt::DisplayRole:
-    case LabelRole:
-        return location->getLabel();
-    case TypeRole:
-        if (location->getType()==LocationEntry::typeCoordinate)
-          return "coordinate";
-        else 
-          return location->getObjectType();
-    case RegionRole:
-        return location->getAdminRegionList();
-    case LatRole:
-        return QVariant::fromValue(location->getCoord().GetLat());
-    case LonRole:
-        return QVariant::fromValue(location->getCoord().GetLon());
-    default:
-        break;
-    }
-
+  if(index.row() < 0 || index.row() >= locations.size()) {
     return QVariant();
+  }
+
+  LocationEntry* location=locations.at(index.row());
+
+  switch (role) {
+  case Qt::DisplayRole:
+  case LabelRole:
+    return location->getLabel();
+  case TypeRole:
+    if (location->getType()==LocationEntry::typeCoordinate)
+      return "coordinate";
+    else
+      return location->getObjectType();
+  case RegionRole:
+    return location->getAdminRegionList();
+  case LatRole:
+    return QVariant::fromValue(location->getCoord().GetLat());
+  case LonRole:
+    return QVariant::fromValue(location->getCoord().GetLon());
+  case DistanceRole:
+    if (searchCenter.GetLat()!=INVALID_COORD && searchCenter.GetLon()!=INVALID_COORD) {
+      return osmscout::GetSphericalDistance(location->getCoord(), searchCenter)*1000;
+    }else{
+      return 0;
+    }
+  case BearingRole:
+    if (searchCenter.GetLat()!=INVALID_COORD && searchCenter.GetLon()!=INVALID_COORD) {
+      return QString::fromStdString(
+          osmscout::BearingDisplayString(
+              osmscout::GetSphericalBearingInitial(searchCenter, location->getCoord())));
+    }else{
+      return "";
+    }
+  case LocationObjectRole:
+    // QML will take ownerhip
+    return QVariant::fromValue(new LocationEntry(*location));
+  default:
+    break;
+  }
+
+  return QVariant();
 }
 
 Qt::ItemFlags LocationListModel::flags(const QModelIndex &index) const
 {
-    if(!index.isValid()) {
-        return Qt::ItemIsEnabled;
-    }
+  if(!index.isValid()) {
+    return Qt::ItemIsEnabled;
+  }
 
-    return QAbstractListModel::flags(index) | Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+  return QAbstractListModel::flags(index) | Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
 QHash<int, QByteArray> LocationListModel::roleNames() const
 {
-    QHash<int, QByteArray> roles=QAbstractListModel::roleNames();
+  QHash<int, QByteArray> roles=QAbstractListModel::roleNames();
 
-    roles[LabelRole]="label";
-    roles[TypeRole]="type";
-    roles[RegionRole]="region";
-    roles[LatRole]="lat";
-    roles[LonRole]="lon";
+  roles[LabelRole]="label";
+  roles[TypeRole]="type";
+  roles[RegionRole]="region";
+  roles[LatRole]="lat";
+  roles[LonRole]="lon";
+  roles[DistanceRole]="distance";
+  roles[BearingRole]="bearing";
+  roles[LocationObjectRole]="locationObject";
 
-    return roles;
+  return roles;
 }
 
 LocationEntry* LocationListModel::get(int row) const

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -22,7 +22,7 @@
 #include <osmscout/SearchLocationModel.h>
 #include <osmscout/OSMScoutQt.h>
 
-#include <QtQml/QQmlEngine>
+#include <QtQml>
 
 #include <iostream>
 

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -985,7 +985,7 @@ namespace osmscout {
   /**
    * \ingroup Geometry
    * Calculates the spherical distance between the two given points
-   * on the sphere.
+   * on the sphere [km].
    */
   extern OSMSCOUT_API double GetSphericalDistance(const GeoCoord& a,
                                                   const GeoCoord& b);
@@ -993,15 +993,15 @@ namespace osmscout {
   /**
    * \ingroup Geometry
    * Calculates the ellipsoidal (WGS-84) distance between the two given points
-   * on the ellipsoid.
+   * on the ellipsoid [km].
    */
   extern OSMSCOUT_API double GetEllipsoidalDistance(double aLon, double aLat,
-                                                   double bLon, double bLat);
+                                                    double bLon, double bLat);
 
   /**
    * \ingroup Geometry
    * Calculates the ellipsoidal (WGS-84) distance between the two given points
-   * on the ellipsoid.
+   * on the ellipsoid [km].
    */
   extern OSMSCOUT_API double GetEllipsoidalDistance(const GeoCoord& a,
                                                     const GeoCoord& b);
@@ -1017,8 +1017,8 @@ namespace osmscout {
 
   /**
    * \ingroup Geometry
-   *Calculates the initial bearing for a line from one coordinate to the other coordinate
-   *on a sphere.
+   * Calculates the initial bearing for a line from one coordinate to the other coordinate
+   * on a sphere.
    */
   extern OSMSCOUT_API double GetSphericalBearingInitial(const GeoCoord& a,
                                                         const GeoCoord& b);

--- a/libosmscout/src/osmscout/util/Geometry.cpp
+++ b/libosmscout/src/osmscout/util/Geometry.cpp
@@ -100,9 +100,9 @@ namespace osmscout {
   }
 
   /**
-    Calculating basic cost for the A* algorithm based on the
-    spherical distance of two points on earth
-    */
+   * Calculating basic cost for the A* algorithm based on the
+   * spherical distance of two points on earth [km].
+   */
   double GetSphericalDistance(const GeoCoord& a,
                               const GeoCoord& b)
   {
@@ -124,9 +124,9 @@ namespace osmscout {
   }
 
   /**
-    Calculating Vincenty's inverse for getting the ellipsoidal distance
-    of two points on earth.
-    */
+   * Calculating Vincenty's inverse for getting the ellipsoidal distance
+   * of two points on earth [km].
+   */
   double GetEllipsoidalDistance(double aLon, double aLat,
                                 double bLon, double bLat)
   {


### PR DESCRIPTION
Hi. This MR improving search results with Qt API. Developer may control what locations should be merged and how results should be sorted just by setting two JavaScript functions. 
```
LocationListModel {
        compare: function(a, b){ return -1; }
        equals: function(a, b){ return false;  }
}
```

...I was trying to wrote some "smart" logic in C++ first, but it will not fit to all usecases. This solutions is more flexible from my point of view.