### PR TITLE
Fix qml invokable methods

### DIFF
--- a/libosmscout-client-qt/include/osmscout/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscout/NearPOIModel.h
@@ -125,7 +125,7 @@ public:
 
   Q_INVOKABLE virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 
-  Q_INVOKABLE LocationEntry* get(int row) const;
+  Q_INVOKABLE QObject* get(int row) const;
 
   virtual QHash<int, QByteArray> roleNames() const;
 

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -112,7 +112,7 @@ public:
 
   QHash<int, QByteArray> roleNames() const;
 
-  Q_INVOKABLE RouteStep* get(int row) const;
+  Q_INVOKABLE QObject* get(int row) const;
 
   inline bool isReady()
   {
@@ -132,7 +132,7 @@ public:
    * Create LocationEntry from geographic coordinate with optional label.
    * It may be used from QML when selecting route start/end via point on map.
    */
-  inline Q_INVOKABLE LocationEntry* locationEntryFromPosition(double lat, double lon, QString label="")
+  inline Q_INVOKABLE QObject* locationEntryFromPosition(double lat, double lon, QString label="")
   {
     return new LocationEntry(label,osmscout::GeoCoord(lat,lon));
   }

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -196,7 +196,7 @@ public:
 
   virtual QHash<int, QByteArray> roleNames() const;
 
-  Q_INVOKABLE LocationEntry* get(int row) const;
+  Q_INVOKABLE QObject* get(int row) const;
 
   inline bool isSearching() const {
     return searching;

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -287,7 +287,7 @@ void MapManager::lookupDatabases()
       if (fInfo.isFile() && fInfo.fileName() == osmscout::TypeConfig::FILE_TYPES_DAT){
         MapDirectory mapDir(fInfo.dir());
         if (mapDir.isValid()) {
-          osmscout::log.Info() << "found database" << mapDir.getName().toStdString() << ":" << fInfo.dir().absolutePath().toStdString();
+          osmscout::log.Info() << "found database " << mapDir.getName().toStdString() << ": " << fInfo.dir().absolutePath().toStdString();
           if (!uniqPaths.contains(fInfo.canonicalFilePath())) {
             databaseDirectories << mapDir;
             databaseFsDirectories << mapDir.getDir();

--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -134,7 +134,7 @@ QHash<int, QByteArray> NearPOIModel::roleNames() const
   return roles;
 }
 
-LocationEntry* NearPOIModel::get(int row) const
+QObject* NearPOIModel::get(int row) const
 {
   if(row < 0 || row >= locations.size()) {
     return NULL;

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -205,7 +205,7 @@ QHash<int, QByteArray> RoutingListModel::roleNames() const
   return roles;
 }
 
-RouteStep* RoutingListModel::get(int row) const
+QObject* RoutingListModel::get(int row) const
 {
   if(!route || row < 0 || row >= route.routeSteps().size()) {
     return NULL;

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -338,7 +338,7 @@ QHash<int, QByteArray> LocationListModel::roleNames() const
   return roles;
 }
 
-LocationEntry* LocationListModel::get(int row) const
+QObject* LocationListModel::get(int row) const
 {
     if(row < 0 || row >= locations.size()) {
         return NULL;


### PR DESCRIPTION
It seems that Qt macro Q_INVOKABLE don't work with custom types in namespace, it fails in runtime with error: `Unknown method return type: LocationEntry*`

Simple change of return type to QObject* fix this issue.
