### PR TITLE
Agg map painter: fix rendering of primitives without fill

### DIFF
--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -261,6 +261,8 @@ namespace osmscout {
                                    color.GetA()));
 
       agg::render_scanlines(*rasterizer,*scanlineP8,*renderer_aa);
+    }else{
+      rasterizer->reset();
     }
 
     if (borderStyle) {


### PR DESCRIPTION
There is fix for Agg backend. Primitives with empty fill style are still rendered with fill. It is visible with "hospital" symbol:

```
  SYMBOL amenity_hospital
    CIRCLE 0,0 0.5 {
      AREA.BORDER {color: @hospitalSymbolColor; width: 0.2mm; }
    }
```

I am not sure if this fix is correct, I don't know Agg api. Please review carefully ;-)