### PR TITLE
Docker fix and notes

### DIFF
--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -4,6 +4,19 @@ When you have Docker installed on your machine,
 you can check libosmscout build on various Linux 
 distributions and configurations.
 
+## Requirements
+
+ - docker ( >= 18.04)
+ - seccomp library ( >= 2.3.3)
+
+Qt tools in our Debian and Archlinux docker images are using 
+`statx` syscall. This syscall is not whitelisted in older 
+docker and it makes our builds failing. This is fixed in 
+docker upstream [#208](https://github.com/docker/for-linux/issues/208) 
+already, but it also requires new seccomp library 
+[#1755250](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1755250).
+To workaround this issue, you need to run containers with `--privileged` switch.
+
 ## Build docker images
 
 For build all available images, you can just execute 

--- a/ci/docker/debian_buster_gcc_meson/Dockerfile
+++ b/ci/docker/debian_buster_gcc_meson/Dockerfile
@@ -22,7 +22,7 @@ ENV LANG en_US.utf8
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update && apt-get install -y \
-          gcc \
+          g++ \
           meson \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Latest docker images are not working in Ubuntu 18.04 without privileged mode... Just adding note about it.
Second commit fixes installed packages in Buster image.