### PR TITLE
Add search breaker (SearchForLocationByString)

### DIFF
--- a/libosmscout-client-qt/include/osmscout/SearchModule.h
+++ b/libosmscout-client-qt/include/osmscout/SearchModule.h
@@ -85,6 +85,7 @@ private:
                        const QString searchPattern,
                        const osmscout::AdminRegionRef defaultRegion,
                        int limit,
+                       osmscout::BreakerRef &breaker,
                        std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap);
 
   bool BuildLocationEntry(const osmscout::ObjectFileRef& object,

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -46,6 +46,7 @@ void SearchModule::SearchLocations(DBInstanceRef &db,
                                    const QString searchPattern,
                                    const osmscout::AdminRegionRef defaultRegion,
                                    int limit,
+                                   osmscout::BreakerRef &breaker,
                                    std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap)
 {
   QList<LocationEntry> locations;
@@ -64,6 +65,7 @@ void SearchModule::SearchLocations(DBInstanceRef &db,
     searchParameter.SetDefaultAdminRegion(defaultRegion);
 
   searchParameter.SetLimit(limit);
+  searchParameter.SetBreaker(breaker);
 
   osmscout::LocationSearchResult result;
 
@@ -185,7 +187,7 @@ void SearchModule::SearchForLocations(const QString searchPattern,
         if (defaultRegionInfo && defaultRegionInfo->database==db->path){
           defaultRegion=defaultRegionInfo->adminRegion;
         }
-        SearchLocations(db,searchPattern,defaultRegion,limit,adminRegionMap);
+        SearchLocations(db,searchPattern,defaultRegion,limit,breaker,adminRegionMap);
 
         if (breaker && breaker->IsAborted()){
           emit searchFinished(searchPattern, /*error*/ false);

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -27,6 +27,7 @@
 #include <osmscout/Location.h>
 
 #include <osmscout/util/StringMatcher.h>
+#include <osmscout/util/Breaker.h>
 
 namespace osmscout {
 
@@ -156,6 +157,8 @@ namespace osmscout {
 
     size_t                  limit;                //!< The maximum number of results over all sub searches requested
 
+    BreakerRef              breaker;              //!< Breaker for search
+
   public:
     explicit LocationStringSearchParameter(const std::string& searchString);
 
@@ -192,6 +195,9 @@ namespace osmscout {
     void SetStringMatcherFactory(const StringMatcherFactoryRef& stringMatcherFactory);
 
     void SetLimit(size_t limit);
+
+    void SetBreaker(BreakerRef &breaker);
+    bool IsAborted() const;
   };
 
   /**

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -1829,6 +1829,7 @@ namespace osmscout {
                                      LocationSearchResult::match,
                                      result);
           if (searchParameter.IsAborted()){
+            osmscout::log.Debug() << "Search aborted";
             return true;
           }
         }
@@ -1841,6 +1842,7 @@ namespace osmscout {
                                 LocationSearchResult::match,
                                 result);
           if (searchParameter.IsAborted()){
+            osmscout::log.Debug() << "Search aborted";
             return true;
           }
         }
@@ -1868,6 +1870,7 @@ namespace osmscout {
 
     //std::cout << "Admin Region visit: " << adminRegionVisitTime.ResultString() << std::endl;
     if (searchParameter.IsAborted()){
+      osmscout::log.Debug() << "Search aborted";
       return true;
     }
 
@@ -1893,6 +1896,7 @@ namespace osmscout {
                                      LocationSearchResult::match,
                                      result);
           if (searchParameter.IsAborted()){
+            osmscout::log.Debug() << "Search aborted";
             return true;
           }
         }
@@ -1905,6 +1909,7 @@ namespace osmscout {
                                 LocationSearchResult::match,
                                 result);
           if (searchParameter.IsAborted()){
+            osmscout::log.Debug() << "Search aborted";
             return true;
           }
         }
@@ -1943,6 +1948,7 @@ namespace osmscout {
                                        LocationSearchResult::candidate,
                                        result);
             if (searchParameter.IsAborted()){
+              osmscout::log.Debug() << "Search aborted";
               return true;
             }
           }
@@ -1955,6 +1961,7 @@ namespace osmscout {
                                   LocationSearchResult::candidate,
                                   result);
             if (searchParameter.IsAborted()){
+              osmscout::log.Debug() << "Search aborted";
               return true;
             }
           }

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -282,6 +282,16 @@ namespace osmscout {
     this->limit=limit;
   }
 
+  void LocationStringSearchParameter::SetBreaker(BreakerRef &breaker)
+  {
+    this->breaker=breaker;
+  }
+
+  bool LocationStringSearchParameter::IsAborted() const
+  {
+    return breaker && breaker->IsAborted();
+  }
+
   StringMatcherFactoryRef LocationStringSearchParameter::GetStringMatcherFactory() const
   {
     return stringMatcherFactory;
@@ -1818,6 +1828,9 @@ namespace osmscout {
                                      regionMatch,
                                      LocationSearchResult::match,
                                      result);
+          if (searchParameter.IsAborted()){
+            return true;
+          }
         }
 
         if (parameter.searchForPOI) {
@@ -1827,6 +1840,9 @@ namespace osmscout {
                                 regionMatch,
                                 LocationSearchResult::match,
                                 result);
+          if (searchParameter.IsAborted()){
+            return true;
+          }
         }
       }
     }
@@ -1851,6 +1867,9 @@ namespace osmscout {
     adminRegionVisitTime.Stop();
 
     //std::cout << "Admin Region visit: " << adminRegionVisitTime.ResultString() << std::endl;
+    if (searchParameter.IsAborted()){
+      return true;
+    }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
       //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' (" << regionMatch.adminRegion->object.GetName() << ") for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
@@ -1873,6 +1892,9 @@ namespace osmscout {
                                      regionMatch,
                                      LocationSearchResult::match,
                                      result);
+          if (searchParameter.IsAborted()){
+            return true;
+          }
         }
 
         if (parameter.searchForPOI) {
@@ -1882,6 +1904,9 @@ namespace osmscout {
                                 regionMatch,
                                 LocationSearchResult::match,
                                 result);
+          if (searchParameter.IsAborted()){
+            return true;
+          }
         }
 
         if (result.results.size()==currentResultSize && parameter.partialMatch) {
@@ -1917,6 +1942,9 @@ namespace osmscout {
                                        regionMatch,
                                        LocationSearchResult::candidate,
                                        result);
+            if (searchParameter.IsAborted()){
+              return true;
+            }
           }
 
           if (parameter.searchForPOI) {
@@ -1926,6 +1954,9 @@ namespace osmscout {
                                   regionMatch,
                                   LocationSearchResult::candidate,
                                   result);
+            if (searchParameter.IsAborted()){
+              return true;
+            }
           }
 
           if (result.results.size()==currentResultSize && parameter.partialMatch) {


### PR DESCRIPTION
Hi, when I am searching some place on mobile phone, location lookup took long time sometimes. Combined with search suggestions, it may happen that background search thread processing lookup of "Pr" when user already typed complete world "Prague". This simple change adds breaker to search parameter and setup breaker instance that already exists in Qt `SearchModule`. It boost search experience ;-)