### PR TITLE
Stylesheet and StyleEditor improvements

### DIFF
--- a/StyleEditor/CMakeLists.txt
+++ b/StyleEditor/CMakeLists.txt
@@ -28,30 +28,32 @@ set(HEADER_FILES
 	src/Highlighter.h
 	src/MainWindow.h
 	src/SettingsDialog.h
-)
+	src/StyleAnalyser.h
+	)
 
 set(SOURCE_FILES
-  src/FileIO.cpp
-  src/Highlighter.cpp
-  src/MainWindow.cpp
-  src/SettingsDialog.cpp
-  src/StyleEditor.cpp
+	src/FileIO.cpp
+	src/Highlighter.cpp
+	src/MainWindow.cpp
+	src/SettingsDialog.cpp
+	src/StyleEditor.cpp
+	src/StyleAnalyser.cpp
 
-  # qml files in CMake sources make it visible in QtCreator
-  qml/AboutDialog.qml
-  qml/main.qml
-  qml/settings.qml
-  qml/SearchGeocodeDialog.qml
-  qml/TextEditor.qml
-  qml/custom/LocationEdit.qml
-  qml/custom/MapDialog.qml
-  qml/custom/ScrollIndicator.qml
-  qml/custom/LineEdit.qml
-  qml/custom/DialogActionButton.qml
-  qml/custom/MapButton.qml
-  qml/SearchLocationDialog.qml
-  qml/MapControl.qml
-)
+	# qml files in CMake sources make it visible in QtCreator
+	qml/AboutDialog.qml
+	qml/main.qml
+	qml/settings.qml
+	qml/SearchGeocodeDialog.qml
+	qml/TextEditor.qml
+	qml/custom/LocationEdit.qml
+	qml/custom/MapDialog.qml
+	qml/custom/ScrollIndicator.qml
+	qml/custom/LineEdit.qml
+	qml/custom/DialogActionButton.qml
+	qml/custom/MapButton.qml
+	qml/SearchLocationDialog.qml
+	qml/MapControl.qml
+	)
 
 set(RESOURCE_FILES
     StyleEditor.qrc

--- a/StyleEditor/meson.build
+++ b/StyleEditor/meson.build
@@ -3,12 +3,19 @@ styleeditorSrc = [
   'src/SettingsDialog.cpp',
   'src/FileIO.cpp',
   'src/Highlighter.cpp',
-  'src/StyleEditor.cpp'
+  'src/StyleEditor.cpp',
+  'src/StyleAnalyser.cpp'
 ]
 
 styleeditorIncDir = include_directories('src')
 
-styleeditorMocs = qt5.preprocess(moc_headers : ['src/MainWindow.h','src/SettingsDialog.h', 'src/FileIO.h','src/Highlighter.h'],
+styleeditorMocs = qt5.preprocess(moc_headers : [
+                                    'src/MainWindow.h',
+                                    'src/SettingsDialog.h',
+                                    'src/FileIO.h',
+                                    'src/Highlighter.h',
+                                    'src/StyleAnalyser.h'
+                                    ],
                                  qresources: ['StyleEditor.qrc'])
 
 OSMScout2 = executable('StyleEditor',

--- a/StyleEditor/meson.build
+++ b/StyleEditor/meson.build
@@ -24,6 +24,6 @@ OSMScout2 = executable('StyleEditor',
                        cpp_args: ['-fPIC'],
                        include_directories: [styleeditorIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
                        dependencies: [mathDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep],
-                       link_with: [osmscoutclientqt, osmscout],
+                       link_with: [osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
                        install: true)
 

--- a/StyleEditor/qml/TextEditor.qml
+++ b/StyleEditor/qml/TextEditor.qml
@@ -191,6 +191,7 @@ Rectangle {
             textArea.cursorPosition=0
             textArea.forceActiveFocus()
         }
+
         Component.onCompleted: {
             read();
         }

--- a/StyleEditor/qml/TextEditor.qml
+++ b/StyleEditor/qml/TextEditor.qml
@@ -191,6 +191,9 @@ Rectangle {
             textArea.cursorPosition=0
             textArea.forceActiveFocus()
         }
+        Component.onCompleted: {
+            read();
+        }
     }
 
 }

--- a/StyleEditor/qml/main.qml
+++ b/StyleEditor/qml/main.qml
@@ -16,7 +16,14 @@ ApplicationWindow {
         Menu {
             title: "File"
             MenuItem { text: "Open..." }
-            MenuItem { text: "Close" }
+            MenuItem {
+                text: "Close"
+                action: Action {
+                    onTriggered: {
+                        mainWindow.close();
+                    }
+                }
+            }
         }
 
         Menu {

--- a/StyleEditor/src/FileIO.cpp
+++ b/StyleEditor/src/FileIO.cpp
@@ -18,61 +18,86 @@
  */
 
 #include "FileIO.h"
+
+#include <osmscout/OSMScoutQt.h>
+
 #include <QFile>
 #include <QTextStream>
 
 FileIO::FileIO(QObject *parent) :
-    QObject(parent),m_source(QString("")),m_target(0)
+    QObject(parent),styleSheetFile(QString("")),targetComponent(0),
+    highlighter(nullptr), styleAnalyser(nullptr)
 {
 
 }
 
+FileIO::~FileIO()
+{
+  stopAnalyser();
+}
+
+void FileIO::stopAnalyser()
+{
+  if (styleAnalyser){
+    styleAnalyser->deleteLater();
+    styleAnalyser=nullptr;
+  }
+}
+
 void FileIO::read()
 {
-    if (m_source.isEmpty()){
+    if (styleSheetFile.isEmpty()){
         emit error("source is empty");
         return;
-    } else if (m_target == 0){
+    } else if (targetComponent == 0){
         emit error("target is not set");
         return;
     }
 
-    QFile file(m_source);
+    QFile file(styleSheetFile);
     if ( file.open(QIODevice::ReadOnly) ) {
         QString line;
         QTextStream t( &file );
-        QVariant length = m_target->property("length");
+        QVariant length = targetComponent->property("length");
         QVariant returnedValue;
 
         if(length>0){
-            QMetaObject::invokeMethod(m_target, "remove",
+            QMetaObject::invokeMethod(targetComponent, "remove",
                                       Q_RETURN_ARG(QVariant, returnedValue),
                                       Q_ARG(QVariant, QVariant(0)),
                                       Q_ARG(QVariant, length));
-            m_lineOffsets.clear();
-            m_lineOffsets.push_back(1);
+            lineOffsets.clear();
+            lineOffsets.push_back(1);
         }
         do {
             line = t.readLine();
             line.replace("\t","        ");
-            m_lineOffsets.push_back(line.length()+1);
+            lineOffsets.push_back(line.length()+1);
             line.replace("<","&lt;").replace(">","&gt;").replace(" ","&nbsp;");
-            QMetaObject::invokeMethod(m_target, "append",
+            QMetaObject::invokeMethod(targetComponent, "append",
                                       Q_RETURN_ARG(QVariant, returnedValue),
                                       Q_ARG(QVariant, QVariant(line)));
         } while (!t.atEnd());
 
         file.close();
-        QVariant doc = m_target->property("textDocument");
-        if (doc.canConvert<QQuickTextDocument*>()) {
-            QQuickTextDocument *qqdoc = doc.value<QQuickTextDocument*>();
-            if (qqdoc)
-                m_doc = qqdoc->textDocument();
-            m_highlighter = new Highlighter(m_doc);
-            m_highlighter->setStyle(12);
+        QVariant docComponent = targetComponent->property("textDocument");
+        if (docComponent.canConvert<QQuickTextDocument*>()) {
+            QQuickTextDocument *qqdoc = docComponent.value<QQuickTextDocument*>();
+            if (qqdoc) {
+              doc = qqdoc->textDocument();
+            }
+
+            stopAnalyser();
+            highlighter = new Highlighter(doc);
+            highlighter->setStyle(12);
+
+            QThread *analyserThread = OSMScoutQt::GetInstance().makeThread("StyleAnalyser");
+            styleAnalyser = new StyleAnalyser(analyserThread, doc, highlighter);
+            styleAnalyser->moveToThread(analyserThread);
+            analyserThread->start();
         }
-        if (m_doc) {
-            m_doc->setModified(false);
+        if (doc) {
+            doc->setModified(false);
         }
     } else {
         emit error("Unable to open the file");
@@ -82,9 +107,9 @@ void FileIO::read()
 
 QString FileIO::getTargetContent()
 {
-    QVariant length = m_target->property("length");
+    QVariant length = targetComponent->property("length");
     QVariant returnedValue;
-    QMetaObject::invokeMethod(m_target, "getText",
+    QMetaObject::invokeMethod(targetComponent, "getText",
                               Q_RETURN_ARG(QVariant, returnedValue),
                               Q_ARG(QVariant, QVariant(0)),
                               Q_ARG(QVariant, length));
@@ -95,12 +120,12 @@ QString FileIO::getTargetContent()
 
 bool FileIO::isModified()
 {
-    return m_doc && m_doc->isModified();
+    return doc && doc->isModified();
 }
 
 bool FileIO::write(const QString &fileName)
 {
-    if (m_target == 0){
+    if (targetComponent == 0){
         return false;
     }
 
@@ -114,38 +139,37 @@ bool FileIO::write(const QString &fileName)
 
     file.close();
 
-    if (m_doc) {
-        m_doc->setModified(false);
+    if (doc) {
+        doc->setModified(false);
     }
-
     return true;
 }
 
 bool FileIO::write()
 {
-    if (m_source.isEmpty()){
+    if (styleSheetFile.isEmpty()){
         return false;
     }
-    return write(m_source);
+    return write(styleSheetFile);
 }
 
 bool FileIO::writeTmp()
 {
-    if (m_source.isEmpty()){
+    if (styleSheetFile.isEmpty()){
         return false;
     }
-    return write(m_source+TMP_SUFFIX);
+    return write(styleSheetFile+TMP_SUFFIX);
 }
 
 void FileIO::setTarget(QQuickItem *target)
 {
-    m_doc = 0;
-    m_highlighter = 0;
-    if(m_target == target){
+    doc = 0;
+    stopAnalyser();
+    if(targetComponent == target){
         return;
     }
-    m_target = target;
-    if (!m_target || m_source.isEmpty())
+    targetComponent = target;
+    if (!targetComponent || styleSheetFile.isEmpty())
         return;
 
     emit targetChanged();
@@ -154,8 +178,8 @@ void FileIO::setTarget(QQuickItem *target)
 int FileIO::lineOffset(int l)
 {
     int s = 0;
-    for(int i=0; i<std::min(l, m_lineOffsets.count()); i++){
-        s += m_lineOffsets[i];
+    for(int i=0; i<std::min(l, lineOffsets.count()); i++){
+        s += lineOffsets[i];
     }
     return s;
 }

--- a/StyleEditor/src/FileIO.h
+++ b/StyleEditor/src/FileIO.h
@@ -42,6 +42,12 @@ public:
     Q_INVOKABLE bool writeTmp();
     Q_INVOKABLE int lineOffset(int l);
 
+    /**
+     * Check if content of file match with content of target
+     * @return true if content in target was changed
+     */
+    Q_INVOKABLE bool isModified();
+
     QQuickItem *target() { return m_target; }
     void setTarget(QQuickItem *target);
 
@@ -62,6 +68,7 @@ signals:
 
 private:
     bool write(const QString &filename);
+    QString getTargetContent();
 
     QString m_source;
     QQuickItem *m_target;

--- a/StyleEditor/src/FileIO.h
+++ b/StyleEditor/src/FileIO.h
@@ -26,6 +26,7 @@
 #include <QVector>
 
 #include "Highlighter.h"
+#include "StyleAnalyser.h"
 
 #define TMP_SUFFIX ".tmp"
 
@@ -36,6 +37,7 @@ public:
     Q_PROPERTY(QQuickItem *target READ target WRITE setTarget NOTIFY targetChanged)
     Q_PROPERTY(QString source READ source WRITE setSource NOTIFY sourceChanged)
     explicit FileIO(QObject *parent = 0);
+    ~FileIO();
 
     Q_INVOKABLE bool write();
     Q_INVOKABLE void read();
@@ -48,14 +50,14 @@ public:
      */
     Q_INVOKABLE bool isModified();
 
-    QQuickItem *target() { return m_target; }
+    QQuickItem *target() { return targetComponent; }
     void setTarget(QQuickItem *target);
 
-    QString source() { return m_source; }
+    QString source() { return styleSheetFile; }
     void setSource(const QString& source) {
-        if(m_source != source){
-            m_source = source;
-            emit sourceChanged(m_source);
+        if(styleSheetFile != source){
+            styleSheetFile = source;
+            emit sourceChanged(styleSheetFile);
         }
     }
 
@@ -67,14 +69,16 @@ signals:
     void error(const QString& msg);
 
 private:
+    void stopAnalyser();
     bool write(const QString &filename);
     QString getTargetContent();
 
-    QString m_source;
-    QQuickItem *m_target;
-    QTextDocument *m_doc;
-    Highlighter *m_highlighter;
-    QVector<int> m_lineOffsets;
+    QString styleSheetFile;
+    QQuickItem *targetComponent;
+    QTextDocument *doc;
+    Highlighter *highlighter;
+    StyleAnalyser *styleAnalyser;
+    QVector<int> lineOffsets;
 };
 
 #endif // FILEIO_H

--- a/StyleEditor/src/Highlighter.h
+++ b/StyleEditor/src/Highlighter.h
@@ -25,6 +25,8 @@
 #include <QHash>
 #include <QTextCharFormat>
 
+#include <QtQuick/QQuickItem>
+
 class QTextDocument;
 
 class Highlighter : public QSyntaxHighlighter
@@ -34,7 +36,12 @@ class Highlighter : public QSyntaxHighlighter
 public:
     Highlighter(QTextDocument *parent = 0);
 
+    virtual ~Highlighter(){};
+
     void setStyle(qreal m_baseFontPointSize);
+
+public slots:
+    void onProblematicLines(QSet<int> errorLines, QSet<int> warningLines);
 
 protected:
     void highlightBlock(const QString &text);
@@ -67,6 +74,12 @@ private:
     QTextCharFormat kwONEWAYFormat;
     QTextCharFormat commentsFormat;
     QTextCharFormat multiLineCommentFormat;
+
+    QTextCharFormat errorFormat;
+    QTextCharFormat warningFormat;
+
+    QSet<int> errorLines;
+    QSet<int> warningLines;
 };
 
 #endif

--- a/StyleEditor/src/StyleAnalyser.cpp
+++ b/StyleEditor/src/StyleAnalyser.cpp
@@ -1,0 +1,98 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2018 Lukas Karas
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "StyleAnalyser.h"
+
+#include <osmscout/DBThread.h>
+#include <osmscout/OSMScoutQt.h>
+
+osmscout::TypeConfigRef getTypeConfig()
+{
+  osmscout::TypeConfigRef typeConfig;
+  OSMScoutQt::GetInstance().GetDBThread()->RunSynchronousJob(
+      [&typeConfig](const std::list<DBInstanceRef>& databases) {
+        for (auto &db:databases) {
+          if (db->database && db->database->IsOpen() && db->database->GetTypeConfig()){
+            typeConfig = db->database->GetTypeConfig();
+            return;
+          }
+        }
+      }
+  );
+  return typeConfig;
+}
+
+
+StyleAnalyser::StyleAnalyser(QThread *thread,
+                             QTextDocument *doc,
+                             Highlighter *highlighter):
+    thread(thread), typeConfig(getTypeConfig()), doc(doc), highlighter(highlighter)
+{
+  if (typeConfig) {
+    connect(doc, SIGNAL(contentsChanged()),
+            this, SLOT(onContentsChanged()));
+
+    connect(this, SIGNAL(updateRequest(QString)),
+            this, SLOT(update(QString)),
+            Qt::QueuedConnection);
+
+    connect(this, SIGNAL(problematicLines(QSet<int>, QSet<int>)),
+            highlighter, SLOT(onProblematicLines(QSet<int>, QSet<int>)),
+            Qt::QueuedConnection);
+
+    onContentsChanged();
+  }
+}
+
+StyleAnalyser::~StyleAnalyser()
+{
+  thread->quit();
+}
+
+void StyleAnalyser::onContentsChanged()
+{
+  QString content = doc->toPlainText();
+  if (content == lastContent) {
+    return;
+  }
+  lastContent = content;
+  emit updateRequest(content);
+}
+
+void StyleAnalyser::update(QString content)
+{
+  osmscout::StyleConfigRef styleConfig=std::make_shared<osmscout::StyleConfig>(typeConfig);
+  styleConfig->LoadContent(content.toStdString());
+
+  QSet<int> errorLines;
+  QSet<int> warningLines;
+  int line;
+  for (auto &w: styleConfig->GetWarnings()) {
+    // TODO: expose warning as some structure with line number
+    osmscout::StringToNumberSigned(w, line);
+    warningLines << line;
+  }
+  for (auto &w: styleConfig->GetErrors()) {
+    // TODO: expose warning as some structure with line number
+    osmscout::StringToNumberSigned(w, line);
+    errorLines << line;
+  }
+
+  emit problematicLines(errorLines, warningLines);
+}

--- a/StyleEditor/src/StyleAnalyser.h
+++ b/StyleEditor/src/StyleAnalyser.h
@@ -1,0 +1,61 @@
+#ifndef LIBOSMSCOUT_STYLEANALYSER_H
+#define LIBOSMSCOUT_STYLEANALYSER_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2018 Lukas Karas
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "Highlighter.h"
+
+#include <osmscout/TypeConfig.h>
+
+#include <QObject>
+#include <QSet>
+#include <QTextDocument>
+
+class StyleAnalyser : public QObject
+{
+  Q_OBJECT
+
+signals:
+  void problematicLines(QSet<int> errorLines, QSet<int> warningLines);
+  void updateRequest(QString content);
+
+public slots:
+  void onContentsChanged();
+
+private slots:
+  void update(QString content);
+
+public:
+  StyleAnalyser(QThread *thread,
+                   QTextDocument *doc,
+                   Highlighter *highlighter);
+  virtual ~StyleAnalyser();
+
+private:
+  QThread *thread;
+  osmscout::TypeConfigRef typeConfig;
+  QTextDocument *doc;
+  Highlighter *highlighter;
+  QString lastContent;
+};
+
+
+
+#endif //LIBOSMSCOUT_STYLEANALYSER_H

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -50,6 +50,7 @@ int main(int argc, char* argv[])
   // register OSMScout library QML types
   OSMScoutQt::RegisterQmlTypes();
 
+  qRegisterMetaType<QSet<int>>("QSet<int>");
   qmlRegisterType<FileIO, 1>("FileIO", 1, 0, "FileIO");
 
   OSMScoutQtBuilder builder=OSMScoutQt::NewInstance();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -330,8 +330,21 @@ if(${OSMSCOUT_BUILD_MAP})
   else()
     target_link_libraries(OSTAndOSSCheck osmscout osmscout_map)
   endif()
-  add_test(NAME OSTAndOSSCheck COMMAND OSTAndOSSCheck)
-  set_tests_properties(OSTAndOSSCheck PROPERTIES ENVIRONMENT TESTS_TOP_DIR=${CMAKE_CURRENT_SOURCE_DIR})
+
+  set(STYLESHEETS
+          standard.oss
+          winter-sports.oss
+          boundaries.oss
+          railways.oss
+          motorways.oss)
+
+  foreach(STYLESHEET ${STYLESHEETS})
+    add_test(NAME CheckStyleSheet-${STYLESHEET}
+            COMMAND OSTAndOSSCheck
+              --warning-as-error
+              ${CMAKE_CURRENT_SOURCE_DIR}/../stylesheets/map.ost
+              ${CMAKE_CURRENT_SOURCE_DIR}/../stylesheets/${STYLESHEET})
+  endforeach()
 else()
-    message("Skip MapRotate test libosmscout-map, is missing.")
+    message("Skip OSTAndOSSCheck test libosmscout-map, is missing.")
 endif()

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -232,9 +232,24 @@ test('Check impl. of geometric functions', Geometry)
 test('Check LocationService', LocationServiceTest, env: ostandossEnv)
 test('Check rotation of maps', MapRotate)
 test('Check correctness of NumberSet class', NumberSet)
-test('Check standard OST and OSS files', OSTAndOSSCheck, env: ostandossEnv)
 test('Check scan conversion code', ScanConversion)
 test('Check tiling calculation code', TilingTest)
 test('Check polygon transformation code', TransPolygon)
 test('Check implementation of work queue', WorkQueue)
 test('Check WString<=>String conversion code', WStringStringConversion)
+
+stylesheets = [
+            'standard.oss',
+            'winter-sports.oss',
+            'boundaries.oss',
+            'railways.oss',
+            'motorways.oss',
+            ]
+
+foreach stylesheet : stylesheets
+    test('Check OST and OSS file '+stylesheet,
+            OSTAndOSSCheck,
+            args : ['--warning-as-error',
+                    meson.current_source_dir() + '/../stylesheets/map.ost',
+                    meson.current_source_dir() + '/../stylesheets/' + stylesheet])
+endforeach

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -570,6 +570,7 @@ namespace osmscout {
     std::unordered_map<std::string,bool>       flags;
     std::unordered_map<std::string,StyleConstantRef> constants;
     std::list<std::string>                     errors;
+    std::list<std::string>                     warnings;
 
   private:
     void Reset();
@@ -746,6 +747,7 @@ namespace osmscout {
     //@{
     bool Load(const std::string& styleFile);
     const std::list<std::string>&  GetErrors();
+    const std::list<std::string>&  GetWarnings();
     //@}
   };
 

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -745,6 +745,7 @@ namespace osmscout {
      * Methods for loading a concrete OSS style sheet
      */
     //@{
+    bool LoadContent(const std::string& content);
     bool Load(const std::string& styleFile);
     const std::list<std::string>&  GetErrors();
     const std::list<std::string>&  GetWarnings();

--- a/libosmscout-map/src/osmscout/StyleConfig.cpp
+++ b/libosmscout-map/src/osmscout/StyleConfig.cpp
@@ -1491,24 +1491,24 @@ namespace osmscout {
       success=!parser->errors->hasErrors;
 
       errors.clear();
-      if (!success) {
-        for (const auto& err : parser->errors->errors) {
-          switch(err.type) {
-          case oss::Errors::Err::Symbol:
-            errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Symbol:")+err.text);
-            break;
-          case oss::Errors::Err::Error:
-            errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Error:")+err.text);
-            break;
-          case oss::Errors::Err::Warning:
-            errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Warning:")+err.text);
-            break;
-          case oss::Errors::Err::Exception:
-            errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Exception:")+err.text);
-            break;
-          default:
-            break;
-          }
+      warnings.clear();
+
+      for (const auto& err : parser->errors->errors) {
+        switch(err.type) {
+        case oss::Errors::Err::Symbol:
+          errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Symbol:")+err.text);
+          break;
+        case oss::Errors::Err::Error:
+          errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Error:")+err.text);
+          break;
+        case oss::Errors::Err::Warning:
+          warnings.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Warning:")+err.text);
+          break;
+        case oss::Errors::Err::Exception:
+          errors.push_back(std::to_string(err.line)+","+std::to_string(err.column)+std::string(" Exception:")+err.text);
+          break;
+        default:
+          break;
         }
       }
 
@@ -1531,5 +1531,10 @@ namespace osmscout {
   const std::list<std::string>& StyleConfig::GetErrors()
   {
     return errors;
+  }
+
+  const std::list<std::string>& StyleConfig::GetWarnings()
+  {
+    return warnings;
   }
 }


### PR DESCRIPTION
Hi. There are various improvements for StyleConfig: 
 - expose list of style warnings (style for type nonexistent in TypeConfig)
 - it is possible to load style config from memory bufffer

stylesheet tests:
 - list of tested style files is stored in CMakeLists, not in binary
 - test may fail optionally when style contains warnings

and StyleEditor:
 - there is highlighting for errors and warning
 - when window is closing and there is some unsaved change, there is a new dialog that ask what to do