### PR TITLE
add breaker to search visitors

### DIFF
--- a/libosmscout/include/osmscout/Location.h
+++ b/libosmscout/include/osmscout/Location.h
@@ -165,6 +165,9 @@ namespace osmscout {
   public:
     virtual ~LocationVisitor() = default;
 
+    /**
+     * @return true if location traversal should continue
+     */
     virtual bool Visit(const AdminRegion& adminRegion,
                        const PostalArea& postalArea,
                        const Location &location) = 0;

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -49,6 +49,7 @@ namespace osmscout {
 
     size_t                  limit;                   //!< The maximum number of results over all sub searches requested
 
+    BreakerRef              breaker;                 //!< Breaker for search
   public:
     explicit POIFormSearchParameter();
 
@@ -71,6 +72,10 @@ namespace osmscout {
     void SetPOIOnlyMatch(bool poiOnlyMatch);
 
     void SetLimit(size_t limit);
+
+    void SetBreaker(BreakerRef &breaker);
+    BreakerRef GetBreaker() const;
+    bool IsAborted() const;
   };
 
   /**
@@ -96,6 +101,7 @@ namespace osmscout {
     StringMatcherFactoryRef stringMatcherFactory;    //!< String matcher factory to use
     size_t                  limit;                   //!< The maximum number of results over all sub searches requested
 
+    BreakerRef              breaker;                 //!< Breaker for search
   public:
     explicit LocationFormSearchParameter();
 
@@ -130,6 +136,10 @@ namespace osmscout {
     void SetPartialMatch(bool partialMatch);
 
     void SetLimit(size_t limit);
+
+    void SetBreaker(BreakerRef &breaker);
+    BreakerRef GetBreaker() const;
+    bool IsAborted() const;
   };
 
   /**
@@ -197,6 +207,7 @@ namespace osmscout {
     void SetLimit(size_t limit);
 
     void SetBreaker(BreakerRef &breaker);
+    BreakerRef GetBreaker() const;
     bool IsAborted() const;
   };
 

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -173,6 +173,21 @@ namespace osmscout {
     this->limit=limit;
   }
 
+  void LocationFormSearchParameter::SetBreaker(BreakerRef &breaker)
+  {
+    this->breaker=breaker;
+  }
+
+  BreakerRef LocationFormSearchParameter::GetBreaker() const
+  {
+    return breaker;
+  }
+
+  bool LocationFormSearchParameter::IsAborted() const
+  {
+    return breaker && breaker->IsAborted();
+  }
+
   POIFormSearchParameter::POIFormSearchParameter()
     : adminRegionOnlyMatch(false),
       poiOnlyMatch(false),
@@ -242,6 +257,21 @@ namespace osmscout {
     this->limit=limit;
   }
 
+  void POIFormSearchParameter::SetBreaker(BreakerRef &breaker)
+  {
+    this->breaker=breaker;
+  }
+
+  BreakerRef POIFormSearchParameter::GetBreaker() const
+  {
+    return breaker;
+  }
+
+  bool POIFormSearchParameter::IsAborted() const
+  {
+    return breaker && breaker->IsAborted();
+  }
+
   LocationStringSearchParameter::LocationStringSearchParameter(const std::string& searchString)
     : searchForLocation(true),
       searchForPOI(true),
@@ -285,6 +315,11 @@ namespace osmscout {
   void LocationStringSearchParameter::SetBreaker(BreakerRef &breaker)
   {
     this->breaker=breaker;
+  }
+
+  BreakerRef LocationStringSearchParameter::GetBreaker() const
+  {
+    return breaker;
   }
 
   bool LocationStringSearchParameter::IsAborted() const
@@ -763,10 +798,13 @@ namespace osmscout {
     std::list<TokenSearch> patterns;
     std::list<Result>      matches;
     std::list<Result>      partialMatches;
+    BreakerRef             breaker;
 
   public:
     PostalAreaSearchVisitor(const StringMatcherFactoryRef& matcherFactory,
-                            const std::list<TokenStringRef>& patterns)
+                            const std::list<TokenStringRef>& patterns,
+                            BreakerRef &breaker):
+      breaker(breaker)
     {
       for (const auto& pattern : patterns) {
         this->patterns.emplace_back(pattern,
@@ -817,6 +855,9 @@ namespace osmscout {
         }
       }
 
+      if (breaker && breaker->IsAborted()){
+        return stop;
+      }
       return visitChildren;
     }
   };
@@ -905,10 +946,13 @@ namespace osmscout {
     std::list<TokenSearch> patterns;
     std::list<Result>      matches;
     std::list<Result>      partialMatches;
+    BreakerRef             breaker;
 
   public:
     LocationSearchVisitor(const StringMatcherFactoryRef& matcherFactory,
-                          const std::list<TokenStringRef>& patterns)
+                          const std::list<TokenStringRef>& patterns,
+                          BreakerRef &breaker):
+      breaker(breaker)
     {
       for (const auto& pattern : patterns) {
         this->patterns.emplace_back(pattern,
@@ -941,7 +985,7 @@ namespace osmscout {
         }
       }
 
-      return true;
+      return !(breaker && breaker->IsAborted());
     }
   };
 
@@ -1299,7 +1343,8 @@ namespace osmscout {
                                          const std::list<std::string>& locationTokens,
                                          const AdminRegionSearchVisitor::Result& regionMatch,
                                          LocationSearchResult::MatchQuality regionMatchQuality,
-                                         LocationSearchResult& result)
+                                         LocationSearchResult& result,
+                                         BreakerRef &breaker)
   {
     std::unordered_set<std::string> locationIgnoreTokenSet;
 
@@ -1318,7 +1363,8 @@ namespace osmscout {
     // Search for locations
 
     LocationSearchVisitor locationVisitor(parameter.stringMatcherFactory,
-                                          locationSearchPatterns);
+                                          locationSearchPatterns,
+                                          breaker);
 
     StopClock locationVisitTime;
 
@@ -1332,6 +1378,9 @@ namespace osmscout {
     //std::cout << "Location (" << regionMatch.adminRegion->name << ") visit time: " << locationVisitTime.ResultString() << std::endl;
 
     for (const auto& locationMatch : locationVisitor.matches) {
+      if (breaker && breaker->IsAborted()){
+        return true;
+      }
       //std::cout << "Found location match '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'" << std::endl;
       std::list<std::string> addressTokens=BuildStringListFromSubToken(locationMatch.tokenString,
                                                                        locationTokens);
@@ -1417,7 +1466,8 @@ namespace osmscout {
                                              const PostalAreaSearchVisitor::Result& postalAreaMatch,
                                              LocationSearchResult::MatchQuality regionMatchQuality,
                                              LocationSearchResult::MatchQuality postalAreaMatchQuality,
-                                             LocationSearchResult& result)
+                                             LocationSearchResult& result,
+                                             BreakerRef &breaker)
   {
     std::unordered_set<std::string> locationIgnoreTokenSet;
 
@@ -1434,7 +1484,8 @@ namespace osmscout {
     // Search for locations
 
     LocationSearchVisitor locationVisitor(parameter.stringMatcherFactory,
-                                          locationSearchPatterns);
+                                          locationSearchPatterns,
+                                          breaker);
 
     //std::cout << "Search for location for " << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "..." << std::endl;
 
@@ -1533,7 +1584,8 @@ namespace osmscout {
                                            const std::string& addressPattern,
                                            const AdminRegionSearchVisitor::Result& regionMatch,
                                            LocationSearchResult::MatchQuality regionMatchQuality,
-                                           LocationSearchResult& result)
+                                           LocationSearchResult& result,
+                                           BreakerRef &breaker)
   {
     /*
     std::unordered_set<std::string> postalAreaIgnoreTokenSet;
@@ -1555,7 +1607,8 @@ namespace osmscout {
     // Search for locations
 
     PostalAreaSearchVisitor postalAreaVisitor(parameter.stringMatcherFactory,
-                                               postalAreaSearchPatterns);
+                                              postalAreaSearchPatterns,
+                                              breaker);
 
     if (!locationIndex->VisitAdminRegions(*regionMatch.adminRegion,
                                           postalAreaVisitor)) {
@@ -1586,7 +1639,8 @@ namespace osmscout {
                                        postalAreaMatch,
                                        regionMatchQuality,
                                        LocationSearchResult::match,
-                                       result);
+                                       result,
+                                       breaker);
 
         if (result.results.size()==currentResultSize &&
             parameter.partialMatch) {
@@ -1625,7 +1679,8 @@ namespace osmscout {
                                          postalAreaMatch,
                                          regionMatchQuality,
                                          LocationSearchResult::candidate,
-                                         result);
+                                         result,
+                                         breaker);
 
           if (result.results.size()==currentResultSize &&
               parameter.partialMatch) {
@@ -1649,7 +1704,8 @@ namespace osmscout {
                                     const std::list<std::string>& poiTokens,
                                     const AdminRegionSearchVisitor::Result& regionMatch,
                                     LocationSearchResult::MatchQuality regionMatchQuality,
-                                    LocationSearchResult& result)
+                                    LocationSearchResult& result,
+                                    BreakerRef &breaker)
   {
     std::unordered_set<std::string> poiIgnoreTokenSet;
 
@@ -1713,7 +1769,8 @@ namespace osmscout {
                                     const std::string& poiPattern,
                                     const AdminRegionSearchVisitor::Result& regionMatch,
                                     LocationSearchResult::MatchQuality regionMatchQuality,
-                                    LocationSearchResult& result)
+                                    LocationSearchResult& result,
+                                    BreakerRef &breaker)
   {
     std::unordered_set<std::string> poiIgnoreTokenSet;
 
@@ -1769,6 +1826,8 @@ namespace osmscout {
     AdminRegionRef                  defaultAdminRegion=searchParameter.GetDefaultAdminRegion();
     std::string                     searchPattern=searchParameter.GetSearchString();
     SearchParameter                 parameter;
+
+    BreakerRef breaker=searchParameter.GetBreaker();
 
     parameter.searchForLocation=searchParameter.GetSearchForLocation();
     parameter.searchForPOI=searchParameter.GetSearchForPOI();
@@ -1827,7 +1886,8 @@ namespace osmscout {
                                      locationTokens,
                                      regionMatch,
                                      LocationSearchResult::match,
-                                     result);
+                                     result,
+                                     breaker);
           if (searchParameter.IsAborted()){
             osmscout::log.Debug() << "Search aborted";
             return true;
@@ -1840,7 +1900,8 @@ namespace osmscout {
                                 locationTokens,
                                 regionMatch,
                                 LocationSearchResult::match,
-                                result);
+                                result,
+                                breaker);
           if (searchParameter.IsAborted()){
             osmscout::log.Debug() << "Search aborted";
             return true;
@@ -1894,7 +1955,8 @@ namespace osmscout {
                                      locationTokens,
                                      regionMatch,
                                      LocationSearchResult::match,
-                                     result);
+                                     result,
+                                     breaker);
           if (searchParameter.IsAborted()){
             osmscout::log.Debug() << "Search aborted";
             return true;
@@ -1907,7 +1969,8 @@ namespace osmscout {
                                 locationTokens,
                                 regionMatch,
                                 LocationSearchResult::match,
-                                result);
+                                result,
+                                breaker);
           if (searchParameter.IsAborted()){
             osmscout::log.Debug() << "Search aborted";
             return true;
@@ -1946,7 +2009,8 @@ namespace osmscout {
                                        locationTokens,
                                        regionMatch,
                                        LocationSearchResult::candidate,
-                                       result);
+                                       result,
+                                       breaker);
             if (searchParameter.IsAborted()){
               osmscout::log.Debug() << "Search aborted";
               return true;
@@ -1959,7 +2023,8 @@ namespace osmscout {
                                   locationTokens,
                                   regionMatch,
                                   LocationSearchResult::candidate,
-                                  result);
+                                  result,
+                                  breaker);
             if (searchParameter.IsAborted()){
               osmscout::log.Debug() << "Search aborted";
               return true;
@@ -1987,6 +2052,8 @@ namespace osmscout {
     LocationIndexRef                locationIndex=database->GetLocationIndex();
     std::unordered_set<std::string> regionIgnoreTokenSet;
     SearchParameter                 parameter;
+
+    BreakerRef breaker=searchParameter.GetBreaker();
 
     parameter.searchForLocation=true;
     parameter.searchForPOI=false;
@@ -2026,6 +2093,10 @@ namespace osmscout {
                                                 regionSearchPatterns);
 
     locationIndex->VisitAdminRegions(adminRegionVisitor);
+    if (searchParameter.IsAborted()){
+      osmscout::log.Debug() << "Search aborted";
+      return true;
+    }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
       //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
@@ -2048,7 +2119,8 @@ namespace osmscout {
                                      searchParameter.GetAddressSearchString(),
                                      regionMatch,
                                      LocationSearchResult::match,
-                                     result);
+                                     result,
+                                     breaker);
 
         if (result.results.size()==currentResultSize &&
             searchParameter.GetPartialMatch()) {
@@ -2083,7 +2155,8 @@ namespace osmscout {
                                      searchParameter.GetAddressSearchString(),
                                      regionMatch,
                                      LocationSearchResult::candidate,
-                                     result);
+                                     result,
+                                     breaker);
 
         if (result.results.size()==currentResultSize &&
             searchParameter.GetPartialMatch()) {
@@ -2109,6 +2182,8 @@ namespace osmscout {
     LocationIndexRef                locationIndex=database->GetLocationIndex();
     std::unordered_set<std::string> regionIgnoreTokenSet;
     SearchParameter                 parameter;
+
+    BreakerRef breaker=searchParameter.GetBreaker();
 
     parameter.searchForLocation=false;
     parameter.searchForPOI=true;
@@ -2147,6 +2222,10 @@ namespace osmscout {
                                                 regionSearchPatterns);
 
     locationIndex->VisitAdminRegions(adminRegionVisitor);
+    if (searchParameter.IsAborted()){
+      osmscout::log.Debug() << "Search aborted";
+      return true;
+    }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
       //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
@@ -2165,7 +2244,8 @@ namespace osmscout {
                               searchParameter.GetPOISearchString(),
                               regionMatch,
                               LocationSearchResult::match,
-                              result);
+                              result,
+                              breaker);
 
         if (result.results.size()==currentResultSize) {
           // If we have not found any result for the given search entry, we create one for the "upper" object
@@ -2195,7 +2275,8 @@ namespace osmscout {
                               searchParameter.GetPOISearchString(),
                               regionMatch,
                               LocationSearchResult::candidate,
-                              result);
+                              result,
+                              breaker);
 
         if (result.results.size()==currentResultSize) {
           // If we have not found any result for the given search entry, we create one for the "upper" object


### PR DESCRIPTION
Hi. 

I tried to measure impact of often check of breaker state (on slow ARM cpu). Difference was less then 1%, so we can add it without worry...

This MR adds breaker to all search types (`LocationStringSearchParameter`, `LocationFormSearchParameter`, `POIFormSearchParameter`) and to all visitors used for search.
