### PR TITLE
Bounding box cache for Area::Ring and Way

### DIFF
--- a/Demos/src/DrawMapDirectX.cpp
+++ b/Demos/src/DrawMapDirectX.cpp
@@ -28,6 +28,7 @@ src/DrawMapDirectX ../maps/nordrhein-westfalen ../stylesheets/standard.oss 7.465
 
 #include <SDKDDKVer.h>
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX // msvc issue with std::max/min
 #include <windows.h>
 #include <tchar.h>
 #include <cmath>

--- a/Tests/src/FileScannerWriter.cpp
+++ b/Tests/src/FileScannerWriter.cpp
@@ -187,273 +187,276 @@ int main()
 
     writer.Close();
 
-    scanner.Open("test.dat",osmscout::FileScanner::Normal,false);
-
-    // Read/Write
-
-    scanner.Read(inBool);
-    if (inBool!=outBool1) {
-      std::cerr << "Read/Write(bool): Expected " << outBool1 << ", got " << inBool << std::endl;
-      errors++;
-    }
-
-    scanner.Read(inBool);
-    if (inBool!=outBool2) {
-      std::cerr << "Read/Write(bool): Expected " << outBool2 << ", got " << inBool << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in16u);
-    if (in16u!=out16u1) {
-      std::cerr << "Read/Write(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in16u);
-    if (in16u!=out16u2) {
-      std::cerr << "Read/Write(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in16u);
-    if (in16u!=out16u3) {
-      std::cerr << "Read/Write(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in32u);
-    if (in32u!=out32u1) {
-      std::cerr << "Read/Write(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in32u);
-    if (in32u!=out32u2) {
-      std::cerr << "Read/Write(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in32u);
-    if (in32u!=out32u3) {
-      std::cerr << "Read/Write(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in64u);
-    if (in64u!=out64u1) {
-      std::cerr << "Read/Write(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in64u);
-    if (in64u!=out64u2) {
-      std::cerr << "Read/Write(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
-      errors++;
-    }
-
-    scanner.Read(in64u);
-    if (in64u!=out64u3) {
-      std::cerr << "Read/Write(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
-      errors++;
-    }
-
-    // Read/WriteNumber
-
-    scanner.ReadNumber(in16u);
-    if (in16u!=out16u1) {
-      std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.ReadNumber(in16u);
-    if (in16u!=out16u2) {
-      std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.ReadNumber(in16u);
-    if (in16u!=out16u3) {
-      std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
-      errors++;
-    }
-
-    scanner.ReadNumber(in32u);
-    if (in32u!=out32u1) {
-      std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
-      errors++;
-    }
-
-    scanner.ReadNumber(in32u);
-    if (in32u!=out32u2) {
-      std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
-      errors++;
-    }
+    for (int mmapMode = 0; mmapMode <= 1; mmapMode++){
+      scanner.Open("test.dat",osmscout::FileScanner::Normal,(bool)mmapMode);
+
+      // Read/Write
+
+      scanner.Read(inBool);
+      if (inBool!=outBool1) {
+        std::cerr << "Read/Write(bool): Expected " << outBool1 << ", got " << inBool << std::endl;
+        errors++;
+      }
+
+      scanner.Read(inBool);
+      if (inBool!=outBool2) {
+        std::cerr << "Read/Write(bool): Expected " << outBool2 << ", got " << inBool << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in16u);
+      if (in16u!=out16u1) {
+        std::cerr << "Read/Write(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in16u);
+      if (in16u!=out16u2) {
+        std::cerr << "Read/Write(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in16u);
+      if (in16u!=out16u3) {
+        std::cerr << "Read/Write(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in32u);
+      if (in32u!=out32u1) {
+        std::cerr << "Read/Write(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in32u);
+      if (in32u!=out32u2) {
+        std::cerr << "Read/Write(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in32u);
+      if (in32u!=out32u3) {
+        std::cerr << "Read/Write(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in64u);
+      if (in64u!=out64u1) {
+        std::cerr << "Read/Write(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in64u);
+      if (in64u!=out64u2) {
+        std::cerr << "Read/Write(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
+        errors++;
+      }
+
+      scanner.Read(in64u);
+      if (in64u!=out64u3) {
+        std::cerr << "Read/Write(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
+        errors++;
+      }
+
+      // Read/WriteNumber
+
+      scanner.ReadNumber(in16u);
+      if (in16u!=out16u1) {
+        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.ReadNumber(in16u);
+      if (in16u!=out16u2) {
+        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.ReadNumber(in16u);
+      if (in16u!=out16u3) {
+        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
+        errors++;
+      }
+
+      scanner.ReadNumber(in32u);
+      if (in32u!=out32u1) {
+        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
+        errors++;
+      }
+
+      scanner.ReadNumber(in32u);
+      if (in32u!=out32u2) {
+        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
+        errors++;
+      }
 
-    scanner.ReadNumber(in32u);
-    if (in32u!=out32u3) {
-      std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
-      errors++;
-    }
+      scanner.ReadNumber(in32u);
+      if (in32u!=out32u3) {
+        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
+        errors++;
+      }
 
-    scanner.ReadNumber(in64u);
-    if (in64u!=out64u1) {
-      std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
-      errors++;
-    }
+      scanner.ReadNumber(in64u);
+      if (in64u!=out64u1) {
+        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
+        errors++;
+      }
 
-    scanner.ReadNumber(in64u);
-    if (in64u!=out64u2) {
-      std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
-      errors++;
-    }
+      scanner.ReadNumber(in64u);
+      if (in64u!=out64u2) {
+        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
+        errors++;
+      }
 
-    scanner.ReadNumber(in64u);
-    if (in64u!=out64u3) {
-      std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
-      errors++;
-    }
+      scanner.ReadNumber(in64u);
+      if (in64u!=out64u3) {
+        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
+        errors++;
+      }
 
-    // Read/WriteFileOffset
+      // Read/WriteFileOffset
 
-    scanner.ReadFileOffset(info);
-    if (info!=outfo1) {
-      std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo1 << ", got " << info << std::endl;
-      errors++;
-    }
+      scanner.ReadFileOffset(info);
+      if (info!=outfo1) {
+        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo1 << ", got " << info << std::endl;
+        errors++;
+      }
 
-    scanner.ReadFileOffset(info);
-    if (info!=outfo2) {
-      std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo2 << ", got " << info << std::endl;
-      errors++;
-    }
+      scanner.ReadFileOffset(info);
+      if (info!=outfo2) {
+        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo2 << ", got " << info << std::endl;
+        errors++;
+      }
 
-    scanner.ReadFileOffset(info);
-    if (info!=outfo3) {
-      std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo3 << ", got " << info << std::endl;
-      errors++;
-    }
+      scanner.ReadFileOffset(info);
+      if (info!=outfo3) {
+        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo3 << ", got " << info << std::endl;
+        errors++;
+      }
 
-    scanner.ReadCoord(inCoord1);
+      scanner.ReadCoord(inCoord1);
 
-    if (inCoord1.GetDisplayText()!=outCoord1.GetDisplayText()) {
-      std::cerr << "Read/WriteCoord(GeoCoord) 1: Expected " << outCoord1.GetDisplayText() << ", got " << inCoord1.GetDisplayText() << std::endl;
-      errors++;
-    }
+      if (inCoord1.GetDisplayText()!=outCoord1.GetDisplayText()) {
+        std::cerr << "Read/WriteCoord(GeoCoord) 1: Expected " << outCoord1.GetDisplayText() << ", got " << inCoord1.GetDisplayText() << std::endl;
+        errors++;
+      }
 
-    osmscout::GeoBox boundingBox;
-    std::vector<osmscout::SegmentGeoBox> segments;
+      osmscout::GeoBox boundingBox;
+      std::vector<osmscout::SegmentGeoBox> segments;
 
-    scanner.Read(inCoords1,segments,boundingBox,false);
-    if (!Equals(inCoords1,outCoords1)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 1: Expected ";
+      scanner.Read(inCoords1,segments,boundingBox,false);
+      if (!Equals(inCoords1,outCoords1)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 1: Expected ";
 
-      DumpGeoCoords(outCoords1);
+        DumpGeoCoords(outCoords1);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords1);
+        DumpGeoCoords(inCoords1);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords2,segments,boundingBox,false);
-    if (!Equals(inCoords2,outCoords2)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 2: Expected ";
+      scanner.Read(inCoords2,segments,boundingBox,false);
+      if (!Equals(inCoords2,outCoords2)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 2: Expected ";
 
-      DumpGeoCoords(outCoords2);
+        DumpGeoCoords(outCoords2);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords2);
+        DumpGeoCoords(inCoords2);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords3,segments,boundingBox,false);
-    if (!Equals(inCoords3,outCoords3)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 3: Expected ";
+      scanner.Read(inCoords3,segments,boundingBox,false);
+      if (!Equals(inCoords3,outCoords3)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 3: Expected ";
 
-      DumpGeoCoords(outCoords3);
+        DumpGeoCoords(outCoords3);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords3);
+        DumpGeoCoords(inCoords3);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords4,segments,boundingBox,false);
-    if (!Equals(inCoords4,outCoords4)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 4: Expected ";
+      scanner.Read(inCoords4,segments,boundingBox,false);
+      if (!Equals(inCoords4,outCoords4)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 4: Expected ";
 
-      DumpGeoCoords(outCoords4);
+        DumpGeoCoords(outCoords4);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords4);
+        DumpGeoCoords(inCoords4);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords5,segments,boundingBox,false);
-    if (!Equals(inCoords5,outCoords5)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 5: Expected ";
+      scanner.Read(inCoords5,segments,boundingBox,false);
+      if (!Equals(inCoords5,outCoords5)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 5: Expected ";
 
-      DumpGeoCoords(outCoords5);
+        DumpGeoCoords(outCoords5);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords5);
+        DumpGeoCoords(inCoords5);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords6,segments,boundingBox,false);
-    if (!Equals(inCoords6,outCoords6)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 6: Expected ";
+      scanner.Read(inCoords6,segments,boundingBox,false);
+      if (!Equals(inCoords6,outCoords6)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 6: Expected ";
 
-      DumpGeoCoords(outCoords6);
+        DumpGeoCoords(outCoords6);
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      DumpGeoCoords(inCoords6);
+        DumpGeoCoords(inCoords6);
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    scanner.Read(inCoords7,segments,boundingBox,false);
-    if (!Equals(inCoords7,outCoords7)) {
-      std::cerr << "Read/Write(std::vector<GeoCoord>) 7: Expected ";
+      scanner.Read(inCoords7,segments,boundingBox,false);
+      if (!Equals(inCoords7,outCoords7)) {
+        std::cerr << "Read/Write(std::vector<GeoCoord>) 7: Expected ";
 
-      std::cout << outCoords7.size();
+        std::cout << outCoords7.size();
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      std::cout << inCoords7.size();
+        std::cout << inCoords7.size();
 
-      std::cout << std::endl;
-      errors++;
-    }
+        std::cout << std::endl;
+        errors++;
+      }
 
-    finalReadFileOffset=scanner.GetPos();
+      finalReadFileOffset=scanner.GetPos();
 
-    if (finalWriteFileOffset!=finalReadFileOffset) {
-      std::cerr << "Final file offset check: Expected ";
+      if (finalWriteFileOffset!=finalReadFileOffset) {
+        std::cerr << "Final file offset check: Expected ";
 
-      std::cout << finalWriteFileOffset;
+        std::cout << finalWriteFileOffset;
 
-      std::cout << ", got ";
+        std::cout << ", got ";
 
-      std::cout << finalReadFileOffset;
+        std::cout << finalReadFileOffset;
 
-      std::cout << std::endl;
-      errors++;
+        std::cout << std::endl;
+        errors++;
+      }
+      scanner.Close();
     }
   }
   catch (osmscout::IOException& e) {

--- a/Tests/src/FileScannerWriter.cpp
+++ b/Tests/src/FileScannerWriter.cpp
@@ -340,7 +340,10 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords1,false);
+    osmscout::GeoBox boundingBox;
+    std::vector<osmscout::SegmentGeoBox> segments;
+
+    scanner.Read(inCoords1,segments,boundingBox,false);
     if (!Equals(inCoords1,outCoords1)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 1: Expected ";
 
@@ -354,7 +357,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords2,false);
+    scanner.Read(inCoords2,segments,boundingBox,false);
     if (!Equals(inCoords2,outCoords2)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 2: Expected ";
 
@@ -368,7 +371,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords3,false);
+    scanner.Read(inCoords3,segments,boundingBox,false);
     if (!Equals(inCoords3,outCoords3)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 3: Expected ";
 
@@ -382,7 +385,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords4,false);
+    scanner.Read(inCoords4,segments,boundingBox,false);
     if (!Equals(inCoords4,outCoords4)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 4: Expected ";
 
@@ -396,7 +399,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords5,false);
+    scanner.Read(inCoords5,segments,boundingBox,false);
     if (!Equals(inCoords5,outCoords5)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 5: Expected ";
 
@@ -410,7 +413,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords6,false);
+    scanner.Read(inCoords6,segments,boundingBox,false);
     if (!Equals(inCoords6,outCoords6)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 6: Expected ";
 
@@ -424,7 +427,7 @@ int main()
       errors++;
     }
 
-    scanner.Read(inCoords7,false);
+    scanner.Read(inCoords7,segments,boundingBox,false);
     if (!Equals(inCoords7,outCoords7)) {
       std::cerr << "Read/Write(std::vector<GeoCoord>) 7: Expected ";
 

--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -49,12 +49,13 @@ class OSMSCOUT_CLIENT_QT_API OverlayObject : public QObject
   Q_PROPERTY(QString name READ getName WRITE setName)
 
 protected:
-  QString                       typeName;
-  std::vector<osmscout::Point>  nodes;
-  osmscout::GeoBox              box;
-  int8_t                        layer{std::numeric_limits<int8_t>::max()};
-  QString                       name;
-  mutable QMutex                lock;
+  QString                             typeName;
+  std::vector<osmscout::Point>        nodes;
+  mutable std::vector<SegmentGeoBox>  segmentsBoxes;
+  mutable osmscout::GeoBox            box;
+  int8_t                              layer{std::numeric_limits<int8_t>::max()};
+  QString                             name;
+  mutable QMutex                      lock;
 
 public slots:
   void clear();
@@ -129,7 +130,9 @@ public:
     name = n;
   }
 
-  osmscout::GeoBox boundingBox();
+  osmscout::GeoBox boundingBox() const;
+
+  std::vector<SegmentGeoBox> segments() const;
 
 protected:
   void setupFeatures(const osmscout::TypeInfoRef &type,

--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -132,11 +132,15 @@ public:
 
   osmscout::GeoBox boundingBox() const;
 
-  std::vector<SegmentGeoBox> segments() const;
-
 protected:
   void setupFeatures(const osmscout::TypeInfoRef &type,
                      osmscout::FeatureValueBuffer &features) const;
+
+  // internal, lock have to be acquired
+  osmscout::GeoBox boundingBoxInternal() const;
+
+  // internal, lock have to be acquired
+  std::vector<SegmentGeoBox> segments() const;
 };
 
 

--- a/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
+++ b/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
@@ -70,15 +70,25 @@ void OverlayObject::addPoint(double lat, double lon)
   QMutexLocker locker(&lock);
   nodes.push_back(osmscout::Point(0,osmscout::GeoCoord(lat,lon)));
   box.Invalidate();
+  segmentsBoxes.clear();
 }
 
-osmscout::GeoBox OverlayObject::boundingBox()
+osmscout::GeoBox OverlayObject::boundingBox() const
 {
   QMutexLocker locker(&lock);
   if (!box.IsValid() && !nodes.empty()){
     osmscout::GetBoundingBox(nodes,box);
   }
   return box;
+}
+
+std::vector<SegmentGeoBox> OverlayObject::segments() const
+{
+  QMutexLocker locker(&lock);
+  if (segmentsBoxes.empty() && !nodes.empty()){
+    osmscout::ComputeSegmentBoxes(nodes, segmentsBoxes, nodes.size(), 1000);
+  }
+  return segmentsBoxes;
 }
 
 void OverlayObject::setupFeatures(const osmscout::TypeInfoRef &type,
@@ -134,6 +144,8 @@ bool OverlayWay::toWay(osmscout::WayRef &way,
   way->SetFeatures(features);
 
   way->nodes=nodes;
+  way->bbox=boundingBox();
+  way->segments=segments();
   return true;
 }
 
@@ -163,6 +175,8 @@ bool OverlayArea::toArea(osmscout::AreaRef &area,
   outerRing.SetType(type);
   outerRing.MarkAsOuterRing();
   outerRing.nodes=nodes;
+  outerRing.bbox=boundingBox();
+  outerRing.segments=segments();
 
   osmscout::FeatureValueBuffer features;
   setupFeatures(type, features);

--- a/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
+++ b/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
@@ -76,6 +76,11 @@ void OverlayObject::addPoint(double lat, double lon)
 osmscout::GeoBox OverlayObject::boundingBox() const
 {
   QMutexLocker locker(&lock);
+  return boundingBoxInternal();
+}
+
+osmscout::GeoBox OverlayObject::boundingBoxInternal() const
+{
   if (!box.IsValid() && !nodes.empty()){
     osmscout::GetBoundingBox(nodes,box);
   }
@@ -84,7 +89,6 @@ osmscout::GeoBox OverlayObject::boundingBox() const
 
 std::vector<SegmentGeoBox> OverlayObject::segments() const
 {
-  QMutexLocker locker(&lock);
   if (segmentsBoxes.empty() && !nodes.empty()){
     osmscout::ComputeSegmentBoxes(nodes, segmentsBoxes, nodes.size(), 1000);
   }
@@ -144,7 +148,7 @@ bool OverlayWay::toWay(osmscout::WayRef &way,
   way->SetFeatures(features);
 
   way->nodes=nodes;
-  way->bbox=boundingBox();
+  way->bbox=boundingBoxInternal();
   way->segments=segments();
   return true;
 }
@@ -175,7 +179,7 @@ bool OverlayArea::toArea(osmscout::AreaRef &area,
   outerRing.SetType(type);
   outerRing.MarkAsOuterRing();
   outerRing.nodes=nodes;
-  outerRing.bbox=boundingBox();
+  outerRing.bbox=boundingBoxInternal();
   outerRing.segments=segments();
 
   osmscout::FeatureValueBuffer features;

--- a/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
@@ -1790,7 +1790,10 @@ namespace osmscout {
         scanner.Read(postalCode);
         scanner.Read(location);
         scanner.Read(address);
-        scanner.Read(nodes,false);
+
+        GeoBox boundingBox;
+        std::vector<SegmentGeoBox> segments;
+        scanner.Read(nodes,segments,boundingBox,false);
 
         typeId=(TypeId)tmpType;
         type=typeConfig.GetAreaTypeInfo(typeId);
@@ -1807,11 +1810,6 @@ namespace osmscout {
         if (!isAddress && !isPOI) {
           continue;
         }
-
-        GeoBox boundingBox;
-
-        GetBoundingBox(nodes,
-                       boundingBox);
 
         RegionRef region=regionIndex.GetRegionForNode(rootRegion,
                                                       boundingBox.GetCenter());
@@ -2002,7 +2000,10 @@ namespace osmscout {
 
         scanner.Read(name);
         scanner.Read(postalCode);
-        scanner.Read(nodes,false);
+
+        GeoBox boundingBox;
+        std::vector<SegmentGeoBox> segments;
+        scanner.Read(nodes,segments,boundingBox,false);
 
         typeId=(TypeId)tmpType;
         type=typeConfig.GetWayTypeInfo(typeId);
@@ -2017,11 +2018,6 @@ namespace osmscout {
         if (!isPOI) {
           continue;
         }
-
-        GeoBox boundingBox;
-
-        GetBoundingBox(nodes,
-                       boundingBox);
 
         RegionRef region=regionIndex.GetRegionForNode(rootRegion,
                                                       boundingBox.GetCenter());

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -361,7 +361,7 @@ namespace osmscout {
                         const MapParameter& parameter,
                         const ObjectFileRef& ref,
                         const FeatureValueBuffer& buffer,
-                        const std::vector<Point>& nodes);
+                        const Way& way);
 
     void PrepareWays(const StyleConfig& styleConfig,
                      const Projection& projection,

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -504,7 +504,7 @@ namespace osmscout {
                        double pixelOffset) const;
 
     bool IsVisibleWay(const Projection& projection,
-                      const std::vector<Point>& nodes,
+                      const GeoBox& boundingBox,
                       double pixelOffset) const;
 
     void Transform(const Projection& projection,

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -443,6 +443,10 @@ namespace osmscout {
                                  const GeoBox& boundingBox,
                                  double pixelOffset) const
   {
+    if (!boundingBox.IsValid()){
+      return false;
+    }
+
     double x;
     double y;
 
@@ -501,17 +505,12 @@ namespace osmscout {
   }
 
   bool MapPainter::IsVisibleWay(const Projection& projection,
-                                const std::vector<Point>& nodes,
+                                const GeoBox& boundingBox,
                                 double pixelOffset) const
   {
-    if (nodes.empty()) {
+    if (!boundingBox.IsValid()){
       return false;
     }
-
-    osmscout::GeoBox boundingBox;
-
-    osmscout::GetBoundingBox(nodes,
-                             boundingBox);
 
     double x;
     double y;
@@ -1594,7 +1593,7 @@ namespace osmscout {
       data.lineWidth=lineWidth;
 
       if (!IsVisibleWay(projection,
-                        way.nodes,
+                        way.GetBoundingBox(),
                         lineWidth/2)) {
         continue;
       }

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1307,17 +1307,36 @@ namespace osmscout {
     std::vector<PolyData> td(area->rings.size());
 
     for (size_t i=0; i<area->rings.size(); i++) {
+      const Area::Ring &ring = area->rings[i];
       // The master ring does not have any nodes, so we skip it
       // Rings with less than 3 nodes should be skipped, too (no area)
-      if (area->rings[i].IsMasterRing() || area->rings[i].nodes.size()<3) {
+      if (ring.IsMasterRing() || ring.nodes.size()<3) {
         continue;
       }
 
-      transBuffer.TransformArea(projection,
-                                parameter.GetOptimizeAreaNodes(),
-                                area->rings[i].nodes,
-                                td[i].transStart,td[i].transEnd,
-                                errorTolerancePixel);
+      if (ring.segments.size() <= 1){
+        transBuffer.TransformArea(projection,
+                                  parameter.GetOptimizeAreaNodes(),
+                                  ring.nodes,
+                                  td[i].transStart,td[i].transEnd,
+                                  errorTolerancePixel);
+      }else{
+        std::vector<Point> nodes;
+        for (const auto &segment:ring.segments){
+          if (projection.GetDimensions().Intersects(segment.bbox, false)){
+            // TODO: add TransBuffer::Transform* methods with vector subrange (begin/end)
+            nodes.insert(nodes.end(), ring.nodes.data() + segment.from, ring.nodes.data() + segment.to);
+          } else {
+            nodes.push_back(ring.nodes[segment.from]);
+            nodes.push_back(ring.nodes[segment.to-1]);
+          }
+        }
+        transBuffer.TransformArea(projection,
+                                  parameter.GetOptimizeAreaNodes(),
+                                  nodes,
+                                  td[i].transStart,td[i].transEnd,
+                                  errorTolerancePixel);
+      }
     }
 
     size_t ringId=Area::outerRingId;
@@ -1492,7 +1511,7 @@ namespace osmscout {
                                   const MapParameter& parameter,
                                   const ObjectFileRef& ref,
                                   const FeatureValueBuffer& buffer,
-                                  const std::vector<Point>& nodes)
+                                  const Way& way)
   {
     styleConfig.GetWayLineStyles(buffer,
                                  projection,
@@ -1575,18 +1594,37 @@ namespace osmscout {
       data.lineWidth=lineWidth;
 
       if (!IsVisibleWay(projection,
-                        nodes,
+                        way.nodes,
                         lineWidth/2)) {
         continue;
       }
 
       if (!transformed) {
-        transBuffer.TransformWay(projection,
-                                 parameter.GetOptimizeWayNodes(),
-                                 nodes,
-                                 transStart,
-                                 transEnd,
-                                 errorTolerancePixel);
+        if (way.segments.size() <= 1) {
+          transBuffer.TransformWay(projection,
+                                   parameter.GetOptimizeWayNodes(),
+                                   way.nodes,
+                                   transStart,
+                                   transEnd,
+                                   errorTolerancePixel);
+        } else {
+          std::vector<Point> nodes;
+          for (const auto &segment : way.segments){
+            if (projection.GetDimensions().Intersects(segment.bbox, false)){
+              // TODO: add TransBuffer::Transform* methods with vector subrange (begin/end)
+              nodes.insert(nodes.end(), way.nodes.data() + segment.from, way.nodes.data() + segment.to);
+            } else {
+              nodes.push_back(way.nodes[segment.from]);
+              nodes.push_back(way.nodes[segment.to-1]);
+            }
+          }
+          transBuffer.TransformWay(projection,
+                                   parameter.GetOptimizeWayNodes(),
+                                   nodes,
+                                   transStart,
+                                   transEnd,
+                                   errorTolerancePixel);
+        }
 
         WayPathData pathData;
 
@@ -1604,8 +1642,8 @@ namespace osmscout {
       data.buffer=&buffer;
       data.lineStyle=lineStyle;
       data.wayPriority=styleConfig.GetWayPrio(buffer.GetType());
-      data.startIsClosed=nodes[0].GetSerial()==0;
-      data.endIsClosed=nodes[nodes.size()-1].GetSerial()==0;
+      data.startIsClosed=way.nodes[0].GetSerial()==0;
+      data.endIsClosed=way.nodes[way.nodes.size()-1].GetSerial()==0;
 
       LayerFeatureValue *layerValue=layerReader.GetValue(buffer);
 
@@ -1676,7 +1714,7 @@ namespace osmscout {
                      ObjectFileRef(way->GetFileOffset(),
                                    refWay),
                      way->GetFeatureValueBuffer(),
-                     way->nodes);
+                     *way);
 
       CalculateWayShieldLabels(styleConfig,
                                projection,
@@ -1691,7 +1729,7 @@ namespace osmscout {
                      ObjectFileRef(way->GetFileOffset(),
                                    refWay),
                      way->GetFeatureValueBuffer(),
-                     way->nodes);
+                     *way);
 
       CalculateWayShieldLabels(styleConfig,
                                projection,

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -31,6 +31,7 @@
 #include <osmscout/util/FileWriter.h>
 #include <osmscout/util/GeoBox.h>
 #include <osmscout/util/Progress.h>
+#include <osmscout/util/Geometry.h>
 
 #include <osmscout/system/Compiler.h>
 
@@ -52,7 +53,15 @@ namespace osmscout {
       uint8_t               ring;               //!< The ring hierarchy number (0...n)
 
     public:
-      std::vector<Point>    nodes;              //!< The array of coordinates
+      /**
+       * Note that ring nodes, bbox and segments fields are public for simple manipulation.
+       * User that modify it is responsible to keep these values in sync!
+       * You should not rely on segments and bbox, it is just a cache used some algorithms.
+       * It may be empty/invalid!
+       */
+      std::vector<Point>          nodes;        //!< The array of coordinates
+      std::vector<SegmentGeoBox>  segments;     //!< Precomputed (cache) segment bounding boxes for optimisation
+      GeoBox                      bbox;         //!< Precomputed (cache) bounding box
 
     public:
       inline Ring()

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -301,6 +301,10 @@ namespace osmscout {
     data.reserve(data.size()+size);
     std::lock_guard<std::mutex> lock(accessMutex);
 
+    if (size > cache.GetMaxSize()){
+      log.Warn() << "Cache size (" << cache.GetMaxSize() << ") for file " << datafile << " is smaller than current request (" << size << ")";
+    }
+
     for (IteratorIn offsetIter=begin; offsetIter!=end; ++offsetIter) {
       ValueCacheRef entryRef;
 
@@ -344,6 +348,10 @@ namespace osmscout {
 
     data.reserve(data.size()+size);
     std::lock_guard<std::mutex> lock(accessMutex);
+
+    if (size > cache.GetMaxSize()){
+      log.Warn() << "Cache size (" << cache.GetMaxSize() << ") for file " << datafile << " is smaller than current request (" << size << ")";
+    }
 
     for (IteratorIn offsetIter=begin; offsetIter!=end; ++offsetIter) {
       ValueType value=std::make_shared<N>();

--- a/libosmscout/include/osmscout/Way.h
+++ b/libosmscout/include/osmscout/Way.h
@@ -152,7 +152,7 @@ namespace osmscout {
 
     inline GeoBox GetBoundingBox() const
     {
-      if (bbox.IsValid()) {
+      if (bbox.IsValid() || nodes.empty()) {
         return bbox;
       }
       GeoBox boundingBox;

--- a/libosmscout/include/osmscout/Way.h
+++ b/libosmscout/include/osmscout/Way.h
@@ -47,7 +47,15 @@ namespace osmscout {
 
 
   public:
-    std::vector<Point> nodes;              //!< List of nodes
+    /**
+     * Note that ring nodes, bbox and segments fields are public for simple manipulation.
+     * User that modify it is responsible to keep these values in sync!
+     * You should not rely on segments and bbox, it is just a cache used some algorithms.
+     * It may be empty/invalid!
+     */
+    std::vector<Point>          nodes;        //!< List of nodes
+    std::vector<SegmentGeoBox>  segments;     //!< Precomputed (cache) segment bounding boxes for optimisation
+    GeoBox                      bbox;         //!< Precomputed (cache) bounding box
 
   public:
     inline Way()
@@ -144,6 +152,9 @@ namespace osmscout {
 
     inline GeoBox GetBoundingBox() const
     {
+      if (bbox.IsValid()) {
+        return bbox;
+      }
       GeoBox boundingBox;
 
       osmscout::GetBoundingBox(nodes,

--- a/libosmscout/include/osmscout/util/FileScanner.h
+++ b/libosmscout/include/osmscout/util/FileScanner.h
@@ -35,6 +35,7 @@
 
 #include <osmscout/util/Exception.h>
 #include <osmscout/util/GeoBox.h>
+#include <osmscout/util/Geometry.h>
 
 #if defined(_WIN32)
   #include <windows.h>
@@ -156,7 +157,18 @@ namespace osmscout {
     void ReadConditionalCoord(GeoCoord& coord,
                               bool& isSet);
 
-    void Read(std::vector<Point>& nodes, bool readIds);
+    /**
+     * Reads vector of Point and pre-compute segments and bounding box for it
+     *
+     * @param nodes
+     * @param segments
+     * @param bbox
+     * @param readIds
+     */
+    void Read(std::vector<Point>& nodes,
+              std::vector<SegmentGeoBox> &segments,
+              GeoBox &bbox,
+              bool readIds);
 
     void ReadBox(GeoBox& box);
 

--- a/libosmscout/include/osmscout/util/FileScanner.h
+++ b/libosmscout/include/osmscout/util/FileScanner.h
@@ -91,6 +91,20 @@ namespace osmscout {
     void AssureByteBufferSize(size_t size);
     void FreeBuffer();
 
+    /**
+     * Reads bytes to internal temporary buffer
+     * or just return pointer to memory mapped file.
+     *
+     * In case of internal buffer, data are valid until
+     * next read. In case of memory mapped file, data
+     * are valid until closing the reader and method don't
+     * copy the memory - it should be fast.
+     *
+     * @param bytes
+     * @return pointer to byteBuffer or memory mapped file
+     */
+    char* ReadInternal(size_t bytes);
+
   public:
     FileScanner();
     virtual ~FileScanner();

--- a/libosmscout/include/osmscout/util/GeoBox.h
+++ b/libosmscout/include/osmscout/util/GeoBox.h
@@ -91,6 +91,11 @@ namespace osmscout {
     void Include(const GeoBox& other);
 
     /**
+     * Resize the bounding box to include the original bounding box and the given point
+     */
+    void Include(const GeoCoord& point);
+
+    /**
      *
      * Returns 'true' if coordinate is within the bounding box.
      *

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -122,6 +122,39 @@ namespace osmscout {
 
   /**
    * \ingroup Geometry
+   * Calculate the bounding box of the (non empty) range of geo coords
+   *
+   * @param [first, last) range of geo coords
+   * @param minLon
+   * @param maxLon
+   * @param minLat
+   * @param maxLat
+   */
+  template< class InputIt >
+  void GetBoundingBox(const InputIt first,
+                      const InputIt last,
+                      GeoBox& boundingBox)
+  {
+    assert(first!=last);
+
+    double minLon=first->GetLon();
+    double maxLon=minLon;
+    double minLat=first->GetLat();
+    double maxLat=minLat;
+
+    for (InputIt i=first; i!=last; i++) {
+      minLon=std::min(minLon,i->GetLon());
+      maxLon=std::max(maxLon,i->GetLon());
+      minLat=std::min(minLat,i->GetLat());
+      maxLat=std::max(maxLat,i->GetLat());
+    }
+
+    boundingBox.Set(GeoCoord(minLat,minLon),
+                    GeoCoord(maxLat,maxLon));
+  }
+
+  /**
+   * \ingroup Geometry
    * Calculate the bounding box of the (non empty) vector of geo coords
    *
    * @param nodes

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -259,6 +259,8 @@ namespace osmscout {
     }
 
     scanner.Read(rings[0].nodes,
+                 rings[0].segments,
+                 rings[0].bbox,
                  rings[0].GetType()->CanRoute());
 
     for (size_t i=1; i<ringCount; i++) {
@@ -276,6 +278,8 @@ namespace osmscout {
 
       scanner.Read(ring.ring);
       scanner.Read(ring.nodes,
+                   ring.segments,
+                   ring.bbox,
                    ring.GetType()->GetAreaId()!=typeIgnore &&
                    ring.GetType()->CanRoute());
     }
@@ -327,24 +331,29 @@ namespace osmscout {
     }
 
     scanner.Read(rings[0].nodes,
+                 rings[0].segments,
+                 rings[0].bbox,
                  true);
 
     for (size_t i=1; i<ringCount; i++) {
+      auto &ring = rings[i];
       scanner.ReadTypeId(ringType,
                          typeConfig.GetAreaTypeIdBytes());
 
       type=typeConfig.GetAreaTypeInfo(ringType);
 
-      rings[i].SetType(type);
+      ring.SetType(type);
 
-      if (rings[i].GetType()->GetAreaId()!=typeIgnore) {
-        rings[i].featureValueBuffer.Read(scanner);
+      if (ring.GetType()->GetAreaId()!=typeIgnore) {
+        ring.featureValueBuffer.Read(scanner);
       }
 
-      scanner.Read(rings[i].ring);
-      scanner.Read(rings[i].nodes,
-                   rings[i].GetType()->GetAreaId()!=typeIgnore ||
-                   rings[i].ring==outerRingId);
+      scanner.Read(ring.ring);
+      scanner.Read(ring.nodes,
+                   ring.segments,
+                   ring.bbox,
+                   ring.GetType()->GetAreaId()!=typeIgnore ||
+                   ring.ring==outerRingId);
     }
     nextFileOffset=scanner.GetPos();
   }
@@ -394,22 +403,27 @@ namespace osmscout {
     }
 
     scanner.Read(rings[0].nodes,
+                 rings[0].segments,
+                 rings[0].bbox,
                  false);
 
     for (size_t i=1; i<ringCount; i++) {
+      auto &ring = rings[i];
       scanner.ReadTypeId(ringType,
                          typeConfig.GetAreaTypeIdBytes());
 
       type=typeConfig.GetAreaTypeInfo(ringType);
 
-      rings[i].SetType(type);
+      ring.SetType(type);
 
-      if (rings[i].featureValueBuffer.GetType()->GetAreaId()!=typeIgnore) {
-        rings[i].featureValueBuffer.Read(scanner);
+      if (ring.featureValueBuffer.GetType()->GetAreaId()!=typeIgnore) {
+        ring.featureValueBuffer.Read(scanner);
       }
 
-      scanner.Read(rings[i].ring);
-      scanner.Read(rings[i].nodes,
+      scanner.Read(ring.ring);
+      scanner.Read(ring.nodes,
+                   ring.segments,
+                   ring.bbox,
                    false);
     }
     nextFileOffset=scanner.GetPos();

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -99,6 +99,10 @@ namespace osmscout {
   void Area::Ring::GetBoundingBox(GeoBox& boundingBox) const
   {
     assert(!nodes.empty());
+    if (bbox.IsValid()) {
+      boundingBox = bbox;
+      return;
+    }
 
     double minLon=nodes[0].GetLon();
     double maxLon=minLon;
@@ -119,6 +123,9 @@ namespace osmscout {
   GeoBox Area::Ring::GetBoundingBox() const
   {
     assert(!nodes.empty());
+    if (bbox.IsValid()) {
+      return bbox;
+    }
 
     double minLon=nodes[0].GetLon();
     double maxLon=minLon;
@@ -255,21 +262,22 @@ namespace osmscout {
                  rings[0].GetType()->CanRoute());
 
     for (size_t i=1; i<ringCount; i++) {
+      auto &ring = rings[i];
       scanner.ReadTypeId(ringType,
                          typeConfig.GetAreaTypeIdBytes());
 
       type=typeConfig.GetAreaTypeInfo(ringType);
 
-      rings[i].SetType(type);
+      ring.SetType(type);
 
-      if (rings[i].GetType()->GetAreaId()!=typeIgnore) {
-        rings[i].featureValueBuffer.Read(scanner);
+      if (ring.GetType()->GetAreaId()!=typeIgnore) {
+        ring.featureValueBuffer.Read(scanner);
       }
 
-      scanner.Read(rings[i].ring);
-      scanner.Read(rings[i].nodes,
-                   rings[i].GetType()->GetAreaId()!=typeIgnore &&
-                   rings[i].GetType()->CanRoute());
+      scanner.Read(ring.ring);
+      scanner.Read(ring.nodes,
+                   ring.GetType()->GetAreaId()!=typeIgnore &&
+                   ring.GetType()->CanRoute());
     }
     nextFileOffset=scanner.GetPos();
   }

--- a/libosmscout/src/osmscout/Way.cpp
+++ b/libosmscout/src/osmscout/Way.cpp
@@ -88,6 +88,8 @@ namespace osmscout {
     featureValueBuffer.Read(scanner);
 
     scanner.Read(nodes,
+                 segments,
+                 bbox,
                  type->CanRoute() ||
                  type->GetOptimizeLowZoom());
     nextFileOffset=scanner.GetPos();
@@ -112,7 +114,7 @@ namespace osmscout {
 
     featureValueBuffer.Read(scanner);
 
-    scanner.Read(nodes,false);
+    scanner.Read(nodes,segments,bbox,false);
     nextFileOffset=scanner.GetPos();
   }
 

--- a/libosmscout/src/osmscout/util/GeoBox.cpp
+++ b/libosmscout/src/osmscout/util/GeoBox.cpp
@@ -88,6 +88,22 @@ namespace osmscout {
                           other.GetMaxCoord().GetLon()));
   }
 
+  void GeoBox::Include(const GeoCoord& point)
+  {
+    if(!valid){
+      minCoord=point;
+      maxCoord=point;
+      valid=true;
+      return;
+    }
+
+    minCoord.Set(std::min(minCoord.GetLat(),point.GetLat()),
+                 std::min(minCoord.GetLon(),point.GetLon()));
+
+    maxCoord.Set(std::max(maxCoord.GetLat(),point.GetLat()),
+                 std::max(maxCoord.GetLon(),point.GetLon()));
+  }
+
   GeoBox GeoBox::Intersection(const GeoBox& other) const
   {
     if (!valid || !other.valid || !Intersects(other))

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -24,7 +24,7 @@ OST
       * Access
       * MaxSpeed
     OPTIMIZE_LOW_ZOOM:
-      Optimize this area or way for idplaying in low zoom by
+      Optimize this area or way for displaying in low zoom by
       reducing visible complexity
     PIN_WAY:
       This is a way, even if the path is closed

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -1930,25 +1930,25 @@ TYPES
     = WAY AREA ("boundary"=="administrative" AND "admin_level"=="2") OR
       RELATION ("type"=="boundary" AND "boundary"=="administrative" AND "admin_level"=="2")
       {Name, NameAlt, AdminLevel}
-      MULTIPOLYGON IGNORESEALAND
+      MULTIPOLYGON IGNORESEALAND OPTIMIZE_LOW_ZOOM
 
   TYPE boundary_state
     = WAY AREA ("boundary"=="administrative" AND "admin_level"=="4") OR
       RELATION ("type"=="boundary" AND "boundary"=="administrative" AND "admin_level"=="4")
       {Name, NameAlt, AdminLevel}
-      MULTIPOLYGON IGNORESEALAND
+      MULTIPOLYGON IGNORESEALAND OPTIMIZE_LOW_ZOOM
 
   TYPE boundary_county
     = WAY AREA ("boundary"=="administrative" AND "admin_level"=="6") OR
       RELATION ("type"=="boundary" AND "boundary"=="administrative" AND "admin_level"=="6")
       {Name, NameAlt, AdminLevel}
-      MULTIPOLYGON IGNORESEALAND
+      MULTIPOLYGON IGNORESEALAND OPTIMIZE_LOW_ZOOM
 
   TYPE boundary_administrative
     = WAY AREA ("boundary"=="administrative") OR
       RELATION ("type"=="boundary" AND "boundary"=="administrative")
       {Name, NameAlt, AdminLevel}
-      MULTIPOLYGON IGNORESEALAND
+      MULTIPOLYGON IGNORESEALAND OPTIMIZE_LOW_ZOOM
 
   TYPE place_continent
     = NODE AREA ("place"=="continent")


### PR DESCRIPTION
Hi Tim. 

I want to return `boundary_country` to stylesheets. Before doing this, I just wanted to know how mutch and why rendering of this type is expensive. So I create this simple stylesheet:

```
OSS
  CONST
    COLOR waterColor                 = #9acffd;
    COLOR landColor                  = #f1eee9;
    COLOR countryBorderColor         = #ff0000;

  STYLE
    [TYPE _tile_sea] AREA {color: @waterColor;}
    [TYPE _tile_land] AREA {color: @landColor;}

    [TYPE boundary_country] WAY {color: @countryBorderColor; displayWidth: 0.4mm; dash: 7,3;}
    [TYPE boundary_country] AREA.BORDER {color: @countryBorderColor; width: 0.4mm; dash: 7,3;}
END
```

...and started experimenting with `PeformanceTest` demo:
```
./Demos/PerformanceTest \
  ~/Maps/europe-czech-republic-20180823-024442/ \
  boundaries-test.oss \
  50.0918 14.402 50.0918 14.402 \
  8 18 \
  1200 1200 \
  Qt
```

`boundary_country` type for Czech Republic has just one area with 87 127 nodes. I updated performance test to repeat map rendering 100x. Without any other modifications, rendering of zoom level 16 took **19 ms** in average (my x86 notebook).

```
Level: 16
Tiles: 100
 Used memory: max: 24.9778 MiB avg: 255.772 KiB
 Tot. data  : nodes: 0 way: 0 areas: 1
 Avg. data  : nodes: 0 way: 0 areas: 0
 DB         : total: 88.0596 min: 88.0596 avg: 0.880596 max: 88.0596 
 Map        : total: 1913.49 min: 18.031 avg: 19.1349 max: 34.7981
```

From perf-top is clear that computation of bounding box is expensive for such huge area. So I pre-compute it for `Area::Ring`. With this change, rendering took **15 ms**.
```
Level: 16
Tiles: 100
 Used memory: max: 24.9794 MiB avg: 255.789 KiB
 Tot. data  : nodes: 0 way: 0 areas: 1
 Avg. data  : nodes: 0 way: 0 areas: 0
 DB         : total: 6.50177 min: 6.50177 avg: 0.0650177 max: 6.50177 
 Map        : total: 1541.2 min: 13.841 avg: 15.412 max: 28.865
```

For such huge areas like `boundary_country`, it is clear that it is not complete visible for higher zoom levels. When just a small segment is intersecting with the projection viewport. It is not necessary to convert all points to screen coordinates and render it. Segments outside viewport can be simplified to boost performance. So my second modification was to pre-compute segment (1000 nodes) bounding boxes and replace complete segment with line when it is outside viewport... With this modification, rendering took **4.9 ms**

```
Level: 16
Tiles: 100
 Used memory: max: 21.0395 MiB avg: 215.445 KiB
 Tot. data  : nodes: 0 way: 0 areas: 1
 Avg. data  : nodes: 0 way: 0 areas: 0
 DB         : total: 99.8611 min: 99.8611 avg: 0.998611 max: 99.8611 
 Map        : total: 497.905 min: 4.55919 avg: 4.97905 max: 7.57603
```

When both optimisations are used, rendering took **0.9 ms**!
```
Level: 16
Tiles: 100
 Used memory: max: 21.0395 MiB avg: 215.445 KiB
 Tot. data  : nodes: 0 way: 0 areas: 1
 Avg. data  : nodes: 0 way: 0 areas: 0
 DB         : total: 9.7306 min: 9.7306 avg: 0.097306 max: 9.7306 
 Map        : total: 92.1714 min: 0.605772 avg: 0.921714 max: 3.41345
```

---

I think that it is clear that it makes sense to pre-compute such values for huge areas (and ways?) and reduce rendered nodes outside projection viewport. For these areas, it is huge change that it will be rendered multiple times during its live in cache. Question is how to do it properly? Store pre-computed values in `Ring` directly as in this POC? Use new separate cache just for rendering https://github.com/Framstag/libosmscout/issues/55 ? How such cache should looks like?