### PR TITLE
fix warning from cppcheck - condition with always false 

### DIFF
--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -1435,8 +1435,8 @@ PRODUCTIONS
                        }
 
                        if (!function.empty()) {
-                         if (factor<0.0 && factor>1.0) {
-                          std::string e="Factor must be in the range [0..1]";
+                         if (factor<0.0 || factor>1.0) {
+                           std::string e="Factor must be in the range [0..1]";
 
                            SemErr(e.c_str());
                          }

--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -1289,7 +1289,7 @@ PRODUCTIONS
                    std::string            subIdent;
                    std::string            stringValue;
                    std::string            function;
-                   double                 factor;
+                   double                 factor=-1;
                    std::string            unit;
                    std::string            number;
                    std::list<std::string> numberList;

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1524,7 +1524,7 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 		std::string            subIdent;
 		std::string            stringValue;
 		std::string            function;
-		double                 factor;
+		double                 factor=-1;
 		std::string            unit;
 		std::string            number;
 		std::list<std::string> numberList;

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1690,8 +1690,8 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 		   }
 		
 		   if (!function.empty()) {
-		     if (factor<0.0 && factor>1.0) {
-		      std::string e="Factor must be in the range [0..1]";
+		     if (factor<0.0 || factor>1.0) {
+		       std::string e="Factor must be in the range [0..1]";
 		
 		       SemErr(e.c_str());
 		     }


### PR DESCRIPTION
cppcheck message:

Logical conjunction always evaluates to false: `factor < 0.0 && factor > 1.0`