### PR TITLE
notify tile callbacks everytime when tile data is marked as completed

### DIFF
--- a/libosmscout-map/include/osmscout/DataTileCache.h
+++ b/libosmscout-map/include/osmscout/DataTileCache.h
@@ -78,7 +78,7 @@ namespace osmscout {
     }
 
     /**
-     * Marks the tile as inpcomplete again, without actually clearing data and types.
+     * Marks the tile as incomplete again, without actually clearing data and types.
      */
     void Invalidate()
     {

--- a/libosmscout-map/src/osmscout/MapService.cpp
+++ b/libosmscout-map/src/osmscout/MapService.cpp
@@ -312,11 +312,13 @@ namespace osmscout {
 
     if (!optimizeAreasLowZoom) {
       tile->GetOptimizedAreaData().SetComplete();
+      NotifyTileStateCallbacks(tile);
       return false;
     }
 
     if (!optimizeAreasLowZoom->HasOptimizations(magnification.GetMagnification())) {
       tile->GetOptimizedAreaData().SetComplete();
+      NotifyTileStateCallbacks(tile);
       return true;
     }
 
@@ -464,11 +466,13 @@ namespace osmscout {
 
     if (!optimizeWaysLowZoom) {
       tile->GetOptimizedWayData().SetComplete();
+      NotifyTileStateCallbacks(tile);
       return false;
     }
 
     if (!optimizeWaysLowZoom->HasOptimizations(magnification.GetMagnification())) {
       tile->GetOptimizedWayData().SetComplete();
+      NotifyTileStateCallbacks(tile);
       return true;
     }
 


### PR DESCRIPTION
When low-zoom data file don't contains data for current zoom level,
tile data is marked as completed without notify tile callbacks.
In rare situations (related with high load probably), when low-zoom
tasks are executed as the last one for current tile (it may be reproduced
by thread sleep), tile is setup as completed without notify callback.
As a result, Qt/DBLoadJob is newer completed and rendering pipeline stops.

This change should solve it.