### PR TITLE
Fix location object bbox

### DIFF
--- a/libosmscout-client-qt/include/osmscout/SearchModule.h
+++ b/libosmscout-client-qt/include/osmscout/SearchModule.h
@@ -103,6 +103,12 @@ private:
                         QString &typeName,
                         osmscout::GeoCoord& coordinates,
                         osmscout::GeoBox& bbox);
+
+  bool GetObjectDetails(DBInstanceRef db,
+                        const std::vector<osmscout::ObjectFileRef>& objects,
+                        QString &typeName,
+                        osmscout::GeoCoord& coordinates,
+                        osmscout::GeoBox& bbox);
 };
 
 #endif /* OSMSCOUT_CLIENT_QT_SEARCHMODULE_H */

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -285,7 +285,7 @@ bool SearchModule::BuildLocationEntry(const osmscout::LocationSearchResult::Entr
              entry.location) {
 
       QString loc=QString::fromUtf8(entry.location->name.c_str());
-      if (!GetObjectDetails(db, entry.location->objects.front(), objectType, coordinates, bbox)){
+      if (!GetObjectDetails(db, entry.location->objects, objectType, coordinates, bbox)){
         return false;
       }
 
@@ -356,37 +356,58 @@ bool SearchModule::GetObjectDetails(DBInstanceRef db,
                                     const osmscout::ObjectFileRef& object,
                                     QString &typeName,
                                     osmscout::GeoCoord& coordinates,
-                                    osmscout::GeoBox& bbox
-                                    )
+                                    osmscout::GeoBox& bbox) {
+
+  std::vector<osmscout::ObjectFileRef> objects;
+  objects.push_back(object);
+  return GetObjectDetails(db,objects,typeName,coordinates,bbox);
+}
+
+bool SearchModule::GetObjectDetails(DBInstanceRef db,
+                                    const std::vector<osmscout::ObjectFileRef>& objects,
+                                    QString &typeName,
+                                    osmscout::GeoCoord& coordinates,
+                                    osmscout::GeoBox& bbox)
 {
-    if (object.GetType()==osmscout::RefType::refNode) {
+  osmscout::GeoBox tmpBox;
+  for (const osmscout::ObjectFileRef& object:objects) {
+    if (!object.Valid()){
+      continue;
+    }
+    if (object.GetType() == osmscout::RefType::refNode) {
       osmscout::NodeRef node;
 
       if (!db->database->GetNodeByOffset(object.GetFileOffset(), node)) {
         return false;
       }
-      typeName = QString::fromUtf8(node->GetType()->GetName().c_str());
-      coordinates = node->GetCoords();
-      bbox = osmscout::GeoBox::BoxByCenterAndRadius(coordinates, 2.0);
-    }
-    else if (object.GetType()==osmscout::RefType::refArea) {
+      if (typeName.isEmpty()) {
+        typeName = QString::fromUtf8(node->GetType()->GetName().c_str());
+      }
+
+      bbox.Include(osmscout::GeoBox::BoxByCenterAndRadius(coordinates, 2.0));
+    } else if (object.GetType() == osmscout::RefType::refArea) {
       osmscout::AreaRef area;
 
       if (!db->database->GetAreaByOffset(object.GetFileOffset(), area)) {
         return false;
       }
-      typeName = QString::fromUtf8(area->GetType()->GetName().c_str());
-      area->GetCenter(coordinates);
-      area->GetBoundingBox(bbox);
-    }
-    else if (object.GetType()==osmscout::RefType::refWay) {
+      if (typeName.isEmpty()) {
+        typeName = QString::fromUtf8(area->GetType()->GetName().c_str());
+      }
+      area->GetBoundingBox(tmpBox);
+      bbox.Include(tmpBox);
+    } else if (object.GetType() == osmscout::RefType::refWay) {
       osmscout::WayRef way;
       if (!db->database->GetWayByOffset(object.GetFileOffset(), way)) {
         return false;
       }
-      typeName = QString::fromUtf8(way->GetType()->GetName().c_str());
-      way->GetCenter(coordinates);
-      way->GetBoundingBox(bbox);
+      if (typeName.isEmpty()) {
+        typeName = QString::fromUtf8(way->GetType()->GetName().c_str());
+      }
+      way->GetBoundingBox(tmpBox);
+      bbox.Include(tmpBox);
     }
-    return true;
+  }
+  coordinates=bbox.GetCenter();
+  return true;
 }

--- a/libosmscout/src/osmscout/util/GeoBox.cpp
+++ b/libosmscout/src/osmscout/util/GeoBox.cpp
@@ -67,8 +67,15 @@ namespace osmscout {
    */
   void GeoBox::Include(const GeoBox& other)
   {
-    assert(valid);
-    assert(other.valid);
+    if (!other.valid){
+      return;
+    }
+    if(!valid){
+      minCoord=other.GetMinCoord();
+      maxCoord=other.GetMaxCoord();
+      valid=true;
+      return;
+    }
 
     minCoord.Set(std::min(minCoord.GetLat(),
                           other.GetMinCoord().GetLat()),


### PR DESCRIPTION
Hi

 - I allow to call `GeoBox::Include` even for invalid GeoBoxes
 - fix bounding box for Qt `LocationObject` when it has more references (street with multiple segments)