### PR TITLE
Qt: improve label layouting with multiple databases

### DIFF
--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -79,17 +79,25 @@ namespace osmscout {
     };
 
   private:
-    QPainter                   *painter;
+    QPainter                   *painter{nullptr}; //! non-owning pointer to Qt painter
 
     QtLabelLayouter            labelLayouter;
 
-    std::vector<QImage>        images;        //! vector of QImage for icons
-    std::vector<QImage>        patternImages; //! vector of QImage for fill patterns
-    std::vector<QBrush>        patterns;      //! vector of QBrush for fill patterns
-    QMap<FontDescriptor,QFont> fonts;         //! Cached fonts
-    std::vector<double>        sin;           //! Lookup table for sin calculation
+    /**
+     * non-owning pointer to layouter
+     * when it is not null, all labels are registered to it
+     * and DrawLabels method is no-op
+     */
+    QtLabelLayouter            *delegateLabelLayouter{nullptr};
 
-    std::mutex                 mutex;         //! Mutex for locking concurrent calls
+    std::map<std::string,QImage> images;        //! map of QImage for icons, key is name of the icon
+                                                //! - it should be independent on the specific style configuration
+    std::vector<QImage>          patternImages; //! vector of QImage for fill patterns, index is patter id
+    std::vector<QBrush>          patterns;      //! vector of QBrush for fill patterns
+    QMap<FontDescriptor,QFont>   fonts;         //! Cached fonts
+    std::vector<double>          sin;           //! Lookup table for sin calculation
+
+    std::mutex                   mutex;         //! Mutex for locking concurrent calls
 
   private:
     QFont GetFont(const Projection& projection,
@@ -129,6 +137,8 @@ namespace osmscout {
                                     double objectWidth,
                                     bool enableWrapping = false,
                                     bool contourLabel = false);
+
+    QtLabelLayouter& GetLayouter();
 
   protected:
     bool HasIcon(const StyleConfig& styleConfig,


### PR DESCRIPTION
It is done by delegating all label and icon layouting
to the last painter in the batch. With this simple trick
labels from multiple databases can't overlap. It is necessary
to use icon label name as a icon cache key, because icon ids
may be different for multiple StyleConfig instances.

Current implementation is just for the Qt map painter.