### PR TITLE
Qml map overlay (tiled)

### DIFF
--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -136,6 +136,23 @@ Window {
                 }
             }
 
+            TiledMapOverlay {
+                anchors.fill: parent
+                view: map.view
+                opacity: 0.5
+                // If you intend to use tiles from OpenMapSurfer services in your own applications please contact us.
+                // https://korona.geog.uni-heidelberg.de/contact.html
+                provider: {
+                      "id": "ASTER_GDEM",
+                      "name": "Hillshade",
+                      "servers": [
+                        "https://korona.geog.uni-heidelberg.de/tiles/asterh/x=%2&y=%3&z=%1"
+                      ],
+                      "maximumZoomLevel": 18,
+                      "copyright": "© IAT, METI, NASA, NOAA",
+                    }
+            }
+
             onTap: {
                 console.log("tap: " + screenX + "x" + screenY + " @ " + lat + " " + lon + " (map center "+ map.view.lat + " " + map.view.lon + ")");
                 map.focus=true;

--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -139,6 +139,7 @@ Window {
             TiledMapOverlay {
                 anchors.fill: parent
                 view: map.view
+                enabled: false
                 opacity: 0.5
                 // If you intend to use tiles from OpenMapSurfer services in your own applications please contact us.
                 // https://korona.geog.uni-heidelberg.de/contact.html

--- a/OSMScout2/src/AppSettings.cpp
+++ b/OSMScout2/src/AppSettings.cpp
@@ -20,6 +20,7 @@
 #include <QDebug>
 
 #include <osmscout/InputHandler.h>
+#include <osmscout/OSMScoutQt.h>
 
 #include "AppSettings.h"
 
@@ -37,7 +38,8 @@ MapView *AppSettings::GetMapView()
     view = new MapView(this,
               osmscout::GeoCoord(lat, lon),
               angle,
-              osmscout::Magnification(mag)
+              osmscout::Magnification(mag),
+              OSMScoutQt::GetInstance().GetSettings()->GetMapDPI()
               );
   }
   return view;
@@ -55,7 +57,8 @@ void AppSettings::SetMapView(QObject *o)
     view = new MapView(this,
               osmscout::GeoCoord(updated->GetLat(), updated->GetLon()),
               updated->GetAngle(),
-              osmscout::Magnification(updated->GetMag())
+              osmscout::Magnification(updated->GetMag()),
+              updated->GetMapDpi()
               );
     changed = true;
   }else{

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -50,6 +50,9 @@ set(HEADER_FILES
     include/osmscout/PlaneMapRenderer.h
     include/osmscout/TiledMapRenderer.h
     include/osmscout/OverlayObject.h
+    include/osmscout/MapOverlay.h
+    include/osmscout/TiledMapOverlay.h
+    include/osmscout/TiledRenderingHelper.h
 )
 
 set(SOURCE_FILES
@@ -85,6 +88,9 @@ set(SOURCE_FILES
     src/osmscout/PlaneMapRenderer.cpp
     src/osmscout/TiledMapRenderer.cpp
     src/osmscout/OverlayObject.cpp
+    src/osmscout/MapOverlay.cpp
+    src/osmscout/TiledMapOverlay.cpp
+    src/osmscout/TiledRenderingHelper.cpp
 )
 
 if(APPLE)

--- a/libosmscout-client-qt/include/Makefile.am
+++ b/libosmscout-client-qt/include/Makefile.am
@@ -22,5 +22,9 @@ nobase_include_HEADERS= osmscout/private/Config.h \
                         osmscout/MapRenderer.h \
                         osmscout/PlaneMapRenderer.h \
                         osmscout/TiledMapRenderer.h \
-                        osmscout/OverlayObject.h
+                        osmscout/OverlayObject.h \
+                        osmscout/MapOverlay.h \
+                        osmscout/TiledMapOverlay.h \
+                        osmscout/TiledRenderingHelper.h
+
 

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -33,7 +33,10 @@ osmscoutclientqtHeader = [
             'osmscout/MapRenderer.h',
             'osmscout/PlaneMapRenderer.h',
             'osmscout/TiledMapRenderer.h',
-            'osmscout/OverlayObject.h'
+            'osmscout/OverlayObject.h',
+            'osmscout/MapOverlay.h',
+            'osmscout/TiledMapOverlay.h',
+            'osmscout/TiledRenderingHelper.h'
           ]
 
 install_headers(osmscoutclientqtHeader)

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -163,15 +163,16 @@ class OSMSCOUT_CLIENT_QT_API MapView: public QObject
   Q_PROPERTY(double   angle     READ GetAngle)
   Q_PROPERTY(double   mag       READ GetMag)
   Q_PROPERTY(uint32_t magLevel  READ GetMagLevel)
+  Q_PROPERTY(double   mapDpi    READ GetMapDpi)
 
 public:
   inline MapView(){}
 
-  inline MapView(QObject *parent, osmscout::GeoCoord center, double angle, osmscout::Magnification magnification):
-    QObject(parent), center(center), angle(angle), magnification(magnification) {}
+  inline MapView(QObject *parent, osmscout::GeoCoord center, double angle, osmscout::Magnification magnification, double mapDpi):
+    QObject(parent), center(center), angle(angle), magnification(magnification), mapDpi(mapDpi) {}
 
-  inline MapView(osmscout::GeoCoord center, double angle, osmscout::Magnification magnification):
-    center(center), angle(angle), magnification(magnification) {}
+  inline MapView(osmscout::GeoCoord center, double angle, osmscout::Magnification magnification, double mapDpi):
+    center(center), angle(angle), magnification(magnification), mapDpi(mapDpi) {}
 
   /**
    * This copy constructor don't transfer ownership
@@ -179,7 +180,7 @@ public:
    * @param mv
    */
   inline MapView(const MapView &mv):
-    QObject(), center(mv.center), angle(mv.angle), magnification(mv.magnification) {}
+    QObject(), center(mv.center), angle(mv.angle), magnification(mv.magnification), mapDpi(mv.mapDpi) {}
 
   virtual inline ~MapView(){}
 
@@ -188,24 +189,27 @@ public:
   inline double GetAngle(){ return angle; }
   inline double GetMag(){ return magnification.GetMagnification(); }
   inline double GetMagLevel(){ return magnification.GetLevel(); }
+  inline double GetMapDpi(){ return mapDpi; }
 
   void inline operator=(const MapView &mv)
   {
     center = mv.center;
     angle = mv.angle;
     magnification = mv.magnification;
+    mapDpi = mv.mapDpi;
   }
 
   osmscout::GeoCoord           center;
-  double                       angle;
+  double                       angle{0};
   osmscout::Magnification      magnification;
+  double                       mapDpi{0};
 };
 
 Q_DECLARE_METATYPE(MapView)
 
 inline bool operator==(const MapView& a, const MapView& b)
 {
-  return a.center == b.center && a.angle == b.angle && a.magnification == b.magnification;
+  return a.center == b.center && a.angle == b.angle && a.magnification == b.magnification && a.mapDpi == b.mapDpi;
 }
 inline bool operator!=(const MapView& a, const MapView& b)
 {
@@ -282,7 +286,7 @@ private slots:
     void onTimeout();
 
 public:
-    MoveHandler(MapView view, double dpi);
+    MoveHandler(MapView view);
     virtual ~MoveHandler();
 
     virtual bool animationInProgress();
@@ -301,8 +305,6 @@ public:
     virtual bool rotateBy(double angleChange);
     virtual bool touch(QTouchEvent *event);
 
-private:
-    double dpi;
 };
 
 /**
@@ -341,7 +343,7 @@ public:
 class OSMSCOUT_CLIENT_QT_API DragHandler : public MoveHandler {
     Q_OBJECT
 public:
-    DragHandler(MapView view, double dpi);
+    DragHandler(MapView view);
     virtual ~DragHandler();
 
     virtual bool animationInProgress();
@@ -371,7 +373,7 @@ private:
 class OSMSCOUT_CLIENT_QT_API MultitouchHandler : public MoveHandler {
     Q_OBJECT
 public:
-    MultitouchHandler(MapView view, double dpi);
+    MultitouchHandler(MapView view);
     virtual ~MultitouchHandler();
 
     virtual bool animationInProgress();
@@ -401,11 +403,10 @@ private:
 class OSMSCOUT_CLIENT_QT_API LockHandler : public JumpHandler {
     Q_OBJECT
 protected:
-    double dpi;
     double moveTolerance;
 public:
-    inline LockHandler(MapView view, double dpi, double moveTolerance):
-      JumpHandler(view), dpi(dpi), moveTolerance(moveTolerance)
+    inline LockHandler(MapView view, double moveTolerance):
+      JumpHandler(view), moveTolerance(moveTolerance)
     {};
 
     virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -166,7 +166,7 @@ class OSMSCOUT_CLIENT_QT_API MapView: public QObject
   Q_PROPERTY(double   mapDpi    READ GetMapDpi)
 
 public:
-  inline MapView(){}
+  inline MapView(QObject *parent=0): QObject(parent) {}
 
   inline MapView(QObject *parent, osmscout::GeoCoord center, double angle, osmscout::Magnification magnification, double mapDpi):
     QObject(parent), center(center), angle(angle), magnification(magnification), mapDpi(mapDpi) {}

--- a/libosmscout-client-qt/include/osmscout/MapOverlay.h
+++ b/libosmscout-client-qt/include/osmscout/MapOverlay.h
@@ -1,0 +1,68 @@
+#ifndef LIBOSMSCOUT_MAPOVERLAY_H
+#define LIBOSMSCOUT_MAPOVERLAY_H
+
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/InputHandler.h>
+
+#include <osmscout/private/ClientQtImportExport.h>
+
+#include <QQuickPaintedItem>
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API MapOverlay : public QQuickPaintedItem
+{
+  Q_OBJECT
+  Q_PROPERTY(QObject *view READ GetView WRITE SetMapView)
+
+protected:
+  MapView          *view;
+
+public slots:
+  void changeView(const MapView &view);
+  void redraw();
+
+public:
+  MapOverlay(QQuickItem* parent = 0);
+  virtual ~MapOverlay();
+
+  inline void SetMapView(QObject *o)
+  {
+    MapView *updated = dynamic_cast<MapView*>(o);
+    if (updated == NULL){
+      qWarning() << "Failed to cast " << o << " to MapView*.";
+      return;
+    }
+
+    bool changed = *view != *updated;
+    if (changed){
+      changeView(*updated);
+    }
+  }
+
+  inline MapView* GetView() const
+  {
+    return view; // We should be owner, parent is set http://doc.qt.io/qt-5/qqmlengine.html#objectOwnership
+  }
+};
+
+#endif //LIBOSMSCOUT_MAPOVERLAY_H

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -75,7 +75,6 @@ private:
   MapRenderer      *renderer;
 
   MapView          *view;
-  double           mapDpi;
 
   InputHandler     *inputHandler;
   TapRecognizer    tapRecognizer;     
@@ -279,7 +278,7 @@ public:
     projection.Set(GetCenter(),
                view->angle,
                view->magnification,
-               mapDpi,
+               view->mapDpi,
                // to avoid invalid projection when scene is not finished yet
                w==0? 100:w,
                h==0? 100:h);

--- a/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
@@ -233,8 +233,6 @@ private:
              QString userAgent,
              QStringList customPoiTypes);
 
-  QThread *makeThread(QString name);
-
 public slots:
   void threadFinished();
 
@@ -242,15 +240,36 @@ public:
   virtual ~OSMScoutQt();
 
   /**
-   * Wait for releasing of dbThread shared pointer from other threads.
+   * Create new background thread with given name.
+   *
+   * Usage:
+   *
+   * QThread *t=OSMScoutQt::GetInstance().makeThread("OverlayTileLoader");
+   * Service *service=new Service(t);
+   * service->moveToThread(thread);
+   * connect(thread, SIGNAL(started()),
+   *         service, SLOT(init()));
+   * thread->start();
+   *
+   * Service should stop thread in own destructor: QThread::stop()
+   *
+   * @param name
+   * @return thread
+   */
+  QThread *makeThread(QString name);
+
+  /**
+   * Wait for releasing of dbThread shared pointer from other threads
+   * and terminating all created service threads.
    * This waiting has configurable timeout, up to [mSleep * maxCount] milliseconds.
    *
-   * Note that on success, this method don't guarantee that that dbThread
+   * Note that on success, this method don't guarantee that dbThread
    * is not used from another thread, see std::shared_ptr::use_count() documentation.
    *
    * @param mSleep wait period between checks (in milliseconds)
    * @param maxCount maximul count
    * @return true if dbThread is holding just from current thread (dbThread.use_count() == 1)
+   *        and all previously created service threads are terminated.
    */
   bool waitForReleasingResources(unsigned long mSleep, unsigned long maxCount) const;
 

--- a/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
@@ -265,6 +265,8 @@ public:
   StyleModule *MakeStyleModule();
 
   QString GetUserAgent();
+  QString GetCacheLocation();
+  size_t  GetOnlineTileCacheSize();
 
   static void RegisterQmlTypes(const char *uri="net.sf.libosmscout.map",
                                int versionMajor=1,

--- a/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
@@ -38,15 +38,16 @@
  */
 class OsmTileDownloader : public QObject
 {
- Q_OBJECT
+  Q_OBJECT
  
 public:
-  OsmTileDownloader(QString diskCacheDir);
+  OsmTileDownloader(QString diskCacheDir,
+                    const OnlineTileProvider &provider);
   virtual ~OsmTileDownloader();
   
 public slots:
   void download(uint32_t zoomLevel, uint32_t x, uint32_t y);
-  void onlineTileProviderChanged();
+  void onlineTileProviderChanged(const OnlineTileProvider &provider);
   
 signals:
   void downloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -67,6 +67,7 @@ signals:
   void MapDPIChange(double dpi);
   void OnlineTilesEnabledChanged(bool);
   void OnlineTileProviderIdChanged(const QString id);
+  void OnlineTileProviderChanged(const OnlineTileProvider &provider);
   void OfflineMapChanged(bool);
   void RenderSeaChanged(bool);
   void StyleSheetDirectoryChanged(const QString dir);

--- a/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
+++ b/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
@@ -58,12 +58,14 @@ class OSMSCOUT_CLIENT_QT_API TiledMapOverlay : public MapOverlay
 {
   Q_OBJECT
   Q_PROPERTY(QJsonValue provider READ getProvider WRITE setProvider)
+  Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled)
 
 private:
   mutable QMutex      tileCacheMutex;
   TileCache           onlineTileCache;
   QJsonValue          providerJson;
   TileLoaderThread    *loader;
+  bool                enabled;
 
 public slots:
   void tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);
@@ -81,6 +83,9 @@ public:
 
   QJsonValue getProvider();
   void setProvider(QJsonValue jv);
+
+  bool isEnabled();
+  void setEnabled(bool b);
 };
 
 #endif //LIBOSMSCOUT_TILEMAPOVERLAY_H

--- a/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
+++ b/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
@@ -1,0 +1,86 @@
+#ifndef LIBOSMSCOUT_TILEMAPOVERLAY_H
+#define LIBOSMSCOUT_TILEMAPOVERLAY_H
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/MapOverlay.h>
+#include <osmscout/TileCache.h>
+#include <osmscout/OsmTileDownloader.h>
+
+#include <osmscout/private/ClientQtImportExport.h>
+
+#include <QImage>
+
+
+class TileLoaderThread: public QObject {
+Q_OBJECT
+
+private:
+  QThread *thread;
+  OsmTileDownloader *tileDownloader;
+  OnlineTileProvider provider;
+
+public slots:
+  void init();
+  void download(uint32_t, uint32_t, uint32_t);
+  void onProviderChanged(const OnlineTileProvider &newProvider);
+
+signals:
+  void downloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);
+  void failed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange);
+
+public:
+  TileLoaderThread(QThread *thread);
+
+  virtual ~TileLoaderThread();
+};
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API TiledMapOverlay : public MapOverlay
+{
+  Q_OBJECT
+  Q_PROPERTY(QJsonValue provider READ getProvider WRITE setProvider)
+
+private:
+  mutable QMutex      tileCacheMutex;
+  TileCache           onlineTileCache;
+  QJsonValue          providerJson;
+  TileLoaderThread    *loader;
+
+public slots:
+  void tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);
+  void tileDownloadFailed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange);
+  void download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile);
+
+signals:
+  void providerChanged(const OnlineTileProvider &provider);
+
+public:
+  TiledMapOverlay(QQuickItem* parent = 0);
+  virtual ~TiledMapOverlay();
+
+  virtual void paint(QPainter *painter);
+
+  QJsonValue getProvider();
+  void setProvider(QJsonValue jv);
+};
+
+#endif //LIBOSMSCOUT_TILEMAPOVERLAY_H

--- a/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
+++ b/libosmscout-client-qt/include/osmscout/TiledMapOverlay.h
@@ -27,8 +27,10 @@
 
 #include <QImage>
 
-
-class TileLoaderThread: public QObject {
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API TileLoaderThread: public QObject {
 Q_OBJECT
 
 private:
@@ -66,6 +68,7 @@ private:
   QJsonValue          providerJson;
   TileLoaderThread    *loader;
   bool                enabled;
+  QColor              transparentColor;
 
 public slots:
   void tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);

--- a/libosmscout-client-qt/include/osmscout/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/TiledMapRenderer.h
@@ -88,21 +88,6 @@ public slots:
 
 private:
 
-  /**
-   * lookup tile in cache, if not found, try upper zoom level for substitute.
-   * (It is better upscaled tile than empty space)
-   * Is is repeated up to zoomLevel - upLimit
-   */
-  bool lookupAndDrawTile(TileCache& tileCache, QPainter& painter,
-        double x, double y, double renderTileWidth, double renderTileHeight,
-        uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
-        uint32_t upLimit, uint32_t downLimit);
-
-  void lookupAndDrawBottomTileRecursive(TileCache& tileCache, QPainter& painter,
-        double x, double y, double renderTileWidth, double renderTileHeight, double overlap,
-        uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
-        uint32_t downLimit);
-
   DatabaseCoverage databaseCoverageOfTile(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile);
 
 public:

--- a/libosmscout-client-qt/include/osmscout/TiledRenderingHelper.h
+++ b/libosmscout-client-qt/include/osmscout/TiledRenderingHelper.h
@@ -1,0 +1,60 @@
+#ifndef LIBOSMSCOUT_TILEDRENDERINGHELPER_H
+#define LIBOSMSCOUT_TILEDRENDERINGHELPER_H
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2010  Tim Teulings
+ Copyright (C) 2017 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/TileCache.h>
+#include <osmscout/DBThread.h>
+
+#include <osmscout/private/ClientQtImportExport.h>
+
+#include <QPainter>
+
+class OSMSCOUT_CLIENT_QT_API TiledRenderingHelper
+{
+private:
+  TiledRenderingHelper(){};
+
+  /**
+   * lookup tile in cache, if not found, try upper zoom level for substitute.
+   * (It is better upscaled tile than empty space)
+   * Is is repeated up to zoomLevel - upLimit
+   */
+  static bool lookupAndDrawTile(TileCache& tileCache, QPainter& painter,
+                                double x, double y, double renderTileWidth, double renderTileHeight,
+                                uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
+                                uint32_t upLimit, uint32_t downLimit,
+                                double overlap);
+
+  static void lookupAndDrawBottomTileRecursive(TileCache& tileCache, QPainter& painter,
+                                               double x, double y, double renderTileWidth, double renderTileHeight, double overlap,
+                                               uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
+                                               uint32_t downLimit);
+
+public:
+  static bool RenderTiles(QPainter& painter,
+                          const MapViewStruct& request,
+                          QList<TileCache*> &layerCaches,
+                          double mapDpi,
+                          const QColor &unknownColor,
+                          double overlap=-1);
+};
+
+#endif //LIBOSMSCOUT_TILEDRENDERINGHELPER_H

--- a/libosmscout-client-qt/src/Makefile.am
+++ b/libosmscout-client-qt/src/Makefile.am
@@ -70,7 +70,13 @@ libosmscoutclientqt_la_SOURCES = osmscout/DBThread.cpp \
                                  osmscout/TiledMapRenderer.cpp \
                                  osmscout/moc_TiledMapRenderer.cpp \
                                  osmscout/OverlayObject.cpp \
-                                 osmscout/moc_OverlayObject.cpp
+                                 osmscout/moc_OverlayObject.cpp \
+                                 osmscout/MapOverlay.cpp \
+                                 osmscout/moc_MapOverlay.cpp \
+                                 osmscout/TiledMapOverlay.cpp \
+                                 osmscout/moc_TiledMapOverlay.cpp \
+                                 osmscout/TiledRenderingHelper.cpp \
+                                 osmscout/moc_TiledRenderingHelper.cpp
 
 osmscout/moc_%.cpp: $(top_srcdir)/include/osmscout/%.h
 	@MOC@ -o$@ $<
@@ -106,3 +112,6 @@ MOSTLYCLEANFILES = osmscout/moc_DBThread.cpp \
                    osmscout/moc_PlaneMapRenderer.cpp \
                    osmscout/moc_TiledMapRenderer.cpp \
                    osmscout/moc_OverlayObject.cpp
+                   osmscout/moc_MapOverlay.cpp \
+                   osmscout/moc_TiledMapOverlay.cpp \
+                   osmscout/moc_TiledRenderingHelper.cpp

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -30,6 +30,9 @@ osmscoutclientqtSrc = [
             'src/osmscout/MapRenderer.cpp',
             'src/osmscout/PlaneMapRenderer.cpp',
             'src/osmscout/TiledMapRenderer.cpp',
-            'src/osmscout/OverlayObject.cpp'
+            'src/osmscout/OverlayObject.cpp',
+            'src/osmscout/MapOverlay.cpp',
+            'src/osmscout/TiledMapOverlay.cpp',
+            'src/osmscout/TiledRenderingHelper.cpp'
           ]
 

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -223,7 +223,7 @@ bool InputHandler::focusOutEvent(QFocusEvent */*event*/)
     return false;
 }
 
-MoveHandler::MoveHandler(MapView view, double dpi): InputHandler(view), dpi(dpi)
+MoveHandler::MoveHandler(MapView view): InputHandler(view)
 {
     connect(&timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
     timer.setSingleShot(false);
@@ -274,7 +274,7 @@ void MoveHandler::onTimeout()
     if (!projection.Set(startMapView.center,
                         finalAngle,
                         osmscout::Magnification(startMag + ((targetMag - startMag) * scale) ),
-                        dpi, 1000, 1000)) {
+                        startMapView.mapDpi, 1000, 1000)) {
         return;
     }
 
@@ -372,7 +372,7 @@ bool MoveHandler::moveNow(QVector2D move)
 
     //qDebug() << "move: " << QString::fromStdString(view.center.GetDisplayText()) << "   by: " << move;
 
-    if (!projection.Set(view.center, view.angle, view.magnification, dpi, 1000, 1000)) {
+    if (!projection.Set(view.center, view.angle, view.magnification, view.mapDpi, 1000, 1000)) {
         return false;
     }
 
@@ -484,7 +484,7 @@ bool JumpHandler::animationInProgress()
 bool JumpHandler::showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification)
 {
     startMapView = view;
-    targetMapView = MapView(coord, view.angle, magnification);
+    targetMapView = MapView(coord, view.angle, magnification, view.mapDpi);
 
     animationStart.restart();
     timer.setInterval(ANIMATION_TICK);
@@ -494,8 +494,8 @@ bool JumpHandler::showCoordinates(osmscout::GeoCoord coord, osmscout::Magnificat
     return true;
 }
 
-DragHandler::DragHandler(MapView view, double dpi):
-        MoveHandler(view, dpi), moving(true), startView(view), fingerId(-1),
+DragHandler::DragHandler(MapView view):
+        MoveHandler(view), moving(true), startView(view), fingerId(-1),
         startX(-1), startY(-1), ended(false)
 {
 }
@@ -560,8 +560,8 @@ bool DragHandler::animationInProgress()
 }
 
 
-MultitouchHandler::MultitouchHandler(MapView view, double dpi):
-    MoveHandler(view, dpi), moving(true), startView(view), initialized(false), ended(false)
+MultitouchHandler::MultitouchHandler(MapView view):
+    MoveHandler(view), moving(true), startView(view), initialized(false), ended(false)
 {
 }
 
@@ -688,7 +688,7 @@ bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord current
     if (locationValid){
         osmscout::MercatorProjection projection;
 
-        if (!projection.Set(view.center, view.magnification, dpi, 1000, 1000)) {
+        if (!projection.Set(view.center, view.magnification, view.mapDpi, 1000, 1000)) {
             return false;
         }
 

--- a/libosmscout-client-qt/src/osmscout/MapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapOverlay.cpp
@@ -1,0 +1,45 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/MapOverlay.h>
+
+MapOverlay::MapOverlay(QQuickItem* parent):
+    QQuickPaintedItem(parent)
+{
+  view=new MapView(this);
+}
+
+MapOverlay::~MapOverlay()
+{
+  delete view;
+}
+
+void MapOverlay::changeView(const MapView &updated)
+{
+  bool changed = *view != updated;
+  if (changed){
+    (*view) = updated;
+    redraw();
+  }
+}
+
+void MapOverlay::redraw()
+{
+  update();
+}

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -47,8 +47,6 @@ MapWidget::MapWidget(QQuickItem* parent)
 
     DBThreadRef dbThread = OSMScoutQt::GetInstance().GetDBThread();
 
-    mapDpi = settings->GetMapDPI();
-
     connect(settings.get(), SIGNAL(MapDPIChange(double)),
             this, SLOT(onMapDPIChange(double)));
 
@@ -72,7 +70,8 @@ MapWidget::MapWidget(QQuickItem* parent)
     view = new MapView(this,
                        osmscout::GeoCoord(0.0, 0.0),
                        /*angle*/ 0,
-                       osmscout::Magnification::magContinent);
+                       osmscout::Magnification::magContinent,
+                       settings->GetMapDPI());
     setupInputHandler(new InputHandler(*view));
     setKeepTouchGrab(true);
 
@@ -175,9 +174,9 @@ void MapWidget::touchEvent(QTouchEvent *event)
     if (!inputHandler->touch(event)){
         if (event->touchPoints().size() == 1){
             QTouchEvent::TouchPoint tp = event->touchPoints()[0];
-            setupInputHandler(new DragHandler(*view, mapDpi));
+            setupInputHandler(new DragHandler(*view));
         }else{
-            setupInputHandler(new MultitouchHandler(*view, mapDpi));
+            setupInputHandler(new MultitouchHandler(*view));
         }
         inputHandler->touch(event);
     }
@@ -361,7 +360,7 @@ void MapWidget::zoom(double zoomFactor, const QPoint widgetPosition)
     return;
 
   if (!inputHandler->zoom(zoomFactor, widgetPosition, QRect(0, 0, width(), height()))){
-    setupInputHandler(new MoveHandler(*view, mapDpi));
+    setupInputHandler(new MoveHandler(*view));
     inputHandler->zoom(zoomFactor, widgetPosition, QRect(0, 0, width(), height()));
   }
 }
@@ -379,7 +378,7 @@ void MapWidget::zoomOut(double zoomFactor, const QPoint widgetPosition)
 void MapWidget::move(QVector2D vector)
 {
     if (!inputHandler->move(vector)){
-        setupInputHandler(new MoveHandler(*view, mapDpi));
+        setupInputHandler(new MoveHandler(*view));
         inputHandler->move(vector);
     }
 }
@@ -407,7 +406,7 @@ void MapWidget::down()
 void MapWidget::rotateTo(double angle)
 {
     if (!inputHandler->rotateTo(angle)){
-        setupInputHandler(new MoveHandler(*view, mapDpi));
+        setupInputHandler(new MoveHandler(*view));
         inputHandler->rotateTo(angle);
     }
 }
@@ -415,7 +414,7 @@ void MapWidget::rotateTo(double angle)
 void MapWidget::rotateLeft()
 {
     if (!inputHandler->rotateBy(-DELTA_ANGLE)){
-        setupInputHandler(new MoveHandler(*view, mapDpi));
+        setupInputHandler(new MoveHandler(*view));
         inputHandler->rotateBy(-DELTA_ANGLE);
     }
 }
@@ -423,7 +422,7 @@ void MapWidget::rotateLeft()
 void MapWidget::rotateRight()
 {
     if (!inputHandler->rotateBy(DELTA_ANGLE)){
-        setupInputHandler(new MoveHandler(*view, mapDpi));
+        setupInputHandler(new MoveHandler(*view));
         inputHandler->rotateBy(DELTA_ANGLE);
     }
 }
@@ -453,7 +452,7 @@ void MapWidget::reloadTmpStyle() {
 void MapWidget::setLockToPosition(bool lock){
     if (lock){
         if (!inputHandler->currentPosition(locationValid, currentPosition)){
-            setupInputHandler(new LockHandler(*view, mapDpi, std::min(width(), height()) / 3));
+            setupInputHandler(new LockHandler(*view, std::min(width(), height()) / 3));
             inputHandler->currentPosition(locationValid, currentPosition);
         }
     }else{
@@ -661,7 +660,7 @@ void MapWidget::onTapLongTap(const QPoint p)
 
 void MapWidget::onMapDPIChange(double dpi)
 {
-    mapDpi = dpi;
+    view->mapDpi = dpi;
 
     // discard current input handler
     setupInputHandler(new InputHandler(*view));

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -39,6 +39,7 @@
 #include <osmscout/RoutingModel.h>
 #include <osmscout/SearchLocationModel.h>
 #include <osmscout/StyleFlagsModel.h>
+#include <osmscout/TiledMapOverlay.h>
 #include <osmscout/Router.h>
 
 static OSMScoutQt* osmScoutInstance=NULL;
@@ -132,6 +133,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<std::unordered_map<std::string,bool>>("std::unordered_map<std::string,bool>");
   qRegisterMetaType<QMap<QString,bool>>("QMap<QString,bool>");
   qRegisterMetaType<LocationEntry>("LocationEntry");
+  qRegisterMetaType<OnlineTileProvider>("OnlineTileProvider");
 
   // regiester osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");
@@ -150,6 +152,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qmlRegisterType<RouteStep>(uri, versionMajor, versionMinor, "RouteStep");
   qmlRegisterType<RoutingListModel>(uri, versionMajor, versionMinor, "RoutingListModel");
   qmlRegisterType<StyleFlagsModel>(uri, versionMajor, versionMinor, "StyleFlagsModel");
+  qmlRegisterType<TiledMapOverlay>(uri, versionMajor, versionMinor, "TiledMapOverlay");
 }
 
 OSMScoutQtBuilder OSMScoutQt::NewInstance()
@@ -325,4 +328,14 @@ Router* OSMScoutQt::MakeRouter()
 
 QString OSMScoutQt::GetUserAgent(){
   return userAgent;
+}
+
+QString OSMScoutQt::GetCacheLocation()
+{
+  return cacheLocation;
+}
+
+size_t OSMScoutQt::GetOnlineTileCacheSize()
+{
+  return onlineTileCacheSize;
 }

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -25,8 +25,10 @@
 #include <osmscout/DBThread.h>
 #include <osmscout/OSMScoutQt.h>
 
-OsmTileDownloader::OsmTileDownloader(QString diskCacheDir):
-  serverNumber(qrand())
+OsmTileDownloader::OsmTileDownloader(QString diskCacheDir,
+                                     const OnlineTileProvider &provider):
+  serverNumber(qrand()),
+  tileProvider(provider)
 {
   connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT (fileDownloaded(QNetworkReply*)));
  
@@ -42,21 +44,14 @@ OsmTileDownloader::OsmTileDownloader(QString diskCacheDir):
   
   diskCache.setCacheDirectory(diskCacheDir);
   webCtrl.setCache(&diskCache);
-
-  SettingsRef settings=OSMScoutQt::GetInstance().GetSettings();
-  
-  connect(settings.get(), SIGNAL(OnlineTileProviderIdChanged(const QString)),
-          this, SLOT(onlineTileProviderChanged()));
-  
-  tileProvider = settings->GetOnlineTileProvider();
 }
 
 OsmTileDownloader::~OsmTileDownloader() {
 }
 
-void OsmTileDownloader::onlineTileProviderChanged()
+void OsmTileDownloader::onlineTileProviderChanged(const OnlineTileProvider &provider)
 {
-  tileProvider=OSMScoutQt::GetInstance().GetSettings()->GetOnlineTileProvider();
+  tileProvider=provider;
   requests.clear();
 }
 

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -100,8 +100,6 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
                                  const MapViewStruct& request)
 {
   //qDebug() << "RenderMap()";
-  painter.save();
-
   QMutexLocker locker(&finishedMutex);
 
   osmscout::Color backgroundColor;
@@ -197,6 +195,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
                                       backgroundColor.GetA()));
   }
 
+  painter.save();
   if (finalImgProjection.GetAngle()!=requestProjection.GetAngle()){
     // rotate final image
     QPointF rotationCenter(targetRectangle.x()+targetRectangle.width()/2.0,

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -126,6 +126,7 @@ void Settings::SetOnlineTileProviderId(QString id){
     if (GetOnlineTileProviderId() != id){
         storage->setValue("OSMScoutLib/Rendering/OnlineTileProvider", id);
         emit OnlineTileProviderIdChanged(id);
+        emit OnlineTileProviderChanged(GetOnlineTileProvider());
     }
 }
 

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -1,0 +1,194 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2017 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/TiledMapOverlay.h>
+#include <osmscout/OsmTileDownloader.h>
+#include <osmscout/OSMScoutQt.h>
+#include <osmscout/TiledRenderingHelper.h>
+
+
+TileLoaderThread::TileLoaderThread(QThread *thread): thread(thread), tileDownloader(NULL) {}
+
+TileLoaderThread::~TileLoaderThread()
+{
+  if (thread!=NULL){
+    thread->quit();
+  }
+  if (tileDownloader!=NULL){
+    delete tileDownloader;
+  }
+}
+
+void TileLoaderThread::init()
+{
+  // create tile downloader in correct thread
+  SettingsRef settings=OSMScoutQt::GetInstance().GetSettings();
+  QString tileCacheDirectory=OSMScoutQt::GetInstance().GetCacheLocation();
+  tileDownloader = new OsmTileDownloader(tileCacheDirectory,provider);
+
+  connect(tileDownloader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
+          this, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)));
+  connect(tileDownloader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
+          this, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)));
+}
+
+void TileLoaderThread::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile)
+{
+  if (tileDownloader == NULL){
+    qWarning() << "tile requested but downloader is not initialized yet";
+    emit failed(zoomLevel, xtile, ytile, false);
+  }else{
+    emit tileDownloader->download(zoomLevel, xtile, ytile);
+  }
+}
+
+void TileLoaderThread::onProviderChanged(const OnlineTileProvider &newProvider)
+{
+  provider=newProvider;
+  if (tileDownloader!=NULL){
+    emit tileDownloader->onlineTileProviderChanged(provider);
+  }
+}
+
+TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
+    MapOverlay(parent),
+    onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize())
+{
+
+  QThread *thread=new QThread();
+  thread->setObjectName("OverlayTileLoader");
+  QObject::connect(thread, SIGNAL(finished()),
+                   thread, SLOT(deleteLater()));
+  loader=new TileLoaderThread(thread);
+  connect(thread, SIGNAL(started()),
+          loader, SLOT(init()));
+  thread->start();
+
+  connect(this, SIGNAL(providerChanged(const OnlineTileProvider &)),
+          loader, SLOT(onProviderChanged(const OnlineTileProvider &)),
+          Qt::QueuedConnection);
+
+  connect(loader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
+          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
+          Qt::QueuedConnection);
+
+  connect(loader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
+          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)),
+          Qt::QueuedConnection);
+
+  connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
+          loader,SLOT(download(uint32_t, uint32_t, uint32_t)),
+          Qt::QueuedConnection);
+  connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
+          this,SLOT(download(uint32_t, uint32_t, uint32_t)),
+          Qt::QueuedConnection);
+}
+
+TiledMapOverlay::~TiledMapOverlay()
+{
+  if (loader!=NULL){
+    delete loader;
+  }
+}
+
+void TiledMapOverlay::paint(QPainter *painter)
+{
+  QMutexLocker locker(&tileCacheMutex);
+  QList<TileCache*> layerCaches;
+
+  layerCaches << &onlineTileCache;
+  onlineTileCache.clearPendingRequests();
+
+  painter->setRenderHint(QPainter::Antialiasing, true);
+  painter->setRenderHint(QPainter::TextAntialiasing, true);
+  painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+  painter->setRenderHint(QPainter::HighQualityAntialiasing, true);
+
+  MapViewStruct request;
+  QRectF        boundingBox = contentsBoundingRect();
+
+  request.coord = view->center;
+  request.angle = view->angle;
+  request.magnification = view->magnification;
+  request.width = boundingBox.width();
+  request.height = boundingBox.height();
+
+  QColor unknownColor=QColor::fromRgbF(0,0,0,0);
+
+  TiledRenderingHelper::RenderTiles(*painter,request,layerCaches,view->mapDpi,unknownColor, /*overlap*/ 0);
+}
+
+void TiledMapOverlay::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile) {
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    if (!onlineTileCache.startRequestProcess(zoomLevel, xtile, ytile)) // request was canceled or started already
+      return;
+  }
+}
+
+void TiledMapOverlay::tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray /*downloadedData*/)
+{
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    onlineTileCache.put(zoomLevel, x, y, image);
+  }
+  //std::cout << "  put: " << zoomLevel << " xtile: " << x << " ytile: " << y << std::endl;
+  emit redraw();
+}
+
+void TiledMapOverlay::tileDownloadFailed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange)
+{
+  QMutexLocker locker(&tileCacheMutex);
+  onlineTileCache.removeRequest(zoomLevel, x, y);
+
+  if (zoomLevelOutOfRange && zoomLevel > 0){
+    // hack: when zoom level is too high for online source,
+    // we try to request tile with lower zoom level and put it to cache
+    // as substitute
+    uint32_t reqZoom = zoomLevel - 1;
+    uint32_t reqX = x / 2;
+    uint32_t reqY = y / 2;
+    if ((!onlineTileCache.contains(reqZoom, reqX, reqY))
+        && onlineTileCache.request(reqZoom, reqX, reqY)){
+      qDebug() << "Tile download failed " << x << " " << y << " zoomLevel " << zoomLevel << " try lower zoom";
+      //triggerTileRequest(reqZoom, reqX, reqY);
+    }
+  }
+}
+
+QJsonValue TiledMapOverlay::getProvider()
+{
+  return providerJson;
+}
+
+void TiledMapOverlay::setProvider(QJsonValue jv)
+{
+  OnlineTileProvider provider=OnlineTileProvider::fromJson(jv);
+  if (!provider.isValid()){
+    qWarning() << "Invalid provider:" << jv;
+    return;
+  }
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    // FIXME: there is possible race condition when provider is changed and there are pending downloads
+    onlineTileCache.cleanupCache();
+  }
+  providerJson=jv;
+  emit providerChanged(provider);
+}

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -68,7 +68,8 @@ void TileLoaderThread::onProviderChanged(const OnlineTileProvider &newProvider)
 
 TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
     MapOverlay(parent),
-    onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize())
+    onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize()),
+    enabled(true)
 {
 
   QThread *thread=new QThread();
@@ -109,6 +110,9 @@ TiledMapOverlay::~TiledMapOverlay()
 
 void TiledMapOverlay::paint(QPainter *painter)
 {
+  if (!enabled){
+    return;
+  }
   QMutexLocker locker(&tileCacheMutex);
   QList<TileCache*> layerCaches;
 
@@ -191,4 +195,18 @@ void TiledMapOverlay::setProvider(QJsonValue jv)
   }
   providerJson=jv;
   emit providerChanged(provider);
+}
+
+bool TiledMapOverlay::isEnabled()
+{
+  return enabled;
+}
+
+void TiledMapOverlay::setEnabled(bool b)
+{
+  enabled=b;
+  if (!enabled){
+    QMutexLocker locker(&tileCacheMutex);
+    onlineTileCache.cleanupCache();
+  }
 }

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -21,12 +21,10 @@
 #include <osmscout/TiledMapRenderer.h>
 
 #include <osmscout/OSMTile.h>
+#include <osmscout/TiledRenderingHelper.h>
 
 #include <osmscout/system/Math.h>
 #include <osmscout/util/Logger.h>
-
-// uncomment or define by compiler parameter to render various debug marks
-// #define DRAW_DEBUG
 
 TiledMapRenderer::TiledMapRenderer(QThread *thread,
                                    SettingsRef settings,
@@ -96,7 +94,12 @@ void TiledMapRenderer::Initialize()
     qDebug() << "Initialize";
 
     // create tile downloader in correct thread
-    tileDownloader = new OsmTileDownloader(tileCacheDirectory);
+    tileDownloader = new OsmTileDownloader(tileCacheDirectory,settings->GetOnlineTileProvider());
+
+    connect(settings.get(), SIGNAL(OnlineTileProviderChanged(const OnlineTileProvider &)),
+            tileDownloader, SLOT(onlineTileProviderChanged(const OnlineTileProvider &)),
+            Qt::QueuedConnection);
+
     connect(tileDownloader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
             this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
             Qt::QueuedConnection);
@@ -164,281 +167,28 @@ void TiledMapRenderer::InvalidateVisualCache()
 bool TiledMapRenderer::RenderMap(QPainter& painter,
                                  const MapViewStruct& request)
 {
-  painter.save();
-  osmscout::MercatorProjection projection;
-
-  // compute canvas transformation from angle
-  double width, height;
-  QPointF translateVector;
-  if (request.angle==0) {
-    width = request.width;
-    height = request.height;
-  } else {
-    double cosAlpha=cos(request.angle);
-    double cosBeta=cos(M_PI_2 - request.angle);
-    double rw=request.width;
-    double rh=request.height;
-    height=abs(rw*cosBeta)+abs(rh*cosAlpha);
-    width=abs(rw*cosAlpha)+abs(rh*cosBeta);
-    if (request.angle>0 && request.angle<=M_PI_2) {
-      translateVector.setY(cosBeta*rw*-1);
-    } else if (request.angle<=M_PI) {
-      translateVector.setY(height*-1);
-      translateVector.setX(cosAlpha * rw);
-    } else if (request.angle<=M_PI+M_PI_2) {
-      translateVector.setX(width*-1);
-      translateVector.setY(height*-1 - cosBeta*rw);
-    } else {
-      translateVector.setX(width*-1 + cosAlpha*rw);
-    }
-  }
-
-  projection.Set(request.coord,
-                 0,
-                 request.magnification,
-                 mapDpi,
-                 width,
-                 height);
-
-  osmscout::GeoBox boundingBox;
-
-  projection.GetDimensions(boundingBox);
-
-  QColor grey2 = QColor::fromRgbF(0.8,0.8,0.8);
-
-  // OpenStreetMap render its tiles up to latitude +-85.0511
-  double osmMinLat = OSMTile::minLat();
-  double osmMaxLat = OSMTile::maxLat();
-  double osmMinLon = OSMTile::minLon();
-  double osmMaxLon = OSMTile::maxLon();
-
-  // check if request center is defined in Mercator projection
-  if (!osmscout::GeoBox(osmscout::GeoCoord(osmMinLat, osmMinLon),
-                       osmscout::GeoCoord(osmMaxLat, osmMaxLon))
-                       .Includes(request.coord)){
-    qWarning() << "Outside projection";
-    return false;
-  }
-
-  uint32_t osmTileRes = OSMTile::worldRes(projection.GetMagnification().GetLevel());
-  double x1;
-  double y1;
-  projection.GeoToPixel(osmscout::GeoCoord(osmMaxLat, osmMinLon), x1, y1);
-  double x2;
-  double y2;
-  projection.GeoToPixel(osmscout::GeoCoord(osmMinLat, osmMaxLon), x2, y2);
-
-  double renderTileWidth = (x2 - x1) / osmTileRes; // pixels
-  double renderTileHeight = (y2 - y1) / osmTileRes; // pixels
-
-  uint32_t osmTileFromX = std::max(0.0, (double)osmTileRes * ((boundingBox.GetMinLon() + (double)180.0) / (double)360.0));
-  double maxLatRad = boundingBox.GetMaxLat() * GRAD_TO_RAD;
-  uint32_t osmTileFromY = std::max(0.0, (double)osmTileRes * ((double)1.0 - (log(tan(maxLatRad) + (double)1.0 / cos(maxLatRad)) / M_PI)) / (double)2.0);
-
-  uint32_t zoomLevel = projection.GetMagnification().GetLevel();
-
-  // render available tiles
-  double x;
-  double y;
   QTime start;
   QMutexLocker locker(&tileCacheMutex);
   int elapsed = start.elapsed();
   if (elapsed > 1){
-      osmscout::log.Warn() << "Mutex acquiere took " << elapsed << " ms";
+    osmscout::log.Warn() << "Mutex acquiere took " << elapsed << " ms";
   }
 
-  if (request.angle!=0) {
-    painter.rotate(qRadiansToDegrees(request.angle));
-    painter.translate(translateVector);
+  QList<TileCache*> layerCaches;
+  if (onlineTilesEnabled){
+    layerCaches << &onlineTileCache;
   }
-
-  painter.setPen(grey2);
-
-  painter.fillRect(0,0,
-                   projection.GetWidth(),projection.GetHeight(),
-                   unknownColor);
-
+  if (offlineTilesEnabled){
+    layerCaches << &offlineTileCache;
+  }
   onlineTileCache.clearPendingRequests();
   offlineTileCache.clearPendingRequests();
-  for ( uint32_t ty = 0;
-        (ty <= (projection.GetHeight() / (uint32_t)renderTileHeight)+1) && ((osmTileFromY + ty) < osmTileRes);
-        ty++ ){
 
-    uint32_t ytile = (osmTileFromY + ty);
-    double ytileLatRad = atan(sinh(M_PI * (1 - 2 * (double)ytile / (double)osmTileRes)));
-    double ytileLatDeg = ytileLatRad * 180.0 / M_PI;
-
-    for ( uint32_t tx = 0;
-          (tx <= (projection.GetWidth() / (uint32_t)renderTileWidth)+1) && ((osmTileFromX + tx) < osmTileRes);
-          tx++ ){
-
-      uint32_t xtile = (osmTileFromX + tx);
-      double xtileDeg = (double)xtile / (double)osmTileRes * 360.0 - 180.0;
-
-      projection.GeoToPixel(osmscout::GeoCoord(ytileLatDeg, xtileDeg), x, y);
-
-      bool lookupTileFound = false;
-      if (onlineTilesEnabled){
-        lookupTileFound |= lookupAndDrawTile(onlineTileCache, painter,
-              x, y, renderTileWidth, renderTileHeight,
-              zoomLevel, xtile, ytile, /* up limit */ 6, /* down limit */ 3
-              );
-      }
-
-      if (offlineTilesEnabled){
-        lookupTileFound |= lookupAndDrawTile(offlineTileCache, painter,
-                x, y, renderTileWidth, renderTileHeight,
-                zoomLevel, xtile, ytile, /* up limit */ 6, /* down limit */ 3
-                );
-      }
-
-      if (!lookupTileFound){
-        // no tile found, draw its outline
-        painter.drawLine(x,y, x + renderTileWidth, y);
-        painter.drawLine(x,y, x, y + renderTileHeight);
-      }
-    }
+  if (!TiledRenderingHelper::RenderTiles(painter,request,layerCaches,mapDpi,unknownColor)){
+    return false;
   }
-#ifdef DRAW_DEBUG
-  painter.setPen(QColor::fromRgbF(1,0,0));
-  painter.drawLine(0,0,width,height);
-  painter.drawLine(width,0,0,height);
 
-  painter.drawLine(0,0,width,0);
-  painter.drawLine(0,height,width,height);
-  painter.drawLine(0,0,0,height);
-  painter.drawLine(width,0,width,height);
-
-  painter.setPen(grey2);
-  painter.drawText(20, 30, QString("%1").arg(projection.GetMagnification().GetLevel()));
-
-  double centerLat;
-  double centerLon;
-  projection.PixelToGeo(projection.GetWidth() / 2.0, projection.GetHeight() / 2.0, centerLon, centerLat);
-  painter.drawText(20, 60, QString::fromStdString(osmscout::GeoCoord(centerLat, centerLon).GetDisplayText()));
-
-  painter.restore();
-  painter.setPen(QColor::fromRgbF(0,0,1));
-  painter.drawLine(0,0,request.width,request.height);
-  painter.drawLine(request.width,0,0,request.height);
-#else
-  painter.restore();
-#endif
   return onlineTileCache.isRequestQueueEmpty() && offlineTileCache.isRequestQueueEmpty();
-}
-
-bool TiledMapRenderer::lookupAndDrawTile(TileCache& tileCache, QPainter& painter,
-        double x, double y, double renderTileWidth, double renderTileHeight,
-        uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
-        uint32_t upLimit, uint32_t downLimit)
-{
-    bool triggerRequest = true;
-
-    // trick for avoiding white lines between tiles caused by antialiasing
-    // http://stackoverflow.com/questions/7332118/antialiasing-leaves-thin-line-between-adjacent-widgets
-    double overlap = painter.testRenderHint(QPainter::Antialiasing) ? 0.5 : 0.0;
-
-    uint32_t lookupTileZoom = zoomLevel;
-    uint32_t lookupXTile = xtile;
-    uint32_t lookupYTile = ytile;
-    QRectF lookupTileViewport(0, 0, 1, 1); // tile viewport (percent)
-    bool lookupTileFound = false;
-
-    // lookup upper zoom levels
-    //qDebug() << "Need paint tile " << xtile << " " << ytile << " zoom " << zoomLevel;
-    while ((!lookupTileFound) && (zoomLevel - lookupTileZoom <= upLimit)){
-      //qDebug() << "  - lookup tile " << lookupXTile << " " << lookupYTile << " zoom " << lookupTileZoom << " " << " viewport " << lookupTileViewport;
-      if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
-          TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
-          if (!val.image.isNull()){
-            double imageWidth = val.image.width();
-            double imageHeight = val.image.height();
-            QRectF imageViewport(imageWidth * lookupTileViewport.x(), imageHeight * lookupTileViewport.y(),
-                    imageWidth * lookupTileViewport.width(), imageHeight * lookupTileViewport.height() );
-
-            // TODO: support map rotation
-            painter.drawPixmap(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
-          }
-          lookupTileFound = true;
-          if (lookupTileZoom == zoomLevel)
-              triggerRequest = false;
-      }else{
-          // no tile found on current zoom zoom level, lookup upper zoom level
-          if (lookupTileZoom==0)
-            break;
-          lookupTileZoom --;
-          uint32_t crop = 1 << (zoomLevel - lookupTileZoom);
-          double viewportWidth = 1.0 / (double)crop;
-          double viewportHeight = 1.0 / (double)crop;
-          lookupTileViewport = QRectF(
-                  (double)(xtile % crop) * viewportWidth,
-                  (double)(ytile % crop) * viewportHeight,
-                  viewportWidth,
-                  viewportHeight);
-          lookupXTile = lookupXTile / 2;
-          lookupYTile = lookupYTile / 2;
-      }
-    }
-
-    // lookup bottom zoom levels
-    if (!lookupTileFound && downLimit > 0){
-        lookupAndDrawBottomTileRecursive(tileCache, painter,
-            x, y, renderTileWidth, renderTileHeight, overlap,
-            zoomLevel, xtile, ytile,
-            downLimit -1);
-    }
-
-    if (triggerRequest){
-       if (tileCache.request(zoomLevel, xtile, ytile)){
-         //std::cout << "  tile request: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
-        }else{
-         //std::cout << "  requested already: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
-       }
-    }
-    return lookupTileFound;
-}
-
-void TiledMapRenderer::lookupAndDrawBottomTileRecursive(TileCache& tileCache, QPainter& painter,
-        double x, double y, double renderTileWidth, double renderTileHeight, double overlap,
-        uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
-        uint32_t downLimit)
-{
-    if (zoomLevel > 20)
-        return;
-
-    //qDebug() << "Need paint tile " << xtile << " " << ytile << " zoom " << zoomLevel;
-    uint32_t lookupTileZoom = zoomLevel + 1;
-    uint32_t lookupXTile;
-    uint32_t lookupYTile;
-    uint32_t tileCnt = 2;
-
-    for (uint32_t ty = 0; ty < tileCnt; ty++){
-        lookupYTile = ytile *2 + ty;
-        for (uint32_t tx = 0; tx < tileCnt; tx++){
-            lookupXTile = xtile *2 + tx;
-            //qDebug() << "  - lookup tile " << lookupXTile << " " << lookupYTile << " zoom " << lookupTileZoom;
-            bool found = false;
-            if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
-                TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
-                if (!val.image.isNull()){
-                    double imageWidth = val.image.width();
-                    double imageHeight = val.image.height();
-                    painter.drawPixmap(
-                            QRectF(x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt + overlap, renderTileHeight/tileCnt + overlap),
-                            val.image,
-                            QRectF(0.0, 0.0, imageWidth, imageHeight));
-                    found = true;
-                }
-            }
-            if (!found && downLimit > 0){
-                // recursion
-                lookupAndDrawBottomTileRecursive(tileCache, painter,
-                    x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt, renderTileHeight/tileCnt, overlap,
-                    zoomLevel +1, lookupXTile, lookupYTile,
-                    downLimit -1);
-            }
-        }
-    }
 }
 
 DatabaseCoverage TiledMapRenderer::databaseCoverageOfTile(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile)
@@ -571,14 +321,11 @@ void TiledMapRenderer::offlineTileRequest(uint32_t zoomLevel, uint32_t xtile, ui
 
 void TiledMapRenderer::tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray /*downloadedData*/)
 {
-    //QMutexLocker locker(&mutex);
-
     {
         QMutexLocker locker(&tileCacheMutex);
         onlineTileCache.put(zoomLevel, x, y, image);
     }
     //std::cout << "  put: " << zoomLevel << " xtile: " << x << " ytile: " << y << std::endl;
-
     emit Redraw();
 }
 

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -32,7 +32,6 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
                                        const QColor &unknownColor,
                                        double overlap)
 {
-  painter.save();
   osmscout::MercatorProjection projection;
 
   // compute canvas transformation from angle
@@ -115,6 +114,7 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
   double x;
   double y;
 
+  painter.save();
   if (request.angle!=0) {
     painter.rotate(qRadiansToDegrees(request.angle));
     painter.translate(translateVector);

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -1,0 +1,300 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2010  Tim Teulings
+ Copyright (C) 2017 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/TiledRenderingHelper.h>
+#include <osmscout/DBThread.h>
+#include <osmscout/OSMTile.h>
+
+// uncomment or define by compiler parameter to render various debug marks
+// #define DRAW_DEBUG
+
+bool TiledRenderingHelper::RenderTiles(QPainter &painter,
+                                       const MapViewStruct &request,
+                                       QList<TileCache*> &layerCaches,
+                                       double mapDpi,
+                                       const QColor &unknownColor,
+                                       double overlap)
+{
+  painter.save();
+  osmscout::MercatorProjection projection;
+
+  // compute canvas transformation from angle
+  double width, height;
+  QPointF translateVector;
+  if (request.angle==0) {
+    width = request.width;
+    height = request.height;
+  } else {
+    double cosAlpha=cos(request.angle);
+    double cosBeta=cos(M_PI_2 - request.angle);
+    double rw=request.width;
+    double rh=request.height;
+    height=abs(rw*cosBeta)+abs(rh*cosAlpha);
+    width=abs(rw*cosAlpha)+abs(rh*cosBeta);
+    if (request.angle>0 && request.angle<=M_PI_2) {
+      translateVector.setY(cosBeta*rw*-1);
+    } else if (request.angle<=M_PI) {
+      translateVector.setY(height*-1);
+      translateVector.setX(cosAlpha * rw);
+    } else if (request.angle<=M_PI+M_PI_2) {
+      translateVector.setX(width*-1);
+      translateVector.setY(height*-1 - cosBeta*rw);
+    } else {
+      translateVector.setX(width*-1 + cosAlpha*rw);
+    }
+  }
+
+  projection.Set(request.coord,
+                 0,
+                 request.magnification,
+                 mapDpi,
+                 width,
+                 height);
+
+  osmscout::GeoBox boundingBox;
+
+  projection.GetDimensions(boundingBox);
+
+  QColor grey2 = QColor::fromRgbF(0.8,0.8,0.8);
+
+  // OpenStreetMap render its tiles up to latitude +-85.0511
+  double osmMinLat = OSMTile::minLat();
+  double osmMaxLat = OSMTile::maxLat();
+  double osmMinLon = OSMTile::minLon();
+  double osmMaxLon = OSMTile::maxLon();
+
+  // check if request center is defined in Mercator projection
+  if (!osmscout::GeoBox(osmscout::GeoCoord(osmMinLat, osmMinLon),
+                        osmscout::GeoCoord(osmMaxLat, osmMaxLon))
+      .Includes(request.coord)){
+    qWarning() << "Outside projection";
+    return false;
+  }
+
+  uint32_t osmTileRes = OSMTile::worldRes(projection.GetMagnification().GetLevel());
+  double x1;
+  double y1;
+  projection.GeoToPixel(osmscout::GeoCoord(osmMaxLat, osmMinLon), x1, y1);
+  double x2;
+  double y2;
+  projection.GeoToPixel(osmscout::GeoCoord(osmMinLat, osmMaxLon), x2, y2);
+
+  double renderTileWidth = (x2 - x1) / osmTileRes; // pixels
+  double renderTileHeight = (y2 - y1) / osmTileRes; // pixels
+
+  uint32_t osmTileFromX = std::max(0.0, (double)osmTileRes * ((boundingBox.GetMinLon() + (double)180.0) / (double)360.0));
+  double maxLatRad = boundingBox.GetMaxLat() * GRAD_TO_RAD;
+  uint32_t osmTileFromY = std::max(0.0, (double)osmTileRes * ((double)1.0 - (log(tan(maxLatRad) + (double)1.0 / cos(maxLatRad)) / M_PI)) / (double)2.0);
+
+  uint32_t zoomLevel = projection.GetMagnification().GetLevel();
+
+  if (overlap<0) {
+    // trick for avoiding white lines between tiles caused by antialiasing
+    // http://stackoverflow.com/questions/7332118/antialiasing-leaves-thin-line-between-adjacent-widgets
+    overlap = painter.testRenderHint(QPainter::Antialiasing) ? 0.5 : 0.0;
+  }
+
+  // render available tiles
+  double x;
+  double y;
+
+  if (request.angle!=0) {
+    painter.rotate(qRadiansToDegrees(request.angle));
+    painter.translate(translateVector);
+  }
+
+  painter.setPen(grey2);
+
+  painter.fillRect(0,0,
+                   projection.GetWidth(),projection.GetHeight(),
+                   unknownColor);
+
+
+  for ( uint32_t ty = 0;
+        (ty <= (projection.GetHeight() / (uint32_t)renderTileHeight)+1) && ((osmTileFromY + ty) < osmTileRes);
+        ty++ ){
+
+    uint32_t ytile = (osmTileFromY + ty);
+    double ytileLatRad = atan(sinh(M_PI * (1 - 2 * (double)ytile / (double)osmTileRes)));
+    double ytileLatDeg = ytileLatRad * 180.0 / M_PI;
+
+    for ( uint32_t tx = 0;
+          (tx <= (projection.GetWidth() / (uint32_t)renderTileWidth)+1) && ((osmTileFromX + tx) < osmTileRes);
+          tx++ ){
+
+      uint32_t xtile = (osmTileFromX + tx);
+      double xtileDeg = (double)xtile / (double)osmTileRes * 360.0 - 180.0;
+
+      projection.GeoToPixel(osmscout::GeoCoord(ytileLatDeg, xtileDeg), x, y);
+
+      bool lookupTileFound = false;
+      for (TileCache *cache:layerCaches){
+        lookupTileFound |= lookupAndDrawTile(*cache, painter,
+                                             x, y, renderTileWidth, renderTileHeight,
+                                             zoomLevel, xtile, ytile, /* up limit */ 6, /* down limit */ 3,
+                                             overlap
+        );
+      }
+
+      if (!lookupTileFound){
+        // no tile found, draw its outline
+        painter.drawLine(x,y, x + renderTileWidth, y);
+        painter.drawLine(x,y, x, y + renderTileHeight);
+      }
+    }
+  }
+#ifdef DRAW_DEBUG
+  painter.setPen(QColor::fromRgbF(1,0,0));
+  painter.drawLine(0,0,width,height);
+  painter.drawLine(width,0,0,height);
+
+  painter.drawLine(0,0,width,0);
+  painter.drawLine(0,height,width,height);
+  painter.drawLine(0,0,0,height);
+  painter.drawLine(width,0,width,height);
+
+  painter.restore();
+
+  painter.setPen(grey2);
+  painter.drawText(20, 30, QString("%1").arg(projection.GetMagnification().GetLevel()));
+
+  double centerLat;
+  double centerLon;
+  projection.PixelToGeo(projection.GetWidth() / 2.0, projection.GetHeight() / 2.0, centerLon, centerLat);
+  painter.drawText(20, 60, QString::fromStdString(osmscout::GeoCoord(centerLat, centerLon).GetDisplayText()));
+
+  painter.setPen(QColor::fromRgbF(0,0,1));
+  painter.drawLine(0,0,request.width,request.height);
+  painter.drawLine(request.width,0,0,request.height);
+#else
+  painter.restore();
+#endif
+  return true;
+}
+
+bool TiledRenderingHelper::lookupAndDrawTile(TileCache& tileCache, QPainter& painter,
+                                             double x, double y, double renderTileWidth, double renderTileHeight,
+                                             uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
+                                             uint32_t upLimit, uint32_t downLimit, double overlap)
+{
+  bool triggerRequest = true;
+
+  uint32_t lookupTileZoom = zoomLevel;
+  uint32_t lookupXTile = xtile;
+  uint32_t lookupYTile = ytile;
+  QRectF lookupTileViewport(0, 0, 1, 1); // tile viewport (percent)
+  bool lookupTileFound = false;
+
+  // lookup upper zoom levels
+  //qDebug() << "Need paint tile " << xtile << " " << ytile << " zoom " << zoomLevel;
+  while ((!lookupTileFound) && (zoomLevel - lookupTileZoom <= upLimit)){
+    //qDebug() << "  - lookup tile " << lookupXTile << " " << lookupYTile << " zoom " << lookupTileZoom << " " << " viewport " << lookupTileViewport;
+    if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
+      TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
+      if (!val.image.isNull()){
+        double imageWidth = val.image.width();
+        double imageHeight = val.image.height();
+        QRectF imageViewport(imageWidth * lookupTileViewport.x(), imageHeight * lookupTileViewport.y(),
+                             imageWidth * lookupTileViewport.width(), imageHeight * lookupTileViewport.height() );
+
+        // TODO: support map rotation
+        painter.drawPixmap(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
+      }
+      lookupTileFound = true;
+      if (lookupTileZoom == zoomLevel)
+        triggerRequest = false;
+    }else{
+      // no tile found on current zoom zoom level, lookup upper zoom level
+      if (lookupTileZoom==0)
+        break;
+      lookupTileZoom --;
+      uint32_t crop = 1 << (zoomLevel - lookupTileZoom);
+      double viewportWidth = 1.0 / (double)crop;
+      double viewportHeight = 1.0 / (double)crop;
+      lookupTileViewport = QRectF(
+          (double)(xtile % crop) * viewportWidth,
+          (double)(ytile % crop) * viewportHeight,
+          viewportWidth,
+          viewportHeight);
+      lookupXTile = lookupXTile / 2;
+      lookupYTile = lookupYTile / 2;
+    }
+  }
+
+  // lookup bottom zoom levels
+  if (!lookupTileFound && downLimit > 0){
+    lookupAndDrawBottomTileRecursive(tileCache, painter,
+                                     x, y, renderTileWidth, renderTileHeight, overlap,
+                                     zoomLevel, xtile, ytile,
+                                     downLimit -1);
+  }
+
+  if (triggerRequest){
+    if (tileCache.request(zoomLevel, xtile, ytile)){
+      //std::cout << "  tile request: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
+    }else{
+      //std::cout << "  requested already: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
+    }
+  }
+  return lookupTileFound;
+}
+
+void TiledRenderingHelper::lookupAndDrawBottomTileRecursive(TileCache& tileCache, QPainter& painter,
+                                                            double x, double y, double renderTileWidth, double renderTileHeight, double overlap,
+                                                            uint32_t zoomLevel, uint32_t xtile, uint32_t ytile,
+                                                            uint32_t downLimit)
+{
+  if (zoomLevel > 20)
+    return;
+
+  //qDebug() << "Need paint tile " << xtile << " " << ytile << " zoom " << zoomLevel;
+  uint32_t lookupTileZoom = zoomLevel + 1;
+  uint32_t lookupXTile;
+  uint32_t lookupYTile;
+  uint32_t tileCnt = 2;
+
+  for (uint32_t ty = 0; ty < tileCnt; ty++){
+    lookupYTile = ytile *2 + ty;
+    for (uint32_t tx = 0; tx < tileCnt; tx++){
+      lookupXTile = xtile *2 + tx;
+      //qDebug() << "  - lookup tile " << lookupXTile << " " << lookupYTile << " zoom " << lookupTileZoom;
+      bool found = false;
+      if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
+        TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
+        if (!val.image.isNull()){
+          double imageWidth = val.image.width();
+          double imageHeight = val.image.height();
+          painter.drawPixmap(
+              QRectF(x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt + overlap, renderTileHeight/tileCnt + overlap),
+              val.image,
+              QRectF(0.0, 0.0, imageWidth, imageHeight));
+          found = true;
+        }
+      }
+      if (!found && downLimit > 0){
+        // recursion
+        lookupAndDrawBottomTileRecursive(tileCache, painter,
+                                         x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt, renderTileHeight/tileCnt, overlap,
+                                         zoomLevel +1, lookupXTile, lookupYTile,
+                                         downLimit -1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi.

This MR creates new possibility how to render on on top of QML map widget. It was requested 5 months ago in https://github.com/Framstag/libosmscout/issues/405 (uff, time is fast). It is not necessary to modify `MapWidget`, just create new component that is child of  `MapOverlay`, overlap Map component with it and connect `view` property.

First implementation of such overlay is `TiledMapOverlay` that allows to add some online tile source as overlay. One nice example is hill shading:


```qml
  Map{
    id: map

            TiledMapOverlay {
                anchors.fill: parent
                view: map.view
                enabled: true
                opacity: 0.5
                // If you intend to use tiles from OpenMapSurfer services in your own applications please contact us.
                // https://korona.geog.uni-heidelberg.de/contact.html
                provider: {
                      "id": "ASTER_GDEM",
                      "name": "Hillshade",
                      "servers": [
                        "https://korona.geog.uni-heidelberg.de/tiles/asterh/x=%2&y=%3&z=%1"
                      ],
                      "maximumZoomLevel": 18,
                      "copyright": "© IAT, METI, NASA, NOAA",
                    }
            }
  }
```
result:
![hillshading overlay](https://user-images.githubusercontent.com/309458/33595128-1904752c-d997-11e7-92b5-01217d718ba5.png)
