### PR TITLE
Don't require free text indexes in Qt database manager

### DIFF
--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -191,7 +191,6 @@ DatabaseCoverage DBThread::databaseCoverage(const osmscout::Magnification &magni
 void DBThread::Initialize()
 {
   QReadLocker locker(&lock);
-  qDebug() << "Initialize databases";
   mapManager->lookupDatabases();
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -189,16 +189,22 @@ MapDirectory::MapDirectory(QDir dir):
             << "intersections.idx"
             << "router.dat"
             << "router2.dat"
-            << "textloc.dat"
-            << "textother.dat"
-            << "textpoi.dat"
-            << "textregion.dat"
             << "types.dat";
   // coverage.idx is optional, introduced after database version 16
+  // text*.dat files are optional, these files are missing
+  // when database is build without Marisa support
 
+  osmscout::log.Debug() << "Checking database files in directory " << dir.absolutePath().toStdString();
   valid=true;
   for (const auto &fileName: fileNames) {
-    valid &= dir.exists(fileName);
+    bool exists=dir.exists(fileName);
+    if (!exists){
+      osmscout::log.Debug() << "Missing mandatory file: " << fileName.toStdString();
+    }
+    valid &= exists;
+  }
+  if (!valid){
+    osmscout::log.Warn() << "Can't use database " << dir.absolutePath().toStdString() << ", some mandatory files are missing.";
   }
 
   // metadata
@@ -267,6 +273,8 @@ MapManager::MapManager(QStringList databaseLookupDirs, SettingsRef settings):
 
 void MapManager::lookupDatabases()
 {
+  osmscout::log.Info() << "Lookup databases";
+
   databaseDirectories.clear();
   QSet<QString> uniqPaths;
   QList<QDir> databaseFsDirectories;
@@ -279,7 +287,7 @@ void MapManager::lookupDatabases()
       if (fInfo.isFile() && fInfo.fileName() == osmscout::TypeConfig::FILE_TYPES_DAT){
         MapDirectory mapDir(fInfo.dir());
         if (mapDir.isValid()) {
-          qDebug() << "found database" << mapDir.getName() << ":" << fInfo.dir().absolutePath();
+          osmscout::log.Info() << "found database" << mapDir.getName().toStdString() << ":" << fInfo.dir().absolutePath().toStdString();
           if (!uniqPaths.contains(fInfo.canonicalFilePath())) {
             databaseDirectories << mapDir;
             databaseFsDirectories << mapDir.getDir();
@@ -368,8 +376,8 @@ void MapManager::onJobFinished()
               mapDir.getPath() == job->getMapPath() &&
               mapDir.getDir().canonicalPath() != job->getDestinationDirectory().canonicalPath()) {
 
-            qDebug() << "deleting map database" << mapDir.getName() << "after upgrade:"
-                     << mapDir.getDir().canonicalPath();
+            osmscout::log.Debug() << "deleting map database" << mapDir.getName().toStdString() << "after upgrade:"
+                     << mapDir.getDir().canonicalPath().toStdString();
             mapDir.deleteDatabase();
           }
         }

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -97,8 +97,8 @@ void SearchModule::FreeTextSearch(DBInstanceRef &db,
   QList<osmscout::ObjectFileRef> objectSet;
   osmscout::TextSearchIndex textSearch;
   if(!textSearch.Load(db->path.toStdString())){
-      qWarning("Failed to load text index files, search was for locations only");
-      return; // silently continue, text indexes are optional in database
+    osmscout::log.Warn() << "Failed to load text index files, search only for locations with database " << db->path.toStdString();
+    return; // silently continue, text indexes are optional in database
   }
   osmscout::TextSearchIndex::ResultsMap resultsTxt;
   textSearch.Search(searchPattern.toStdString(),


### PR DESCRIPTION
Free text indexes (Marisa tries) are optional, Qt database manager should not require it. See https://github.com/Framstag/libosmscout/issues/593 
...and improve logging for database lookup