### PR TITLE
Qt: reset painter's pen before drawing way cap

### DIFF
--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -792,6 +792,7 @@ namespace osmscout {
     if (dash.empty() &&
         startCap==LineStyle::capRound &&
         endCap!=LineStyle::capRound) {
+      painter->setPen(QColor(Qt::transparent));
       painter->setBrush(QBrush(QColor::fromRgbF(color.GetR(),
                                                 color.GetG(),
                                                 color.GetB(),
@@ -805,6 +806,7 @@ namespace osmscout {
     if (dash.empty() &&
         endCap==LineStyle::capRound &&
         startCap!=LineStyle::capRound) {
+      painter->setPen(QColor(Qt::transparent));
       painter->setBrush(QBrush(QColor::fromRgbF(color.GetR(),
                                                 color.GetG(),
                                                 color.GetB(),


### PR DESCRIPTION
Pen may be setup from previous steps and it affect way cap then. This simple patch fix it.

![obrazek](https://user-images.githubusercontent.com/309458/44508541-f33a3a80-a6ae-11e8-802c-7e4ceb3f026e.png)
