### PR TITLE
Add a ClosestPointOnRoute() method that return the closest point on the current route

### DIFF
--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -513,7 +513,7 @@ struct RouteDescriptionGeneratorCallback : public osmscout::RouteDescriptionGene
     //std::cout << "MaxSpeed: " << (unsigned int)maxSpeedDescription->GetMaxSpeed() << std::endl;
   }
 
-  void OnPOIAtRoute(const osmscout::RouteDescription::POIAtRouteDescriptionRef& poiAtRouteDescription)
+  void OnPOIAtRoute(const osmscout::RouteDescription::POIAtRouteDescriptionRef& poiAtRouteDescription) override
   {
     NextLine(lineCount);
     std::cout << "Pass: " << poiAtRouteDescription->GetName()->GetDescription() << std::endl;

--- a/libosmscout/include/osmscout/Navigation.h
+++ b/libosmscout/include/osmscout/Navigation.h
@@ -97,7 +97,6 @@ namespace osmscout {
           // Stop the search we have a good candidate
           break;
         }
-        nextNode++;
       }
       return found;
     }
@@ -215,6 +214,34 @@ namespace osmscout {
         return false;
       }
     };
+      
+    bool ClosestPointOnRoute(const GeoCoord& location, GeoCoord& locOnRoute)
+    {
+      if(!route){
+        return false;
+      }
+      std::list<RouteDescription::Node>::const_iterator nextNode = route->Nodes().begin();
+      GeoCoord intersection, foundIntersection;
+      double abscissa;
+      double minDistance=std::numeric_limits<double>::max();
+      for (auto node=nextNode++; node!=route->Nodes().end(); node++) {
+        if (nextNode==route->Nodes().end()) {
+          break;
+        }
+        double d = DistanceToSegment(location,
+                                     node->GetLocation(),
+                                     nextNode->GetLocation(),
+                                     abscissa,
+                                     intersection);
+        if (minDistance > d) {
+          minDistance = d;
+          foundIntersection = intersection;
+        }
+      }
+      locOnRoute = foundIntersection;
+        
+      return true;
+    }
 
   private:
     RouteDescription* route;                 // current route description


### PR DESCRIPTION
Add a ClosestPointOnRoute() method that return the closest point on the current route from a given location. It seems that sometimes it returns strange results...
Fix a bug that increment nextNode twice in SearchClosestSegment()
Fix a warning in compilation of the Routing demo (missing override)