### PR TITLE
take ring type into account in area sorter

### DIFF
--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -236,6 +236,7 @@ namespace osmscout {
       FillStyleRef             fillStyle;       //!< Fill style
       BorderStyleRef           borderStyle;     //!< Border style
       GeoBox                   boundingBox;     //!< Bounding box of the area
+      bool                     isOuter;         //!< flag if this area is outer ring of some relation
       size_t                   transStart;      //!< Start of coordinates in transformation buffer
       size_t                   transEnd;        //!< End of coordinates in transformation buffer
       std::list<PolyData>      clippings;       //!< Clipping polygons to be used during drawing of this area

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -115,7 +115,16 @@ namespace osmscout {
     if (a.boundingBox.GetMinCoord().GetLon()==b.boundingBox.GetMinCoord().GetLon()) {
       if (a.boundingBox.GetMaxCoord().GetLon()==b.boundingBox.GetMaxCoord().GetLon()) {
         if (a.boundingBox.GetMinCoord().GetLat()==b.boundingBox.GetMinCoord().GetLat()) {
-          return a.boundingBox.GetMaxCoord().GetLat()>b.boundingBox.GetMaxCoord().GetLat();
+          if (a.boundingBox.GetMaxCoord().GetLat()==b.boundingBox.GetMaxCoord().GetLat()){
+            /**
+             * Condition for the case when one area exists in two relations
+             *  - in one as outer ring (type of relation is used) and in second relation as inner ring.
+             * In such case, we want to draw area with outer type after that one of inner type
+             */
+            return !a.isOuter && b.isOuter;
+          } else {
+            return a.boundingBox.GetMaxCoord().GetLat() > b.boundingBox.GetMaxCoord().GetLat();
+          }
         }
         else {
           return a.boundingBox.GetMinCoord().GetLat()<b.boundingBox.GetMinCoord().GetLat();
@@ -1497,6 +1506,8 @@ namespace osmscout {
         double   borderWidth=borderStyle ? borderStyle->GetWidth() : 0.0;
 
         ring.GetBoundingBox(a.boundingBox);
+
+        a.isOuter = ring.IsOuterRing();
 
         if (!IsVisibleArea(projection,
                            a.boundingBox,


### PR DESCRIPTION
Hi Tim. Consider this as solution for https://github.com/Framstag/libosmscout/issues/622

Add extra condition into area sorter for the case when one area exists in two relations - in one as outer ring (type of relation is used) and in second relation as inner ring.

In such case, we want to draw area with outer type after that one of inner type