### PR TITLE
fix StyleEditor signal connection

### DIFF
--- a/StyleEditor/src/MainWindow.cpp
+++ b/StyleEditor/src/MainWindow.cpp
@@ -29,9 +29,9 @@ MainWindow::MainWindow(DBThreadRef dbThread)
    dbThread(dbThread)
 {
   connect(dbThread.get(),
-          SIGNAL(InitialisationFinished(DatabaseLoadedResponse)),
+          SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)),
           this,
-          SLOT(InitialisationFinished(DatabaseLoadedResponse)));
+          SLOT(InitialisationFinished(const DatabaseLoadedResponse&)));
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
fix for Qt warning:
```
QObject::connect: No such signal DBThread::InitialisationFinished(DatabaseLoadedResponse) in libosmscout/StyleEditor/src/MainWindow.cpp:32
```