### PR TITLE
fix SVG painter for when area.fillStyle is NULL 

### DIFF
--- a/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscout/MapPainterSVG.h
@@ -77,15 +77,17 @@ namespace osmscout {
     using SvgLabelLayouter = LabelLayouter<NativeGlyph, NativeLabel, MapPainterSVG>;
     friend SvgLabelLayouter;
 
-    SvgLabelLayouter                labelLayouter;
+    SvgLabelLayouter                  labelLayouter;
 
-    std::map<FillStyle,std::string> fillStyleNameMap;
-    std::map<LineStyle,std::string> lineStyleNameMap;
-    std::ostream                    stream;
-    TypeConfigRef                   typeConfig;
-    std::mutex                      mutex;         //! Mutex for locking concurrent calls
+    std::map<FillStyle,std::string>   fillStyleNameMap;
+    std::map<BorderStyle,std::string> borderStyleNameMap;
+    std::map<LineStyle,std::string>   lineStyleNameMap;
 
-    std::vector<std::string>        images;
+    std::ostream                      stream;
+    TypeConfigRef                     typeConfig;
+    std::mutex                        mutex;         //! Mutex for locking concurrent calls
+
+    std::vector<std::string>          images;
 
   private:
     std::string GetColorValue(const Color& color);

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -578,11 +578,16 @@ namespace osmscout {
     return *this;
   }
 
-  BorderStyle::BorderStyle(const BorderStyle& style)
+  BorderStyle::BorderStyle(const BorderStyle& style):
+    slot(style.slot),
+    color(style.color),
+    gapColor(style.gapColor),
+    width(style.width),
+    dash(style.dash),
+    displayOffset(style.displayOffset),
+    offset(style.offset),
+    priority(style.priority)
   {
-    this->color=style.color;
-    this->width=style.width;
-    this->dash=style.dash;
   }
 
   void BorderStyle::SetColorValue(int attribute, const Color& value)
@@ -733,22 +738,22 @@ namespace osmscout {
     }
 
     if (width!=other.width) {
-      return width<other.width;
+      return false;
     }
 
     if (dash!=other.dash) {
-      return dash<other.dash;
+      return false;
     }
 
     if (displayOffset!=other.displayOffset) {
-      return displayOffset<other.displayOffset;
+      return false;
     }
 
     if (offset!=other.offset) {
-      return offset<other.offset;
+      return false;
     }
 
-    return priority<other.priority;
+    return priority==other.priority;
   }
 
   bool BorderStyle::operator!=(const BorderStyle& other) const


### PR DESCRIPTION
When I tried SVG painter with `boundary_country` style just with defined `AREA.BORDER`, it crashed, because `area.fillStyle` is null in such cases...

So I split area fill and border classes and use special transparent class where fillStyle is not defined...