### PR TITLE
disable Client/Qt library on Wercker CI

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -5,7 +5,7 @@ build:
   steps:
     - script:
         name: Configure project
-        code: meson debug
+        code: meson -DenableClientQt=false debug
     - script:
         name: Build project
         code: ninja


### PR DESCRIPTION
Current Qt tools is not possible to run with old Docker.
See the issue: https://github.com/docker/for-linux/issues/208
We need to temporary disable building of Client/Qt library
until Oracle update its Docker in Wercker service.