### PR TITLE
Fix qt translations

### DIFF
--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -1,315 +1,250 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="cs">
 <context>
     <name>NavigationSimulation</name>
     <message>
-        <location filename="../qml/NavigationSimulation.qml" line="183"/>
-        <location filename="../qml/NavigationSimulation.qml" line="186"/>
         <source>meters</source>
-        <translation type="unfinished"></translation>
+        <translation>metrů</translation>
     </message>
     <message>
-        <location filename="../qml/NavigationSimulation.qml" line="188"/>
         <source>km</source>
-        <translation type="unfinished"></translation>
+        <translation>km</translation>
     </message>
 </context>
 <context>
-    <name>RouteDescriptionBuilder</name>
+    <name>osmscout::RouteDescriptionBuilder</name>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="73"/>
-        <source>Turn</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="77"/>
         <source>Turn sharp left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="79"/>
         <source>Turn left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="81"/>
         <source>Turn slightly left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte mírně vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="83"/>
         <source>Straight on</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokračuje rovně</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="85"/>
         <source>Turn slightly right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte mírně vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="87"/>
         <source>Turn right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="89"/>
         <source>Turn sharp right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="100"/>
+        <source>Turn</source>
+        <translation>Zahněte</translation>
+    </message>
+    <message>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="104"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="106"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="108"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="110"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračuje rovně&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="112"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="114"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="116"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="127"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="131"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="133"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="135"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="137"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračujte rovně&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="139"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="141"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="143"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="157"/>
-        <source>unnamed road</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="160"/>
-        <source>(%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="163"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="226"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="265"/>
-        <source>&quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="165"/>
-        <source>&quot;%1&quot; (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="235"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="236"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="248"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="253"/>
-        <source>Start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="241"/>
-        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="242"/>
-        <source>Continue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="247"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="252"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="269"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="271"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="273"/>
-        <source>Target reached</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="319"/>
         <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="322"/>
-        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="324"/>
         <source>Enter roundabout</source>
-        <translation type="unfinished"></translation>
+        <translation>Vjeďte na kruhový objezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="334"/>
+        <source>unnamed road</source>
+        <translation>nepojmenovaná cesta</translation>
+    </message>
+    <message>
+        <source>(%1)</source>
+        <translation>(%1)</translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot;</source>
+        <translation>&quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; (%2)</source>
+        <translation>&quot;%1&quot; (%2)</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
+        <translation>&lt;strong&gt;Vjeďte&lt;/strong&gt; na %1</translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation>Vyjeďte</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
+        <translation>&lt;strong&gt;Pokračujte&lt;/strong&gt; po %1</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation>Pokračujte</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt; po %1</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt; na %1</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <source>Target reached</source>
+        <translation>Dosaženo cíle</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
+    </message>
+    <message>
         <source>Leave roundabout</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z kruhového objezdu</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="339"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu na ulici %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="343"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="356"/>
         <source>Enter motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Vjeďte na dálnici</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="368"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="372"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="377"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="380"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="392"/>
         <source>Change motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Změna dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="399"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="403"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="416"/>
         <source>Leave motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="425"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="429"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="433"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="444"/>
         <source>Way changes name</source>
-        <translation type="unfinished"></translation>
+        <translation>Změna silnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="447"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="451"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1</translation>
     </message>
 </context>
 </TS>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en">
 <context>
     <name>NavigationSimulation</name>
     <message>
@@ -16,7 +16,7 @@
     </message>
 </context>
 <context>
-    <name>RouteDescriptionBuilder</name>
+    <name>osmscout::RouteDescriptionBuilder</name>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="73"/>
         <source>Turn</source>

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -411,7 +411,7 @@ void FileDownloader::onProcessRead()
 void FileDownloader::onProcessStopped(int exitCode)
 {
   if (exitCode != 0){
-    QString err = tr("Error in processing downloaded data");
+    QString err = osmscout::FileDownloader::tr("Error in processing downloaded data");
     m_isok = false;
     emit error(err, false);
     return;
@@ -441,7 +441,7 @@ void FileDownloader::onProcessReadError()
 void FileDownloader::onProcessStateChanged(QProcess::ProcessState state)
 {
   if ( !m_process_started && state == QProcess::NotRunning ) {
-    QString err = tr("Error in processing downloaded data: could not start the program") + " " + m_process->program();
+    QString err = osmscout::FileDownloader::tr("Error in processing downloaded data: could not start the program") + " " + m_process->program();
     onError(err);
   }
 }

--- a/libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp
+++ b/libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp
@@ -70,23 +70,23 @@ static QString TurnCommandType(const osmscout::RouteDescription::DirectionDescri
 static QString ShortTurnCommand(const osmscout::RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("Turn");
+    return osmscout::RouteDescriptionBuilder::tr("Turn");
   }
   switch (directionDescription->GetCurve()) {
     case osmscout::RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("Turn sharp left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn sharp left");
     case osmscout::RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("Turn left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn left");
     case osmscout::RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("Turn slightly left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn slightly left");
     case osmscout::RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("Straight on");
+      return osmscout::RouteDescriptionBuilder::tr("Straight on");
     case osmscout::RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("Turn slightly right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn slightly right");
     case osmscout::RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("Turn right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn right");
     case osmscout::RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("Turn sharp right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn sharp right");
   }
 
   assert(false);
@@ -97,23 +97,23 @@ static QString ShortTurnCommand(const osmscout::RouteDescription::DirectionDescr
 static QString FullTurnCommand(const osmscout::RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong> into %2");
+    return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong> into %2");
   }
   switch (directionDescription->GetCurve()) {
     case osmscout::RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong> into %2");
     case osmscout::RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong> into %2");
   }
 
   assert(false);
@@ -124,23 +124,23 @@ static QString FullTurnCommand(const osmscout::RouteDescription::DirectionDescri
 static QString TurnCommandWithList(const osmscout::RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong>");
+    return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong>");
   }
   switch (directionDescription->GetCurve()) {
     case osmscout::RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong>");
     case osmscout::RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong>");
     case osmscout::RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong>");
     case osmscout::RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong>");
     case osmscout::RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong>");
     case osmscout::RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong>");
     case osmscout::RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong>");
   }
 
   assert(false);
@@ -154,15 +154,15 @@ static QString FormatName(const osmscout::RouteDescription::NameDescription &nam
   std::string ref=nameDescription.GetRef();
   if (name.empty() &&
       ref.empty()) {
-    return RouteDescriptionBuilder::tr("unnamed road");
+    return osmscout::RouteDescriptionBuilder::tr("unnamed road");
   }
   if (name.empty()){
-    return RouteDescriptionBuilder::tr("(%1)").arg(QString::fromStdString(ref));
+    return osmscout::RouteDescriptionBuilder::tr("(%1)").arg(QString::fromStdString(ref));
   }
   if (ref.empty()){
-    return RouteDescriptionBuilder::tr("\"%1\"").arg(QString::fromStdString(name));
+    return osmscout::RouteDescriptionBuilder::tr("\"%1\"").arg(QString::fromStdString(name));
   }
-  return RouteDescriptionBuilder::tr("\"%1\" (%2)").arg(QString::fromStdString(name)).arg(QString::fromStdString(ref));
+  return osmscout::RouteDescriptionBuilder::tr("\"%1\" (%2)").arg(QString::fromStdString(name)).arg(QString::fromStdString(ref));
 }
 
 static QString CrossingWaysDescriptionToString(const osmscout::RouteDescription::CrossingWaysDescription& crossingWaysDescription)
@@ -223,7 +223,7 @@ void RouteDescriptionBuilder::DumpStartDescription(QList<RouteStep> &routeSteps,
   QString startDesc;
   QString driveAlongDesc;
   if (startDescription && !startDescription->GetDescription().empty()) {
-    startDesc = RouteDescriptionBuilder::tr("\"%1\"")
+    startDesc = osmscout::RouteDescriptionBuilder::tr("\"%1\"")
         .arg(QString::fromStdString(startDescription->GetDescription()));
   }
   if (nameDescription && nameDescription->HasName()) {
@@ -232,25 +232,25 @@ void RouteDescriptionBuilder::DumpStartDescription(QList<RouteStep> &routeSteps,
 
   if (!startDesc.isEmpty()){
     RouteStep startAt("start");
-    startAt.description=RouteDescriptionBuilder::tr("<strong>Start</strong> at %1").arg(startDesc);
-    startAt.shortDescription=RouteDescriptionBuilder::tr("Start");
+    startAt.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong> at %1").arg(startDesc);
+    startAt.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(startAt);
 
     if (!driveAlongDesc.isEmpty()) {
       RouteStep driveAlong("drive-along");
-      driveAlong.description=RouteDescriptionBuilder::tr("<strong>Continue</strong> along %1").arg(driveAlongDesc);
-      driveAlong.shortDescription=RouteDescriptionBuilder::tr("Continue");
+      driveAlong.description=osmscout::RouteDescriptionBuilder::tr("<strong>Continue</strong> along %1").arg(driveAlongDesc);
+      driveAlong.shortDescription=osmscout::RouteDescriptionBuilder::tr("Continue");
       routeSteps.push_back(driveAlong);
     }
   } else if (!driveAlongDesc.isEmpty()) {
     RouteStep startAt("start");
-    startAt.description=RouteDescriptionBuilder::tr("<strong>Start</strong> along %1").arg(driveAlongDesc);
-    startAt.shortDescription=RouteDescriptionBuilder::tr("Start");
+    startAt.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong> along %1").arg(driveAlongDesc);
+    startAt.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(startAt);
   } else {
     RouteStep start("start");
-    start.description=RouteDescriptionBuilder::tr("<strong>Start</strong>");
-    start.shortDescription=RouteDescriptionBuilder::tr("Start");
+    start.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong>");
+    start.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(start);
   }
 }
@@ -262,15 +262,15 @@ void RouteDescriptionBuilder::DumpTargetDescription(QList<RouteStep> &routeSteps
 
   QString targetDesc;
   if (targetDescription && !targetDescription->GetDescription().empty()){
-    targetDesc = RouteDescriptionBuilder::tr("\"%1\"")
+    targetDesc = osmscout::RouteDescriptionBuilder::tr("\"%1\"")
         .arg(QString::fromStdString(targetDescription->GetDescription()));
   }
   if (!targetDesc.isEmpty()){
-    targetReached.description=RouteDescriptionBuilder::tr("<strong>Target reached</strong> at %1").arg(targetDesc);
+    targetReached.description=osmscout::RouteDescriptionBuilder::tr("<strong>Target reached</strong> at %1").arg(targetDesc);
   }else{
-    targetReached.description=RouteDescriptionBuilder::tr("<strong>Target reached</strong>");
+    targetReached.description=osmscout::RouteDescriptionBuilder::tr("<strong>Target reached</strong>");
   }
-  targetReached.shortDescription=RouteDescriptionBuilder::tr("Target reached");
+  targetReached.shortDescription=osmscout::RouteDescriptionBuilder::tr("Target reached");
   routeSteps.push_back(targetReached);
 }
 
@@ -316,12 +316,12 @@ void RouteDescriptionBuilder::DumpRoundaboutEnterDescription(QList<RouteStep> &r
   }
 
   if (!crossingWaysString.isEmpty()) {
-    enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter roundabout</strong>")
+    enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter roundabout</strong>")
         .arg(crossingWaysString);
   }else {
-    enter.description=RouteDescriptionBuilder::tr("<strong>Enter roundabout</strong>");
+    enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter roundabout</strong>");
   }
-  enter.shortDescription=RouteDescriptionBuilder::tr("Enter roundabout");
+  enter.shortDescription=osmscout::RouteDescriptionBuilder::tr("Enter roundabout");
   routeSteps.push_back(enter);
 }
 
@@ -331,16 +331,16 @@ void RouteDescriptionBuilder::DumpRoundaboutLeaveDescription(QList<RouteStep> &r
 {
   RouteStep leave("leave-roundabout");
 
-  leave.shortDescription=RouteDescriptionBuilder::tr("Leave roundabout");
+  leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Leave roundabout");
 
   if (nameDescription &&
       nameDescription->HasName()) {
 
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit into street %2")
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit into street %2")
         .arg(roundaboutLeaveDescription->GetExitCount())
         .arg(FormatName(*nameDescription));
   }else{
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit")
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit")
         .arg(roundaboutLeaveDescription->GetExitCount());
   }
 
@@ -353,7 +353,7 @@ void RouteDescriptionBuilder::DumpMotorwayEnterDescription(QList<RouteStep> &rou
 {
   RouteStep   enter("enter-motorway");
 
-  enter.shortDescription=RouteDescriptionBuilder::tr("Enter motorway");
+  enter.shortDescription=osmscout::RouteDescriptionBuilder::tr("Enter motorway");
 
   QString crossingWaysString;
 
@@ -365,19 +365,19 @@ void RouteDescriptionBuilder::DumpMotorwayEnterDescription(QList<RouteStep> &rou
       motorwayEnterDescription->GetToDescription()->HasName()) {
 
     if (!crossingWaysString.isEmpty()){
-      enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong> %2")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong> %2")
           .arg(crossingWaysString)
           .arg(FormatName(*(motorwayEnterDescription->GetToDescription())));
     }else {
-      enter.description=RouteDescriptionBuilder::tr("<strong>Enter motorway</strong> %1")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter motorway</strong> %1")
           .arg(FormatName(*(motorwayEnterDescription->GetToDescription())));
     }
   }else{
     if (!crossingWaysString.isEmpty()){
-      enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong>")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong>")
           .arg(crossingWaysString);
     }else {
-      enter.description=RouteDescriptionBuilder::tr("<strong>Enter motorway</strong>");
+      enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter motorway</strong>");
     }
   }
 
@@ -389,18 +389,18 @@ void RouteDescriptionBuilder::DumpMotorwayChangeDescription(QList<RouteStep> &ro
 {
   RouteStep change("change-motorway");
 
-  change.shortDescription=RouteDescriptionBuilder::tr("Change motorway");
+  change.shortDescription=osmscout::RouteDescriptionBuilder::tr("Change motorway");
 
   if (motorwayChangeDescription->GetFromDescription() &&
       motorwayChangeDescription->GetFromDescription()->HasName() &&
       motorwayChangeDescription->GetToDescription() &&
       motorwayChangeDescription->GetToDescription()->HasName()) {
 
-    change.description=RouteDescriptionBuilder::tr("<strong>Change motorway</strong> from %1 to %2")
+    change.description=osmscout::RouteDescriptionBuilder::tr("<strong>Change motorway</strong> from %1 to %2")
         .arg(FormatName(*(motorwayChangeDescription->GetFromDescription())))
         .arg(FormatName(*(motorwayChangeDescription->GetToDescription())));
   }else{
-    change.description=RouteDescriptionBuilder::tr("<strong>Change motorway</strong>");
+    change.description=osmscout::RouteDescriptionBuilder::tr("<strong>Change motorway</strong>");
   }
 
   routeSteps.push_back(change);
@@ -413,7 +413,7 @@ void RouteDescriptionBuilder::DumpMotorwayLeaveDescription(QList<RouteStep> &rou
 {
   RouteStep leave("leave-motorway");
 
-  leave.shortDescription=RouteDescriptionBuilder::tr("Leave motorway");
+  leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Leave motorway");
 
   // TODO: should we add leave direction to phrase? directionDescription->GetCurve()
   if (motorwayLeaveDescription->GetFromDescription() &&
@@ -422,15 +422,15 @@ void RouteDescriptionBuilder::DumpMotorwayLeaveDescription(QList<RouteStep> &rou
     if (nameDescription &&
         nameDescription->HasName()) {
 
-      leave.description = RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1 into %2")
+      leave.description = osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1 into %2")
           .arg(FormatName(*(motorwayLeaveDescription->GetFromDescription())))
           .arg(FormatName(*nameDescription));
     }else{
-      leave.description = RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1")
+      leave.description = osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1")
           .arg(FormatName(*(motorwayLeaveDescription->GetFromDescription())));
     }
   }else{
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave motorway</strong>");
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong>");
   }
 
   routeSteps.push_back(leave);
@@ -441,14 +441,14 @@ void RouteDescriptionBuilder::DumpNameChangedDescription(QList<RouteStep> &route
 {
   RouteStep changed("name-change");
 
-  changed.shortDescription=RouteDescriptionBuilder::tr("Way changes name");
+  changed.shortDescription=osmscout::RouteDescriptionBuilder::tr("Way changes name");
 
   if (nameChangedDescription->GetOriginDesccription()) {
-    changed.description=RouteDescriptionBuilder::tr("<strong>Way changes name</strong> from %1 to %2")
+    changed.description=osmscout::RouteDescriptionBuilder::tr("<strong>Way changes name</strong> from %1 to %2")
         .arg(FormatName(*(nameChangedDescription->GetOriginDesccription())))
         .arg(FormatName(*(nameChangedDescription->GetTargetDesccription())));
   } else {
-    changed.description=RouteDescriptionBuilder::tr("<strong>Way changes name</strong> to %1")
+    changed.description=osmscout::RouteDescriptionBuilder::tr("<strong>Way changes name</strong> to %1")
       .arg(FormatName(*(nameChangedDescription->GetTargetDesccription())));
   }
 


### PR DESCRIPTION
Hi. 

Qt localisation (lupdate stage) is broken after moving Qt classes to `osmscout` namespace. Second commit workaround this issue.

In first commit I am reverting localisation strings that was removed accidentally.
