### PR TITLE
add brand as a tag for name and namealt

### DIFF
--- a/libosmscout-import/src/osmscout/import/Import.cpp
+++ b/libosmscout-import/src/osmscout/import/Import.cpp
@@ -1072,12 +1072,12 @@ namespace osmscout {
         progress.Info("  default");
         typeConfig->GetTagRegistry().RegisterNameTag("name", langIndex);
         typeConfig->GetTagRegistry().RegisterNameTag("place_name", langIndex+1);
-        typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
+        typeConfig->GetTagRegistry().RegisterNameTag("brand", langIndex+2);
       } else {
           progress.Info("  " + lang);
           typeConfig->GetTagRegistry().RegisterNameTag("name:"+lang, langIndex);
           typeConfig->GetTagRegistry().RegisterNameTag("place_name:"+lang, langIndex+1);
-          typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
+          typeConfig->GetTagRegistry().RegisterNameTag("brand:"+lang, langIndex+2);
       }
       langIndex+=3;
     }
@@ -1094,7 +1094,7 @@ namespace osmscout {
         progress.Info("  " + lang);
         typeConfig->GetTagRegistry().RegisterNameAltTag("name:"+lang, langIndex);
         typeConfig->GetTagRegistry().RegisterNameAltTag("place_name:"+lang, langIndex+1);
-        typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
+        typeConfig->GetTagRegistry().RegisterNameAltTag("brand:"+lang, langIndex+2);
       }
       langIndex+=3;
     }

--- a/libosmscout-import/src/osmscout/import/Import.cpp
+++ b/libosmscout-import/src/osmscout/import/Import.cpp
@@ -1072,12 +1072,14 @@ namespace osmscout {
         progress.Info("  default");
         typeConfig->GetTagRegistry().RegisterNameTag("name", langIndex);
         typeConfig->GetTagRegistry().RegisterNameTag("place_name", langIndex+1);
+        typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
       } else {
           progress.Info("  " + lang);
           typeConfig->GetTagRegistry().RegisterNameTag("name:"+lang, langIndex);
           typeConfig->GetTagRegistry().RegisterNameTag("place_name:"+lang, langIndex+1);
+          typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
       }
-      langIndex+=2;
+      langIndex+=3;
     }
 
     progress.Info("Parsed alt language(s) :");
@@ -1087,12 +1089,14 @@ namespace osmscout {
         progress.Info("  default");
         typeConfig->GetTagRegistry().RegisterNameAltTag("name", langIndex);
         typeConfig->GetTagRegistry().RegisterNameAltTag("place_name", langIndex+1);
+        typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
       } else {
         progress.Info("  " + lang);
         typeConfig->GetTagRegistry().RegisterNameAltTag("name:"+lang, langIndex);
         typeConfig->GetTagRegistry().RegisterNameAltTag("place_name:"+lang, langIndex+1);
+        typeConfig->GetTagRegistry().RegisterNameAltTag("brand", langIndex+2);
       }
-      langIndex+=2;
+      langIndex+=3;
     }
 
     ImportErrorReporterRef errorReporter=std::make_shared<ImportErrorReporter>(progress,


### PR DESCRIPTION
Some nodes don't have names, but use brand as a corresponding tag [https://wiki.openstreetmap.org/wiki/Key%3Abrand]. This commit brings "brand" as the third choice for Name and NameAlt