### PR TITLE
allow to route by foot on cycleway

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -345,7 +345,7 @@ TYPES
   TYPE highway_cycleway
     = WAY ("highway"=="cycleway")
       {Name, NameAlt}
-      PATH[BICYCLE] PIN_WAY
+      PATH[FOOT BICYCLE] PIN_WAY
       DESC
         en: "cycleway"
         de: "Fahradweg"


### PR DESCRIPTION
When I was experimenting with router in terrain, it plans the foot route by detour. But there was a shorter alternative by cycleway. It is allowed to go on cycleway in Czechia, but when I am looking to [OSM wiki](https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions) it is forbidden in many countries. 

Should we allow it in router, or make it more complicated and create separated type (when permit is explicit)? How to handle country specific defaults? ...it is just minor problem, I don't want to create any country specific table ;-)