### PR TITLE
Improve Qt map management

### DIFF
--- a/OSMScout2/qml/MapDownloadDialog.qml
+++ b/OSMScout2/qml/MapDownloadDialog.qml
@@ -162,8 +162,10 @@ MapDialog {
                 width: 30
             }
             TableViewColumn {
-                role: "progressDescription"
                 title: "Downloading"
+                delegate: Text {
+                    text: (model!=null) ? (model.errorString!="" ? model.errorString : model.progressDescription) : ""
+                }
                 width: 100
             }
             TableViewColumn {

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -47,7 +47,11 @@ public:
   enum Type { Plain=0, BZ2=1 };
 
 public:
-  explicit FileDownloader(QNetworkAccessManager *manager, QString url, QString path, const Type mode = Plain, QObject *parent = 0);
+  explicit FileDownloader(QNetworkAccessManager *manager,
+                          QString url,
+                          QString path,
+                          const Type mode = Plain,
+                          QObject *parent = 0);
   ~FileDownloader();
 
   operator bool() const { return m_isok; }
@@ -59,7 +63,7 @@ signals:
   void downloadedBytes(uint64_t sz);
   void writtenBytes(uint64_t sz);
   void finished(QString path);
-  void error(QString error_text);
+  void error(QString error_text, bool recoverable);
 
 public slots:
   void startDownload();

--- a/libosmscout-client-qt/include/osmscout/MapDownloadsModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapDownloadsModel.h
@@ -60,6 +60,7 @@ public:
     TargetDirectoryRole = Qt::UserRole+1,
     ProgressRole = Qt::UserRole+2,
     ProgressDescriptionRole = Qt::UserRole+3,
+    ErrorStringRole = Qt::UserRole+4,
   };
 
   Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;

--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -58,14 +58,18 @@ class OSMSCOUT_CLIENT_QT_API MapDownloadJob: public QObject
 
   uint64_t                downloadedBytes;
 
+  QString                 error;
+
 signals:
   void finished();
+  void failed(QString error);
   void downloadProgress();
 
 public slots:
-  void onJobFailed(QString error_text);
+  void onJobFailed(QString errorMessage, bool recoverable);
   void onJobFinished();
   void downloadNextFile();
+  void onDownloadProgress(uint64_t);
 
 public:
   MapDownloadJob(QNetworkAccessManager *webCtrl, AvailableMapsModelMap map, QDir target);
@@ -97,6 +101,12 @@ public:
   {
     return started && !done;
   }
+
+  inline QString getError()
+  {
+    return error;
+  }
+
   double getProgress();
   QString getDownloadingFile();
 };
@@ -119,7 +129,8 @@ private:
 public slots:
   void lookupDatabases();
   void onJobFinished();
-  
+  void onJobFailed(QString errorMessage);
+
 signals:
   void mapDownloadFails(QString message);
   void databaseListChanged(QList<QDir> databaseDirectories);

--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -46,7 +46,7 @@
 class OSMSCOUT_CLIENT_QT_API MapDownloadJob: public QObject
 {
   Q_OBJECT
-  
+
   QList<FileDownloader*>  jobs;
   QNetworkAccessManager   *webCtrl;
   
@@ -60,6 +60,8 @@ class OSMSCOUT_CLIENT_QT_API MapDownloadJob: public QObject
 
   QString                 error;
 
+  bool                    replaceExisting;
+
 signals:
   void finished();
   void failed(QString error);
@@ -72,43 +74,138 @@ public slots:
   void onDownloadProgress(uint64_t);
 
 public:
-  MapDownloadJob(QNetworkAccessManager *webCtrl, AvailableMapsModelMap map, QDir target);
+  static const char* FILE_METADATA;
+
+  MapDownloadJob(QNetworkAccessManager *webCtrl, AvailableMapsModelMap map, QDir target, bool replaceExisting);
   virtual ~MapDownloadJob();
   
   void start();
 
-  inline QString getMapName()
+  inline QString getMapName() const
   {
     return map.getName();
   }
 
-  inline size_t expectedSize()
+  inline QStringList getMapPath() const
+  {
+    return map.getPath();
+  }
+
+  inline size_t expectedSize() const
   {
     return map.getSize();
   }
 
-  inline QDir getDestinationDirectory()
+  inline QDir getDestinationDirectory() const
   {
     return target;
   }
 
-  inline bool isDone()
+  inline bool isDone() const
   {
     return done;
   }
 
-  inline bool isDownloading()
+  inline bool isDownloading() const
   {
     return started && !done;
   }
 
-  inline QString getError()
+  inline QString getError() const
   {
     return error;
   }
 
+  inline bool isReplaceExisting() const
+  {
+    return replaceExisting;
+  }
+
   double getProgress();
   QString getDownloadingFile();
+};
+
+/**
+ * Holder for map database metadata
+ *
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API MapDirectory
+{
+public:
+  explicit MapDirectory(QDir dir);
+  ~MapDirectory() = default;
+
+  MapDirectory(const MapDirectory &other) = default;
+  MapDirectory &operator=(const MapDirectory &other) = default;
+
+  MapDirectory(MapDirectory &&other) = default;
+  MapDirectory &operator=(MapDirectory &&other) = default;
+
+  QDir getDir() const
+  {
+    return dir;
+  }
+
+  /**
+   * Delete complete database
+   */
+  bool deleteDatabase();
+
+  /**
+   * Check if directory contains all required files for osmscout database
+   * @return true if all requirements met and directory may be used as database
+   */
+  bool isValid() const
+  {
+    return valid;
+  }
+
+  /**
+   * Check if map directory contains metadata created by downloader
+   * @return true if map directory contains metadata
+   */
+  bool hasMetadata() const
+  {
+    return metadata;
+  }
+
+  /**
+   * Human readable name of the map. It is name of geographical region usually (eg: Germany, Czech Republic...).
+   * Name is localised by server when it is downloading. When locale is changed later, name will remain
+   * in its original locale.
+   * @return map name
+   */
+  QString getName() const
+  {
+    return name;
+  }
+
+  /**
+   * Logical path of the map, eg: europe/gemany; europe/czech-republic
+   * @return
+   */
+  QStringList getPath() const
+  {
+    return path;
+  }
+
+  /**
+   * Time of map import
+   * @return
+   */
+  inline QDateTime getCreation() const
+  {
+    return creation;
+  }
+
+private:
+  QDir dir;
+  bool valid{false};
+  bool metadata{false};
+  QString name;
+  QStringList path;
+  QDateTime creation;
 };
 
 /**
@@ -122,7 +219,7 @@ class OSMSCOUT_CLIENT_QT_API MapManager: public QObject
   
 private:
   QStringList databaseLookupDirs;
-  QList<QDir> databaseDirectories;
+  QList<MapDirectory> databaseDirectories;
   QList<MapDownloadJob*> downloadJobs;
   QNetworkAccessManager webCtrl;
 
@@ -141,7 +238,14 @@ public:
   
   virtual ~MapManager();
 
-  void downloadMap(AvailableMapsModelMap map, QDir dir);
+  /**
+   * Start map downloading into local dir.
+   *
+   * @param map
+   * @param dir
+   * @param replaceExisting - when true, manager will delete existing database with same path (MapDirectory::getPath)
+   */
+  void downloadMap(AvailableMapsModelMap map, QDir dir, bool replaceExisting = true);
   void downloadNext();
   
   inline QList<MapDownloadJob*> getDownloadJobs(){

--- a/libosmscout-client-qt/src/osmscout/MapDownloadsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapDownloadsModel.cpp
@@ -95,6 +95,7 @@ void MapDownloadsModel::onDownloadProgress()
   QVector<int> roles;
   roles<<ProgressRole;
   roles<<ProgressDescriptionRole;
+  roles<<ErrorStringRole;
   emit dataChanged(createIndex(0,0), createIndex(count-1,0),roles);
 }
 
@@ -121,6 +122,8 @@ QVariant MapDownloadsModel::data(const QModelIndex &index, int role) const
       return job->getProgress();
     case ProgressDescriptionRole:
       return job->getDownloadingFile();
+    case ErrorStringRole:
+      return job->getError();
     default:
       break;
   }
@@ -135,6 +138,7 @@ QHash<int, QByteArray> MapDownloadsModel::roleNames() const
   roles[TargetDirectoryRole]="targetDirectory";
   roles[ProgressRole]="progressRole";
   roles[ProgressDescriptionRole]="progressDescription";
+  roles[ErrorStringRole]="errorString";
 
   return roles;
 }

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -42,6 +42,25 @@ MapDownloadJob::~MapDownloadJob()
 
 void MapDownloadJob::start()
 {
+  QJsonObject mapMetadata;
+  mapMetadata["name"] = map.getName();
+  mapMetadata["map"] = map.getPath().join("/");
+  mapMetadata["version"] = map.getVersion();
+  mapMetadata["creation"] = (double)map.getCreation().toTime_t();
+
+  QJsonDocument doc(mapMetadata);
+  QFile metadataFile(target.filePath("metadata.json"));
+  metadataFile.open(QFile::OpenModeFlag::WriteOnly);
+  metadataFile.write(doc.toJson());
+  metadataFile.close();
+  if (metadataFile.error() != QFile::FileError::NoError){
+    started = true;
+    done = true;
+    error = metadataFile.errorString();
+    emit failed(metadataFile.errorString());
+    return;
+  }
+
   QStringList fileNames;
   fileNames << "bounding.dat"
             << "nodes.dat"

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -27,8 +27,15 @@
 #include <osmscout/util/Logger.h>
 #include <osmscout/DBThread.h>
 
-MapDownloadJob::MapDownloadJob(QNetworkAccessManager *webCtrl, AvailableMapsModelMap map, QDir target):
-  webCtrl(webCtrl), map(map), target(target), done(false), started(false), downloadedBytes(0)
+const char* MapDownloadJob::FILE_METADATA = "metadata.json";
+
+MapDownloadJob::MapDownloadJob(QNetworkAccessManager *webCtrl,
+                               AvailableMapsModelMap map,
+                               QDir target,
+                               bool replaceExisting):
+  webCtrl(webCtrl), map(map), target(target),
+  done(false), started(false), downloadedBytes(0),
+  replaceExisting(replaceExisting)
 {
 }
 
@@ -49,7 +56,7 @@ void MapDownloadJob::start()
   mapMetadata["creation"] = (double)map.getCreation().toTime_t();
 
   QJsonDocument doc(mapMetadata);
-  QFile metadataFile(target.filePath("metadata.json"));
+  QFile metadataFile(target.filePath(FILE_METADATA));
   metadataFile.open(QFile::OpenModeFlag::WriteOnly);
   metadataFile.write(doc.toJson());
   metadataFile.close();
@@ -162,19 +169,108 @@ QString MapDownloadJob::getDownloadingFile()
   return "";
 }
 
+MapDirectory::MapDirectory(QDir dir):
+    dir(dir)
+{
+  QStringList fileNames;
+  fileNames << "bounding.dat"
+            << "nodes.dat"
+            << "areas.dat"
+            << "ways.dat"
+            << "areanode.idx"
+            << "areaarea.idx"
+            << "areaway.idx"
+            << "areasopt.dat"
+            << "waysopt.dat"
+            << "location.idx"
+            << "water.idx"
+            << "intersections.dat"
+            << "intersections.idx"
+            << "router.dat"
+            << "router2.dat"
+            << "router.idx"
+            << "textloc.dat"
+            << "textother.dat"
+            << "textpoi.dat"
+            << "textregion.dat"
+            << "types.dat";
+  // coverage.idx is optional, introduced after database version 16
+
+  valid=true;
+  for (const auto &fileName: fileNames) {
+    valid &= dir.exists(fileName);
+  }
+
+  // metadata
+  if (dir.exists(MapDownloadJob::FILE_METADATA)){
+    QFile jsonFile(dir.filePath(MapDownloadJob::FILE_METADATA));
+    jsonFile.open(QFile::OpenModeFlag::ReadOnly);
+    QJsonDocument doc = QJsonDocument::fromJson(jsonFile.readAll());
+    QJsonObject metadataObject = doc.object();
+    if (metadataObject.contains("name") &&
+                                    metadataObject.contains("map") &&
+                                    metadataObject.contains("creation") ){
+      name = metadataObject["name"].toString();
+      path = metadataObject["map"].toString().split("/");
+      creation.setTime_t(metadataObject["creation"].toDouble());
+      metadata = true;
+    }
+  }
+}
+
+bool MapDirectory::deleteDatabase()
+{
+  valid=false;
+
+  QStringList fileNames;
+  fileNames << "bounding.dat"
+            << "nodes.dat"
+            << "areas.dat"
+            << "ways.dat"
+            << "areanode.idx"
+            << "areaarea.idx"
+            << "areaway.idx"
+            << "areasopt.dat"
+            << "waysopt.dat"
+            << "location.idx"
+            << "water.idx"
+            << "intersections.dat"
+            << "intersections.idx"
+            << "router.dat"
+            << "router2.dat"
+            << "router.idx"
+            << "textloc.dat"
+            << "textother.dat"
+            << "textpoi.dat"
+            << "textregion.dat"
+            << "coverage.idx"
+            << "types.dat"
+            << MapDownloadJob::FILE_METADATA;
+
+  bool result=true;
+  for (const auto &fileName: fileNames) {
+    if(dir.exists(fileName)){
+      result&=dir.remove(fileName);
+    }
+  }
+  QDir parent=dir;
+  parent.cdUp();
+  return result && parent.rmdir(dir.dirName());
+}
+
 MapManager::MapManager(QStringList databaseLookupDirs, SettingsRef settings):
   databaseLookupDirs(databaseLookupDirs)
 {
   qDebug() << "MapManager ctor";
   webCtrl.setCookieJar(new PersistentCookieJar(settings));
   // we don't use disk cache here
-
 }
 
 void MapManager::lookupDatabases()
 {
   databaseDirectories.clear();
-  QSet<QString> uniqPahts;
+  QSet<QString> uniqPaths;
+  QList<QDir> databaseFsDirectories;
 
   for (QString lookupDir:databaseLookupDirs){
     QDirIterator dirIt(lookupDir, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
@@ -182,15 +278,19 @@ void MapManager::lookupDatabases()
       dirIt.next();
       QFileInfo fInfo(dirIt.filePath());
       if (fInfo.isFile() && fInfo.fileName() == osmscout::TypeConfig::FILE_TYPES_DAT){
-        qDebug() << "found database: " << fInfo.dir().absolutePath();
-        if (!uniqPahts.contains(fInfo.absolutePath())){
-          databaseDirectories << fInfo.dir();
-          uniqPahts << fInfo.absolutePath();
+        MapDirectory mapDir(fInfo.dir());
+        if (mapDir.isValid()) {
+          qDebug() << "found database" << mapDir.getName() << ":" << fInfo.dir().absolutePath();
+          if (!uniqPaths.contains(fInfo.canonicalFilePath())) {
+            databaseDirectories << mapDir;
+            databaseFsDirectories << mapDir.getDir();
+            uniqPaths << fInfo.canonicalFilePath();
+          }
         }
       }
     }
   }
-  emit databaseListChanged(databaseDirectories);
+  emit databaseListChanged(databaseFsDirectories);
 }
 
 MapManager::~MapManager(){
@@ -200,26 +300,36 @@ MapManager::~MapManager(){
   downloadJobs.clear();
 }
 
-void MapManager::downloadMap(AvailableMapsModelMap map, QDir dir)
+void MapManager::downloadMap(AvailableMapsModelMap map, QDir dir, bool replaceExisting)
 {
   if (dir.exists()){
-    qWarning() << "Directory already exists"<<dir.path()<<"!";
+    MapDirectory mapDir(dir);
+    if (mapDir.hasMetadata() &&
+        !mapDir.isValid() &&
+        mapDir.getPath() == map.getPath() &&
+        mapDir.getCreation() == map.getCreation()) {
+      // directory contains partial download
+      // (contains downloader metadata, but not all required files)
+      // TODO: continue partial download
+    }
+    qWarning() << "Directory already exists"<<dir.canonicalPath()<<"!";
     emit mapDownloadFails("Directory already exists");
     return;
-  }
-  if (!dir.mkpath(dir.path())){
-    qWarning() << "Can't create directory"<<dir.path()<<"!";
-    emit mapDownloadFails("Can't create directory");
-    return;
+  } else {
+    if (!dir.mkpath(dir.path())) {
+      qWarning() << "Can't create directory" << dir.canonicalPath() << "!";
+      emit mapDownloadFails("Can't create directory");
+      return;
+    }
   }
 #ifdef HAS_QSTORAGE
   QStorageInfo storage=QStorageInfo(dir);
   if (storage.bytesAvailable()<(double)map.getSize()){
-    qWarning() << "Free space"<<storage.bytesAvailable()<<" bytes is less than map size ("<<map.getSize()<<")!";
+    qWarning() << "Free space" << storage.bytesAvailable() << "bytes is less than map size ("<<map.getSize()<<")!";
   }
 #endif
   
-  auto job=new MapDownloadJob(&webCtrl, map, dir);
+  auto job=new MapDownloadJob(&webCtrl, map, dir, replaceExisting);
   connect(job, SIGNAL(finished()), this, SLOT(onJobFinished()));
   connect(job, SIGNAL(failed(QString)), this, SLOT(onJobFailed(QString)));
   downloadJobs<<job;
@@ -251,6 +361,20 @@ void MapManager::onJobFinished()
   for (auto job:downloadJobs){
     if (job->isDone()){
       finished<<job;
+
+      if (job->isReplaceExisting()){
+        // if there is upgrade requested, delete old database with same (logical) path
+        for (auto &mapDir:databaseDirectories) {
+          if (mapDir.hasMetadata() &&
+              mapDir.getPath() == job->getMapPath() &&
+              mapDir.getDir().canonicalPath() != job->getDestinationDirectory().canonicalPath()) {
+
+            qDebug() << "deleting map database" << mapDir.getName() << "after upgrade:"
+                     << mapDir.getDir().canonicalPath();
+            mapDir.deleteDatabase();
+          }
+        }
+      }
     }
   }
   if (!finished.isEmpty()){

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -62,7 +62,8 @@ void MapDownloadJob::start()
             << "textloc.dat"
             << "textother.dat"
             << "textpoi.dat"
-            << "textregion.dat";
+            << "textregion.dat"
+            << "coverage.idx";
 
   // types.dat should be last, when download is interrupted,
   // directory is not recognized as valid map


### PR DESCRIPTION
Hi. 

These changes moves simple Qt map downloader more to be map manager ;-) Map manager (download job) creates small json with metadata inside database directory. When new database is downloaded for same region, the old one is deleted. It solves this issue: https://github.com/Karry/osmscout-sailfish/issues/73

