### PR TITLE
City walls

### DIFF
--- a/libosmscout-import/src/osmscout/import/Preprocess.cpp
+++ b/libosmscout-import/src/osmscout/import/Preprocess.cpp
@@ -335,7 +335,7 @@ namespace osmscout {
 
         parameter.GetErrorReporter()->ReportWay(data.id,
                                                 data.tags,
-                                                "Should be way but is area");
+                                                "Should be way but is area (" + wayType->GetName() + ")");
       }
 
       if (areaType==typeConfig->typeInfoIgnore ||
@@ -361,7 +361,7 @@ namespace osmscout {
           areaType!=typeConfig->typeInfoIgnore) {
         parameter.GetErrorReporter()->ReportWay(data.id,
                                                 data.tags,
-                                                "Should be area but is way");
+                                                "Should be area but is way (" + areaType->GetName() + ")");
       }
 
       if (wayType==typeConfig->typeInfoIgnore ||

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -1622,7 +1622,7 @@ TYPES
       GROUP historic, building, routingPOI
 
   TYPE historic
-    = NODE AREA (EXISTS "historic")
+    = NODE AREA (EXISTS "historic" AND !("historic" IN ["citywalls"]))
       {Name, NameAlt}
       ADDRESS POI
       GROUP historic
@@ -2067,7 +2067,7 @@ TYPES
       IGNORESEALAND
 
   TYPE barrier_city_wall
-    = WAY AREA ("barrier"=="city_wall")
+    = WAY AREA ("barrier"=="city_wall" OR "historic"=="citywalls")
       {Name, NameAlt, Width}
 
   TYPE barrier_bollard


### PR DESCRIPTION
Hi. I found city wall in Florence that was matched as `historic` type, but reported as a error, because it is a way, not the area. So I updated type definition to always use `barrier_city_wall` type to these cases...

https://www.openstreetmap.org/way/140235977#map=17/43.76333/11.25962
