### PR TITLE
fix DirectX demo on x64 Windows

### DIFF
--- a/Demos/src/DrawMapDirectX.cpp
+++ b/Demos/src/DrawMapDirectX.cpp
@@ -396,7 +396,7 @@ private:
 			::SetWindowLongPtrW(
 				hWnd,
 				GWLP_USERDATA,
-				PtrToUlong(pDemoApp)
+				(LONG_PTR)pDemoApp
 				);
 
 			result = 1;


### PR DESCRIPTION
long has 32 bites on x64 Windows (msvc), but pointers 64 bites.
So converting pointer to long discard upper bites.
Use LONG_PTR to avoid this issue.