### PR TITLE
use new tiled index in multi database router

### DIFF
--- a/Tests/src/MultiDBRouting.cpp
+++ b/Tests/src/MultiDBRouting.cpp
@@ -32,11 +32,10 @@
 
 struct Arguments
 {
-  bool                   help=false;
-  std::string            databaseDirectory1;
-  std::string            databaseDirectory2;
-  osmscout::GeoCoord     start;
-  osmscout::GeoCoord     target;
+  bool                     help=false;
+  std::vector<std::string> databaseDirectories;
+  osmscout::GeoCoord       start;
+  osmscout::GeoCoord       target;
 };
 
 void GetCarSpeedTable(std::map<std::string,double>& map)
@@ -76,18 +75,6 @@ int main(int argc, char* argv[])
                       "Return argument help",
                       true);
 
-  argParser.AddPositional(osmscout::CmdLineStringOption([&args](const std::string& value) {
-                            args.databaseDirectory1=value;
-                          }),
-                          "DATABASE1",
-                          "Directory of the first database to use");
-
-  argParser.AddPositional(osmscout::CmdLineStringOption([&args](const std::string& value) {
-                            args.databaseDirectory2=value;
-                          }),
-                          "DATABASE2",
-                          "Directory of the second database to use");
-
   argParser.AddPositional(osmscout::CmdLineGeoCoordOption([&args](const osmscout::GeoCoord& value) {
                             args.start=value;
                           }),
@@ -99,6 +86,12 @@ int main(int argc, char* argv[])
                           }),
                           "TARGET",
                           "target coordinate");
+
+  argParser.AddPositional(osmscout::CmdLineStringListOption([&args](const std::string& value) {
+                            args.databaseDirectories.push_back(value);
+                          }),
+                          "DATABASE 1 [... DATABASE X]",
+                          "Directories with databases to use");
 
   osmscout::CmdLineParseResult result=argParser.Parse();
 
@@ -116,8 +109,7 @@ int main(int argc, char* argv[])
   // Database
 
   osmscout::DatabaseParameter dbParameter;
-  osmscout::DatabaseRef       database1=std::make_shared<osmscout::Database>(dbParameter);
-  osmscout::DatabaseRef       database2=std::make_shared<osmscout::Database>(dbParameter);
+  std::vector<osmscout::DatabaseRef> databases;
   osmscout::RouterParameter   routerParameter;
 
   osmscout::log.Debug(true);
@@ -127,27 +119,18 @@ int main(int argc, char* argv[])
 
   routerParameter.SetDebugPerformance(true);
 
-  std::cout << "Opening database 1..." << std::endl;
+  for (auto const &databaseDirectory:args.databaseDirectories) {
+    std::cout << "Opening database " << databaseDirectory << std::endl;
+    osmscout::DatabaseRef database=std::make_shared<osmscout::Database>(dbParameter);;
+    if (!database->Open(databaseDirectory)) {
+      std::cerr << "Cannot open database " << databaseDirectory << std::endl;
 
-  if (!database1->Open(args.databaseDirectory1)) {
-    std::cerr << "Cannot open database 1" << std::endl;
-
-    return 1;
+      return 1;
+    }
+    databases.push_back(database);
   }
 
   std::cout << "Done." << std::endl;
-
-  std::cout << "Opening database 2..." << std::endl;
-
-  if (!database2->Open(args.databaseDirectory2)) {
-    std::cerr << "Cannot open database 2" << std::endl;
-
-    return 1;
-  }
-
-  std::cout << "Done." << std::endl;
-
-  std::vector<osmscout::DatabaseRef> databases={database1,database2};
 
   osmscout::RouterParameter routerParam;
   routerParam.SetDebugPerformance(true);
@@ -201,11 +184,10 @@ int main(int argc, char* argv[])
 
   router->Close();
 
-  database1->Close();
-  database1.reset();
-
-  database2->Close();
-  database2.reset();
+  for (auto &db: databases) {
+    db->Close();
+    db.reset();
+  }
 
   std::cout << "Done." << std::endl;
 

--- a/libosmscout/include/osmscout/routing/AbstractRoutingService.h
+++ b/libosmscout/include/osmscout/routing/AbstractRoutingService.h
@@ -121,8 +121,8 @@ namespace osmscout {
     virtual bool ResolveRouteDataJunctions(RouteData& route) = 0;
 
     virtual std::vector<DBId> GetNodeTwins(const RoutingState& state,
-                                           DatabaseId database,
-                                           Id id) = 0;
+                                           const DatabaseId database,
+                                           const Id id) = 0;
 
     void GetStartForwardRouteNode(const RoutingState& state,
                                   const DatabaseId& database,

--- a/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
+++ b/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
@@ -60,22 +60,6 @@ namespace osmscout {
     bool                        isOpen;
 
   private:
-
-    Pixel GetCell(const osmscout::GeoCoord& coord);
-
-    bool ReadCellsForRoutingTree(osmscout::Database& database,
-                                 std::unordered_set<uint64_t>& cells);
-
-    bool ReadRouteNodesForCells(osmscout::Database& database,
-                                std::unordered_set<uint64_t>& cells,
-                                std::unordered_set<osmscout::Id>& routeNodes);
-
-    bool FindCommonRoutingNodes(const BreakerRef &breaker,
-                                DatabaseRef &database1,
-                                DatabaseRef &database2,
-                                std::set<Id> &commonRouteNodes);
-
-  private:
     Vehicle GetVehicle(const MultiDBRoutingState& state) override;
 
     bool CanUseForward(const MultiDBRoutingState& state,
@@ -125,8 +109,8 @@ namespace osmscout {
     bool ResolveRouteDataJunctions(RouteData& route) override;
 
     std::vector<DBId> GetNodeTwins(const MultiDBRoutingState& state,
-                                   DatabaseId database,
-                                   Id id) override;
+                                   const DatabaseId database,
+                                   const Id id) override;
 
     bool CanUse(const MultiDBRoutingState& state,
                 DatabaseId databaseId,

--- a/libosmscout/include/osmscout/routing/MultiDBRoutingState.h
+++ b/libosmscout/include/osmscout/routing/MultiDBRoutingState.h
@@ -38,31 +38,9 @@ namespace osmscout {
    */
   class MultiDBRoutingState
   {
-  private:
-    DatabaseId          dbId1;
-    DatabaseId          dbId2;
-
-    RoutingProfileRef   profile1;
-    RoutingProfileRef   profile2;
-
-    std::set<Id>        overlapNodes;
-
   public:
-    MultiDBRoutingState(DatabaseId dbId1,
-                        DatabaseId dbId2,
-                        const RoutingProfileRef& profile1,
-                        const RoutingProfileRef& profile2,
-                        const std::set<Id>& overlapNodes);
-
+    MultiDBRoutingState() = default;
     virtual ~MultiDBRoutingState() =default;
-
-    Vehicle GetVehicle() const;
-
-    RoutingProfileRef GetProfile(DatabaseId database) const;
-
-    void GetOverlappingDatabases(const DatabaseId &database,
-                                 const Id &nodeId,
-                                 std::set<DatabaseId> &overlappingDatabases) const;
   };
 
 }

--- a/libosmscout/include/osmscout/routing/RoutingDB.h
+++ b/libosmscout/include/osmscout/routing/RoutingDB.h
@@ -86,6 +86,13 @@ namespace osmscout {
     {
       return objectVariantDataFile.GetData();
     }
+
+    inline bool ContainsNode(const Id id) const
+    {
+      RouteNodeRef node;
+      routeNodeDataFile.Get(id, node);
+      return (bool)node;
+    }
   };
 
   /**

--- a/libosmscout/include/osmscout/routing/SimpleRoutingService.h
+++ b/libosmscout/include/osmscout/routing/SimpleRoutingService.h
@@ -140,8 +140,8 @@ namespace osmscout {
     bool ResolveRouteDataJunctions(RouteData& route) override;
 
     std::vector<DBId> GetNodeTwins(const RoutingProfile& state,
-                                   DatabaseId database,
-                                   Id id) override;
+                                   const DatabaseId database,
+                                   const Id id) override;
 
   public:
     SimpleRoutingService(const DatabaseRef& database,

--- a/libosmscout/src/osmscout/routing/MultiDBRoutingState.cpp
+++ b/libosmscout/src/osmscout/routing/MultiDBRoutingState.cpp
@@ -23,49 +23,4 @@
 
 namespace osmscout {
 
-  MultiDBRoutingState::MultiDBRoutingState(DatabaseId dbId1,
-                                           DatabaseId dbId2,
-                                           const RoutingProfileRef& profile1,
-                                           const RoutingProfileRef& profile2,
-                                           const std::set<Id>& overlapNodes):
-    dbId1(dbId1),
-    dbId2(dbId2),
-    profile1(profile1),
-    profile2(profile2),
-    overlapNodes(overlapNodes)
-  {
-  }
-
-  Vehicle MultiDBRoutingState::GetVehicle() const
-  {
-    return profile1->GetVehicle();
-  }
-
-  RoutingProfileRef MultiDBRoutingState::GetProfile(DatabaseId database) const
-  {
-    if (database==dbId1) {
-      return profile1;
-    }
-    else if (database==dbId2) {
-      return profile2;
-    }
-
-    assert(false);
-
-    return nullptr;
-  }
-
-  void MultiDBRoutingState::GetOverlappingDatabases(const DatabaseId &database,
-                                                    const Id &nodeId,
-                                                    std::set<DatabaseId> &overlappingDatabases) const
-  {
-    if (overlapNodes.find(nodeId)!=overlapNodes.end()) {
-      if (database==dbId1) {
-        overlappingDatabases.insert(dbId2);
-      }
-      else if (database==dbId2) {
-        overlappingDatabases.insert(dbId1);
-      }
-    }
-  }
 }

--- a/libosmscout/src/osmscout/routing/RouteNodeDataFile.cpp
+++ b/libosmscout/src/osmscout/routing/RouteNodeDataFile.cpp
@@ -209,8 +209,8 @@ namespace osmscout {
   {
     auto entry=index.find(tile);
 
-      return entry!=index.end();
-    }
+    return entry!=index.end();
+  }
 
   bool RouteNodeDataFile::IsCovered(const GeoCoord& coord) const
   {


### PR DESCRIPTION
Hi. These changes in `MultiDBRoutingService` should make possible (not tested yet) to route via multiple (not just two) databases! It even improves performance, routing time from Prague to Berlin took 1:40 with master branch, but just 12 seconds with this update (on my x86 notebook).

I will provide more measurements on later... 