### PR TITLE
Qt renderer improvements

### DIFF
--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -55,6 +55,7 @@ struct MapViewStruct
   osmscout::Magnification magnification;
   size_t                  width;
   size_t                  height;
+  double                  dpi;
 };
 
 inline bool operator!=(const MapViewStruct &r1, const MapViewStruct &r2)

--- a/libosmscout-client-qt/include/osmscout/TileCache.h
+++ b/libosmscout-client-qt/include/osmscout/TileCache.h
@@ -59,6 +59,7 @@ struct TileCacheVal
 {
   QTime lastAccess;
   QPixmap image;
+  size_t epoch;
 };
 
 /**
@@ -118,17 +119,36 @@ public:
    * @return 
    */
   bool invalidate(osmscout::GeoBox box = osmscout::GeoBox());
-  
-  void removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y);
-  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image);
+
+  /**
+   * Remove pending request
+   *
+   * @param zoomLevel
+   * @param x
+   * @param y
+   * @return true if there was such request
+   */
+  bool removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y);
+  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, size_t epoch = 0);
   
   void cleanupCache();
+
+  inline size_t getEpoch() const
+  {
+    return epoch;
+  }
+
+  inline void incEpoch()
+  {
+    epoch ++;
+  }
   
 private:
   QHash<TileCacheKey, TileCacheVal> tiles;
   QHash<TileCacheKey, RequestState> requests;
   size_t                            cacheSize; // maximum count of elements in cache
   uint32_t                          maximumLivetimeMs;
+  size_t                            epoch{0};
 };
 
 }

--- a/libosmscout-client-qt/include/osmscout/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/TiledMapRenderer.h
@@ -45,7 +45,11 @@ private:
   //
   // Online cache may contain NULL images (QImage::isNull() is true) for areas
   // covered by offline database and offline cache can contain NULL images
-  // for areas not coverred by database.
+  // for areas not covered by database.
+  //
+  // When offlineTileCache is invalidated, cache keeps unchanged,
+  // just its epoch is increased. When there is retrieved pixmap with
+  // old epoch from cache, it is used, but rendering request is triggered.
   //
   // Offline tiles should be in ARGB format on database area interface.
   mutable QMutex                tileCacheMutex;
@@ -67,6 +71,7 @@ private:
   uint32_t                      loadYFrom;
   uint32_t                      loadYTo;
   MagnificationLevel            loadZ;
+  size_t                        loadEpoch; // guarded by lock
 
   QColor                        unknownColor;
 

--- a/libosmscout-client-qt/include/osmscout/TiledRenderingHelper.h
+++ b/libosmscout-client-qt/include/osmscout/TiledRenderingHelper.h
@@ -54,7 +54,6 @@ public:
   static bool RenderTiles(QPainter& painter,
                           const MapViewStruct& request,
                           QList<TileCache*> &layerCaches,
-                          double mapDpi,
                           const QColor &unknownColor,
                           double overlap=-1);
 };

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -252,6 +252,7 @@ void MapWidget::paint(QPainter *painter)
     request.magnification = view->magnification;
     request.width = boundingBox.width();
     request.height = boundingBox.height();
+    request.dpi = view->mapDpi;
 
     bool oldFinished = finished;
     //finished = dbThread->RenderMap(*painter,request);
@@ -664,7 +665,9 @@ void MapWidget::onTapLongTap(const QPoint p)
 
 void MapWidget::onMapDPIChange(double dpi)
 {
-    view->mapDpi = dpi;
+    MapView v = *view;
+    v.mapDpi = dpi;
+    changeView(v);
 
     // discard current input handler
     setupInputHandler(new InputHandler(*view));

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -129,8 +129,9 @@ void TiledMapOverlay::paint(QPainter *painter)
   request.magnification = view->magnification;
   request.width = boundingBox.width();
   request.height = boundingBox.height();
+  request.dpi = view->mapDpi;
 
-  TiledRenderingHelper::RenderTiles(*painter,request,layerCaches,view->mapDpi,transparentColor, /*overlap*/ 0);
+  TiledRenderingHelper::RenderTiles(*painter,request,layerCaches,transparentColor, /*overlap*/ 0);
 }
 
 void TiledMapOverlay::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile) {

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -152,9 +152,8 @@ void TiledMapRenderer::InvalidateVisualCache()
 {
   // invalidate tile cache and emit Redraw
   {
-      QMutexLocker locker(&tileCacheMutex);
-      offlineTileCache.invalidate();
-      offlineTileCache.clearPendingRequests();
+    QMutexLocker locker(&tileCacheMutex);
+    offlineTileCache.incEpoch();
   }
   emit Redraw();
 }
@@ -258,6 +257,8 @@ void TiledMapRenderer::offlineTileRequest(uint32_t zoomLevel, uint32_t xtile, ui
         QMutexLocker locker(&tileCacheMutex);
         if (!offlineTileCache.startRequestProcess(zoomLevel, xtile, ytile)) // request was canceled or started already
             return;
+
+        loadEpoch = offlineTileCache.getEpoch();
     }
 
     DatabaseCoverage state = databaseCoverageOfTile(zoomLevel, xtile, ytile);
@@ -494,8 +495,13 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
 
     {
         QMutexLocker locker(&tileCacheMutex);
+
+        if (loadEpoch != offlineTileCache.getEpoch()){
+          qWarning() << "Rendered from outdated data" << loadEpoch << "!=" << offlineTileCache.getEpoch();
+        }
+
         if (width == 1 && height == 1){
-            offlineTileCache.put(loadZ.Get(), loadXFrom, loadYFrom, canvas);
+            offlineTileCache.put(loadZ.Get(), loadXFrom, loadYFrom, canvas, loadEpoch);
         }else{
             for (uint32_t y = loadYFrom; y <= loadYTo; ++y){
                 for (uint32_t x = loadXFrom; x <= loadXTo; ++x){
@@ -506,7 +512,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
                             osmTileDimension, osmTileDimension
                             );
 
-                    offlineTileCache.put(loadZ.Get(), x, y, tile);
+                    offlineTileCache.put(loadZ.Get(), x, y, tile, loadEpoch);
                 }
             }
         }

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -184,7 +184,7 @@ bool TiledMapRenderer::RenderMap(QPainter& painter,
   onlineTileCache.clearPendingRequests();
   offlineTileCache.clearPendingRequests();
 
-  if (!TiledRenderingHelper::RenderTiles(painter,request,layerCaches,mapDpi,unknownColor)){
+  if (!TiledRenderingHelper::RenderTiles(painter,request,layerCaches,unknownColor)){
     return false;
   }
 

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -221,8 +221,9 @@ bool TiledRenderingHelper::lookupAndDrawTile(TileCache& tileCache, QPainter& pai
         painter.drawPixmap(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
       }
       lookupTileFound = true;
-      if (lookupTileZoom == zoomLevel)
+      if (lookupTileZoom == zoomLevel && val.epoch == tileCache.getEpoch()) {
         triggerRequest = false;
+      }
     }else{
       // no tile found on current zoom zoom level, lookup upper zoom level
       if (lookupTileZoom==0)

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -31,7 +31,6 @@ namespace osmscout {
 bool TiledRenderingHelper::RenderTiles(QPainter &painter,
                                        const MapViewStruct &request,
                                        QList<TileCache*> &layerCaches,
-                                       double mapDpi,
                                        const QColor &unknownColor,
                                        double overlap)
 {
@@ -66,7 +65,7 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
   projection.Set(request.coord,
                  0,
                  request.magnification,
-                 mapDpi,
+                 request.dpi,
                  width,
                  height);
 


### PR DESCRIPTION
Hi. 

These two commits improves rendering experience with `TiledMapRenderer`.

- As I added support for rendering gpx files to my app (via POI objects), it often get tile cache to inconsistent state when cache is invalidated (after adding POI) but rendering thread may be processing old data already and it put old map tiles to cache at its end. Introducing cache "epoch" fix this race condition. Second effect is that it removes map blinking when POI items are modified.

 - Second commit is small and provide immediate view change when you change map DPI. It don't wait for renderer thread, it may be busy.
