### PR TITLE
remove experimental GLM transform.hpp header

### DIFF
--- a/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
+++ b/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
@@ -24,7 +24,6 @@
 #include <GL/glew.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtx/transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/ext.hpp>
 #include <osmscout/MapParameter.h>


### PR DESCRIPTION
After upgrade to Ubuntu 17.04 that contains `libglm-dev` package in version 0.9.9, build of OpenGL renderer fails with:

```
[ 46%] Building CXX object libosmscout-map-opengl/CMakeFiles/OSMScoutMapOpenGL.dir/src/osmscout/MapPainterOpenGL.cpp.o
In file included from /home/karry/data/cecko/OSM/libosmscout/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h:27:0,
                 from /home/karry/data/cecko/OSM/libosmscout/libosmscout-map-opengl/include/osmscout/MapPainterOpenGL.h:30,
                 from /home/karry/data/cecko/OSM/libosmscout/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp:24:
/usr/include/glm/gtx/transform.hpp:23:3: error: #error "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
 # error "GLM: GLM_GTX_transform is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
   ^~~~~
```

It seems that we don't use these experimental transformations and we may remove this header safely.
