### PR TITLE
separate overlay tile loader and downloader to avoid deadlock

### DIFF
--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -50,9 +50,11 @@ void TileLoaderThread::init()
   tileDownloader = new OsmTileDownloader(tileCacheDirectory,provider);
 
   connect(tileDownloader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
-          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)));
+          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)),
+          Qt::QueuedConnection);
   connect(tileDownloader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
-          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)));
+          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
+          Qt::QueuedConnection);
 
   connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
           this,SLOT(download(uint32_t, uint32_t, uint32_t)),


### PR DESCRIPTION
When there is attempt to download tile with higher zoom level than
is supported by online source, failed signal is emitted immediately.
When there is no event queue between tile loader and downloader,
it may lead to deadlock, because loader mutex is not resursive.