### PR TITLE
register overlay types as Qt metatypes

### DIFF
--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -145,6 +145,9 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<LocationEntry>("LocationEntry");
   qRegisterMetaType<OnlineTileProvider>("OnlineTileProvider");
   qRegisterMetaType<RouteStep>("RouteStep");
+  qRegisterMetaType<OverlayWay*>("OverlayWay*");
+  qRegisterMetaType<OverlayArea*>("OverlayArea*");
+  qRegisterMetaType<OverlayNode*>("OverlayNode*");
 
   // regiester osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");


### PR DESCRIPTION
Qt metatype system is crazy sometimes. I don't know what changed, but overlay objects are not working (as described in documention: http://libosmscout.sourceforge.net/documentation/qt_qml_api/). 

This patch fixes that.