### PR TITLE
Fix icon size

### DIFF
--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -455,12 +455,8 @@ namespace osmscout {
 
     size_t idx = style.GetIconId() - 1;
 
-    // Already cached?
-    if (idx < images.size() &&
-        images[idx] != nullptr) {
-      return true;
-    }
-
+    // there is possible that exists multiple IconStyle instances with same iconId (point and area icon with same icon name)
+    // setup dimensions for all of them
     if (parameter.GetIconMode()==MapParameter::IconMode::Scalable ||
         parameter.GetIconMode()==MapParameter::IconMode::ScaledPixmap){
 
@@ -469,6 +465,17 @@ namespace osmscout {
     }else{
       style.SetWidth(std::round(parameter.GetIconPixelSize()));
       style.SetHeight(style.GetWidth());
+    }
+
+    // Already cached?
+    if (idx < images.size() &&
+        images[idx] != nullptr) {
+
+      if (parameter.GetIconMode()==MapParameter::IconMode::OriginalPixmap){
+        style.SetWidth(cairo_image_surface_get_width(images[idx]));
+        style.SetHeight(cairo_image_surface_get_height(images[idx]));
+      }
+      return true;
     }
 
     for (std::list<std::string>::const_iterator path = parameter.GetIconPaths().begin();

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -93,11 +93,9 @@ namespace osmscout {
 
     size_t idx=style.GetIconId()-1;
 
-    if (idx<images.size() &&
-        !images[idx].isNull()) {
-      return true;
-    }
-
+    // there is possible that exists multiple IconStyle instances with same iconId (point and area icon with same icon name)
+    // setup dimensions for all of them
+    // std::cout << style.GetIconId() << ": " << style.GetIconName() << " @ " << &style << std::endl;
     if (parameter.GetIconMode()==MapParameter::IconMode::Scalable ||
         parameter.GetIconMode()==MapParameter::IconMode::ScaledPixmap){
 
@@ -106,6 +104,16 @@ namespace osmscout {
     }else{
       style.SetWidth(std::round(parameter.GetIconPixelSize()));
       style.SetHeight(style.GetWidth());
+    }
+
+    if (idx<images.size() &&
+        !images[idx].isNull()) {
+
+      if (parameter.GetIconMode()==MapParameter::IconMode::OriginalPixmap){
+        style.SetWidth(images[idx].width());
+        style.SetHeight(images[idx].height());
+      }
+      return true;
     }
 
     std::list<std::string> erronousPaths;

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -585,11 +585,8 @@ namespace osmscout {
 
     size_t idx=style.GetIconId()-1;
 
-    if (idx<images.size() &&
-        !images[idx].empty()) {
-      return true;
-    }
-
+    // there is possible that exists multiple IconStyle instances with same iconId (point and area icon with same icon name)
+    // setup dimensions for all of them
     double dimension;
     if (parameter.GetIconMode()==MapParameter::IconMode::Scalable) {
       dimension = projection.ConvertWidthToPixel(parameter.GetIconSize());
@@ -601,6 +598,11 @@ namespace osmscout {
 
     style.SetWidth(dimension);
     style.SetHeight(dimension);
+
+    if (idx<images.size() &&
+        !images[idx].empty()) {
+      return true;
+    }
 
     for (const auto& path : parameter.GetIconPaths()) {
       std::string filename;

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -885,26 +885,26 @@ namespace osmscout {
       return;
     }
 
-    double minX;
-    double maxX;
-    double minY;
-    double maxY;
+    double x1;
+    double x2;
+    double y1;
+    double y2;
 
     projection.GeoToPixel(areaData.boundingBox.GetMinCoord(),
-                          minX,minY);
+                          x1,y1);
 
     projection.GeoToPixel(areaData.boundingBox.GetMaxCoord(),
-                          maxX,maxY);
+                          x2,y2);
 
     LayoutPointLabels(projection,
                       parameter,
                       *areaData.buffer,
                       iconStyle,
                       textStyles,
-                      (minX+maxX)/2,
-                      (minY+maxY)/2,
-                      maxX-minX,
-                      maxY-minY);
+                      (x1+x2)/2,
+                      (y1+y2)/2,
+                      std::max(x1, x2) - std::min(x1, x2),
+                      std::max(y1, y2) - std::min(y1, y2));
   }
 
   bool MapPainter::DrawAreaBorderLabel(const StyleConfig& styleConfig,


### PR DESCRIPTION
When there are multiple icons styles with same icon id (parking as a point and parking as a area), second style has incorrect (default) size. This MR fixes it.