### PR TITLE
Performance test improvements

### DIFF
--- a/Demos/src/PerformanceTest.cpp
+++ b/Demos/src/PerformanceTest.cpp
@@ -184,6 +184,8 @@ std::string formatAlloc(double size)
 
 class PerformanceTestBackend {
 public:
+  virtual ~PerformanceTestBackend() = default;
+
   virtual void DrawMap(const osmscout::TileProjection &/*projection*/,
                        const osmscout::MapParameter &/*drawParameter*/,
                        const osmscout::MapData &/*data*/)


### PR DESCRIPTION
Hi

When I want to benchmark some change, I have to modify and rebuild PerformanceTest usually. To avoid that or simplify it, I made few changes:

 - use CmdLineParser, make some arguments optional
 - create abstraction for backends, it makes main loop more readable by reducing `#ifdefs`
 - make possible repeat rendering and data loading multiple times to get more stable average values between multiple runs
 - add possibility to flush osmscout data caches or even system disk cache (just on Linux)
