### PR TITLE
add icon size to map parameter, tell requested icon size to painter

### DIFF
--- a/Android/OsmScoutLib/jni/include/jniMapPainterCanvas.h
+++ b/Android/OsmScoutLib/jni/include/jniMapPainterCanvas.h
@@ -77,6 +77,7 @@ namespace osmscout {
   protected:
 
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style);
 

--- a/Android/OsmScoutLib/jni/src/jniMapPainterCanvas.cpp
+++ b/Android/OsmScoutLib/jni/src/jniMapPainterCanvas.cpp
@@ -51,6 +51,7 @@ namespace osmscout {
   }
   
   bool MapPainterCanvas::HasIcon(const StyleConfig& styleConfig,
+                                 const Projection& /*projection*/,
                                  const MapParameter& parameter,
                                  IconStyle& style)
   {

--- a/Demos/src/DrawMapCairo.cpp
+++ b/Demos/src/DrawMapCairo.cpp
@@ -114,6 +114,13 @@ int main(int argc, char* argv[])
       drawParameter.SetLabelLineFitToArea(true);
       drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight()));
 
+      /*
+      std::list<std::string> paths;
+      paths.push_back("./libosmscout/data/icons/14x14/standard/");
+      drawParameter.SetIconMode(osmscout::MapParameter::FixedSizePixmap);
+      drawParameter.SetIconPaths(paths);
+      */
+
       projection.Set(osmscout::GeoCoord(lat,lon),
                      osmscout::Magnification(zoom),
                      DPI,

--- a/Demos/src/DrawMapQt.cpp
+++ b/Demos/src/DrawMapQt.cpp
@@ -218,6 +218,14 @@ int main(int argc, char* argv[])
   drawParameter.SetFontSize(3.0);
   drawParameter.SetRenderSeaLand(true);
 
+  /*
+  std::list<std::string> paths;
+  paths.push_back("./libosmscout/data/icons/svg/standard/");
+  paths.push_back("./libosmscout/data/icons/14x14/standard/");
+  drawParameter.SetIconMode(osmscout::MapParameter::Scalable);
+  drawParameter.SetIconPaths(paths);
+  */
+
   projection.Set(osmscout::GeoCoord(lat,lon),
                  osmscout::Magnification(zoom),
                  dpi,

--- a/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
@@ -115,6 +115,7 @@ namespace osmscout {
 
   protected:
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style) override;
 

--- a/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
@@ -127,7 +127,8 @@ namespace osmscout {
                     const FillStyle& style) override;
 
     void DrawIcon(const IconStyle* style,
-                  double x, double y) override;
+                  double centerX, double centerY,
+                  double width, double height) override;
 
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -450,7 +450,8 @@ namespace osmscout {
   }
 
   void MapPainterAgg::DrawIcon(const IconStyle* /*style*/,
-                              double /*x*/, double /*y*/)
+                               double /*centerX*/, double /*centerY*/,
+                               double /*width*/, double /*height*/)
   {
     // Not implemented
   }

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -212,8 +212,9 @@ namespace osmscout {
   }
 
   bool MapPainterAgg::HasIcon(const StyleConfig& /*styleConfig*/,
-                             const MapParameter& /*parameter*/,
-                             IconStyle& /*style*/)
+                              const Projection& /*projection*/,
+                              const MapParameter& /*parameter*/,
+                              IconStyle& /*style*/)
   {
     //TODO
 

--- a/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
+++ b/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
@@ -108,6 +108,7 @@ namespace osmscout {
 
   protected:
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style) override;
 

--- a/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
+++ b/libosmscout-map-cairo/include/osmscout/MapPainterCairo.h
@@ -185,7 +185,8 @@ namespace osmscout {
                     double x, double y) override;
 
     void DrawIcon(const IconStyle* style,
-                  double x, double y) override;
+                  double centerX, double centerY,
+                  double width, double height) override;
 
     void DrawPath(const Projection& projection,
                   const MapParameter& parameter,

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -1196,17 +1196,31 @@ namespace osmscout {
   }
 
   void MapPainterCairo::DrawIcon(const IconStyle* style,
-                                 double x, double y,
-                                 double /*width*/, double /*height*/)
+                                 double centerX, double centerY,
+                                 double width, double height)
   {
     size_t idx=style->GetIconId()-1;
 
     assert(idx<images.size());
     assert(images[idx]!=nullptr);
 
-    cairo_set_source_surface(draw,images[idx],x-7,y-7);
-    // TODO: rescale to requested width and height
+    cairo_surface_t *icon = images[idx];
+    int w = cairo_image_surface_get_width(icon);
+    int h = cairo_image_surface_get_height(icon);
+
+    cairo_matrix_t matrix;
+    cairo_get_matrix(draw, &matrix);
+    double scaleW = width/w;
+    double scaleH = height/h;
+    cairo_scale(draw, scaleW, scaleH);
+
+    cairo_set_source_surface(draw,
+                             icon,
+                             (centerX-width/2) / scaleW,
+                             (centerY-height/2) / scaleH);
+
     cairo_paint(draw);
+    cairo_set_matrix(draw, &matrix);
   }
 
   void MapPainterCairo::DrawPath(const Projection& /*projection*/,

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -1196,7 +1196,8 @@ namespace osmscout {
   }
 
   void MapPainterCairo::DrawIcon(const IconStyle* style,
-                                 double x, double y)
+                                 double x, double y,
+                                 double /*width*/, double /*height*/)
   {
     size_t idx=style->GetIconId()-1;
 
@@ -1204,6 +1205,7 @@ namespace osmscout {
     assert(images[idx]!=nullptr);
 
     cairo_set_source_surface(draw,images[idx],x-7,y-7);
+    // TODO: rescale to requested width and height
     cairo_paint(draw);
   }
 

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -444,6 +444,7 @@ namespace osmscout {
   }
 
   bool MapPainterCairo::HasIcon(const StyleConfig & /*styleConfig*/,
+                                const Projection& projection,
                                 const MapParameter &parameter,
                                 IconStyle &style)
   {
@@ -460,9 +461,21 @@ namespace osmscout {
       return true;
     }
 
+    if (parameter.GetIconMode()==MapParameter::IconMode::Scalable ||
+        parameter.GetIconMode()==MapParameter::IconMode::ScaledPixmap){
+
+      style.SetWidth(std::round(projection.ConvertWidthToPixel(parameter.GetIconSize())));
+      style.SetHeight(style.GetWidth());
+    }else{
+      style.SetWidth(std::round(parameter.GetIconPixelSize()));
+      style.SetHeight(style.GetWidth());
+    }
+
     for (std::list<std::string>::const_iterator path = parameter.GetIconPaths().begin();
          path != parameter.GetIconPaths().end();
          ++path) {
+
+      // TODO: add support for reading svg images (using librsvg?)
       std::string filename = *path + style.GetIconName() + ".png";
 
       cairo_surface_t *image = osmscout::LoadPNG(filename);

--- a/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
+++ b/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
@@ -178,7 +178,8 @@ namespace osmscout {
 		const MapData& data);
 
     virtual void DrawIcon(const IconStyle* style,
-                          double x, double y);
+                          double centerX, double centerY,
+                          double width, double height);
 
     virtual void DrawSymbol(const Projection& projection,
                             const MapParameter& parameter,

--- a/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
+++ b/libosmscout-map-directx/include/osmscout/MapPainterDirectX.h
@@ -126,6 +126,7 @@ namespace osmscout {
                               const MapData& data);
 
     virtual bool HasIcon(const StyleConfig& styleConfig,
+                         const Projection& projection,
                          const MapParameter& parameter,
                          IconStyle& style);
 

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -666,7 +666,9 @@ namespace osmscout
     m_LabelLayouter.Reset();
   }
 
-  void MapPainterDirectX::DrawIcon(const IconStyle* style, double x, double y)
+  void MapPainterDirectX::DrawIcon(const IconStyle* style,
+                                   double x, double y,
+                                   double /*width*/, double /*height*/)
   {
     size_t idx = style->GetIconId() - 1;
     assert(idx < m_Bitmaps.size());

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -431,6 +431,7 @@ namespace osmscout
   }
 
   bool MapPainterDirectX::HasIcon(const StyleConfig& /*styleConfig*/,
+                                  const Projection& projection,
                                   const MapParameter& parameter,
                                   IconStyle& style)
   {
@@ -450,8 +451,19 @@ namespace osmscout
 
     if (m_pImagingFactory == NULL) return false;
 
+    if (parameter.GetIconMode()==MapParameter::IconMode::Scalable ||
+        parameter.GetIconMode()==MapParameter::IconMode::ScaledPixmap){
+
+      style.SetWidth(std::round(projection.ConvertWidthToPixel(parameter.GetIconSize())));
+      style.SetHeight(style.GetWidth());
+    }else{
+      style.SetWidth(std::round(parameter.GetIconPixelSize()));
+      style.SetHeight(style.GetWidth());
+    }
+
     for (std::list<std::string>::const_iterator path = parameter.GetIconPaths().begin(); path != parameter.GetIconPaths().end(); ++path)
     {
+      // TODO: add support for reading svg images
       std::wstring filename = s2w(*path + style.GetIconName() + ".png");
       ID2D1Bitmap* pBitmap = NULL;
       if (LoadBitmapFromFile(filename.c_str(), &pBitmap))
@@ -668,14 +680,14 @@ namespace osmscout
 
   void MapPainterDirectX::DrawIcon(const IconStyle* style,
                                    double x, double y,
-                                   double /*width*/, double /*height*/)
+                                   double width, double height)
   {
     size_t idx = style->GetIconId() - 1;
     assert(idx < m_Bitmaps.size());
     assert(m_Bitmaps[idx] != NULL);
-    D2D1_SIZE_U size = m_Bitmaps[idx]->GetPixelSize();
-    FLOAT dx = (FLOAT)size.width / 2.0f;
-    FLOAT dy = (FLOAT)size.height / 2.0f;
+
+    FLOAT dx = (FLOAT)width / 2.0f;
+    FLOAT dy = (FLOAT)height / 2.0f;
     m_pRenderTarget->DrawBitmap(m_Bitmaps[idx], RECTF(x - dx, y - dy, x + dx, y + dy));
   }
 

--- a/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
+++ b/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
@@ -144,7 +144,8 @@ namespace osmscout {
                                 const MapData& data) override;
         
         void DrawIcon(const IconStyle* style,
-                      double x, double y) override;
+                      double centerX, double centerY,
+                      double width, double height) override;
         
         void DrawSymbol(const Projection& projection,
                         const MapParameter& parameter,

--- a/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
+++ b/libosmscout-map-iOSX/include/osmscout/MapPainterIOS.h
@@ -101,6 +101,7 @@ namespace osmscout {
                                           CGContextRef paintCG);
     protected:
         bool HasIcon(const StyleConfig& styleConfig,
+                     const Projection& projection,
                      const MapParameter& parameter,
                      IconStyle& style) override;
         

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -301,6 +301,7 @@ namespace osmscout {
      * HasIcon()
      */
     bool MapPainterIOS::HasIcon(const StyleConfig& /* styleConfig */,
+                                const Projection& /*projection*/,
                                 const MapParameter& parameter,
                                 IconStyle& style){
         if (style.GetIconId()==0) {

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -929,10 +929,12 @@ namespace osmscout {
     /*
      *
      * DrawIcon(const IconStyle* style,
-     *          double x, double y)
+     *          double centerX, double centerY,
+     *          double width, double height)
      */
     void MapPainterIOS::DrawIcon(const IconStyle* style,
-                  double x, double y){
+                                 double x, double y,
+                                 double /*width*/, double /*height*/){
         size_t idx=style->GetIconId()-1;
 
         assert(idx<images.size());

--- a/libosmscout-map-qt/CMakeLists.txt
+++ b/libosmscout-map-qt/CMakeLists.txt
@@ -52,7 +52,8 @@ endif()
 target_link_libraries(OSMScoutMapQt
 		OSMScout
 		OSMScoutMap
-		Qt5::Gui)
+		Qt5::Gui
+		Qt5::Svg)
 
 target_compile_definitions(OSMScoutMapQt PRIVATE -DOSMSCOUT_MAP_QT_EXPORT_SYMBOLS)
 

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -132,6 +132,7 @@ namespace osmscout {
 
   protected:
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style) override;
 

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -180,7 +180,8 @@ namespace osmscout {
                             const MapData& data) override;
 
     void DrawIcon(const IconStyle* style,
-                  double x, double y) override;
+                  double centerX, double centerY,
+                  double width, double height) override;
 
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,

--- a/libosmscout-map-qt/meson.build
+++ b/libosmscout-map-qt/meson.build
@@ -17,7 +17,7 @@ osmscoutmapqt = library('osmscout_map_qt',
                         osmscoutmapqtSrc,
                         include_directories: [osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
                         cpp_args: cppArgs,
-                        dependencies: [mathDep, threadDep, qt5GuiDep],
+                        dependencies: [mathDep, threadDep, qt5GuiDep, qt5SvgDep],
                         link_with: [osmscout, osmscoutmap],
                         install: true)
         

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -111,19 +111,37 @@ namespace osmscout {
     std::list<std::string> erronousPaths;
 
     for (const auto& path : parameter.GetIconPaths()) {
-      std::string filename=AppendFileToDir(path,style.GetIconName()+".png");
-
       QImage image;
+      std::string filename;
+      bool success=false;
+      if (parameter.GetIconMode()==MapParameter::IconMode::Scalable){
+        filename=AppendFileToDir(path,style.GetIconName()+".svg");
 
-      if (image.load(filename.c_str())) {
-        if (idx>=images.size()) {
-          images.resize(idx+1);
+        // Load SVG
+        QSvgRenderer renderer(QString::fromStdString(filename));
+        if (renderer.isValid()) {
+          image = QImage(style.GetWidth(), style.GetHeight(), QImage::Format_ARGB32);
+          image.fill(Qt::transparent);
+
+          QPainter painter(&image);
+          renderer.render(&painter);
+          painter.end();
+          success = !image.isNull();
+        }
+      }else{
+        filename=AppendFileToDir(path,style.GetIconName()+".png");
+        if (image.load(filename.c_str())) {
+          success = true;
+        }
+      }
+
+      if (success) {
+        if (idx >= images.size()) {
+          images.resize(idx + 1);
         }
 
-        images[idx]=image;
-
+        images[idx] = image;
         //std::cout << "Loaded image '" << filename << "'" << std::endl;
-
         return true;
       }
 

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -26,6 +26,7 @@
 #include <QPainterPath>
 #include <QTextLayout>
 #include <QDebug>
+#include <QtSvg/QSvgRenderer>
 
 #include <osmscout/system/Assert.h>
 #include <osmscout/system/Math.h>
@@ -82,6 +83,7 @@ namespace osmscout {
   }
 
   bool MapPainterQt::HasIcon(const StyleConfig& /*styleConfig*/,
+                             const Projection& projection,
                              const MapParameter& parameter,
                              IconStyle& style)
   {
@@ -94,6 +96,16 @@ namespace osmscout {
     if (idx<images.size() &&
         !images[idx].isNull()) {
       return true;
+    }
+
+    if (parameter.GetIconMode()==MapParameter::IconMode::Scalable ||
+        parameter.GetIconMode()==MapParameter::IconMode::ScaledPixmap){
+
+      style.SetWidth(std::round(projection.ConvertWidthToPixel(parameter.GetIconSize())));
+      style.SetHeight(style.GetWidth());
+    }else{
+      style.SetWidth(std::round(parameter.GetIconPixelSize()));
+      style.SetHeight(style.GetWidth());
     }
 
     std::list<std::string> erronousPaths;

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -559,16 +559,17 @@ namespace osmscout {
   }
 
   void MapPainterQt::DrawIcon(const IconStyle* style,
-                              double x, double y)
+                              double x, double y,
+                              double width, double height)
   {
     size_t idx=style->GetIconId()-1;
 
     assert(idx<images.size());
     assert(!images[idx].isNull());
 
-    painter->drawImage(QPointF(x-images[idx].width()/2,
-                               y-images[idx].height()/2),
-                       images[idx]);
+    painter->drawImage(QRectF(x-width/2, y-height/2, width, height),
+                       images[idx],
+                       QRectF(0, 0, images[idx].width(), images[idx].height()));
   }
 
   void MapPainterQt::DrawSymbol(const Projection& projection,

--- a/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
@@ -186,7 +186,8 @@ namespace osmscout {
                     double x, double y) override;
 
     void DrawIcon(const IconStyle* style,
-                  double x, double y) override;
+                  double centerX, double centerY,
+                  double width, double height) override;
 
     void DrawPath(const Projection& projection,
                   const MapParameter& parameter,

--- a/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
@@ -147,6 +147,7 @@ namespace osmscout {
                       const MapData& data) override;
 
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style) override;
 

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -730,7 +730,8 @@ namespace osmscout {
   }
 
   void MapPainterSVG::DrawIcon(const IconStyle* /*style*/,
-                                 double /*x*/, double /*y*/)
+                               double /*x*/, double /*y*/,
+                               double /*width*/, double /*height*/)
   {
     // Not implemented
   }

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -572,6 +572,7 @@ namespace osmscout {
   }
 
   bool MapPainterSVG::HasIcon(const StyleConfig& /*styleConfig*/,
+                              const Projection& /*projection*/,
                               const MapParameter& /*parameter*/,
                               IconStyle& /*style*/)
   {

--- a/libosmscout-map/include/osmscout/LabelLayouter.h
+++ b/libosmscout-map/include/osmscout/LabelLayouter.h
@@ -505,7 +505,8 @@ namespace osmscout {
      *                      double x, double y) override;
      *
      *      void DrawIcon(const IconStyle* style,
-     *                    double x, double y) override;
+     *                    double centerX, double centerY,
+     *                    double width, double height) override;
      *
      *      void DrawLabel(const Projection& projection,
      *                     const MapParameter& parameter,
@@ -554,7 +555,9 @@ namespace osmscout {
           } else if (el.labelData.type==LabelData::Icon){
             p->DrawIcon(el.labelData.iconStyle.get(),
                         el.x + el.labelData.iconWidth/2,
-                        el.y + el.labelData.iconHeight/2);
+                        el.y + el.labelData.iconHeight/2,
+                        el.labelData.iconWidth,
+                        el.labelData.iconHeight);
 
           } else {
             // postpone text elements

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -609,7 +609,8 @@ namespace osmscout {
       Draw the Icon as defined by the IconStyle at the given pixel coordinate (icon center).
      */
     virtual void DrawIcon(const IconStyle* style,
-                          double x, double y) = 0;
+                          double centerX, double centerY,
+                          double width, double height) = 0;
 
     /**
       Draw the Symbol as defined by the SymbolStyle at the given pixel coordinate (symbol center).

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -562,8 +562,11 @@ namespace osmscout {
       Return true, if the icon in the IconStyle is available and can be drawn.
       If this method returns false, possibly a fallback (using a Symbol)
       will be chosen.
+
+      Icon style dimensions and iconId may be setup for later usage.
      */
     virtual bool HasIcon(const StyleConfig& styleConfig,
+                         const Projection& projection,
                          const MapParameter& parameter,
                          IconStyle& style)= 0;
 

--- a/libosmscout-map/include/osmscout/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscout/MapPainterNoOp.h
@@ -36,6 +36,7 @@ namespace osmscout {
   {
   protected:
     bool HasIcon(const StyleConfig& styleConfig,
+                 const Projection& projection,
                  const MapParameter& parameter,
                  IconStyle& style) override;
 

--- a/libosmscout-map/include/osmscout/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscout/MapPainterNoOp.h
@@ -63,8 +63,8 @@ namespace osmscout {
                     const MapData& data) override;
 
     void DrawIcon(const IconStyle* style,
-                  double x,
-                  double y) override;
+                  double centerX, double centerY,
+                  double width, double height) override;
 
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -39,6 +39,14 @@ namespace osmscout {
    */
   class OSMSCOUT_MAP_API MapParameter CLASS_FINAL
   {
+  public:
+    enum IconMode
+    {
+      FixedSizePixmap,  // !< raster icons should be used, iconPixelSize will be used for rendering
+      ScaledPixmap,     // !< raster icons should be used, icons will be scaled to iconSize
+      Scalable          // !< vector icons should be used, icons will be scaled to iconSize
+    };
+
   private:
     std::string                         fontName;                  //!< Name of the font to use
     double                              fontSize;                  //!< Metric size of base font (aka font size 100%) in millimeter
@@ -64,8 +72,12 @@ namespace osmscout {
     double                              labelPadding;              //!< Space around point labels in mm (default 1).
     double                              plateLabelPadding;         //!< Space around plates in mm (default 5).
     double                              overlayLabelPadding;       //!< Space around overlay labels in mm (default 6).
+
+    IconMode                            iconMode;                  //!< Mode of icon, it controls what type of files would be loaded and computation of icon dimensions
     double                              iconSize;                  //!< Size of icons in mm (default 3.7)
+    double                              iconPixelSize;             //!< Size of icons in px (default 14)
     double                              iconPadding;               //!< Space around icons and symbols in mm (default 1).
+
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
 
   private:
@@ -117,8 +129,12 @@ namespace osmscout {
     void SetLabelPadding(double labelPadding);
     void SetPlateLabelPadding(double plateLabelPadding);
     void SetOverlayLabelPadding(double padding);
+
+    void SetIconMode(const IconMode &mode);
     void SetIconSize(double size);
+    void SetIconPixelSize(double size);
     void SetIconPadding(double padding);
+
     void SetContourLabelPadding(double padding);
 
     void SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels);
@@ -236,9 +252,19 @@ namespace osmscout {
       return overlayLabelPadding;
     }
 
+    inline IconMode GetIconMode() const
+    {
+      return iconMode;
+    }
+
     inline double GetIconSize() const
     {
       return iconSize;
+    }
+
+    inline double GetIconPixelSize() const
+    {
+      return iconPixelSize;
     }
 
     inline double GetIconPadding() const

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -64,6 +64,7 @@ namespace osmscout {
     double                              labelPadding;              //!< Space around point labels in mm (default 1).
     double                              plateLabelPadding;         //!< Space around plates in mm (default 5).
     double                              overlayLabelPadding;       //!< Space around overlay labels in mm (default 6).
+    double                              iconSize;                  //!< Size of icons in mm (default 3.7)
     double                              iconPadding;               //!< Space around icons and symbols in mm (default 1).
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
 
@@ -116,6 +117,7 @@ namespace osmscout {
     void SetLabelPadding(double labelPadding);
     void SetPlateLabelPadding(double plateLabelPadding);
     void SetOverlayLabelPadding(double padding);
+    void SetIconSize(double size);
     void SetIconPadding(double padding);
     void SetContourLabelPadding(double padding);
 
@@ -232,6 +234,11 @@ namespace osmscout {
     inline double GetOverlayLabelPadding() const
     {
       return overlayLabelPadding;
+    }
+
+    inline double GetIconSize() const
+    {
+      return iconSize;
     }
 
     inline double GetIconPadding() const

--- a/libosmscout-map/include/osmscout/Styles.h
+++ b/libosmscout-map/include/osmscout/Styles.h
@@ -845,10 +845,12 @@ namespace osmscout {
     };
 
   private:
-    SymbolRef   symbol;
-    std::string iconName; //!< name of the icon as given in style
-    size_t      iconId;   //!< Id for external resource binding
-    size_t      position; //!< Relative vertical position of the label
+    SymbolRef    symbol;
+    std::string  iconName; //!< name of the icon as given in style
+    size_t       iconId;   //!< Id for external resource binding
+    unsigned int width;    //!< width of icon in pixels
+    unsigned int height;   //!< height of icon in pixels
+    size_t       position; //!< Relative vertical position of the label
 
   public:
     IconStyle();
@@ -861,6 +863,8 @@ namespace osmscout {
     IconStyle& SetSymbol(const SymbolRef& symbol);
     IconStyle& SetIconName(const std::string& iconName);
     IconStyle& SetIconId(size_t id);
+    IconStyle& SetWidth(unsigned int w);
+    IconStyle& SetHeight(unsigned int h);
     IconStyle& SetPosition(size_t position);
 
     inline bool IsVisible() const
@@ -882,6 +886,16 @@ namespace osmscout {
     inline size_t GetIconId() const
     {
       return iconId;
+    }
+
+    inline unsigned int GetWidth() const
+    {
+      return width;
+    }
+
+    inline unsigned int GetHeight() const
+    {
+      return height;
     }
 
     inline size_t GetPosition() const

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -694,8 +694,8 @@ namespace osmscout {
         //data.priority=iconStyle->GetPriority();
 
         data.iconStyle=iconStyle;
-        data.iconWidth=projection.ConvertWidthToPixel(14.0);
-        data.iconHeight=projection.ConvertWidthToPixel(14.0);
+        data.iconWidth=projection.ConvertWidthToPixel(parameter.GetIconSize());
+        data.iconHeight=projection.ConvertWidthToPixel(parameter.GetIconSize());
 
         labelLayoutData.push_back(data);
       } else if (iconStyle->GetSymbol()) {

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -683,6 +683,7 @@ namespace osmscout {
     if (iconStyle) {
       if (!iconStyle->GetIconName().empty() &&
           HasIcon(*styleConfig,
+                  projection,
                   parameter,
                   *iconStyle)) {
         LabelData data;
@@ -694,8 +695,8 @@ namespace osmscout {
         //data.priority=iconStyle->GetPriority();
 
         data.iconStyle=iconStyle;
-        data.iconWidth=projection.ConvertWidthToPixel(parameter.GetIconSize());
-        data.iconHeight=projection.ConvertWidthToPixel(parameter.GetIconSize());
+        data.iconWidth=iconStyle->GetWidth();
+        data.iconHeight=iconStyle->GetHeight();
 
         labelLayoutData.push_back(data);
       } else if (iconStyle->GetSymbol()) {

--- a/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
@@ -79,8 +79,8 @@ namespace osmscout {
   }
 
   void MapPainterNoOp::DrawIcon(const IconStyle* /*style*/,
-                                double /*x*/,
-                                double /*y*/)
+                                double /*centerX*/, double /*centerY*/,
+                                double /*width*/, double /*height*/)
   {
     // no code
   }

--- a/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
@@ -32,6 +32,7 @@ namespace osmscout {
   }
 
   bool MapPainterNoOp::HasIcon(const StyleConfig& /*styleConfig*/,
+                               const Projection& /*projection*/,
                                const MapParameter& /*parameter*/,
                                IconStyle& /*style*/)
   {

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -38,7 +38,9 @@ namespace osmscout {
     labelPadding(1.0),
     plateLabelPadding(5.0),
     overlayLabelPadding(6.0),
+    iconMode(IconMode::FixedSizePixmap),
     iconSize(3.7),
+    iconPixelSize(14),
     iconPadding(1.0),
     dropNotVisiblePointLabels(true),
     contourLabelOffset(5.0),
@@ -145,9 +147,19 @@ namespace osmscout {
     this->overlayLabelPadding=padding;
   }
 
+  void MapParameter::SetIconMode(const IconMode &mode)
+  {
+    this->iconMode = mode;
+  }
+
   void MapParameter::SetIconSize(double size)
   {
     this->iconSize = size;
+  }
+
+  void MapParameter::SetIconPixelSize(double size)
+  {
+    this->iconPixelSize = size;
   }
 
   void MapParameter::SetIconPadding(double padding)

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -38,6 +38,7 @@ namespace osmscout {
     labelPadding(1.0),
     plateLabelPadding(5.0),
     overlayLabelPadding(6.0),
+    iconSize(3.7),
     iconPadding(1.0),
     dropNotVisiblePointLabels(true),
     contourLabelOffset(5.0),
@@ -142,6 +143,11 @@ namespace osmscout {
   void MapParameter::SetOverlayLabelPadding(double padding)
   {
     this->overlayLabelPadding=padding;
+  }
+
+  void MapParameter::SetIconSize(double size)
+  {
+    this->iconSize = size;
   }
 
   void MapParameter::SetIconPadding(double padding)

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -1670,6 +1670,8 @@ namespace osmscout {
 
   IconStyle::IconStyle()
    : iconId(0),
+     width(14),
+     height(14),
      position(0)
   {
     // no code
@@ -1678,6 +1680,8 @@ namespace osmscout {
   IconStyle::IconStyle(const IconStyle& style)
   : iconName(style.iconName),
     iconId(style.iconId),
+    width(style.width),
+    height(style.height),
     position(style.position)
   {
     // no code
@@ -1736,6 +1740,20 @@ namespace osmscout {
   IconStyle& IconStyle::SetIconId(size_t id)
   {
     this->iconId=id;
+
+    return *this;
+  }
+
+  IconStyle& IconStyle::SetWidth(unsigned int w)
+  {
+    this->width=w;
+
+    return *this;
+  }
+
+  IconStyle& IconStyle::SetHeight(unsigned int h)
+  {
+    this->height=h;
 
     return *this;
   }


### PR DESCRIPTION
* add support icons rescaling to Qt map painter
* set default icon size to 3.7 mm (~14px with 96 DPI)

Hi @Framstag , @vyskocil and others. Before merge this MR, we should decide how to handle icon size. Label layouter now assumes that icon size is 14 mm (not px), but Qt, Cairo and Mac render icon with dimension of source image (14px with default icons), iOS renderer use upscaling by `contentScale`.

14 pixels is too small for hi-DPI displays and there is no possibility to change it... So I added icon size to render arguments (with default value 3.7 mm = 14px @ 96 DPI) and use this value in layouter and DrawIcon method then...