### PR TITLE
don't show continent and country labels on higher zooms, increase its size

### DIFF
--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -1870,13 +1870,17 @@ STYLE
  // Places
  //
 
- [MAG world-city] {
-   [TYPE place_continent] NODE.TEXT {label: IName; style: emphasize; priority: @labelPrioContinent; }
+ [MAG world-continent] {
+   [TYPE place_continent] NODE.TEXT {label: IName; style: emphasize; size: 1.6; color: #00000080; priority: @labelPrioContinent; }
  }
+ [MAG 2-] { [TYPE place_continent] NODE.TEXT { size: 4; color: #00000060; }}
+ [MAG continent-] { [TYPE place_continent] NODE.TEXT { size: 6; color: #00000040; }}
 
- [MAG stateOver-city] {
-   [TYPE place_country] NODE.TEXT {label: IName; style: emphasize; priority: @labelPrioCounty; }
+ [MAG continent-stateOver] {
+   [TYPE place_country] NODE.TEXT {label: IName; style: emphasize; size: 2.2; priority: @labelPrioCounty; }
  }
+ [MAG state-] { [TYPE place_country] NODE.TEXT { size: 3; color: #00000080; }}
+ [MAG stateOver-] { [TYPE place_country] NODE.TEXT { size: 4; color: #00000060; }}
 
  [MAG state-county] {
    [TYPE place_state] NODE.TEXT {label: IName; style: emphasize; size: 1.7; scaleMag: state; priority: @labelPrioState; }

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -1829,13 +1829,17 @@ STYLE
  // Places
  //
 
- [MAG world-city] {
-   [TYPE place_continent] NODE.TEXT {label: IName; style: emphasize; priority: @labelPrioContinent; }
+ [MAG world-continent] {
+   [TYPE place_continent] NODE.TEXT {label: IName; style: emphasize; size: 1.6; color: #00000080; priority: @labelPrioContinent; }
  }
+ [MAG 2-] { [TYPE place_continent] NODE.TEXT { size: 4; color: #00000060; }}
+ [MAG continent-] { [TYPE place_continent] NODE.TEXT { size: 6; color: #00000040; }}
 
- [MAG stateOver-city] {
-   [TYPE place_country] NODE.TEXT {label: IName; style: emphasize; priority: @labelPrioCounty; }
+ [MAG continent-stateOver] {
+   [TYPE place_country] NODE.TEXT {label: IName; style: emphasize; size: 2.2; priority: @labelPrioCounty; }
  }
+ [MAG state-] { [TYPE place_country] NODE.TEXT { size: 3; color: #00000080; }}
+ [MAG stateOver-] { [TYPE place_country] NODE.TEXT { size: 4; color: #00000060; }}
 
  [MAG state-county] {
    [TYPE place_state] NODE.TEXT {label: IName; style: emphasize; size: 1.7; scaleMag: state; priority: @labelPrioState; }


### PR DESCRIPTION
Hi. When you zoom Germany map to level 11 (city magnification) on coordinates 50.9997 10.0002, there is shown label "Europe" with smaller fonts than towns around :-) This simple style change fix this issue - place_continent labels are displayed on first four levels only, place_country on zoom levels 4-6. Size of these top-level labels was increased and semi-transparent color is used...