### PR TITLE
Plane Qt renderer: round target rectangle possition and size to avoid extra antialisign

### DIFF
--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -205,6 +205,21 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
     painter.translate(rotationCenter*-1.0);
   }
 
+  // After our computations with float numbers, target rectangle is not aligned to pixel.
+  // It leads to additional anti-aliasing that blurs output...
+  double absDiff=abs((targetRectangle.x()-targetTopLeftX) - sourceRectangle.x()) +
+                 abs((targetRectangle.y()-targetTopLeftY) - sourceRectangle.y()) +
+                 abs(targetRectangle.width()              - sourceRectangle.width()) +
+                 abs(targetRectangle.height()             - sourceRectangle.height());
+
+  // ...for that reason, when rectangles are (almost) the same,
+  // round target position to get better output
+  if (absDiff < 1e-3){
+    targetRectangle.setX(sourceRectangle.x() + round(targetTopLeftX));
+    targetRectangle.setY(sourceRectangle.y() + round(targetTopLeftY));
+    targetRectangle.setSize(sourceRectangle.size());
+  }
+
   painter.drawImage(targetRectangle,
                     *finishedImage,
                     sourceRectangle);

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -214,7 +214,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
 
   // ...for that reason, when rectangles are (almost) the same,
   // round target position to get better output
-  if (absDiff < 1e-3){
+  if (absDiff < 1e-3 && finalImgProjection.GetAngle()==requestProjection.GetAngle()){
     targetRectangle.setX(sourceRectangle.x() + round(targetTopLeftX));
     targetRectangle.setY(sourceRectangle.y() + round(targetTopLeftY));
     targetRectangle.setSize(sourceRectangle.size());


### PR DESCRIPTION
This patch was initialised by @aquiles2k , it round position of rendered `finishedImage` to avoid additional antialiasign. Difference is small, but visible.