### PR TITLE
qt search module: fix position of LocationEntry with node references

### DIFF
--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -384,7 +384,7 @@ bool SearchModule::GetObjectDetails(DBInstanceRef db,
         typeName = QString::fromUtf8(node->GetType()->GetName().c_str());
       }
 
-      bbox.Include(osmscout::GeoBox::BoxByCenterAndRadius(coordinates, 2.0));
+      bbox.Include(osmscout::GeoBox::BoxByCenterAndRadius(node->GetCoords(), 2.0));
     } else if (object.GetType() == osmscout::RefType::refArea) {
       osmscout::AreaRef area;
 


### PR DESCRIPTION
fix for bug that I created in recent MR