### PR TITLE
add support for label and icon padding

### DIFF
--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -422,7 +422,7 @@ namespace osmscout {
                                  const MapParameter& parameter,
                                  const MapData& /*data*/)
   {
-    labelLayouter.Layout();
+    labelLayouter.Layout(projection, parameter);
 
     labelLayouter.DrawLabels(projection,
                              parameter,

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -1099,7 +1099,7 @@ namespace osmscout {
                                    const MapParameter& parameter,
                                    const MapData& /*data*/)
   {
-    labelLayouter.Layout();
+    labelLayouter.Layout(projection, parameter);
 
     labelLayouter.DrawLabels(projection,
                              parameter,

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -657,7 +657,7 @@ namespace osmscout
 	  const MapParameter& parameter,
 	  const MapData& /*data*/)
   {
-    m_LabelLayouter.Layout();
+    m_LabelLayouter.Layout(projection, parameter);
 
     m_LabelLayouter.DrawLabels(projection,
                                parameter,

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -694,7 +694,7 @@ namespace osmscout {
     void MapPainterIOS::DrawLabels(const Projection& projection,
                             const MapParameter& parameter,
                             const MapData& data) {
-        labelLayouter.Layout();
+        labelLayouter.Layout(projection, parameter);
         labelLayouter.DrawLabels(projection,
                                  parameter,
                                  this);

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -926,7 +926,7 @@ namespace osmscout {
                                 const MapParameter& parameter,
                                 const MapData& /*data*/)
   {
-    labelLayouter.Layout();
+    labelLayouter.Layout(projection, parameter);
 
     labelLayouter.DrawLabels(projection,
                              parameter,

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -644,7 +644,7 @@ namespace osmscout {
                                  const MapParameter& parameter,
                                  const MapData& /*data*/)
   {
-    labelLayouter.Layout();
+    labelLayouter.Layout(projection, parameter);
 
     labelLayouter.DrawLabels(projection,
                              parameter,

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -55,21 +55,23 @@ namespace osmscout {
     bool                                drawFadings;               //!< Draw label fadings (default: true)
     bool                                drawWaysWithFixedWidth;    //!< Draw ways using the size of the style sheet, if if the way has a width explicitly given
 
-    // Node and area labels
+    // Node and area labels, icons
     size_t                              labelLineMinCharCount;     //!< Labels will be _never_ word wrapped if they are shorter then the given characters
     size_t                              labelLineMaxCharCount;     //!< Labels will be word wrapped if they are longer then the given characters
     bool                                labelLineFitToArea;        //!< Labels will be word wrapped to fit object area
     double                              labelLineFitToWidth;       //!< Labels will be word wrapped to fit given width in pixels
 
-    double                              labelSpace;                //!< Space between point labels in mm (default 3).
-    double                              plateLabelSpace;           //!< Space between plates in mm (default 5).
-    double                              sameLabelSpace;            //!< Space between labels with the same value in mm (default 40)
+    double                              labelPadding;              //!< Space around point labels in mm (default 1).
+    double                              plateLabelPadding;         //!< Space around plates in mm (default 5).
+    double                              overlayLabelPadding;       //!< Space around overlay labels in mm (default 6).
+    double                              iconPadding;               //!< Space around icons and symbols in mm (default 1).
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
 
   private:
 // Contour labels
     double                              contourLabelOffset;        //!< Offset in mm for beginning and end of an contour label in relation to contour begin and end
     double                              contourLabelSpace;         //!< Space in mm between repetitive labels on the same contour
+    double                              contourLabelPadding;       //!< Space around contour labels in mm (default 1).
 
     bool                                renderBackground;          //!< Render any background features, else render like the background should be transparent
     bool                                renderSeaLand;             //!< Rendering of sea/land tiles
@@ -111,9 +113,12 @@ namespace osmscout {
     void SetLabelLineFitToArea(bool labelLineFitToArea);
     void SetLabelLineFitToWidth(double labelLineFitToWidth);
 
-    void SetLabelSpace(double labelSpace);
-    void SetPlateLabelSpace(double plateLabelSpace);
-    void SetSameLabelSpace(double sameLabelSpace);
+    void SetLabelPadding(double labelPadding);
+    void SetPlateLabelPadding(double plateLabelPadding);
+    void SetOverlayLabelPadding(double padding);
+    void SetIconPadding(double padding);
+    void SetContourLabelPadding(double padding);
+
     void SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels);
 
     void SetContourLabelOffset(double contourLabelOffset);
@@ -214,19 +219,29 @@ namespace osmscout {
       return labelLineFitToWidth;
     }
 
-    inline double GetLabelSpace() const
+    inline double GetLabelPadding() const
     {
-      return labelSpace;
+      return labelPadding;
     }
 
-    inline double GetPlateLabelSpace() const
+    inline double GetPlateLabelPadding() const
     {
-      return plateLabelSpace;
+      return plateLabelPadding;
     }
 
-    inline double GetSameLabelSpace() const
+    inline double GetOverlayLabelPadding() const
     {
-      return sameLabelSpace;
+      return overlayLabelPadding;
+    }
+
+    inline double GetIconPadding() const
+    {
+      return iconPadding;
+    }
+
+    inline double GetContourLabelPadding() const
+    {
+      return contourLabelPadding;
     }
 
     inline bool GetDropNotVisiblePointLabels() const

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -35,12 +35,14 @@ namespace osmscout {
     labelLineMaxCharCount(1000/*20*/),
     labelLineFitToArea(true),
     labelLineFitToWidth(8000),
-    labelSpace(1.0),
-    plateLabelSpace(5.0),
-    sameLabelSpace(40.0),
+    labelPadding(1.0),
+    plateLabelPadding(5.0),
+    overlayLabelPadding(6.0),
+    iconPadding(1.0),
     dropNotVisiblePointLabels(true),
     contourLabelOffset(5.0),
     contourLabelSpace(30.0),
+    contourLabelPadding(1.0),
     renderBackground(true),
     renderSeaLand(false),
     renderUnknowns(false),
@@ -127,19 +129,29 @@ namespace osmscout {
     this->labelLineFitToWidth=labelLineFitToWidth;
   }
 
-  void MapParameter::SetLabelSpace(double labelSpace)
+  void MapParameter::SetLabelPadding(double labelSpace)
   {
-    this->labelSpace=labelSpace;
+    this->labelPadding=labelSpace;
   }
 
-  void MapParameter::SetPlateLabelSpace(double plateLabelSpace)
+  void MapParameter::SetPlateLabelPadding(double plateLabelSpace)
   {
-    this->plateLabelSpace=plateLabelSpace;
+    this->plateLabelPadding=plateLabelSpace;
   }
 
-  void MapParameter::SetSameLabelSpace(double sameLabelSpace)
+  void MapParameter::SetOverlayLabelPadding(double padding)
   {
-    this->sameLabelSpace=sameLabelSpace;
+    this->overlayLabelPadding=padding;
+  }
+
+  void MapParameter::SetIconPadding(double padding)
+  {
+    this->iconPadding=padding;
+  }
+
+  void MapParameter::SetContourLabelPadding(double padding)
+  {
+    this->contourLabelPadding=padding;
   }
 
   void MapParameter::SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels)


### PR DESCRIPTION
Add support for label and icon padding (again). I just removed `sameLabelSpace` option, because it would be hard to implement with current layouter.