### PR TITLE
fix debug code hidden by #ifdefs usually

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenWaterIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenWaterIndex.cpp
@@ -43,8 +43,8 @@
 //#define DEBUG_COASTLINE
 #endif
 
-#if !defined(DEBUG_TILING)
-//#define DEBUG_TILING
+#if defined(DEBUG_COASTLINE)
+#include <iostream>
 #endif
 
 namespace osmscout {
@@ -261,7 +261,7 @@ namespace osmscout {
           for (const auto& coord : coords) {
             if (stateMap.IsInAbsolute(coord.x,coord.y)) {
               if (stateMap.GetStateAbsolute(coord.x,coord.y)==WaterIndexProcessor::unknown) {
-#if defined(DEBUG_TILING)
+#if defined(DEBUG_COASTLINE)
                 std::cout << "Assume land: " << coord.x-stateMap.GetXStart() << "," << coord.y-stateMap.GetYStart() << " Way " << way.GetFileOffset() << " " << way.GetType()->GetName() << " is defining area as land" << std::endl;
 #endif
                 stateMap.SetStateAbsolute(coord.x,coord.y,WaterIndexProcessor::land);

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -1338,7 +1338,6 @@ namespace osmscout {
       DrawArea(projection,parameter,areaData);
 
 #if defined(DEBUG_GROUNDTILES)
-      size_t   labelId=nextLabelId++;
       GeoCoord cc=areaData.boundingBox.GetCenter();
 
       std::string label;
@@ -1346,7 +1345,7 @@ namespace osmscout {
       size_t x=(cc.GetLon()+180)/tile.cellWidth;
       size_t y=(cc.GetLat()+90)/tile.cellHeight;
 
-      label=NumberToString(tile.xRel)+","+NumberToString(tile.yRel);
+      label=std::to_string(tile.xRel)+","+std::to_string(tile.yRel);
 
       double lon=(x*tile.cellWidth+tile.cellWidth/2)-180.0;
       double lat=(y*tile.cellHeight+tile.cellHeight/2)-90.0;
@@ -1361,31 +1360,21 @@ namespace osmscout {
         continue;
       }
 
-      LabelLayoutData labelData;
+      LabelData labelBox;
 
-      labelData.fontSize=debugLabel->GetSize();
+      labelBox.priority=0;
+      labelBox.alpha=debugLabel->GetAlpha();;
+      labelBox.fontSize=debugLabel->GetSize();
+      labelBox.style=debugLabel;
+      labelBox.text=label;
 
-      GetTextDimension(projection,
-                       parameter,
-                       -1,
-                       labelData.fontSize,
-                       label,
-                       labelData.xOff,
-                       labelData.yOff,
-                       labelData.width,
-                       labelData.height);
-
-      labelData.alpha=debugLabel->GetAlpha();
-      labelData.position=0;
-      labelData.label=label;
-      labelData.textStyle=debugLabel;
-      labelData.icon=false;
-
-      RegisterPointLabel(projection,
-                         parameter,
-                         labelData,
-                         px,py,
-                         labelId);
+      std::vector<LabelData> vect;
+      vect.push_back(labelBox);
+      RegisterRegularLabel(projection,
+                           parameter,
+                           vect,
+                           Vertex2D(px,py),
+                           /*proposedWidth*/ -1);
 
       drawnLabels.insert(GeoCoord(x,y));
 #endif

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -266,6 +266,7 @@ namespace osmscout {
 
   protected:
     CoordBuffer                  *coordBuffer;      //!< Reference to the coordinate buffer
+    TextStyleRef                 debugLabel;
 
   private:
     std::vector<StepMethod>      stepMethods;
@@ -284,7 +285,6 @@ namespace osmscout {
     //@{
     FillStyleRef                 landFill;
     FillStyleRef                 seaFill;
-    TextStyleRef                 debugLabel;
     FeatureValueBuffer           coastlineSegmentAttributes;
     //@}
 

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -2066,7 +2066,6 @@ namespace osmscout {
       DrawArea(projection,parameter,areaData);
 
 #if defined(DEBUG_GROUNDTILES)
-      size_t   labelId=nextLabelId++;
       GeoCoord cc=areaData.boundingBox.GetCenter();
 
       std::string label;
@@ -2074,7 +2073,7 @@ namespace osmscout {
       size_t x=(cc.GetLon()+180)/tile.cellWidth;
       size_t y=(cc.GetLat()+90)/tile.cellHeight;
 
-      label=NumberToString(tile.xRel)+","+NumberToString(tile.yRel);
+      label=std::to_string(tile.xRel)+","+std::to_string(tile.yRel);
 
       double lon=(x*tile.cellWidth+tile.cellWidth/2)-180.0;
       double lat=(y*tile.cellHeight+tile.cellHeight/2)-90.0;
@@ -2089,27 +2088,21 @@ namespace osmscout {
         continue;
       }
 
-      LabelLayoutData labelData;
+      LabelData labelBox;
 
-      labelData.fontSize=debugLabel->GetSize();
+      labelBox.priority=0;
+      labelBox.alpha=debugLabel->GetAlpha();;
+      labelBox.fontSize=debugLabel->GetSize();
+      labelBox.style=debugLabel;
+      labelBox.text=label;
 
-      labelData.dimension=GetTextDimension(projection,
-                                           parameter,
-                                           -1,
-                                           labelData.fontSize,
-                                           label);
-
-      labelData.alpha=debugLabel->GetAlpha();
-      labelData.position=0;
-      labelData.label=label;
-      labelData.textStyle=debugLabel;
-      labelData.icon=false;
-
-      RegisterPointLabel(projection,
-                         parameter,
-                         labelData,
-                         px,py,
-                         labelId);
+      std::vector<LabelData> vect;
+      vect.push_back(labelBox);
+      RegisterRegularLabel(projection,
+                           parameter,
+                           vect,
+                           Vertex2D(px,py),
+                           /*proposedWidth*/ -1);
 
       drawnLabels.insert(GeoCoord(x,y));
 #endif


### PR DESCRIPTION
CMake build allows turn on debug code. But it is not part of the CI now, so this code is not maintained... https://ci.appveyor.com/project/Framstag/libosmscout/build/1832/job/vfbuvv9xure7cbai

Lets fix it... Question is how usable is this code? :-) I am using it when developing, but I am using it just once usually...