### PR TITLE
fix symbol rendering, update rectangle primitive documentation to correspond with code

### DIFF
--- a/Demos/src/DrawMapAgg.cpp
+++ b/Demos/src/DrawMapAgg.cpp
@@ -109,6 +109,7 @@ int main(int argc, char* argv[])
 
   if (!styleConfig->Load(style)) {
     std::cerr << "Cannot open style" << std::endl;
+    return 1;
   }
 
   unsigned char *buffer=new unsigned char[width*height*3];

--- a/Demos/src/DrawMapCairo.cpp
+++ b/Demos/src/DrawMapCairo.cpp
@@ -91,6 +91,7 @@ int main(int argc, char* argv[])
 
   if (!styleConfig->Load(style)) {
     std::cerr << "Cannot open style" << std::endl;
+    return 1;
   }
 
   cairo_surface_t *surface;

--- a/Demos/src/DrawMapOpenGL.cpp
+++ b/Demos/src/DrawMapOpenGL.cpp
@@ -91,6 +91,7 @@ int main(int argc, char* argv[]) {
 
   if (!styleConfig->Load(style)) {
     std::cerr << "Cannot open style" << std::endl;
+    return 1;
   }
 
   osmscout::MercatorProjection projection;

--- a/Demos/src/DrawMapQt.cpp
+++ b/Demos/src/DrawMapQt.cpp
@@ -186,6 +186,7 @@ int main(int argc, char* argv[])
 
   if (!styleConfig->Load(style)) {
     std::cerr << "Cannot open style" << std::endl;
+    return 1;
   }
 
   QPixmap *pixmap=new QPixmap(static_cast<int>(width),

--- a/Demos/src/DrawMapSVG.cpp
+++ b/Demos/src/DrawMapSVG.cpp
@@ -100,6 +100,7 @@ int main(int argc, char* argv[])
 
   if (!styleConfig->Load(style)) {
     std::cerr << "Cannot open style" << std::endl;
+    return 1;
   }
 
   std::ofstream stream(output.c_str(), std::ios_base::binary|std::ios_base::trunc|std::ios_base::out);

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -532,11 +532,11 @@ namespace osmscout {
              ++pixel) {
           if (pixel==polygon->GetCoords().begin()) {
             path.move_to(x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                         y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                         y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
           }
           else {
             path.line_to(x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                         y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                         y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
           }
         }
 
@@ -556,7 +556,7 @@ namespace osmscout {
         BorderStyleRef    borderStyle=rectangle->GetBorderStyle();
         agg::path_storage path;
         double            xPos=x+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()-centerX);
-        double            yPos=y+projection.ConvertWidthToPixel(maxY-rectangle->GetTopLeft().GetY()-centerY);
+        double            yPos=y+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY()-centerY);
         double            width=projection.ConvertWidthToPixel(rectangle->GetWidth());
         double            height=projection.ConvertWidthToPixel(rectangle->GetHeight());
 
@@ -583,7 +583,7 @@ namespace osmscout {
         double            radius=projection.ConvertWidthToPixel(circle->GetRadius());
 
         agg::ellipse ellipse(x+projection.ConvertWidthToPixel(circle->GetCenter().GetX()-centerX),
-                             y+projection.ConvertWidthToPixel(maxY-circle->GetCenter().GetY()-centerY),
+                             y+projection.ConvertWidthToPixel(circle->GetCenter().GetY()-centerY),
                              radius,
                              radius);
 

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -515,8 +515,8 @@ namespace osmscout {
 
     symbol.GetBoundingBox(minX,minY,maxX,maxY);
 
-    centerX=maxX-minX;
-    centerY=maxY-minY;
+    centerX=(minX+maxX)/2;
+    centerY=(minY+maxY)/2;
 
     for (const auto& primitive : symbol.GetPrimitives()) {
       const DrawPrimitive *primitivePtr=primitive.get();

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -1159,12 +1159,12 @@ namespace osmscout {
         if (pixel==polygon->GetCoords().begin()) {
           cairo_move_to(draw,
                         x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                        y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                        y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
         }
         else {
           cairo_line_to(draw,
                         x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                        y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                        y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
         }
       }
 
@@ -1175,7 +1175,7 @@ namespace osmscout {
 
       cairo_rectangle(draw,
                       x+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()-centerX),
-                      y+projection.ConvertWidthToPixel(maxY-rectangle->GetTopLeft().GetY()-centerY),
+                      y+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY()-centerY),
                       projection.ConvertWidthToPixel(rectangle->GetWidth()),
                       projection.ConvertWidthToPixel(rectangle->GetHeight()));
     }
@@ -1184,7 +1184,7 @@ namespace osmscout {
 
       cairo_arc(draw,
                 x+projection.ConvertWidthToPixel(circle->GetCenter().GetX()-centerX),
-                y+projection.ConvertWidthToPixel(maxY-circle->GetCenter().GetY()-centerY),
+                y+projection.ConvertWidthToPixel(circle->GetCenter().GetY()-centerY),
                 projection.ConvertWidthToPixel(circle->GetRadius()),
                 0,2*M_PI);
     }

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -536,9 +536,9 @@ namespace osmscout
       {
         RectanglePrimitive* rectangle = dynamic_cast<RectanglePrimitive*>(primitive);
         D2D1_RECT_F rect = RECTF(x + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX() - centerX),
-                                 y + projection.ConvertWidthToPixel(maxY - rectangle->GetTopLeft().GetY() - centerY),
+                                 y + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY() - centerY),
                                  x + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX() - centerX) + projection.ConvertWidthToPixel(rectangle->GetWidth()),
-                                 y + projection.ConvertWidthToPixel(maxY - rectangle->GetTopLeft().GetY() - centerY) + projection.ConvertWidthToPixel(rectangle->GetHeight()));
+                                 y + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY() - centerY) + projection.ConvertWidthToPixel(rectangle->GetHeight()));
         m_pRenderTarget->FillRectangle(rect, GetColorBrush(fillStyle->GetFillColor()));
         if (hasBorder) m_pRenderTarget->DrawRectangle(rect, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
       }

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -893,10 +893,10 @@ namespace osmscout {
                      ++pixel) {
                     if (pixel==polygon->GetCoords().begin()) {
                         CGContextMoveToPoint(cg,x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                                             y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                                             y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
                     } else {
                         CGContextAddLineToPoint(cg,x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                                                y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                                                y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
                     }
                 }
 
@@ -918,7 +918,7 @@ namespace osmscout {
                     CGContextSetRGBStrokeColor(cg,0,0,0,0);
                 }
                 CGRect rect = CGRectMake(x+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()-centerX),
-                                         y+projection.ConvertWidthToPixel(maxY-rectangle->GetTopLeft().GetY()-centerY),
+                                         y+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY()-centerY),
                                          projection.ConvertWidthToPixel(rectangle->GetWidth()),
                                          projection.ConvertWidthToPixel(rectangle->GetHeight()));
                 CGContextAddRect(cg,rect);
@@ -940,7 +940,7 @@ namespace osmscout {
                     CGContextSetRGBStrokeColor(cg,0,0,0,0);
                 }
                 CGRect rect = CGRectMake(x+projection.ConvertWidthToPixel(circle->GetCenter().GetX()-centerX),
-                                         y+projection.ConvertWidthToPixel(maxY-circle->GetCenter().GetY()-centerY),
+                                         y+projection.ConvertWidthToPixel(circle->GetCenter().GetY()-centerY),
                                          projection.ConvertWidthToPixel(circle->GetRadius()),
                                          projection.ConvertWidthToPixel(circle->GetRadius()));
                 CGContextAddEllipseInRect(cg, rect);

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -1045,7 +1045,7 @@ namespace osmscout {
                 double x =
                     node->GetCoords().GetLon() + (projection.ConvertWidthToPixel(pixel.GetX() - centerX) * scale);
                 double y = node->GetCoords().GetLat() +
-                           (projection.ConvertWidthToPixel(maxY - pixel.GetY() - centerY) * scaleLat);
+                           (projection.ConvertWidthToPixel(pixel.GetY() - centerY) * scaleLat);
 
                 vertices.push_back(osmscout::Vertex2D(x, y));
               }

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -782,11 +782,11 @@ namespace osmscout {
                ++pixel) {
             if (pixel==polygon->GetCoords().begin()) {
               path.moveTo(x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                          y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                          y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
             }
             else {
               path.lineTo(x+projection.ConvertWidthToPixel(pixel->GetX()-centerX),
-                          y+projection.ConvertWidthToPixel(maxY-pixel->GetY()-centerY));
+                          y+projection.ConvertWidthToPixel(pixel->GetY()-centerY));
             }
           }
         }
@@ -796,11 +796,11 @@ namespace osmscout {
                ++pixel) {
             if (pixel==polygon->GetCoords().begin()) {
               path.moveTo(x+projection.GetMeterInPixel()*(pixel->GetX()-centerX),
-                          y+projection.GetMeterInPixel()*(maxY-pixel->GetY()-centerY));
+                          y+projection.GetMeterInPixel()*(pixel->GetY()-centerY));
             }
             else {
               path.lineTo(x+projection.GetMeterInPixel()*(pixel->GetX()-centerX),
-                          y+projection.GetMeterInPixel()*(maxY-pixel->GetY()-centerY));
+                          y+projection.GetMeterInPixel()*(pixel->GetY()-centerY));
 
             }
           }
@@ -835,13 +835,13 @@ namespace osmscout {
 
         if (rectangle->GetProjectionMode()==DrawPrimitive::ProjectionMode::MAP) {
           path.addRect(x+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()-centerX),
-                       y+projection.ConvertWidthToPixel(maxY-rectangle->GetTopLeft().GetY()-centerY),
+                       y+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY()-centerY),
                        projection.ConvertWidthToPixel(rectangle->GetWidth()),
                        projection.ConvertWidthToPixel(rectangle->GetHeight()));
         }
         else {
           path.addRect(x+projection.GetMeterInPixel()*(rectangle->GetTopLeft().GetX()-centerX),
-                       y+projection.GetMeterInPixel()*(maxY-rectangle->GetTopLeft().GetY()-centerY),
+                       y+projection.GetMeterInPixel()*(rectangle->GetTopLeft().GetY()-centerY),
                        projection.GetMeterInPixel()*rectangle->GetWidth(),
                        projection.GetMeterInPixel()*rectangle->GetHeight());
         }
@@ -857,13 +857,13 @@ namespace osmscout {
 
         if (circle->GetProjectionMode()==DrawPrimitive::ProjectionMode::MAP) {
           center=QPointF(x+projection.ConvertWidthToPixel(circle->GetCenter().GetX()-centerX),
-                         y+projection.ConvertWidthToPixel(maxY-circle->GetCenter().GetY()-centerY));
+                         y+projection.ConvertWidthToPixel(circle->GetCenter().GetY()-centerY));
 
           radius=projection.ConvertWidthToPixel(circle->GetRadius());
         }
         else {
           center=QPointF(x+projection.GetMeterInPixel()*(circle->GetCenter().GetX()-centerX),
-                         y+projection.GetMeterInPixel()*(maxY-circle->GetCenter().GetY()-centerY));
+                         y+projection.GetMeterInPixel()*(circle->GetCenter().GetY()-centerY));
 
           radius=projection.GetMeterInPixel()*circle->GetRadius();
         }

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -905,8 +905,8 @@ namespace osmscout {
         QPainterPath path;
 
         path.addEllipse(center,
-                        2*radius,
-                        2*radius);
+                        radius,
+                        radius);
 
         painter->drawPath(path);
       }

--- a/libosmscout-map/include/osmscout/Styles.h
+++ b/libosmscout-map/include/osmscout/Styles.h
@@ -1042,7 +1042,7 @@ namespace osmscout {
    * \ingroup Stylesheet
    *
    * Definition of a symbol. A symbol consists of a list of DrawPrimitives
-   * with with assigned rendering styes.
+   * with with assigned rendering styles.
    */
   class OSMSCOUT_MAP_API Symbol
   {

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -1572,10 +1572,10 @@ namespace osmscout {
                                           double& maxY) const
   {
     minX=topLeft.GetX();
-    minY=topLeft.GetY()-height;
+    minY=topLeft.GetY();
 
     maxX=topLeft.GetX()+width;
-    maxY=topLeft.GetY();
+    maxY=topLeft.GetY()+height;
   }
 
   CirclePrimitive::CirclePrimitive(ProjectionMode projectionMode,

--- a/stylesheets/boundaries.oss
+++ b/stylesheets/boundaries.oss
@@ -5,12 +5,12 @@ OSS
     COLOR unknownColor               = @waterColor;
 
   SYMBOL place_city
-    CIRCLE 0,0 1.25 {
+    CIRCLE 0,0 2.5 {
       AREA {color: #ff0000aa; }
     }
 
   SYMBOL place_town
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #ff000055; }
     }
 

--- a/stylesheets/motorways.oss
+++ b/stylesheets/motorways.oss
@@ -8,17 +8,17 @@ OSS
     COLOR unknownColor               = @waterColor;
 
   SYMBOL highway_services
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #00ff0055; }
     }
 
   SYMBOL place_city
-    CIRCLE 0,0 1.25 {
+    CIRCLE 0,0 2.5 {
       AREA {color: #ff0000aa; }
     }
 
   SYMBOL place_town
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #ff000055; }
     }
 

--- a/stylesheets/public-transport.oss
+++ b/stylesheets/public-transport.oss
@@ -21,22 +21,22 @@ CONST
   COLOR unknownColor               = @waterColor;
 
 SYMBOL place_city
-  CIRCLE 0,0 1.25 {
+  CIRCLE 0,0 2.5 {
     AREA {color: #ff000050; }
   }
 
 SYMBOL place_town
-  CIRCLE 0,0 0.66 {
+  CIRCLE 0,0 1.32 {
     AREA {color: #ff000040; }
   }
  
 SYMBOL railway_station
-  CIRCLE 0,0 0.50 {
+  CIRCLE 0,0 1.0 {
     AREA {color: #60005070; }
   }
 
 SYMBOL railway_halt
-  CIRCLE 0,0 0.25 {
+  CIRCLE 0,0 0.5 {
     AREA {color: #00800080; }
   }
 SYMBOL railway_tram_stop

--- a/stylesheets/railways.oss
+++ b/stylesheets/railways.oss
@@ -5,22 +5,22 @@ OSS
     COLOR unknownColor               = @waterColor;
 
   SYMBOL place_city
-    CIRCLE 0,0 1.25 {
+    CIRCLE 0,0 2.5 {
       AREA {color: #ff0000aa; }
     }
 
   SYMBOL place_town
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #ff000055; }
     }
    
   SYMBOL railway_station
-    CIRCLE 0,0 1.25 {
+    CIRCLE 0,0 2.5 {
       AREA {color: #00ff0055; }
     }
 
   SYMBOL railway_halt
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #00ff0055; }
     }
 

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -401,7 +401,7 @@ CONST
     }
 
   SYMBOL highway_bus_stop
-    CIRCLE 0,0 0.4 {
+    CIRCLE 0,0 0.8 {
       AREA {color: @busSymbolColor; }
     }
 
@@ -416,7 +416,7 @@ CONST
     }
 
   SYMBOL amenity_hospital
-    CIRCLE 0,0 0.5 {
+    CIRCLE 0,0 1.0 {
       AREA.BORDER {color: @hospitalSymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
@@ -443,7 +443,7 @@ CONST
     }
 
   SYMBOL amenity_parking
-    CIRCLE 0,0 0.4 {
+    CIRCLE 0,0 0.8 {
       AREA {color: #4bb2da; }
     }
 
@@ -466,17 +466,17 @@ CONST
     }
 
   SYMBOL speed_camera
-    CIRCLE 0,0 0.4 {
+    CIRCLE 0,0 0.8 {
       AREA {color: @red; }
     }
 
   SYMBOL highway_street_lamp
-    CIRCLE GROUND 0,0 10 {
+    CIRCLE GROUND 0,0 20 {
       AREA {color: #f5fb5b44; }
     }
 
   SYMBOL marker
-    CIRCLE 0,0 0.4 {
+    CIRCLE 0,0 0.8 {
       AREA {color: #ff0000; }
     }
 

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -420,25 +420,25 @@ CONST
       AREA.BORDER {color: @hospitalSymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
-    RECTANGLE -0.75,0.25 1.5 x 0.5 {
+    RECTANGLE -0.75,-0.25 1.5 x 0.5 {
       AREA { color: @hospitalSymbolColor; }
     }
     // Vertical bar
-    RECTANGLE -0.25,0.75 0.5 x 1.5 {
+    RECTANGLE -0.25,-0.75 0.5 x 1.5 {
       AREA { color: @hospitalSymbolColor; }
     }
 
   SYMBOL amenity_pharmacy
     // Box
-    RECTANGLE -1,1 2 x 2 {
+    RECTANGLE -1,-1 2 x 2 {
       AREA.BORDER {color: @pharmacySymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
-    RECTANGLE -0.75,0.25 1.5 x 0.5 {
+    RECTANGLE -0.75,-0.25 1.5 x 0.5 {
       AREA { color: @pharmacySymbolColor; }
     }
     // Vertical bar
-    RECTANGLE -0.25,0.75 0.5 x 1.5 {
+    RECTANGLE -0.25,-0.75 0.5 x 1.5 {
       AREA {color: @pharmacySymbolColor; }
     }
 
@@ -458,10 +458,10 @@ CONST
     }
 
   SYMBOL christian_church_cross
-    RECTANGLE 0.5,2 0.5 x 2 {
+    RECTANGLE 0.5,-2 0.5 x 2 {
       AREA { color: #000000; }   // vertical bar
     }
-    RECTANGLE 0,1.5 1.5 x 0.5 {
+    RECTANGLE 0,-1.5 1.5 x 0.5 {
       AREA { color: #000000; } // horizontal bar
     }
 

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -411,11 +411,11 @@ CONST
       AREA.BORDER {color: @hospitalSymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
-    RECTANGLE -0.75,0.25 1.5 x 0.5 {
+    RECTANGLE -0.75,-0.25 1.5 x 0.5 {
       AREA { color: @hospitalSymbolColor; }
     }
     // Vertical bar
-    RECTANGLE -0.25,0.75 0.5 x 1.5 {
+    RECTANGLE -0.25,-0.75 0.5 x 1.5 {
       AREA { color: @hospitalSymbolColor; }
     }
 
@@ -425,11 +425,11 @@ CONST
       AREA.BORDER {color: @pharmacySymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
-    RECTANGLE -0.75,0.25 1.5 x 0.5 {
+    RECTANGLE -0.75,-0.25 1.5 x 0.5 {
       AREA { color: @pharmacySymbolColor; }
     }
     // Vertical bar
-    RECTANGLE -0.25,0.75 0.5 x 1.5 {
+    RECTANGLE -0.25,-0.75 0.5 x 1.5 {
       AREA {color: @pharmacySymbolColor; }
     }
 
@@ -449,10 +449,10 @@ CONST
     }
 
   SYMBOL christian_church_cross
-    RECTANGLE 0.5,2 0.5 x 2 {
+    RECTANGLE 0.5,-2 0.5 x 2 {
       AREA { color: #000000; }   // vertical bar
     }
-    RECTANGLE 0,1.5 1.5 x 0.5 {
+    RECTANGLE 0,-1.5 1.5 x 0.5 {
       AREA { color: #000000; } // horizontal bar
     }
 

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -397,7 +397,7 @@ CONST
     }
 
   SYMBOL highway_bus_stop
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: @busSymbolColor; }
     }
 
@@ -407,7 +407,7 @@ CONST
     }
 
   SYMBOL amenity_hospital
-    CIRCLE 0,0 1 {
+    CIRCLE 0,0 2 {
       AREA.BORDER {color: @hospitalSymbolColor; width: 0.2mm; }
     }
     // Horizontal bar
@@ -434,7 +434,7 @@ CONST
     }
 
   SYMBOL amenity_parking
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #4bb2da; }
     }
 
@@ -457,17 +457,17 @@ CONST
     }
 
   SYMBOL speed_camera
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: @red; }
     }
 
   SYMBOL highway_street_lamp
-    CIRCLE 0,0 1 {
+    CIRCLE 0,0 2 {
       AREA {color: #f5fb5b; }
     }
 
   SYMBOL marker
-    CIRCLE 0,0 0.75 {
+    CIRCLE 0,0 1.5 {
       AREA {color: #ff0000; }
     }
 

--- a/webpage/content/documentation/stylesheet.md
+++ b/webpage/content/documentation/stylesheet.md
@@ -124,8 +124,8 @@ like oneway arrows, simple signs or similar.
 
 Currently the following primives are supported:
 
-* `RECTANGLE <x> , <y> <width> x <height> { area style definitions }`
-* `CIRCLE    <x> , <y> <radius> { area style definitions }`
+* `RECTANGLE <left-x> , <top-y> <width> x <height> { area style definitions }`
+* `CIRCLE    <center-x> , <center-y> <radius> { area style definitions }`
 * `POLYGON   <x> , <y> ...more coordinates... { area style definitions }`
 
 "area style definitions" are normal style definitions for areas as


### PR DESCRIPTION
Hi. 

Rectangle primitive for symbols uses `topLeft` as coordinate, but its `GetBoundingBox` method don't respect it. So I updated this method and documentation to be in sync with code. Symbols in stylesheets had to be updated too.

Another fix in `MapPainterQt::DrawSymbol` move symbol horizontally to put its center to given point.

I tested these changes with Qt backend, it is possible that symbol rendering with other backends is broken now!
