### PR TITLE
use deleteLater for object living in its own thread

### DIFF
--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -100,7 +100,8 @@ TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
 TiledMapOverlay::~TiledMapOverlay()
 {
   if (loader!=NULL){
-    delete loader;
+    loader->deleteLater();
+    loader=NULL;
   }
 }
 


### PR DESCRIPTION
It fixes SIGSEGV in OverlayTileLoader thread when TiledMapOverlay
is destroyed and some tile is still downloading...