### PR TITLE
Fast emphasize (Qt)

### DIFF
--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -331,14 +331,21 @@ namespace osmscout {
         QColor                          textColor=QColor::fromRgbF(r,g,b,label.alpha);
         QColor                          outlineColor=QColor::fromRgbF(1.0,1.0,1.0,label.alpha);
 
-        painter->setPen(outlineColor);
-
         LayoutTextLayout(fontMetrics,
                          proposedWidth,
                          textLayout,
                          boundingBox);
 
         QPointF topLeft = rect.topLeft() + boundingBox.topLeft();
+
+        /**
+         * Use text outline for emphasize is better (more accurate)
+         * (QTextLayout::FormatRange::setTextOutline),
+         * but it has terribly performance.
+         * So we draw text multiple times with move,
+         * it will create similar effect.
+         */
+        painter->setPen(outlineColor);
 
         textLayout.draw(painter, topLeft-QPointF(1,0));
         textLayout.draw(painter, topLeft+QPointF(1,0));

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -338,18 +338,16 @@ namespace osmscout {
                          textLayout,
                          boundingBox);
 
-        textLayout.draw(painter, rect.topLeft()-QPointF(1,0));
-        textLayout.draw(painter, rect.topLeft()+QPointF(1,0));
-        textLayout.draw(painter, rect.topLeft()-QPointF(0,1));
-        textLayout.draw(painter, rect.topLeft()+QPointF(0,1));
+        QPointF topLeft = rect.topLeft() + boundingBox.topLeft();
+
+        textLayout.draw(painter, topLeft-QPointF(1,0));
+        textLayout.draw(painter, topLeft+QPointF(1,0));
+        textLayout.draw(painter, topLeft-QPointF(0,1));
+        textLayout.draw(painter, topLeft+QPointF(0,1));
 
         painter->setPen(textColor);
 
-        textLayout.draw(painter,
-                        QPointF(label.x+boundingBox.x(),
-                                label.y+boundingBox.y()));
-
-
+        textLayout.draw(painter, topLeft);
       }
     }
     else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -284,6 +284,11 @@ namespace osmscout {
                                const MapParameter& parameter,
                                const LabelData& label)
   {
+    QRectF rect(label.bx1, label.by1, label.bx2-label.bx1, label.by2-label.by1);
+    if (!QRectF(painter->viewport()).intersects(rect)){
+      return;
+    }
+
     QFont        font(GetFont(projection,
                               parameter,
                               label.fontSize));
@@ -325,44 +330,26 @@ namespace osmscout {
         QRectF                          boundingBox;
         QColor                          textColor=QColor::fromRgbF(r,g,b,label.alpha);
         QColor                          outlineColor=QColor::fromRgbF(1.0,1.0,1.0,label.alpha);
-        QPen                            outlinePen(outlineColor,2.0,Qt::SolidLine,Qt::RoundCap,Qt::RoundJoin);
-        QList<QTextLayout::FormatRange> formatList;
-        QTextLayout::FormatRange        range;
 
-        range.start=0;
-        range.length=string.length();
-        range.format.setForeground(QBrush(outlineColor));
-        range.format.setTextOutline(outlinePen);
-        formatList.append(range);
-
-        textLayout.setAdditionalFormats(formatList);
+        painter->setPen(outlineColor);
 
         LayoutTextLayout(fontMetrics,
                          proposedWidth,
                          textLayout,
                          boundingBox);
 
-        textLayout.draw(painter,
-                        QPointF(label.x+boundingBox.x(),
-                                label.y+boundingBox.y()));
+        textLayout.draw(painter, rect.topLeft()-QPointF(1,0));
+        textLayout.draw(painter, rect.topLeft()+QPointF(1,0));
+        textLayout.draw(painter, rect.topLeft()-QPointF(0,1));
+        textLayout.draw(painter, rect.topLeft()+QPointF(0,1));
 
-        range.start=0;
-        range.length=string.length();
-        range.format.setForeground(QBrush(textColor));
-        range.format.setTextOutline(QPen(Qt::transparent));
-        formatList.clear();
-        formatList.append(range);
-
-        textLayout.setAdditionalFormats(formatList);
-
-        LayoutTextLayout(fontMetrics,
-                         proposedWidth,
-                         textLayout,
-                         boundingBox);
+        painter->setPen(textColor);
 
         textLayout.draw(painter,
                         QPointF(label.x+boundingBox.x(),
                                 label.y+boundingBox.y()));
+
+
       }
     }
     else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {


### PR DESCRIPTION
As we discussed on mailing list. This simple change may speedup rendering by 30% with Qt renderer (tested with citi area, zoom level 16, on armv7). Note that data loading is not included to this measurement.

Here is difference:

upper label is using the fast method, bottom is using current text outline (400% scale up)

![emphasize](https://user-images.githubusercontent.com/309458/42243925-391ed65a-7f13-11e8-9941-e9ab25be6d5c.png)
