### PR TITLE
Coord buffer improvements

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -229,3 +229,10 @@ target_link_libraries(Base64 OSMScout)
 target_include_directories(Base64 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_test(NAME Base64 COMMAND Base64)
 
+#---- CoordBufferTest
+add_executable(CoordBufferTest src/CoordBufferTest.cpp)
+set_property(TARGET CoordBufferTest PROPERTY CXX_STANDARD 11)
+target_link_libraries(CoordBufferTest OSMScout OSMScoutMap)
+target_include_directories(CoordBufferTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_test(NAME CoordBufferTest COMMAND CoordBufferTest)
+

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -221,6 +221,13 @@ Base64Test = executable('Base64Test',
            link_with: [osmscout],
            install: false)
 
+CoordBufferTest = executable('CoordBufferTest',
+           'src/CoordBufferTest.cpp',
+           include_directories: [testIncDir, osmscoutmapIncDir, osmscoutIncDir],
+           dependencies: [mathDep],
+           link_with: [osmscoutmap, osmscout],
+           install: false)
+
 ostandossEnv = environment()
 
 ostandossEnv.set('TESTS_TOP_DIR', meson.current_source_dir())

--- a/Tests/src/CoordBufferTest.cpp
+++ b/Tests/src/CoordBufferTest.cpp
@@ -1,0 +1,59 @@
+
+#include <osmscout/util/Transformation.h>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+using namespace osmscout;
+
+TEST_CASE("Check rejection of invalid offsets")
+{
+  CoordBuffer buffer;
+  size_t trFrom, trTo;
+  // should fail - buffer is empty
+  REQUIRE_FALSE(buffer.GenerateParallelWay(/*from*/0, /*to*/1, /*offset*/-1, trFrom, trTo));
+
+  buffer.PushCoord(0,0);
+  buffer.PushCoord(10,0);
+  buffer.PushCoord(5,1);
+  buffer.PushCoord(0,0);
+
+  // should fail - end after last valid point
+  REQUIRE_FALSE(buffer.GenerateParallelWay(/*from*/0, /*to*/4, /*offset*/-1, trFrom, trTo));
+  // should fail - just one point
+  REQUIRE_FALSE(buffer.GenerateParallelWay(/*from*/3, /*to*/3, /*offset*/-1, trFrom, trTo));
+}
+
+TEST_CASE("Check bounding box of generated parallel way")
+{
+  CoordBuffer buffer;
+  size_t trFrom, trTo;
+
+  buffer.PushCoord(0,0);
+  buffer.PushCoord(10,0);
+  buffer.PushCoord(5,1);
+  buffer.PushCoord(0,0);
+
+  REQUIRE(buffer.GenerateParallelWay(/*from*/0, /*to*/3, /*offset*/-1, trFrom, trTo));
+  REQUIRE(trTo - trFrom >= 3);
+  REQUIRE(trFrom > 3);
+
+  // get bounding box of parallel way
+  double minX, maxX, minY, maxY;
+  minX = maxX = buffer.buffer[trFrom].GetX();
+  minY = maxY = buffer.buffer[trFrom].GetY();
+  for (size_t i=trFrom; i<=trTo; i++){
+    minX = std::min(minX, buffer.buffer[i].GetX());
+    maxX = std::max(maxX, buffer.buffer[i].GetX());
+    minY = std::min(minY, buffer.buffer[i].GetY());
+    maxY = std::max(maxY, buffer.buffer[i].GetY());
+  }
+
+  REQUIRE(minX > -1);
+  REQUIRE(maxX <= 12);
+  REQUIRE(minY >= -1);
+  REQUIRE(maxY < 3);
+
+  REQUIRE(buffer.GenerateParallelWay(/*from*/0, /*to*/3, /*offset*/1, trFrom, trTo));
+  REQUIRE(trFrom > 7);
+}

--- a/Tests/src/CoordBufferTest.cpp
+++ b/Tests/src/CoordBufferTest.cpp
@@ -43,6 +43,7 @@ TEST_CASE("Check bounding box of generated parallel way")
   minX = maxX = buffer.buffer[trFrom].GetX();
   minY = maxY = buffer.buffer[trFrom].GetY();
   for (size_t i=trFrom; i<=trTo; i++){
+    //std::cout << buffer.buffer[i].GetX() << " , " << buffer.buffer[i].GetY() << std::endl;
     minX = std::min(minX, buffer.buffer[i].GetX());
     maxX = std::max(maxX, buffer.buffer[i].GetX());
     minY = std::min(minY, buffer.buffer[i].GetY());

--- a/Tests/src/TransPolygon.cpp
+++ b/Tests/src/TransPolygon.cpp
@@ -1,5 +1,5 @@
 /*
-  DrawTextQt - a test program for libosmscout
+  TransPolygon - a test program for libosmscout
   Copyright (C) 2017  Lukas Karas
 
   This program is free software; you can redistribute it and/or modify

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -180,6 +180,19 @@ namespace osmscout {
 
     void Reset();
     size_t PushCoord(double x, double y);
+
+    /**
+     * Generate parallel way to way stored in this buffer on range orgStart, orgEnd (inclusive)
+     * Result is stored after the last valid point. Generated way offsets are returned
+     * in start and end.
+     *
+     * @param orgStart original way start
+     * @param orgEnd original way end (inclusive)
+     * @param offset offset of parallel way - positive offset is left, negative right
+     * @param start start of result
+     * @param end end of result (inclusive)
+     * @return true on success, false othervise
+     */
     bool GenerateParallelWay(size_t orgStart,
                              size_t orgEnd,
                              double offset,

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -207,7 +207,7 @@ namespace osmscout {
                                         size_t& start,
                                         size_t& end)
   {
-    if (orgStart+1>orgEnd) {
+    if (orgStart+1>orgEnd || orgEnd >= usedPoints) {
       // To avoid "not initialized" warnings
       return false;
     }

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -252,8 +252,18 @@ namespace osmscout {
                       buffer[i+1].GetY()-buffer[i].GetY());
 
       if (fabs(det2)>0.0001) {
-        PushCoord(buffer[i].GetX()+oax+det1/det2*(buffer[i].GetX()-buffer[i-1].GetX()),
-                  buffer[i].GetY()+oay+det1/det2*(buffer[i].GetY()-buffer[i-1].GetY()));
+        double addX = det1/det2*(buffer[i].GetX()-buffer[i-1].GetX());
+        double addY = det1/det2*(buffer[i].GetY()-buffer[i-1].GetY());
+        if (std::abs(addX) < 2*std::abs(offset) && std::abs(addY) < 2*std::abs(offset)) {
+          PushCoord(buffer[i].GetX() + oax + addX,
+                    buffer[i].GetY() + oay + addY);
+        }else{
+          // cut the edge of too sharp angles
+          PushCoord(buffer[i].GetX() + oax,
+                    buffer[i].GetY() + oay);
+          PushCoord(buffer[i].GetX() + obx,
+                    buffer[i].GetY() + oby);
+        }
       }
       else {
         PushCoord(buffer[i].GetX()+oax,


### PR DESCRIPTION
Hi.

When there is some line with `displayOffset` in stylesheet, `CoordBuffer::GenerateParallelWay` is used to generate it. This method works fine in sense of correctness, but for sharp angles create line that is placed in distance of multiple offsets from original way.

This patch is solving it. It cuts the edges of sharp angles in generated parallel way. It also adds unittest for `CoordBuffer`.

See this example stylesheet:
```
OSS
STYLE

   [MAG world-] {
     [TYPE leisure_nature_reserve] {
       AREA.BORDER#dashed { color: #ff0000; width: 0.3mm; displayOffset: -0.5mm; }
       AREA.BORDER#solid { color: #0000ff; width: 1.0mm; }
     }
   }

END
```

There map with nature reserve  at coordinates `50.37847 15.65940`, top part is before fix, bottom with the fix:

![way-offset-cut](https://user-images.githubusercontent.com/309458/46910731-e832b680-cf49-11e8-80d4-53d7dff73308.png)
