### PR TITLE
Optimise TileId

### DIFF
--- a/libosmscout/include/osmscout/util/TileId.h
+++ b/libosmscout/include/osmscout/util/TileId.h
@@ -116,6 +116,19 @@ namespace osmscout {
                           const GeoCoord& coord);
   };
 
+  /**
+   * Hasher that can be used in std::unordered_map with TileId as a key
+   */
+  struct OSMSCOUT_API TileIdHasher
+  {
+    std::size_t operator()(const TileId& id) const noexcept
+    {
+      std::size_t h1 = static_cast<size_t>(id.GetX());
+      std::size_t h2 = static_cast<size_t>(id.GetY());
+      return h1 ^ (h2 << 16);
+    }
+  };
+
   class OSMSCOUT_API TileKey
   {
   private:

--- a/libosmscout/include/osmscout/util/TileId.h
+++ b/libosmscout/include/osmscout/util/TileId.h
@@ -74,11 +74,36 @@ namespace osmscout {
 
     std::string GetDisplayText() const;
 
-    bool operator==(const TileId& other) const;
+    /**
+     * Compare tile ids for equality
+     */
+    inline bool operator==(const TileId& other) const
+    {
+      return y==other.y &&
+             x==other.x;
+    }
 
-    bool operator!=(const TileId& other) const;
+    /**
+     * Compare tile ids for inequality
+     */
+    inline bool operator!=(const TileId& other) const
+    {
+      return y!=other.y ||
+             x!=other.x;
+    }
 
-    bool operator<(const TileId& other) const;
+    /**
+     * Compare tile ids by their order. Needed for sorting tile ids and placing them into (some)
+     * containers.
+     */
+    inline bool operator<(const TileId& other) const
+    {
+      if (y!=other.y) {
+        return y<other.y;
+      }
+
+      return x<other.x;
+    }
 
     GeoCoord GetTopLeftCoord(const Magnification& magnification) const;
     GeoBox GetBoundingBox(const MagnificationLevel& level) const;

--- a/libosmscout/src/osmscout/util/TileId.cpp
+++ b/libosmscout/src/osmscout/util/TileId.cpp
@@ -43,37 +43,6 @@ namespace osmscout {
   }
 
   /**
-   * Compare tile ids for equality
-   */
-  bool TileId::operator==(const TileId& other) const
-  {
-    return y==other.y &&
-           x==other.x;
-  }
-
-  /**
-   * Compare tile ids for inequality
-   */
-  bool TileId::operator!=(const TileId& other) const
-  {
-    return y!=other.y ||
-           x!=other.x;
-  }
-
-  /**
-   * Compare tile ids by their order. Needed for sorting tile ids and placing them into (some)
-   * containers.
-   */
-  bool TileId::operator<(const TileId& other) const
-  {
-    if (y!=other.y) {
-      return y<other.y;
-    }
-
-    return x<other.x;
-  }
-
-  /**
    * Return the top left coordinate of the tile
    * @param magnification
    *    Magnification to complete the definition of the tile id (these are relative


### PR DESCRIPTION
Following mailing list discussion, it seems that most expensive part of node index loading is building of std::map in TypeData struct.  I created micro-benchmark that open node index multiple times (100x, France DB), build it with -O2 for Arm7 and tried multiple modifications:

```
current master:                                1203.87 ms
inline compare and equal operators of TileId:  1073.74 ms
replace std::map with std::unordered_map :     1441.61 ms
```

It is clear that inlining helps a lot...