### PR TITLE
Fix segmentation fault

### DIFF
--- a/libosmscout/src/osmscout/AreaNodeIndex.cpp
+++ b/libosmscout/src/osmscout/AreaNodeIndex.cpp
@@ -232,6 +232,10 @@ namespace osmscout {
                                  std::vector<FileOffset>& offsets,
                                  TypeInfoSet& loadedTypes) const
   {
+    if (nodeTypeData.empty()) {
+      return true;
+    }
+    
     StopClock time;
 
     loadedTypes.Clear();

--- a/libosmscout/src/osmscout/AreaNodeIndex.cpp
+++ b/libosmscout/src/osmscout/AreaNodeIndex.cpp
@@ -232,9 +232,6 @@ namespace osmscout {
                                  std::vector<FileOffset>& offsets,
                                  TypeInfoSet& loadedTypes) const
   {
-    if (nodeTypeData.empty()) {
-      return true;
-    }
     
     StopClock time;
 
@@ -248,9 +245,9 @@ namespace osmscout {
           continue;
         }
 
-        if (!GetOffsets(nodeTypeData[type->GetNodeId()],
-                        boundingBox,
-                        offsets)) {
+        auto typeNodeId = type->GetNodeId();
+        if (typeNodeId < nodeTypeData.size() && 
+                !GetOffsets(nodeTypeData[typeNodeId], boundingBox, offsets)) {
           return false;
         }
 


### PR DESCRIPTION
Segmentation fault at line 251:
nodeTypeData[type->GetNodeId()]
when nodeTypeData is empty.

It happened to me while playing with tiny osm files.