### PR TITLE
Meson build: fix Qt metacompiler arguments

### DIFF
--- a/OSMScout2/meson.build
+++ b/OSMScout2/meson.build
@@ -12,6 +12,7 @@ osmscout2Mocs = qt5.preprocess(moc_headers : [
                                 'src/Theme.h',
                                 'src/PositionSimulator.h'
                                ],
+                               include_directories: include_directories('src'),
                                qresources: ['res.qrc'])
 
 subdir('translations')

--- a/StyleEditor/meson.build
+++ b/StyleEditor/meson.build
@@ -16,6 +16,7 @@ styleeditorMocs = qt5.preprocess(moc_headers : [
                                     'src/Highlighter.h',
                                     'src/StyleAnalyser.h'
                                     ],
+                                 include_directories: include_directories('src'),
                                  qresources: ['StyleEditor.qrc'])
 
 OSMScout2 = executable('StyleEditor',

--- a/libosmscout-client-qt/meson.build
+++ b/libosmscout-client-qt/meson.build
@@ -20,7 +20,8 @@ foreach hdr : osmscoutclientqtHeader
   mocHeaders += headerTemplate.format('include/',hdr)
 endforeach  
 
-mocFiles = qt5.preprocess(moc_headers : mocHeaders)
+mocFiles = qt5.preprocess(moc_headers : mocHeaders,
+                          include_directories: include_directories('include'))
 
 osmscoutclientqt = library('osmscout_client_qt',
                            mocFiles,


### PR DESCRIPTION
Fix for https://github.com/Framstag/libosmscout/issues/607 - I don't know why, I just compare `moc` (Qt metacompiler) arguments in CMake and Meson build :-)