### PR TITLE
Qt model improvements

### DIFF
--- a/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
@@ -205,6 +205,7 @@ public:
     SizeRole = Qt::UserRole+9,
     MapRole = Qt::UserRole+10,
   };
+  Q_ENUM(Roles)
 
   Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
   Q_INVOKABLE virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;

--- a/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
@@ -37,10 +37,10 @@ class OSMSCOUT_CLIENT_QT_API InstalledMapsModel : public QAbstractListModel {
 Q_OBJECT
 
 signals:
-  void databaseListChagned();
+  void databaseListChanged();
 
 public slots:
-  void onDatabaseListChagned();
+  void onDatabaseListChanged();
 
 public:
   InstalledMapsModel();

--- a/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
@@ -53,6 +53,7 @@ public:
     DirectoryRole = Qt::UserRole + 2, // directory
     TimeRole = Qt::UserRole + 3, // generating time of map
   };
+  Q_ENUM(Roles)
 
   Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
   Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;

--- a/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
@@ -36,6 +36,9 @@ namespace osmscout {
 class OSMSCOUT_CLIENT_QT_API InstalledMapsModel : public QAbstractListModel {
 Q_OBJECT
 
+signals:
+  void databaseListChagned();
+
 public slots:
   void onDatabaseListChagned();
 

--- a/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/InstalledMapsModel.h
@@ -66,6 +66,7 @@ public:
    * @return true on success
    */
   Q_INVOKABLE bool deleteMap(int row);
+  Q_INVOKABLE virtual bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
 
   /**
    * Generation time of map with given path. Null if don't exists
@@ -77,6 +78,7 @@ public:
   Q_INVOKABLE QVariant timeOfMap(QStringList path);
 
 private:
+  QList<MapDirectory> dirs;
   MapManagerRef mapManager;
 };
 

--- a/libosmscout-client-qt/include/osmscout/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/LocationInfoModel.h
@@ -79,6 +79,7 @@ public:
         AddressLocationRole = Qt::UserRole+11,
         AddressNumberRole = Qt::UserRole+12
     };
+    Q_ENUM(Roles)
 
 public:
     LocationInfoModel();

--- a/libosmscout-client-qt/include/osmscout/MapDownloadsModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapDownloadsModel.h
@@ -64,6 +64,7 @@ public:
     ProgressDescriptionRole = Qt::UserRole+3,
     ErrorStringRole = Qt::UserRole+4,
   };
+  Q_ENUM(Roles)
 
   Q_INVOKABLE virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
   Q_INVOKABLE virtual QVariant data(const QModelIndex &index, int role) const;

--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -135,6 +135,7 @@ public:
 class OSMSCOUT_CLIENT_QT_API MapDirectory
 {
 public:
+  MapDirectory() = default;
   explicit MapDirectory(QDir dir);
   ~MapDirectory() = default;
 
@@ -199,6 +200,14 @@ public:
   inline QDateTime getCreation() const
   {
     return creation;
+  }
+
+  inline bool operator<(const MapDirectory &o) const
+  {
+    if (getName() == o.getName()){
+      return getDir().absolutePath() < o.getDir().absolutePath();
+    }
+    return getName() < o.getName();
   }
 
 private:

--- a/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
@@ -61,6 +61,7 @@ public:
       NameRole   = Qt::UserRole+3,
       ObjectRole = Qt::UserRole+4,
   };
+  Q_ENUM(Roles)
 
 signals:
   void readyChange(bool ready);

--- a/libosmscout-client-qt/include/osmscout/MapStyleModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapStyleModel.h
@@ -50,6 +50,7 @@ public:
       FileRole = Qt::UserRole+1,
       PathRole = Qt::UserRole+2,
   };
+  Q_ENUM(Roles)
 
   MapStyleModel();
   virtual ~MapStyleModel();

--- a/libosmscout-client-qt/include/osmscout/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscout/NearPOIModel.h
@@ -87,6 +87,7 @@ public:
     BearingRole = Qt::UserRole +6,
     LocationObjectRole = Qt::UserRole +7
   };
+  Q_ENUM(Roles)
 
 signals:
   void countChanged(int);

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -95,6 +95,7 @@ public:
     DescriptionRole = Qt::UserRole + 2,
     TypeRole = Qt::UserRole + 3
   };
+  Q_ENUM(Roles)
 
 public:
   RoutingListModel(QObject* parent = 0);

--- a/libosmscout-client-qt/include/osmscout/StyleFlagsModel.h
+++ b/libosmscout-client-qt/include/osmscout/StyleFlagsModel.h
@@ -56,6 +56,7 @@ public:
     ValueRole      = Qt::UserRole+1,
     InProgressRole = Qt::UserRole+2,
   };
+  Q_ENUM(Roles)
 
   StyleFlagsModel();
   virtual ~StyleFlagsModel();

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -131,7 +131,7 @@ Qt::ItemFlags InstalledMapsModel::flags(const QModelIndex &index) const
   return QAbstractListModel::flags(index) | Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-Q_INVOKABLE bool InstalledMapsModel::removeRows(int fromRow, int count, const QModelIndex &parent)
+Q_INVOKABLE bool InstalledMapsModel::removeRows(int fromRow, int count, const QModelIndex &/*parent*/)
 {
   if (fromRow < 0 || count <= 0 || fromRow + count > dirs.size()){
     return false;

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -27,6 +27,8 @@ InstalledMapsModel::InstalledMapsModel()
   mapManager=OSMScoutQt::GetInstance().GetMapManager();
   connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
           this, SLOT(onDatabaseListChagned()));
+  connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
+          this, SIGNAL(databaseListChagned()));
   onDatabaseListChagned();
 }
 

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -26,17 +26,17 @@ InstalledMapsModel::InstalledMapsModel()
 {
   mapManager=OSMScoutQt::GetInstance().GetMapManager();
   connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
-          this, SLOT(onDatabaseListChagned()));
+          this, SLOT(onDatabaseListChanged()));
   connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
-          this, SIGNAL(databaseListChagned()));
-  onDatabaseListChagned();
+          this, SIGNAL(databaseListChanged()));
+  onDatabaseListChanged();
 }
 
 InstalledMapsModel::~InstalledMapsModel()
 {
 }
 
-void InstalledMapsModel::onDatabaseListChagned()
+void InstalledMapsModel::onDatabaseListChanged()
 {
   beginResetModel();
   endResetModel();

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -38,19 +38,58 @@ InstalledMapsModel::~InstalledMapsModel()
 
 void InstalledMapsModel::onDatabaseListChanged()
 {
-  beginResetModel();
-  endResetModel();
+  QList<MapDirectory> currentDirs=mapManager->getDatabaseDirectories();
+
+  qStableSort(currentDirs);
+
+  // following process is little bit complicated, but we don't want to call
+  // model reset - it breaks UI animations for changes
+
+  // process removals
+  QMap<QString, MapDirectory> currentDirMap;
+  for (auto dir: currentDirs){
+    currentDirMap[dir.getDir().absolutePath()] = dir;
+  }
+
+  bool deleteDone=false;
+  while (!deleteDone){
+    deleteDone=true;
+    for (int row=0;row<dirs.size(); row++){
+      if (!currentDirMap.contains(dirs.at(row).getDir().absolutePath())){
+        beginRemoveRows(QModelIndex(), row, row);
+        dirs.removeAt(row);
+        endRemoveRows();
+        deleteDone = false;
+        break;
+      }
+    }
+  }
+
+  // process adds
+  QMap<QString, MapDirectory> oldDirMap;
+  for (auto dir: dirs){
+    oldDirMap[dir.getDir().absolutePath()] = dir;
+  }
+
+  for (int row = 0; row < currentDirs.size(); row++) {
+    auto dir = currentDirs.at(row);
+    if (!oldDirMap.contains(dir.getDir().absolutePath())){
+      beginInsertRows(QModelIndex(), row, row);
+      dirs.insert(row, dir);
+      endInsertRows();
+      oldDirMap[dir.getDir().absolutePath()] = dir;
+    }
+  }
 }
 
 int InstalledMapsModel::rowCount(const QModelIndex &/*parent*/) const
 {
-  return mapManager->getDatabaseDirectories().size();
+  return dirs.size();
 }
 
 QVariant InstalledMapsModel::data(const QModelIndex &index, int role) const
 {
-  QList<MapDirectory> dirs=mapManager->getDatabaseDirectories();
-  if (index.row() >= dirs.size()){
+  if (index.row() < 0 || index.row() >= dirs.size()){
     return QVariant();
   }
   auto dir=dirs.at(index.row());
@@ -92,16 +131,26 @@ Qt::ItemFlags InstalledMapsModel::flags(const QModelIndex &index) const
   return QAbstractListModel::flags(index) | Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-bool InstalledMapsModel::deleteMap(int row)
+Q_INVOKABLE bool InstalledMapsModel::removeRows(int fromRow, int count, const QModelIndex &parent)
 {
-  QList<MapDirectory> dirs=mapManager->getDatabaseDirectories();
-  if (row < 0 || row >= dirs.size()){
+  if (fromRow < 0 || count <= 0 || fromRow + count > dirs.size()){
     return false;
   }
-  auto dir=dirs.at(row);
-  bool result = dir.deleteDatabase();
+
+  for (int row = fromRow; row < (fromRow + count); row++){
+      auto dir=dirs.at(row);
+      if (!dir.deleteDatabase()){
+        qWarning() << "Failed to remove " << dir.getDir().absolutePath();
+        break;
+      }
+  }
   mapManager->lookupDatabases();
-  return result;
+  return true;
+}
+
+bool InstalledMapsModel::deleteMap(int row)
+{
+  return removeRows(row, 1);
 }
 
 QVariant InstalledMapsModel::timeOfMap(QStringList path)
@@ -109,7 +158,6 @@ QVariant InstalledMapsModel::timeOfMap(QStringList path)
   if (path.empty()){
     return QVariant();
   }
-  QList<MapDirectory> dirs=mapManager->getDatabaseDirectories();
   for (const auto &dir:dirs){
     if (dir.hasMetadata() && dir.getPath()==path){
       return dir.getCreation();

--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,9 @@ qt5SvgDep = dependency('qt5', modules: 'Svg', required: false)
 qt5NetworkDep = dependency('qt5', modules: 'Network', required: false)
 qt5LocationDep = dependency('qt5', modules: 'Location', required: false)
 
-if qt5GuiDep.found() and qt5QmlDep.found() and qt5QuickDep.found() and qt5WidgetsDep.found() and qt5NetworkDep.found()
+message('Qt version : @0@ (required >= 5.5)'.format(qt5GuiDep.version()))
+
+if qt5GuiDep.found() and qt5GuiDep.version().version_compare('>=5.5') and qt5QmlDep.found() and qt5QuickDep.found() and qt5WidgetsDep.found() and qt5NetworkDep.found()
   buildClientQt=true
   buildMapQt=true
 else
@@ -254,6 +256,7 @@ message('libosmscout-map-iosx:    @0@'.format(buildMapIOSX))
 message('libosmscout-map-opengl:  @0@'.format(buildMapOpenGL))
 message('libosmscout-map-qt:      @0@'.format(buildMapQt))
 message('libosmscout-map-svg:     @0@'.format(true))
+message('libosmscout-client-qt:   @0@'.format(buildClientQt))
 message('BasemapImport:           @0@'.format(true))
 message('Import:                  @0@'.format(true))
 message('Demos:                   @0@'.format(true))


### PR DESCRIPTION
Hi. Qt Models are powerful and heavily used for exposing libosmscout data to QML world. There are some improvements for better results...

- mark model Roles as Qt enums to make it accessible from QML - it allows simper accessing data inside models
- sort maps in `InstalledMapsModel` by name
- avoid reseting `InstalledMapsModel` model - it breaks UI animations with Sailfish components...
