### PR TITLE
DirectX: Add a guard against null styles for areas

### DIFF
--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -670,6 +670,7 @@ namespace osmscout
     std::shared_ptr<BorderStyle> borderStyle = area.borderStyle;
 
     bool hasBorder = borderStyle && borderStyle->GetWidth() > 0.0 && borderStyle->GetColor().IsVisible();
+    bool hasFilling = fillStyle && fillStyle->GetFillColor().IsVisible();
     float borderWidth = hasBorder ? float(projection.ConvertWidthToPixel(borderStyle->GetWidth())) : 0.0f;
 
     ID2D1PathGeometry* pPathGeometry;
@@ -690,8 +691,10 @@ namespace osmscout
         pSink = NULL;
       }
     }
-    m_pRenderTarget->FillGeometry(pPathGeometry, GetColorBrush(fillStyle->GetFillColor()));
-    if (hasBorder) m_pRenderTarget->DrawGeometry(pPathGeometry, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
+    if (hasFilling)
+      m_pRenderTarget->FillGeometry(pPathGeometry, GetColorBrush(fillStyle->GetFillColor()));
+    if (hasBorder)
+      m_pRenderTarget->DrawGeometry(pPathGeometry, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
     pPathGeometry->Release();
 
     for (std::list<PolyData>::const_iterator c = area.clippings.begin();
@@ -717,8 +720,10 @@ namespace osmscout
           pSink = NULL;
         }
       }
-      m_pRenderTarget->FillGeometry(pPathGeometry, GetColorBrush(fillStyle->GetFillColor()));
-      if (hasBorder) m_pRenderTarget->DrawGeometry(pPathGeometry, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
+      if (hasFilling)
+        m_pRenderTarget->FillGeometry(pPathGeometry, GetColorBrush(fillStyle->GetFillColor()));
+      if (hasBorder)
+	    m_pRenderTarget->DrawGeometry(pPathGeometry, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
       pPathGeometry->Release();
     }
   }


### PR DESCRIPTION
Apparently sometimes some areas don't have fill styles. I know at least
in one instance it's a bug since I can see a fill color in the default
style (which I used), but until I figure out why exactly this happens,
and because the other renderers all seem to do the same, I'm patching the
symptom before fixing the underlying cause.

For the record, the problem is when drawing an area in Rennes,France which has
the type "tourism_attraction_building". I'll open an issue if I can't find out what's going on.