### PR TITLE
Fix overlay tile cache

### DIFF
--- a/libosmscout-client-qt/include/osmscout/TileCache.h
+++ b/libosmscout-client-qt/include/osmscout/TileCache.h
@@ -31,9 +31,12 @@
 #include <QTime>
 #include <QImage>
 #include <QPixmap>
+#include <QDebug>
 
 #include <osmscout/util/GeoBox.h>
 #include <osmscout/ClientQtImportExport.h>
+
+//#define DEBUG_TILE_CACHE
 
 namespace osmscout {
 
@@ -51,6 +54,8 @@ struct TileCacheKey
 bool operator==(const TileCacheKey a, const TileCacheKey b);
 
 uint qHash(const TileCacheKey &key);
+
+QDebug& operator<<(QDebug &out, const TileCacheKey &key);
 
 /**
  * \ingroup QtAPI
@@ -88,7 +93,7 @@ public:
   virtual ~TileCache();
   
   /**
-   * revove all pending requests
+   * remove all pending requests
    * TODO: in case of multiple map widgets, add some id to avoid removing requests 
    * of another widget
    */

--- a/libosmscout-client-qt/include/osmscout/TileCache.h
+++ b/libosmscout-client-qt/include/osmscout/TileCache.h
@@ -42,16 +42,22 @@ namespace osmscout {
 
 /**
  * \ingroup QtAPI
+ *
+ * The key type of a QMap must provide operator<()
+ *
+ * The key type of a QHash must provide operator==()
+ * and a global hash function called qHash() (see qHash).
  */
 struct TileCacheKey
 {
     uint32_t zoomLevel;
     uint32_t xtile; 
     uint32_t ytile;
-  
 };
 
-bool operator==(const TileCacheKey a, const TileCacheKey b);
+bool operator==(const TileCacheKey &a, const TileCacheKey &b);
+
+bool operator<(const TileCacheKey &a, const TileCacheKey &b);
 
 uint qHash(const TileCacheKey &key);
 

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -76,7 +76,7 @@ void OsmTileDownloader::download(uint32_t zoomLevel, uint32_t x, uint32_t y)
   QString server = servers.at(serverNumber % servers.size());
 
   QUrl tileUrl(server.arg(zoomLevel).arg(x).arg(y));
-  qDebug() << "Download tile " << tileUrl << " (current thread: " << QThread::currentThread() << ")";
+  qDebug() << "Download tile" << tileUrl << "(current thread:" << QThread::currentThread() << ")";
   
   TileCacheKey key = {zoomLevel, x, y};
   requests.insert(tileUrl, key);
@@ -91,15 +91,13 @@ void OsmTileDownloader::fileDownloaded(QNetworkReply* reply)
 { 
   QUrl url = reply->url();
   if (!requests.contains(url)){
-    qWarning() << "Response from non-requested url: " << url;
+    qWarning() << "Response from non-requested url:" << url;
   }else{
     
     TileCacheKey key = requests.value(url);
     requests.remove(url);
     if (reply->error() != QNetworkReply::NoError){
-        // TODO: it seems that this code is affected by https://bugreports.qt.io/browse/QTBUG-46323
-        // on Jolla phone (Qt 5.2.2), exists some workaround? Can we copy-paste fixed QNetworkAccessManager to project?
-      qWarning() << "Downloading " << url << "failed with " << reply->errorString();
+      qWarning() << "Downloading" << url << "failed with" << reply->errorString();
       serverNumber = qrand(); // try another server for future requests
       emit failed(key.zoomLevel, key.xtile, key.ytile, false);
     }else{

--- a/libosmscout-client-qt/src/osmscout/TileCache.cpp
+++ b/libosmscout-client-qt/src/osmscout/TileCache.cpp
@@ -34,9 +34,18 @@ uint qHash(const TileCacheKey &key){
   return (key.zoomLevel << 24) ^ (key.xtile << 12) ^ key.ytile;
 }
 
-bool operator==(const TileCacheKey a, const TileCacheKey b)
+bool operator==(const TileCacheKey &a, const TileCacheKey &b)
 {
-    return a.zoomLevel == b.zoomLevel && a.xtile == b.xtile && a.ytile == b.ytile;
+  return a.zoomLevel == b.zoomLevel && a.xtile == b.xtile && a.ytile == b.ytile;
+}
+
+bool operator<(const TileCacheKey &a, const TileCacheKey &b)
+{
+  if (a.zoomLevel != b.zoomLevel)
+    return a.zoomLevel < b.zoomLevel;
+  if (a.xtile != b.xtile)
+    return a.xtile < b.xtile;
+  return a.ytile < b.ytile;
 }
 
 QDebug& operator<<(QDebug &out, const TileCacheKey &key)

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -23,7 +23,14 @@
 #include <osmscout/TiledRenderingHelper.h>
 
 namespace osmscout {
-TileLoaderThread::TileLoaderThread(QThread *thread): thread(thread), tileDownloader(NULL) {}
+
+TileLoaderThread::TileLoaderThread(QThread *thread):
+  thread(thread),
+  tileDownloader(NULL),
+  onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize())
+{
+  qDebug() << "Overlay tile cache:" << &onlineTileCache;
+}
 
 TileLoaderThread::~TileLoaderThread()
 {
@@ -43,32 +50,82 @@ void TileLoaderThread::init()
   tileDownloader = new OsmTileDownloader(tileCacheDirectory,provider);
 
   connect(tileDownloader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
-          this, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)));
+          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)));
   connect(tileDownloader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
-          this, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)));
+          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)));
+
+  connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
+          this,SLOT(download(uint32_t, uint32_t, uint32_t)),
+          Qt::QueuedConnection);
 }
 
 void TileLoaderThread::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile)
 {
   if (tileDownloader == NULL){
     qWarning() << "tile requested but downloader is not initialized yet";
-    emit failed(zoomLevel, xtile, ytile, false);
+    emit failed(zoomLevel, xtile, ytile);
   }else{
-    emit tileDownloader->download(zoomLevel, xtile, ytile);
+    QMutexLocker locker(&tileCacheMutex);
+    if (onlineTileCache.startRequestProcess(zoomLevel, xtile, ytile)) {
+      emit tileDownloader->download(zoomLevel, xtile, ytile);
+    }
   }
 }
 
 void TileLoaderThread::onProviderChanged(const OnlineTileProvider &newProvider)
 {
+  QMutexLocker locker(&tileCacheMutex);
+  onlineTileCache.clearPendingRequests();
+  onlineTileCache.cleanupCache();
+
   provider=newProvider;
   if (tileDownloader!=NULL){
     emit tileDownloader->onlineTileProviderChanged(provider);
   }
 }
 
+void TileLoaderThread::accessCache(std::function<void(TileCache&)> fn)
+{
+  QMutexLocker locker(&tileCacheMutex);
+  fn(onlineTileCache);
+}
+
+
+void TileLoaderThread::tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray /*downloadedData*/)
+{
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    onlineTileCache.put(zoomLevel, x, y, image);
+  }
+
+  emit downloaded(zoomLevel, x, y);
+}
+
+void TileLoaderThread::tileDownloadFailed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange)
+{
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    onlineTileCache.removeRequest(zoomLevel, x, y);
+
+    if (zoomLevelOutOfRange && zoomLevel > 0) {
+      // hack: when zoom level is too high for online source,
+      // we try to request tile with lower zoom level and put it to cache
+      // as substitute
+      uint32_t reqZoom = zoomLevel - 1;
+      uint32_t reqX = x / 2;
+      uint32_t reqY = y / 2;
+      if ((!onlineTileCache.contains(reqZoom, reqX, reqY))
+          && onlineTileCache.request(reqZoom, reqX, reqY)) {
+        qDebug() << "Tile download failed" << x << y << "zoomLevel" << zoomLevel << "try lower zoom";
+        //triggerTileRequest(reqZoom, reqX, reqY);
+      }
+    }
+  }
+  emit failed(zoomLevel, x, y);
+}
+
 TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
     MapOverlay(parent),
-    onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize()),
     enabled(true),
     transparentColor(QColor::fromRgbF(0,0,0,0))
 {
@@ -84,16 +141,8 @@ TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
           loader, SLOT(onProviderChanged(const OnlineTileProvider &)),
           Qt::QueuedConnection);
 
-  connect(loader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
-          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
-          Qt::QueuedConnection);
-
-  connect(loader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
-          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)),
-          Qt::QueuedConnection);
-
-  connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
-          loader,SLOT(download(uint32_t, uint32_t, uint32_t)),
+  connect(loader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t)),
+          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t)),
           Qt::QueuedConnection);
 }
 
@@ -110,66 +159,35 @@ void TiledMapOverlay::paint(QPainter *painter)
   if (!enabled || !view->IsValid()){
     return;
   }
-  QMutexLocker locker(&tileCacheMutex);
-  QList<TileCache*> layerCaches;
+  loader->accessCache([&](TileCache& onlineTileCache){
 
-  layerCaches << &onlineTileCache;
-  onlineTileCache.clearPendingRequests();
+    QList<TileCache*> layerCaches;
 
-  painter->setRenderHint(QPainter::Antialiasing, true);
-  painter->setRenderHint(QPainter::TextAntialiasing, true);
-  painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
-  painter->setRenderHint(QPainter::HighQualityAntialiasing, true);
+    layerCaches << &onlineTileCache;
+    onlineTileCache.clearPendingRequests();
 
-  MapViewStruct request;
-  QRectF        boundingBox = contentsBoundingRect();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setRenderHint(QPainter::TextAntialiasing, true);
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+    painter->setRenderHint(QPainter::HighQualityAntialiasing, true);
 
-  request.coord = view->center;
-  request.angle = view->angle;
-  request.magnification = view->magnification;
-  request.width = boundingBox.width();
-  request.height = boundingBox.height();
-  request.dpi = view->mapDpi;
+    MapViewStruct request;
+    QRectF        boundingBox = contentsBoundingRect();
 
-  TiledRenderingHelper::RenderTiles(*painter,request,layerCaches,transparentColor, /*overlap*/ 0);
+    request.coord = view->center;
+    request.angle = view->angle;
+    request.magnification = view->magnification;
+    request.width = boundingBox.width();
+    request.height = boundingBox.height();
+    request.dpi = view->mapDpi;
+
+    TiledRenderingHelper::RenderTiles(*painter,request,layerCaches,transparentColor, /*overlap*/ 0);
+  });
 }
 
-void TiledMapOverlay::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile) {
-  {
-    QMutexLocker locker(&tileCacheMutex);
-    if (!onlineTileCache.startRequestProcess(zoomLevel, xtile, ytile)) // request was canceled or started already
-      return;
-  }
-}
-
-void TiledMapOverlay::tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray /*downloadedData*/)
+void TiledMapOverlay::tileDownloaded(uint32_t /*zoomLevel*/, uint32_t /*x*/, uint32_t /*y*/)
 {
-  {
-    QMutexLocker locker(&tileCacheMutex);
-    onlineTileCache.put(zoomLevel, x, y, image);
-  }
-  //std::cout << "  put: " << zoomLevel << " xtile: " << x << " ytile: " << y << std::endl;
   emit redraw();
-}
-
-void TiledMapOverlay::tileDownloadFailed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange)
-{
-  QMutexLocker locker(&tileCacheMutex);
-  onlineTileCache.removeRequest(zoomLevel, x, y);
-
-  if (zoomLevelOutOfRange && zoomLevel > 0){
-    // hack: when zoom level is too high for online source,
-    // we try to request tile with lower zoom level and put it to cache
-    // as substitute
-    uint32_t reqZoom = zoomLevel - 1;
-    uint32_t reqX = x / 2;
-    uint32_t reqY = y / 2;
-    if ((!onlineTileCache.contains(reqZoom, reqX, reqY))
-        && onlineTileCache.request(reqZoom, reqX, reqY)){
-      qDebug() << "Tile download failed " << x << " " << y << " zoomLevel " << zoomLevel << " try lower zoom";
-      //triggerTileRequest(reqZoom, reqX, reqY);
-    }
-  }
 }
 
 QJsonValue TiledMapOverlay::getProvider()
@@ -184,11 +202,7 @@ void TiledMapOverlay::setProvider(QJsonValue jv)
     qWarning() << "Invalid provider:" << jv;
     return;
   }
-  {
-    QMutexLocker locker(&tileCacheMutex);
-    // FIXME: there is possible race condition when provider is changed and there are pending downloads
-    onlineTileCache.cleanupCache();
-  }
+
   providerJson=jv;
   emit providerChanged(provider);
   redraw();
@@ -206,8 +220,10 @@ void TiledMapOverlay::setEnabled(bool b)
   }
   enabled=b;
   if (!enabled){
-    QMutexLocker locker(&tileCacheMutex);
-    onlineTileCache.cleanupCache();
+    // cleanup cache to release memory
+    loader->accessCache([&](TileCache& onlineTileCache) {
+      onlineTileCache.cleanupCache();
+    });
   }
   redraw();
 }

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -314,10 +314,8 @@ void TiledMapRenderer::offlineTileRequest(uint32_t zoomLevel, uint32_t xtile, ui
 
     }else{
         // put Null image
-        {
-            QMutexLocker locker(&tileCacheMutex);
-            offlineTileCache.put(zoomLevel, xtile, ytile, QImage());
-        }
+        QMutexLocker locker(&tileCacheMutex);
+        offlineTileCache.put(zoomLevel, xtile, ytile, QImage(), loadEpoch);
     }
 }
 

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -251,9 +251,17 @@ bool TiledRenderingHelper::lookupAndDrawTile(TileCache& tileCache, QPainter& pai
 
   if (triggerRequest){
     if (tileCache.request(zoomLevel, xtile, ytile)){
-      //std::cout << "  tile request: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
+
+#ifdef DEBUG_TILE_CACHE
+      qDebug() << &tileCache << QString("tile request: z: %1, %2x%3").arg(zoomLevel).arg(xtile).arg(ytile);
+#endif
+
     }else{
-      //std::cout << "  requested already: " << zoomLevel << " xtile: " << xtile << " ytile: " << ytile << std::endl;
+
+#ifdef DEBUG_TILE_CACHE
+      qDebug() << &tileCache << QString("requested already: z: %1, %2x%3").arg(zoomLevel).arg(xtile).arg(ytile);
+#endif
+
     }
   }
   return lookupTileFound;


### PR DESCRIPTION
I wanted to fix (unwanted) parallel request to online tile, but it ends up with bigger patch...

separate commits:

- add comparator for TileCacheKey
- enable/disable debug output of tile cache by macro
- use correct epoch for offline tile placeholder
- remove TODO, Qt on latest SailfishOS should be fixed
- move tile cache from TiledMapOverlay to TileLoaderThread
 