### PR TITLE
add boundary_protected_area type and style

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -1018,6 +1018,11 @@ TYPES
       {Name, NameAlt}
       MERGE_AREAS
 
+  TYPE boundary_protected_area
+    = AREA RELATION ("boundary"=="national_park" OR "boundary"=="protected_area")
+      {Name, NameAlt}
+      OPTIMIZE_LOW_ZOOM MERGE_AREAS
+
   TYPE leisure_park
     = NODE AREA ("leisure"=="park")
       {Name, NameAlt}
@@ -2220,9 +2225,6 @@ TYPES
 
   TYPE boundary_civil IGNORE
     = AREA ("boundary"=="civil")
-
-  TYPE boundary_national_park IGNORE
-    = WAY AREA RELATION ("boundary"=="national_park")
 
   TYPE boundary_maritime IGNORE
     = AREA RELATION ("boundary"=="maritime")

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -279,8 +279,8 @@ CONST
   // Leisure
 
   COLOR natureReserveColor         = #abde9622;
-  COLOR natureReserveLabelColor    = darken(@natureReserveColor, 0.5);
-  COLOR natureReserveBorderColor   = darken(@natureReserveColor, 0.3);
+  COLOR natureReserveLabelColor    = #566f4bb0;
+  COLOR natureReserveBorderColor   = #82a77180;
 
   COLOR playgroundColor            = #ccffff;
   COLOR playgroundBorderColor      = darken(@playgroundColor, 0.3);
@@ -1435,6 +1435,20 @@ STYLE
      [TYPE leisure_marina,
            leisure_fishing,
            leisure_ice_rink] AREA { color: #b5d6f1; }
+   }
+
+   [TYPE boundary_protected_area] {
+     [MAG stateOver-]{
+       AREA.BORDER#dashed { color: @natureReserveBorderColor; width: 0.3mm; dash: 6,6; displayOffset: -0.5mm; }
+       AREA.BORDER#solid { color: lighten(@natureReserveBorderColor, 0.3); width: 1.0mm; }
+     }
+     [MAG stateOver-detail]{
+       AREA.TEXT { label: Name.name; priority: @labelPrioNatural; color: @natureReserveLabelColor; autoSize: true;}
+     }
+     // Semiransparent overlay just for low zoom
+     [MAG stateOver-proximity]{
+       AREA { color: @natureReserveColor;}
+     }
    }
 
    [MAG city-] {

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -282,8 +282,8 @@ CONST
   // Leisure
 
   COLOR natureReserveColor         = #abde9622;
-  COLOR natureReserveLabelColor    = darken(@natureReserveColor, 0.5);
-  COLOR natureReserveBorderColor   = darken(@natureReserveColor, 0.3);
+  COLOR natureReserveLabelColor    = #566f4bb0;
+  COLOR natureReserveBorderColor   = #82a77180;
 
   COLOR playgroundColor            = #ccffff;
   COLOR playgroundBorderColor      = darken(@playgroundColor, 0.3);
@@ -1369,6 +1369,20 @@ STYLE
      [TYPE leisure_marina,
            leisure_fishing,
            leisure_ice_rink] AREA { color: #b5d6f1; }
+   }
+
+   [TYPE boundary_protected_area] {
+     [MAG stateOver-]{
+       AREA.BORDER#dashed { color: @natureReserveBorderColor; width: 0.3mm; dash: 6,6; displayOffset: -0.5mm; }
+       AREA.BORDER#solid { color: lighten(@natureReserveBorderColor, 0.3); width: 1.0mm; }
+     }
+     [MAG stateOver-detail]{
+       AREA.TEXT { label: Name.name; priority: @labelPrioNatural; color: @natureReserveLabelColor; autoSize: true;}
+     }
+     // Semiransparent overlay just for low zoom
+     [MAG stateOver-proximity]{
+       AREA { color: @natureReserveColor;}
+     }
    }
 
    [MAG city-] {


### PR DESCRIPTION
Hi. 

I Czech OSM mailing list was discussion what tags should be used for nationals parks. If `boundary: national_park` or `boundary: protected_area`. Resolution is not so important, but I was surprised that we don't import this. As huge areas should not have major performance impact now, there is type definition and stylesheet. Used colors are same as for `leisure_nature_reserve`, it is similar, but it is used for smaller areas.

![obrazek](https://user-images.githubusercontent.com/309458/49831762-06bffd00-fd95-11e8-9f42-a813566d53ad.png)
