### PR TITLE
fix abs method resolution issue with gcc 6 (use full std::abs name)

### DIFF
--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -402,7 +402,7 @@ bool MoveHandler::rotateTo(double angle)
     targetMagnification = view.magnification;
 
     targetAngle = angle;
-    if (abs(targetAngle-view.angle)>M_PI){
+    if (std::abs(targetAngle-view.angle)>M_PI){
         targetAngle+=2*M_PI;
     }
 

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -19,8 +19,9 @@
  */
 
 #include <osmscout/PlaneMapRenderer.h>
-
 #include <osmscout/OSMTile.h>
+
+#include <osmscout/system/Math.h>
 
 // uncomment or define by compiler parameter to render various debug marks
 // #define DRAW_DEBUG
@@ -207,10 +208,10 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
 
   // After our computations with float numbers, target rectangle is not aligned to pixel.
   // It leads to additional anti-aliasing that blurs output...
-  double absDiff=abs((targetRectangle.x()-targetTopLeftX) - sourceRectangle.x()) +
-                 abs((targetRectangle.y()-targetTopLeftY) - sourceRectangle.y()) +
-                 abs(targetRectangle.width()              - sourceRectangle.width()) +
-                 abs(targetRectangle.height()             - sourceRectangle.height());
+  double absDiff=std::abs((targetRectangle.x()-targetTopLeftX) - sourceRectangle.x()) +
+                 std::abs((targetRectangle.y()-targetTopLeftY) - sourceRectangle.y()) +
+                 std::abs(targetRectangle.width()              - sourceRectangle.width()) +
+                 std::abs(targetRectangle.height()             - sourceRectangle.height());
 
   // ...for that reason, when rectangles are (almost) the same,
   // round target position to get better output

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -22,6 +22,8 @@
 #include <osmscout/DBThread.h>
 #include <osmscout/OSMTile.h>
 
+#include <osmscout/system/Math.h>
+
 // uncomment or define by compiler parameter to render various debug marks
 // #define DRAW_DEBUG
 
@@ -45,8 +47,8 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
     double cosBeta=cos(M_PI_2 - request.angle);
     double rw=request.width;
     double rh=request.height;
-    height=abs(rw*cosBeta)+abs(rh*cosAlpha);
-    width=abs(rw*cosAlpha)+abs(rh*cosBeta);
+    height=std::abs(rw*cosBeta)+std::abs(rh*cosAlpha);
+    width=std::abs(rw*cosAlpha)+std::abs(rh*cosBeta);
     if (request.angle>0 && request.angle<=M_PI_2) {
       translateVector.setY(cosBeta*rw*-1);
     } else if (request.angle<=M_PI) {


### PR DESCRIPTION
should fix https://github.com/Framstag/libosmscout/issues/539
verified in Debian Stretch docker image