### PR TITLE
Scalable patterns

### DIFF
--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -328,7 +328,8 @@ void PlaneMapRenderer::DrawMap()
 
     paths.push_back(iconDirectory.toLocal8Bit().data());
 
-    drawParameter.SetIconMode(osmscout::MapParameter::Scalable);
+    drawParameter.SetIconMode(osmscout::MapParameter::IconMode::Scalable);
+    drawParameter.SetPatternMode(osmscout::MapParameter::PatternMode::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
     drawParameter.SetDebugData(false);

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -328,6 +328,7 @@ void PlaneMapRenderer::DrawMap()
 
     paths.push_back(iconDirectory.toLocal8Bit().data());
 
+    drawParameter.SetIconMode(osmscout::MapParameter::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
     drawParameter.SetDebugData(false);

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -422,6 +422,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
 
     paths.push_back(iconDirectory.toLocal8Bit().data());
 
+    drawParameter.SetIconMode(osmscout::MapParameter::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
     drawParameter.SetDebugData(false);

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -422,7 +422,8 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
 
     paths.push_back(iconDirectory.toLocal8Bit().data());
 
-    drawParameter.SetIconMode(osmscout::MapParameter::Scalable);
+    drawParameter.SetIconMode(osmscout::MapParameter::IconMode::Scalable);
+    drawParameter.SetPatternMode(osmscout::MapParameter::PatternMode::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
     drawParameter.SetDebugData(false);

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -485,6 +485,11 @@ namespace osmscout {
           images.resize(idx + 1, nullptr);
         }
 
+        if (parameter.GetIconMode()==MapParameter::IconMode::OriginalPixmap){
+          style.SetWidth(cairo_image_surface_get_width(image));
+          style.SetHeight(cairo_image_surface_get_height(image));
+        }
+
         images[idx] = image;
 
         std::cout << "Loaded image '" << filename << "'" << std::endl;

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -468,6 +468,12 @@ namespace osmscout
       ID2D1Bitmap* pBitmap = NULL;
       if (LoadBitmapFromFile(filename.c_str(), &pBitmap))
       {
+        if (parameter.GetIconMode()==MapParameter::IconMode::OriginalPixmap){
+          D2D1_SIZE_U size = pBitmap->GetPixelSize();
+          style.SetWidth(size.width);
+          style.SetHeight(size.height);
+        }
+
         std::wcout << L"Loaded image '" << filename << L"'" << std::endl;
         m_Bitmaps[idx] = pBitmap;
         return true;

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -136,7 +136,8 @@ namespace osmscout {
                  const MapParameter& parameter,
                  IconStyle& style) override;
 
-    bool HasPattern(const MapParameter& parameter,
+    bool HasPattern(const Projection& projection,
+                    const MapParameter& parameter,
                     const FillStyle& style);
 
     double GetFontHeight(const Projection& projection,

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -163,7 +163,8 @@ namespace osmscout {
     return false;
   }
 
-  bool MapPainterQt::HasPattern(const MapParameter& parameter,
+  bool MapPainterQt::HasPattern(const Projection& projection,
+                                const MapParameter& parameter,
                                 const FillStyle& style)
   {
     assert(style.HasPattern());
@@ -183,11 +184,35 @@ namespace osmscout {
     std::list<std::string> erronousPaths;
 
     for (const auto& path : parameter.GetPatternPaths()) {
-      std::string filename=AppendFileToDir(path,style.GetPatternName()+".png");
-
+      bool success = false;
+      std::string filename;
       QImage image;
+      if (parameter.GetPatternMode()==MapParameter::PatternMode::Scalable){
+        filename=AppendFileToDir(path,style.GetPatternName()+".svg");
 
-      if (image.load(filename.c_str())) {
+        // Load SVG
+        QSvgRenderer renderer(QString::fromStdString(filename));
+        if (renderer.isValid()) {
+          int dimension = std::round(projection.ConvertWidthToPixel(parameter.GetPatternSize()));
+          image = QImage(dimension, dimension, QImage::Format_ARGB32);
+
+          // Qt svg don't support page background from Inkscape SVGs, use fill color as workaround for it
+          image.fill(QColor::fromRgbF(style.GetFillColor().GetR(),
+                                      style.GetFillColor().GetG(),
+                                      style.GetFillColor().GetB(),
+                                      style.GetFillColor().GetA()));
+
+          QPainter painter(&image);
+          renderer.render(&painter);
+          painter.end();
+          success = !image.isNull();
+        }
+      }else {
+        filename = AppendFileToDir(path, style.GetPatternName() + ".png");
+        success = image.load(filename.c_str());
+      }
+
+      if (success) {
         if (idx>=patternImages.size()) {
           patternImages.resize(idx+1);
         }
@@ -1016,7 +1041,7 @@ namespace osmscout {
   {
     if (fillStyle.HasPattern() &&
         projection.GetMagnification()>=fillStyle.GetPatternMinMag() &&
-        HasPattern(parameter,fillStyle)) {
+        HasPattern(projection, parameter, fillStyle)) {
       size_t idx=fillStyle.GetPatternId()-1;
 
       painter->setBrush(patterns[idx]);

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -131,6 +131,10 @@ namespace osmscout {
       }else{
         filename=AppendFileToDir(path,style.GetIconName()+".png");
         if (image.load(filename.c_str())) {
+          if (parameter.GetIconMode()==MapParameter::IconMode::OriginalPixmap){
+            style.SetWidth(image.width());
+            style.SetHeight(image.height());
+          }
           success = true;
         }
       }

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -40,12 +40,18 @@ namespace osmscout {
   class OSMSCOUT_MAP_API MapParameter CLASS_FINAL
   {
   public:
-    enum IconMode
+    enum class IconMode
     {
       FixedSizePixmap,  // !< raster icons should be used, iconPixelSize will be used for rendering
       ScaledPixmap,     // !< raster icons should be used, icons will be scaled to iconSize
       OriginalPixmap,   // !< raster icons should be used, icons will keep dimensions of original image
       Scalable          // !< vector icons should be used, icons will be scaled to iconSize
+    };
+
+    enum class PatternMode
+    {
+      OriginalPixmap,   // !< raster pattern should be used, it will keep dimensions of original image
+      Scalable          // !< vector pattern should be used, it will be scaled to patternSize
     };
 
   private:
@@ -74,10 +80,13 @@ namespace osmscout {
     double                              plateLabelPadding;         //!< Space around plates in mm (default 5).
     double                              overlayLabelPadding;       //!< Space around overlay labels in mm (default 6).
 
-    IconMode                            iconMode;                  //!< Mode of icon, it controls what type of files would be loaded and computation of icon dimensions
+    IconMode                            iconMode;                  //!< Mode of icons, it controls what type of files would be loaded and how icon dimensions will be calculated
     double                              iconSize;                  //!< Size of icons in mm (default 3.7)
     double                              iconPixelSize;             //!< Size of icons in px (default 14)
     double                              iconPadding;               //!< Space around icons and symbols in mm (default 1).
+
+    PatternMode                         patternMode;               //!< Mode of pattern, it controls what type of files would be loaded and how pattern geometry will be canculated
+    double                              patternSize;               //!< Size of pattern image in mm (default 3.7)
 
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
 
@@ -135,6 +144,9 @@ namespace osmscout {
     void SetIconSize(double size);
     void SetIconPixelSize(double size);
     void SetIconPadding(double padding);
+
+    void SetPatternMode(const PatternMode &mode);
+    void SetPatternSize(double size);
 
     void SetContourLabelPadding(double padding);
 
@@ -271,6 +283,16 @@ namespace osmscout {
     inline double GetIconPadding() const
     {
       return iconPadding;
+    }
+
+    inline PatternMode GetPatternMode() const
+    {
+      return patternMode;
+    }
+
+    inline double GetPatternSize() const
+    {
+      return patternSize;
     }
 
     inline double GetContourLabelPadding() const

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -44,6 +44,7 @@ namespace osmscout {
     {
       FixedSizePixmap,  // !< raster icons should be used, iconPixelSize will be used for rendering
       ScaledPixmap,     // !< raster icons should be used, icons will be scaled to iconSize
+      OriginalPixmap,   // !< raster icons should be used, icons will keep dimensions of original image
       Scalable          // !< vector icons should be used, icons will be scaled to iconSize
     };
 

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -42,6 +42,8 @@ namespace osmscout {
     iconSize(3.7),
     iconPixelSize(14),
     iconPadding(1.0),
+    patternMode(PatternMode::OriginalPixmap),
+    patternSize(3.7),
     dropNotVisiblePointLabels(true),
     contourLabelOffset(5.0),
     contourLabelSpace(30.0),
@@ -165,6 +167,16 @@ namespace osmscout {
   void MapParameter::SetIconPadding(double padding)
   {
     this->iconPadding=padding;
+  }
+
+  void MapParameter::SetPatternMode(const PatternMode &mode)
+  {
+    this->patternMode = mode;
+  }
+
+  void MapParameter::SetPatternSize(double size)
+  {
+    this->patternSize = size;
   }
 
   void MapParameter::SetContourLabelPadding(double padding)


### PR DESCRIPTION
API changes in MapParameter:

 * added icon mode `OriginalPixmap` => raster icons should be used, icons will keep dimensions of original image
 * added new option pattern mode that controls how are patterns are rendered. 

```
    enum class PatternMode
    {
      OriginalPixmap,   // !< raster pattern should be used, it will keep dimensions of original image
      Scalable          // !< vector pattern should be used, it will be scaled to patternSize
    };
```

 * add support for scalable (svg) patters in Qt map painter
 * and finally, use scalable (svg) icons and patterns as default in Client-Qt library ;-)
