### PR TITLE
make taphandler slots virtual

### DIFF
--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -173,10 +173,10 @@ public slots:
 
 private slots:
 
-  void onTap(const QPoint p);
-  void onDoubleTap(const QPoint p);
-  void onLongTap(const QPoint p);
-  void onTapLongTap(const QPoint p);
+  virtual void onTap(const QPoint p);
+  virtual void onDoubleTap(const QPoint p);
+  virtual void onLongTap(const QPoint p);
+  virtual void onTapLongTap(const QPoint p);
   
   void onMapDPIChange(double dpi);  
   


### PR DESCRIPTION
We subclass the mapwidget to implement some special use cases. For example do we need to change the double tap behaviour to either zoom or to start some geocodeing at the clicked location depending on configuration by the user. Thus we need the slots to be virtual to be able to intercept.