### PR TITLE
replace NULL macro with nullptr keyword

### DIFF
--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -522,10 +522,10 @@ int main(int argc, char* argv[])
   osmscout::MercatorProjection  projection;
   QPixmap *pixmap=new QPixmap(args.width,args.height);
 
-  if (pixmap!=NULL) {
+  if (pixmap!=nullptr) {
     QPainter* painter=new QPainter(pixmap);
 
-    if (painter!=NULL) {
+    if (painter!=nullptr) {
       osmscout::MapParameter        drawParameter;
       osmscout::AreaSearchParameter searchParameter;
       osmscout::MapData             data;

--- a/OSMScout2/src/AppSettings.cpp
+++ b/OSMScout2/src/AppSettings.cpp
@@ -26,13 +26,13 @@
 
 using namespace osmscout;
 
-AppSettings::AppSettings(): view(NULL)
+AppSettings::AppSettings(): view(nullptr)
 {
 }
 
 MapView *AppSettings::GetMapView()
 {
-  if (view == NULL){
+  if (view == nullptr){
     double lat   = settings.value("settings/map/lat",   0).toDouble();
     double lon   = settings.value("settings/map/lon",   0).toDouble();
     double angle = settings.value("settings/map/angle", 0).toDouble();

--- a/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
+++ b/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
@@ -317,7 +317,7 @@ int main(int argc, char *argv[]) {
   glfwGetMonitorPhysicalSize(monitor, &widthMM, &heightMM);
   const double dpi = mode->width / (widthMM / 25.4);
 
-  window = glfwCreateWindow(width, height, "OSMScoutOpenGL", NULL, NULL);
+  window = glfwCreateWindow(width, height, "OSMScoutOpenGL", nullptr, nullptr);
   if (!window) {
     glfwTerminate();
     return -1;

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -118,6 +118,6 @@ int main(int argc, char* argv[])
 
 #if defined(__WIN32__) || defined(WIN32)
 int CALLBACK WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int /*nCmdShow*/){
-	main(0, NULL);
+	main(0, nullptr);
 }
 #endif

--- a/Tests/src/AccessParse.cpp
+++ b/Tests/src/AccessParse.cpp
@@ -152,7 +152,7 @@ void CheckParseSuccess(bool canFoot,
 
   osmscout::AccessFeatureValue *accessFeatureValue=accessValueReader.GetValue(buffer);
 
-  if (accessFeatureValue!=NULL) {
+  if (accessFeatureValue!=nullptr) {
     actualAccessValue=accessFeatureValue->GetAccess();
   }
   else {

--- a/libosmscout-client-qt/include/osmscout/MapOverlay.h
+++ b/libosmscout-client-qt/include/osmscout/MapOverlay.h
@@ -50,7 +50,7 @@ public:
   inline void SetMapView(QObject *o)
   {
     MapView *updated = dynamic_cast<MapView*>(o);
-    if (updated == NULL){
+    if (updated == nullptr){
       qWarning() << "Failed to cast " << o << " to MapView*.";
       return;
     }

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -208,7 +208,7 @@ public:
   inline void SetMapView(QObject *o)
   {
     MapView *updated = dynamic_cast<MapView*>(o);
-    if (updated == NULL){
+    if (updated == nullptr){
         qWarning() << "Failed to cast " << o << " to MapView*.";
         return;
     }

--- a/libosmscout-client-qt/include/osmscout/NavigationModel.h
+++ b/libosmscout-client-qt/include/osmscout/NavigationModel.h
@@ -101,7 +101,7 @@ public:
   inline OverlayWay* getRouteWay()
   {
     if (!route){
-      return NULL;
+      return nullptr;
     }
     return new OverlayWay(route.routeWay().nodes);
   }

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -154,7 +154,7 @@ public:
   inline OverlayWay* getRouteWay()
   {
     if (!route){
-      return NULL;
+      return nullptr;
     }
     return new OverlayWay(route.routeWay().nodes);
   }

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -85,7 +85,7 @@ private:
   QList<MapProvider> mapProviders;
 
 public:
-  Settings(QSettings *providedStorage=NULL);
+  Settings(QSettings *providedStorage=nullptr);
   virtual ~Settings();
 
   double GetPhysicalDPI() const;

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -283,17 +283,17 @@ QVariant AvailableMapsModel::data(const QModelIndex &index, int role) const
     case DirRole:
       return item->isDirectory(); // isDir? true: false
     case ServerDirectoryRole:
-      return map==NULL ? QVariant(): map->getServerDirectory();// server path for this map
+      return map==nullptr ? QVariant(): map->getServerDirectory();// server path for this map
     case TimeRole:
-      return map==NULL ? QVariant(): map->getCreation();// QTime of map creation 
+      return map==nullptr ? QVariant(): map->getCreation();// QTime of map creation 
     case VersionRole:
-      return map==NULL ? QVariant(): map->getVersion();
+      return map==nullptr ? QVariant(): map->getVersion();
     case ByteSizeRole:
-      return map==NULL ? QVariant(): QVariant((double)map->getSize());
+      return map==nullptr ? QVariant(): QVariant((double)map->getSize());
     case SizeRole:
-      return map==NULL ? "": QVariant(map->getSizeHuman());
+      return map==nullptr ? "": QVariant(map->getSizeHuman());
     case ProviderUriRole:
-      return map==NULL ? QVariant(): map->getProvider().getName();
+      return map==nullptr ? QVariant(): map->getProvider().getName();
     case DescriptionRole:
       return item->getDescription();
     case MapRole:

--- a/libosmscout-client-qt/src/osmscout/DBInstance.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBInstance.cpp
@@ -133,7 +133,7 @@ bool DBInstance::LoadStyle(QString stylesheetFilename,
       errors.append(err);
     }
 
-    styleConfig=NULL;
+    styleConfig=nullptr;
 
     return false;
   }
@@ -145,7 +145,7 @@ osmscout::MapPainterQt* DBInstance::GetPainter()
 {
   QMutexLocker locker(&mutex);
   if (!styleConfig)
-    return NULL;
+    return nullptr;
 
   if (!painterHolder.contains(QThread::currentThread())){
     painterHolder[QThread::currentThread()]=new osmscout::MapPainterQt(styleConfig);

--- a/libosmscout-client-qt/src/osmscout/DBJob.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBJob.cpp
@@ -58,7 +58,7 @@ void DBJob::Close()
     qWarning() << "Closing" << this << "from non Job thread" << thread << " in " << QThread::currentThread();
   }
   delete locker;
-  locker=NULL;
+  locker=nullptr;
   databases.clear();
 }
 

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -76,7 +76,7 @@ DBThread::~DBThread()
 
   if (basemapDatabase) {
     basemapDatabase->Close();
-    basemapDatabase=NULL;
+    basemapDatabase=nullptr;
   }
 
   for (auto db:databases){
@@ -200,7 +200,7 @@ void DBThread::onDatabaseListChanged(QList<QDir> databaseDirectories)
 
   if (basemapDatabase) {
     basemapDatabase->Close();
-    basemapDatabase=NULL;
+    basemapDatabase=nullptr;
   }
 
   for (auto db:databases){
@@ -315,12 +315,12 @@ void DBThread::onDatabaseListChanged(QList<QDir> databaseDirectories)
 
         if (!styleConfig->Load(stylesheetFilename.toLocal8Bit().data())) {
           qWarning() << "Cannot load style sheet '" << stylesheetFilename << "'!";
-          styleConfig=NULL;
+          styleConfig=nullptr;
         }
       }
       else {
         qWarning() << "TypeConfig invalid!";
-        styleConfig=NULL;
+        styleConfig=nullptr;
       }
     }
     else {

--- a/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
@@ -197,17 +197,17 @@ void LocationInfoModel::addToModel(const QString database,
           osmscout::FeatureValue *value=place.GetObjectFeatures()->GetValue(featureInstance.GetIndex());
           
           const osmscout::PostalCodeFeatureValue *postalCodeValue = dynamic_cast<const osmscout::PostalCodeFeatureValue*>(value);
-          if (postalCodeValue!=NULL){
+          if (postalCodeValue!=nullptr){
             postalCode = QString::fromStdString(postalCodeValue->GetPostalCode());
           }
           
           const osmscout::WebsiteFeatureValue *websiteValue = dynamic_cast<const osmscout::WebsiteFeatureValue*>(value);
-          if (websiteValue!=NULL){
+          if (websiteValue!=nullptr){
             website = QString::fromStdString(websiteValue->GetWebsite());
           }
           
           const osmscout::PhoneFeatureValue *phoneValue = dynamic_cast<const osmscout::PhoneFeatureValue*>(value);
-          if (phoneValue!=NULL){
+          if (phoneValue!=nullptr){
             phone = QString::fromStdString(phoneValue->GetPhone());
           }
         }

--- a/libosmscout-client-qt/src/osmscout/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/LookupModule.cpp
@@ -27,7 +27,7 @@ LookupModule::LookupModule(QThread *thread,DBThreadRef dbThread):
   QObject(),
   thread(thread),
   dbThread(dbThread),
-  loadJob(NULL)
+  loadJob(nullptr)
 {
 
   connect(dbThread.get(), SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)),
@@ -39,7 +39,7 @@ LookupModule::~LookupModule()
   if (thread!=QThread::currentThread()){
     qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }
@@ -53,7 +53,7 @@ void LookupModule::requestObjectsOnView(const MapViewStruct &view)
   lookupProjection.Set(view.coord,  0, view.magnification, mapDpi, view.width*1.5, view.height*1.5);
   lookupProjection.SetLinearInterpolationUsage(view.magnification.GetLevel() >= 10);
 
-  if (loadJob!=NULL){
+  if (loadJob!=nullptr){
     delete loadJob;
   }
 
@@ -197,8 +197,8 @@ AdminRegionInfoRef LookupModule::buildAdminRegionInfo(DBInstanceRef &db,
   osmscout::WayRef                way;
   osmscout::AreaRef               area;
 
-  osmscout::NameAltFeatureValue    *altNameValue=NULL;
-  osmscout::AdminLevelFeatureValue *adminLevelValue=NULL;
+  osmscout::NameAltFeatureValue    *altNameValue=nullptr;
+  osmscout::AdminLevelFeatureValue *adminLevelValue=nullptr;
 
   switch (region->object.GetType()){
     case osmscout::refNode:
@@ -228,9 +228,9 @@ AdminRegionInfoRef LookupModule::buildAdminRegionInfo(DBInstanceRef &db,
       break;
   }
 
-  if (altNameValue!=NULL)
+  if (altNameValue!=nullptr)
     info->altName=QString::fromStdString(altNameValue->GetNameAlt());
-  if (adminLevelValue!=NULL)
+  if (adminLevelValue!=nullptr)
     info->adminLevel=(int)adminLevelValue->GetAdminLevel();
 
   return info;

--- a/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
@@ -64,7 +64,7 @@ MapRenderer::~MapRenderer()
     qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
   qDebug() << "~MapRenderer";
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }
@@ -300,7 +300,7 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
 
         if (o->getObjectType()==osmscout::RefType::refWay){
           OverlayWay *ow=dynamic_cast<OverlayWay*>(o.get());
-          if (ow != NULL) {
+          if (ow != nullptr) {
             osmscout::WayRef w = std::make_shared<osmscout::Way>();
             if (ow->toWay(w, *typeConfig)) {
               data->poiWays.push_back(w);
@@ -308,7 +308,7 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
           }
         } else if (o->getObjectType()==osmscout::RefType::refArea){
           OverlayArea *oa=dynamic_cast<OverlayArea*>(o.get());
-          if (oa != NULL) {
+          if (oa != nullptr) {
             osmscout::AreaRef a = std::make_shared<osmscout::Area>();
             if (oa->toArea(a, *typeConfig)) {
               data->poiAreas.push_back(a);
@@ -316,7 +316,7 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
           }
         } else if (o->getObjectType()==osmscout::RefType::refNode){
           OverlayNode *oo=dynamic_cast<OverlayNode*>(o.get());
-          if (oo != NULL) {
+          if (oo != nullptr) {
             osmscout::NodeRef n = std::make_shared<osmscout::Node>();
             if (oo->toNode(n, *typeConfig)) {
               data->poiNodes.push_back(n);

--- a/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
@@ -49,9 +49,9 @@ MapStyleModel::MapStyleModel():
 
 MapStyleModel::~MapStyleModel()
 {
-  if (styleModule!=NULL){
+  if (styleModule!=nullptr){
     styleModule->deleteLater();
-    styleModule=NULL;
+    styleModule=nullptr;
   }
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -34,8 +34,8 @@ static double DELTA_ANGLE=2*M_PI/16.0;
 
 MapWidget::MapWidget(QQuickItem* parent)
     : QQuickPaintedItem(parent),
-      renderer(NULL),
-      inputHandler(NULL),
+      renderer(nullptr),
+      inputHandler(nullptr),
       showCurrentPosition(false),
       finished(false),
       renderingType(RenderingType::PlaneRendering)
@@ -85,9 +85,9 @@ MapWidget::~MapWidget()
 {
     delete inputHandler;
     delete view;
-    if (renderer!=NULL){
+    if (renderer!=nullptr){
       renderer->deleteLater();
-      renderer=NULL;
+      renderer=nullptr;
     }
 }
 
@@ -135,7 +135,7 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* event)
 void MapWidget::setupInputHandler(InputHandler *newGesture)
 {
     bool locked = false;
-    if (inputHandler != NULL){
+    if (inputHandler != nullptr){
         locked = inputHandler->isLockedToPosition();
         inputHandler->deleteLater();
     }
@@ -575,7 +575,7 @@ void MapWidget::addOverlayObject(int id, QObject *o)
 {
   OverlayObjectRef copy;
   const OverlayObject *obj = dynamic_cast<const OverlayObject*>(o);
-  if (obj == NULL){
+  if (obj == nullptr){
       qWarning() << "Failed to cast " << o << " to OverlayObject.";
       return;
   }

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -37,7 +37,7 @@ NavigationModule::~NavigationModule()
     qWarning() << "Destroy" << this << "from incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
   qDebug() << "~NavigationModule";
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }

--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -137,7 +137,7 @@ QHash<int, QByteArray> NearPOIModel::roleNames() const
 QObject* NearPOIModel::get(int row) const
 {
   if(row < 0 || row >= locations.size()) {
-    return NULL;
+    return nullptr;
   }
 
   LocationEntry* location=locations.at(row);

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -49,10 +49,10 @@
 
 namespace osmscout {
 
-static OSMScoutQt* osmScoutInstance=NULL;
+static OSMScoutQt* osmScoutInstance=nullptr;
 
 OSMScoutQtBuilder::OSMScoutQtBuilder():
-  settingsStorage(NULL),
+  settingsStorage(nullptr),
   onlineTileCacheSize(100),
   offlineTileCacheSize(200),
   styleSheetDirectoryConfigured(false),
@@ -73,7 +73,7 @@ OSMScoutQtBuilder::OSMScoutQtBuilder():
 
 bool OSMScoutQtBuilder::Init()
 {
-  if (osmScoutInstance!=NULL){
+  if (osmScoutInstance!=nullptr){
     return false;
   }
 
@@ -193,7 +193,7 @@ void OSMScoutQt::FreeInstance()
     osmscout::log.Warn() << "Some resources still acquired by other components";
   }
   delete osmScoutInstance;
-  osmScoutInstance=NULL;
+  osmScoutInstance=nullptr;
   osmscout::log.Debug() << "OSMScoutQt freed";
 }
 

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -34,7 +34,7 @@ POILookupModule::~POILookupModule()
   if (thread!=QThread::currentThread()){
     qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }
@@ -51,7 +51,7 @@ LocationEntry buildLocationEntry(T obj,
   QString objectType = QString::fromUtf8(obj->GetType()->GetName().c_str());
   const osmscout::FeatureValueBuffer &features=obj->GetFeatureValueBuffer();
   const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
-  if (name!=NULL){
+  if (name!=nullptr){
     title=QString::fromStdString(name->GetLabel(0));
     //std::cout << " \"" << name->GetLabel() << "\"";
   }

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -40,13 +40,13 @@ PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
                                    QString iconDirectory):
   MapRenderer(thread,settings,dbThread,iconDirectory),
   canvasOverrun(1.5),
-  loadJob(NULL),
+  loadJob(nullptr),
   pendingRenderingTimer(this),
-  currentImage(NULL),
+  currentImage(nullptr),
   currentCoord(0.0,0.0),
   currentAngle(0.0),
   currentMagnification(0),
-  finishedImage(NULL),
+  finishedImage(nullptr),
   finishedCoord(0.0,0.0),
   finishedMagnification(0)
 {
@@ -76,11 +76,11 @@ PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
 PlaneMapRenderer::~PlaneMapRenderer()
 {
   qDebug() << "~PlaneMapRenderer";
-  if (currentImage!=NULL)
+  if (currentImage!=nullptr)
     delete currentImage;
-  if (finishedImage!=NULL)
+  if (finishedImage!=nullptr)
     delete finishedImage;
-  if (loadJob!=NULL)
+  if (loadJob!=nullptr)
     delete loadJob;
 }
 
@@ -90,7 +90,7 @@ void PlaneMapRenderer::InvalidateVisualCache()
   osmscout::log.Debug() << "Invalidate finished image";
   if (finishedImage)
     delete finishedImage;
-  finishedImage=NULL;
+  finishedImage=nullptr;
 }
 
 /**
@@ -112,7 +112,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
     backgroundColor=osmscout::Color(0,0,0);
   }
 
-  if (finishedImage==NULL) {
+  if (finishedImage==nullptr) {
     painter.fillRect(0,
                      0,
                      request.width,
@@ -305,7 +305,7 @@ void PlaneMapRenderer::DrawMap()
 {
   {
     QMutexLocker locker(&lock);
-    if (loadJob==NULL){
+    if (loadJob==nullptr){
       return;
     }
     osmscout::log.Debug() << "DrawMap()";
@@ -313,7 +313,7 @@ void PlaneMapRenderer::DrawMap()
       osmscout::log.Warn() << "Incorrect thread!";
     }
 
-    if (currentImage==NULL ||
+    if (currentImage==nullptr ||
         currentImage->width()!=(int)currentWidth ||
         currentImage->height()!=(int)currentHeight) {
       delete currentImage;
@@ -404,7 +404,7 @@ void PlaneMapRenderer::DrawMap()
     if (loadJob->IsFinished()){
       // this slot is may be called from DBLoadJob, we can't delete it now
       loadJob->deleteLater();
-      loadJob=NULL;
+      loadJob=nullptr;
     }
 
     if (!success)  {
@@ -462,10 +462,10 @@ void PlaneMapRenderer::TriggerMapRendering(const MapViewStruct& request)
   osmscout::log.Debug() << "Start data loading...";
   {
     QMutexLocker locker(&lock);
-    if (loadJob!=NULL){
+    if (loadJob!=nullptr){
       // TODO: check if job contains same tiles...
       loadJob->deleteLater();
-      loadJob=NULL;
+      loadJob=nullptr;
     }
     if (thread!=QThread::currentThread()){
       osmscout::log.Warn() << "Incorrect thread!";

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -45,9 +45,9 @@ RoutingListModel::RoutingListModel(QObject* parent)
 
 RoutingListModel::~RoutingListModel()
 {
-  if (router!=NULL){
+  if (router!=nullptr){
     router->deleteLater();
-    router=NULL;
+    router=nullptr;
   }
 }
 
@@ -208,7 +208,7 @@ QHash<int, QByteArray> RoutingListModel::roleNames() const
 QObject* RoutingListModel::get(int row) const
 {
   if(!route || row < 0 || row >= route.routeSteps().size()) {
-    return NULL;
+    return nullptr;
   }
 
   RouteStep step=route.routeSteps().at(row);

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -75,13 +75,13 @@ LocationListModel::~LocationListModel()
     breaker->Break();
     breaker.reset();
   }
-  if (searchModule!=NULL){
+  if (searchModule!=nullptr){
     searchModule->deleteLater();
-    searchModule=NULL;
+    searchModule=nullptr;
   }
-  if (lookupModule!=NULL){
+  if (lookupModule!=nullptr){
     lookupModule->deleteLater();
-    lookupModule=NULL;
+    lookupModule=nullptr;
   }
 }
 
@@ -341,7 +341,7 @@ QHash<int, QByteArray> LocationListModel::roleNames() const
 QObject* LocationListModel::get(int row) const
 {
     if(row < 0 || row >= locations.size()) {
-        return NULL;
+        return nullptr;
     }
 
     LocationEntry* location=locations.at(row);

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -34,12 +34,12 @@ SearchModule::SearchModule(QThread *thread,DBThreadRef dbThread,LookupModule *lo
 SearchModule::~SearchModule()
 {
   lookupModule->deleteLater();
-  lookupModule=NULL;
+  lookupModule=nullptr;
 
   if (thread!=QThread::currentThread()){
     qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -37,7 +37,7 @@ namespace osmscout {
 Settings::Settings(QSettings *providedStorage):
   storage(providedStorage)
 {
-    if (storage==NULL){
+    if (storage==nullptr){
       storage=new QSettings(this);
     }
     /* Warning: Sailfish OS before version 2.0.1 reports incorrect DPI (100)

--- a/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
@@ -46,9 +46,9 @@ StyleFlagsModel::StyleFlagsModel():
 
 StyleFlagsModel::~StyleFlagsModel()
 {
-  if (styleModule!=NULL){
+  if (styleModule!=nullptr){
     styleModule->deleteLater();
-    styleModule=NULL;
+    styleModule=nullptr;
   }
 }
 

--- a/libosmscout-client-qt/src/osmscout/StyleModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/StyleModule.cpp
@@ -42,7 +42,7 @@ StyleModule::~StyleModule()
   if (thread!=QThread::currentThread()){
     qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
 }

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -26,7 +26,7 @@ namespace osmscout {
 
 TileLoaderThread::TileLoaderThread(QThread *thread):
   thread(thread),
-  tileDownloader(NULL),
+  tileDownloader(nullptr),
   onlineTileCache(OSMScoutQt::GetInstance().GetOnlineTileCacheSize())
 {
   qDebug() << "Overlay tile cache:" << &onlineTileCache;
@@ -34,10 +34,10 @@ TileLoaderThread::TileLoaderThread(QThread *thread):
 
 TileLoaderThread::~TileLoaderThread()
 {
-  if (thread!=NULL){
+  if (thread!=nullptr){
     thread->quit();
   }
-  if (tileDownloader!=NULL){
+  if (tileDownloader!=nullptr){
     delete tileDownloader;
   }
 }
@@ -63,7 +63,7 @@ void TileLoaderThread::init()
 
 void TileLoaderThread::download(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile)
 {
-  if (tileDownloader == NULL){
+  if (tileDownloader == nullptr){
     qWarning() << "tile requested but downloader is not initialized yet";
     emit failed(zoomLevel, xtile, ytile);
   }else{
@@ -81,7 +81,7 @@ void TileLoaderThread::onProviderChanged(const OnlineTileProvider &newProvider)
   onlineTileCache.cleanupCache();
 
   provider=newProvider;
-  if (tileDownloader!=NULL){
+  if (tileDownloader!=nullptr){
     emit tileDownloader->onlineTileProviderChanged(provider);
   }
 }
@@ -150,9 +150,9 @@ TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
 
 TiledMapOverlay::~TiledMapOverlay()
 {
-  if (loader!=NULL){
+  if (loader!=nullptr){
     loader->deleteLater();
-    loader=NULL;
+    loader=nullptr;
   }
 }
 

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -38,8 +38,8 @@ TiledMapRenderer::TiledMapRenderer(QThread *thread,
   tileCacheDirectory(tileCacheDirectory),
   onlineTileCache(onlineTileCacheSize), // online tiles can be loaded from disk cache easily
   offlineTileCache(offlineTileCacheSize), // render offline tile is expensive
-  tileDownloader(NULL), // it will be created in different thread
-  loadJob(NULL),
+  tileDownloader(nullptr), // it will be created in different thread
+  loadJob(nullptr),
   unknownColor(QColor::fromRgbF(1.0,1.0,1.0)) // white
 {
   QScreen *srn=QGuiApplication::primaryScreen();
@@ -80,10 +80,10 @@ TiledMapRenderer::TiledMapRenderer(QThread *thread,
 TiledMapRenderer::~TiledMapRenderer()
 {
   qDebug() << "~TiledMapRenderer";
-  if (tileDownloader != NULL){
+  if (tileDownloader != nullptr){
     delete tileDownloader;
   }
-  if (loadJob!=NULL){
+  if (loadJob!=nullptr){
     delete loadJob;
   }
 }

--- a/libosmscout-extern/src/matlab/libosmscoutmx.cpp
+++ b/libosmscout-extern/src/matlab/libosmscoutmx.cpp
@@ -443,10 +443,10 @@ void DrawMapCairo(std::string map_directory, std::string style_file, size_t widt
 	cairo_surface_t *surface;
 	cairo_t         *cairo;
 	surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
-	if (surface != NULL)
+	if (surface != nullptr)
 	{
 		cairo = cairo_create(surface);
-		if (cairo != NULL)
+		if (cairo != nullptr)
 		{
 			osmscout::MercatorProjection  projection;
 			osmscout::MapParameter        drawParameter;
@@ -466,7 +466,7 @@ void DrawMapCairo(std::string map_directory, std::string style_file, size_t widt
 				int stride = cairo_image_surface_get_stride(surface);
 				size_t dims[3] = { height, width, 3 };
 				plhs[0] = mxCreateNumericArray(3, dims, mxUINT8_CLASS, mxREAL);
-				if (imgdata == NULL)
+				if (imgdata == nullptr)
 				{
 					cairo_destroy(cairo);
 					cairo_surface_destroy(surface);

--- a/libosmscout-gpx/include/osmscout/gpx/Export.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Export.h
@@ -36,7 +36,7 @@ namespace gpx {
 
 extern OSMSCOUT_GPX_API bool ExportGpx(const GpxFile &gpxFile,
                                        const std::string &filePath,
-                                       BreakerRef breaker = NULL,
+                                       BreakerRef breaker = nullptr,
                                        ProcessCallbackRef callback = std::make_shared<ProcessCallback>());
 }
 }

--- a/libosmscout-gpx/src/osmscout/gpx/Export.cpp
+++ b/libosmscout-gpx/src/osmscout/gpx/Export.cpp
@@ -82,14 +82,14 @@ public:
              const std::string &filePath,
              BreakerRef breaker,
              ProcessCallbackRef callback):
-      writer(NULL),
+      writer(nullptr),
       callback(callback),
       gpxFile(gpxFile),
       breaker(breaker)
   {
     /* Create a new XmlWriter for uri, with no compression. */
     writer = xmlNewTextWriterFilename(filePath.c_str(), 0);
-    if (writer == NULL && callback) {
+    if (writer == nullptr && callback) {
       callback->Error("Error creating the xml writer");
     }
     if (writer) {
@@ -101,19 +101,19 @@ public:
 
   ~GpxWritter()
   {
-    if (writer!=NULL){
+    if (writer!=nullptr){
       xmlFreeTextWriter(writer);
-      writer=NULL;
+      writer=nullptr;
     }
   }
 
   bool Process()
   {
-    if (writer==NULL) {
+    if (writer==nullptr) {
       return false;
     }
 
-    if (xmlTextWriterStartDocument(writer, NULL, Encoding, NULL) < 0) {
+    if (xmlTextWriterStartDocument(writer, nullptr, Encoding, nullptr) < 0) {
       if (callback) {
         callback->Error("Error at xmlTextWriterStartDocument");
       }
@@ -153,7 +153,7 @@ public:
 
 bool GpxWritter::StartElement(const char *name)
 {
-  if (writer==NULL){
+  if (writer==nullptr){
     return false;
   }
   if (xmlTextWriterStartElement(writer, (const xmlChar *)name) < 0) {
@@ -167,7 +167,7 @@ bool GpxWritter::StartElement(const char *name)
 
 bool GpxWritter::EndElement()
 {
-  if (writer==NULL){
+  if (writer==nullptr){
     return false;
   }
   if (xmlTextWriterEndElement(writer) < 0) {
@@ -181,7 +181,7 @@ bool GpxWritter::EndElement()
 
 bool GpxWritter::WriteTextElement(const char *elementName, const std::string &text)
 {
-  if (writer==NULL){
+  if (writer==nullptr){
     return false;
   }
   if (xmlTextWriterWriteElement(writer, (const xmlChar *)elementName, (const xmlChar *)text.c_str()) < 0) {
@@ -211,7 +211,7 @@ bool GpxWritter::WriteTextElement(const char *elementName, const Timestamp &time
 
 bool GpxWritter::WriteAttribute(const char *name, const char *content)
 {
-  if (writer==NULL){
+  if (writer==nullptr){
     return false;
   }
   if (xmlTextWriterWriteAttribute(writer, (const xmlChar *)name, (const xmlChar *)content) < 0) {

--- a/libosmscout-map-cairo/src/osmscout/LoaderPNG.cpp
+++ b/libosmscout-map-cairo/src/osmscout/LoaderPNG.cpp
@@ -43,8 +43,8 @@ namespace osmscout {
     int             channels,intent;
     double          screen_gamma;
     png_uint_32     rowbytes;
-    png_bytepp      row_pointers=NULL;
-    unsigned char   *image_data=NULL;
+    png_bytepp      row_pointers=nullptr;
+    unsigned char   *image_data=nullptr;
     unsigned char   *data;
     cairo_surface_t *image;
     bool            littleEndian;
@@ -56,41 +56,41 @@ namespace osmscout {
     /* open the file */
     file=std::fopen(filename.c_str(),"rb");
 
-    if (file==NULL) {
-      return NULL;
+    if (file==nullptr) {
+      return nullptr;
     }
 
     /* could pass pointers to user-defined error handlers instead of NULLs: */
 
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,NULL,NULL,NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,nullptr,nullptr,nullptr);
     if (!png_ptr) {
       std::fclose(file);
-      return NULL;   /* out of memory */
+      return nullptr;   /* out of memory */
     }
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {
-      png_destroy_read_struct(&png_ptr,NULL,NULL);
+      png_destroy_read_struct(&png_ptr,nullptr,nullptr);
       std::fclose(file);
-      return NULL;   /* out of memory */
+      return nullptr;   /* out of memory */
     }
 
     if (setjmp(png_jmpbuf(png_ptr))) {
-      png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+      png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     png_init_io(png_ptr,file);
     png_read_info(png_ptr,info_ptr);
 
     png_get_IHDR(png_ptr,info_ptr,&width,&height,&bit_depth,&color_type,
-                 NULL,NULL,NULL);
+                 nullptr,nullptr,nullptr);
 
     if (setjmp(png_jmpbuf(png_ptr))) {
-      png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+      png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     /* We always want RGB or RGBA */
@@ -135,17 +135,17 @@ namespace osmscout {
     rowbytes=png_get_rowbytes(png_ptr,info_ptr);
     channels=(int)png_get_channels(png_ptr,info_ptr);
 
-    if ((image_data=(unsigned char *)malloc(rowbytes*height)) == NULL) {
-      png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    if ((image_data=(unsigned char *)malloc(rowbytes*height)) == nullptr) {
+      png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
-    if ((row_pointers=(png_bytepp)malloc(height*sizeof(png_bytep))) == NULL) {
-      png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    if ((row_pointers=(png_bytepp)malloc(height*sizeof(png_bytep))) == nullptr) {
+      png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
       free(image_data);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     for (size_t i=0;  i<height; ++i) {
@@ -155,9 +155,9 @@ namespace osmscout {
     png_read_image(png_ptr,row_pointers);
 
     free(row_pointers);
-    row_pointers=NULL;
+    row_pointers=nullptr;
 
-    png_read_end(png_ptr,NULL);
+    png_read_end(png_ptr,nullptr);
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 6, 0)
     int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32,width);
@@ -225,7 +225,7 @@ namespace osmscout {
     image=cairo_image_surface_create_for_data(data,
                                               CAIRO_FORMAT_ARGB32,
                                               width,height,stride);
-    if (image!=NULL) {
+    if (image!=nullptr) {
       cairo_surface_set_user_data(image,&imageDataKey,
                                   data,&free);
     }
@@ -233,7 +233,7 @@ namespace osmscout {
       free(data);
     }
 
-    png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+    png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
     free(image_data);
     std::fclose(file);
 

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -289,7 +289,7 @@ namespace osmscout {
     }
 
     for (const auto &entry : fonts) {
-      if (entry.second != NULL) {
+      if (entry.second != nullptr) {
 #if defined(OSMSCOUT_MAP_CAIRO_HAVE_LIB_PANGO)
         pango_font_description_free(entry.second);
 #else

--- a/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
+++ b/libosmscout-map-opengl/include/osmscout/OpenGLMapData.h
@@ -188,7 +188,7 @@ namespace osmscout {
     void clearData() {
       Vertices.clear();
       Elements.clear();
-      Textures = NULL;
+      Textures = nullptr;
       TexturesBuffer.clear();
       textureSize = 0;
       textureWidth = 0;

--- a/libosmscout-map-opengl/include/poly2tri/sweep/advancing_front.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/advancing_front.h
@@ -48,11 +48,11 @@ struct Node {
 
   double value;
 
-  Node(Point& p) : point(&p), triangle(NULL), next(NULL), prev(NULL), value(p.x)
+  Node(Point& p) : point(&p), triangle(nullptr), next(nullptr), prev(nullptr), value(p.x)
   {
   }
 
-  Node(Point& p, Triangle& t) : point(&p), triangle(&t), next(NULL), prev(NULL), value(p.x)
+  Node(Point& p, Triangle& t) : point(&p), triangle(&t), next(nullptr), prev(nullptr), value(p.x)
   {
   }
 

--- a/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
@@ -103,15 +103,15 @@ struct Basin {
   double width;
   bool left_highest;
 
-  Basin() : left_node(NULL), bottom_node(NULL), right_node(NULL), width(0.0), left_highest(false)
+  Basin() : left_node(nullptr), bottom_node(nullptr), right_node(nullptr), width(0.0), left_highest(false)
   {
   }
 
   void Clear()
   {
-    left_node = NULL;
-    bottom_node = NULL;
-    right_node = NULL;
+    left_node = nullptr;
+    bottom_node = nullptr;
+    right_node = nullptr;
     width = 0.0;
     left_highest = false;
   }
@@ -121,7 +121,7 @@ struct EdgeEvent {
   Edge* constrained_edge;
   bool right;
 
-  EdgeEvent() : constrained_edge(NULL), right(false)
+  EdgeEvent() : constrained_edge(nullptr), right(false)
   {
   }
 };

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -580,7 +580,7 @@ namespace osmscout {
         if (lineStyles[l]->GetWidth() > 0.0) {
           WidthFeatureValue *widthValue = widthReader.GetValue(buffer);
 
-          if (widthValue != NULL) {
+          if (widthValue != nullptr) {
             lineWidth += widthValue->GetWidth() / projection.GetPixelSize();
           } else {
             lineWidth += lineStyles[l]->GetWidth() / projection.GetPixelSize();
@@ -946,7 +946,7 @@ namespace osmscout {
 
           image = osmscout::LoadPNGOpenGL(filename);
 
-          if (image != NULL) {
+          if (image != nullptr) {
             ImageRenderer.AddNewTexture(image);
             icons.push_back(id);
             hasIcon = true;

--- a/libosmscout-map-opengl/src/osmscout/PNGLoaderOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/PNGLoaderOpenGL.cpp
@@ -41,8 +41,8 @@ namespace osmscout {
     int             channels,intent;
     double          screen_gamma;
     png_uint_32     rowbytes;
-    png_bytepp      row_pointers=NULL;
-    unsigned char   *image_data=NULL;
+    png_bytepp      row_pointers=nullptr;
+    unsigned char   *image_data=nullptr;
     unsigned char   *data;
     bool            littleEndian;
 
@@ -53,41 +53,41 @@ namespace osmscout {
     // open the file
     file=std::fopen(filename.c_str(),"rb");
 
-    if (file==NULL) {
-      return NULL;
+    if (file==nullptr) {
+      return nullptr;
     }
 
     // could pass pointers to user-defined error handlers instead of NULLs:
 
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,NULL,NULL,NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,nullptr,nullptr,nullptr);
     if (!png_ptr) {
       std::fclose(file);
-      return NULL;   // out of memory
+      return nullptr;   // out of memory
     }
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {
-      png_destroy_read_struct(&png_ptr,NULL,NULL);
+      png_destroy_read_struct(&png_ptr,nullptr,nullptr);
       std::fclose(file);
-      return NULL;   // out of memory
+      return nullptr;   // out of memory
     }
 
     if (setjmp(png_jmpbuf(png_ptr))) {
-      png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+      png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     png_init_io(png_ptr,file);
     png_read_info(png_ptr,info_ptr);
 
     png_get_IHDR(png_ptr,info_ptr,&width,&height,&bit_depth,&color_type,
-                 NULL,NULL,NULL);
+                 nullptr,nullptr,nullptr);
 
     if (setjmp(png_jmpbuf(png_ptr))) {
-      png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+      png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     // We always want RGB or RGBA
@@ -132,17 +132,17 @@ namespace osmscout {
     rowbytes=png_get_rowbytes(png_ptr,info_ptr);
     channels=(int)png_get_channels(png_ptr,info_ptr);
 
-    if ((image_data=(unsigned char *)malloc(rowbytes*height)) == NULL) {
-      png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    if ((image_data=(unsigned char *)malloc(rowbytes*height)) == nullptr) {
+      png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
-    if ((row_pointers=(png_bytepp)malloc(height*sizeof(png_bytep))) == NULL) {
-      png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    if ((row_pointers=(png_bytepp)malloc(height*sizeof(png_bytep))) == nullptr) {
+      png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
       free(image_data);
       std::fclose(file);
-      return NULL;
+      return nullptr;
     }
 
     for (size_t i=0;  i<height; ++i) {
@@ -152,9 +152,9 @@ namespace osmscout {
     png_read_image(png_ptr,row_pointers);
 
     free(row_pointers);
-    row_pointers=NULL;
+    row_pointers=nullptr;
 
-    png_read_end(png_ptr,NULL);
+    png_read_end(png_ptr,nullptr);
 
     int stride = width*4;
     data=(unsigned char *)malloc(stride*height);
@@ -208,7 +208,7 @@ namespace osmscout {
       }
     }
 
-    png_destroy_read_struct(&png_ptr,&info_ptr,NULL);
+    png_destroy_read_struct(&png_ptr,&info_ptr,nullptr);
     free(image_data);
     std::fclose(file);
 

--- a/libosmscout-map-opengl/src/osmscout/Triangulate.cpp
+++ b/libosmscout-map-opengl/src/osmscout/Triangulate.cpp
@@ -48,7 +48,7 @@ namespace osmscout {
 
     std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
     delete cdt;
-    cdt = NULL;
+    cdt = nullptr;
 
     return result;
 
@@ -78,7 +78,7 @@ namespace osmscout {
 
     std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
     delete cdt;
-    cdt = NULL;
+    cdt = nullptr;
 
     return result;
 
@@ -108,7 +108,7 @@ namespace osmscout {
 
     std::for_each(polyline.begin(), polyline.end(), [](p2t::Point *p){delete p;});
     delete cdt;
-    cdt = NULL;
+    cdt = nullptr;
 
     return result;
 
@@ -155,7 +155,7 @@ namespace osmscout {
     }
 
     delete cdt;
-    cdt = NULL;
+    cdt = nullptr;
 
     return result;
 

--- a/libosmscout-map-opengl/src/poly2tri/common/shapes.cc
+++ b/libosmscout-map-opengl/src/poly2tri/common/shapes.cc
@@ -36,7 +36,7 @@ namespace p2t {
 Triangle::Triangle(Point& a, Point& b, Point& c)
 {
   points_[0] = &a; points_[1] = &b; points_[2] = &c;
-  neighbors_[0] = NULL; neighbors_[1] = NULL; neighbors_[2] = NULL;
+  neighbors_[0] = nullptr; neighbors_[1] = nullptr; neighbors_[2] = nullptr;
   constrained_edge[0] = constrained_edge[1] = constrained_edge[2] = false;
   delaunay_edge[0] = delaunay_edge[1] = delaunay_edge[2] = false;
   interior_ = false;
@@ -79,36 +79,36 @@ void Triangle::Clear()
     for( int i=0; i<3; i++ )
     {
         t = neighbors_[i];
-        if( t != NULL )
+        if( t != nullptr )
         {
             t->ClearNeighbor( this );
         }
     }
     ClearNeighbors();
-    points_[0]=points_[1]=points_[2] = NULL;
+    points_[0]=points_[1]=points_[2] = nullptr;
 }
 
 void Triangle::ClearNeighbor(Triangle *triangle )
 {
     if( neighbors_[0] == triangle )
     {
-        neighbors_[0] = NULL;
+        neighbors_[0] = nullptr;
     }
     else if( neighbors_[1] == triangle )
     {
-        neighbors_[1] = NULL;            
+        neighbors_[1] = nullptr;
     }
     else
     {
-        neighbors_[2] = NULL;
+        neighbors_[2] = nullptr;
     }
 }
     
 void Triangle::ClearNeighbors()
 {
-  neighbors_[0] = NULL;
-  neighbors_[1] = NULL;
-  neighbors_[2] = NULL;
+  neighbors_[0] = nullptr;
+  neighbors_[1] = nullptr;
+  neighbors_[2] = nullptr;
 }
 
 void Triangle::ClearDelunayEdges()

--- a/libosmscout-map-opengl/src/poly2tri/sweep/advancing_front.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/advancing_front.cc
@@ -44,21 +44,21 @@ Node* AdvancingFront::LocateNode(const double& x)
   Node* node = search_node_;
 
   if (x < node->value) {
-    while ((node = node->prev) != NULL) {
+    while ((node = node->prev) != nullptr) {
       if (x >= node->value) {
         search_node_ = node;
         return node;
       }
     }
   } else {
-    while ((node = node->next) != NULL) {
+    while ((node = node->next) != nullptr) {
       if (x < node->value) {
         search_node_ = node->prev;
         return node->prev;
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 Node* AdvancingFront::FindSearchNode(const double& x)
@@ -86,13 +86,13 @@ Node* AdvancingFront::LocatePoint(const Point* point)
       }
     }
   } else if (px < nx) {
-    while ((node = node->prev) != NULL) {
+    while ((node = node->prev) != nullptr) {
       if (point == node->point) {
         break;
       }
     }
   } else {
-    while ((node = node->next) != NULL) {
+    while ((node = node->next) != nullptr) {
       if (point == node->point)
         break;
     }

--- a/libosmscout-map-opengl/src/poly2tri/sweep/sweep.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/sweep.cc
@@ -261,12 +261,12 @@ bool Sweep::LargeHole_DontFill(Node* node) {
   // Check additional points on front.
   Node* next2Node = nextNode->next;
   // "..Plus.." because only want angles on same side as point being added.
-  if ((next2Node != NULL) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, next2Node->point, prevNode->point))
+  if ((next2Node != nullptr) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, next2Node->point, prevNode->point))
           return false;
 
   Node* prev2Node = prevNode->prev;
   // "..Plus.." because only want angles on same side as point being added.
-  if ((prev2Node != NULL) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, nextNode->point, prev2Node->point))
+  if ((prev2Node != nullptr) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, nextNode->point, prev2Node->point))
           return false;
 
   return true;
@@ -702,7 +702,7 @@ void Sweep::FlipEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* t, 
   Triangle& ot = t->NeighborAcross(p);
   Point& op = *ot.OppositePoint(*t, p);
 
-  //if (ot == NULL) {
+  //if (ot == nullptr) {
   // If we want to integrate the fillEdgeEvent do it here
   // With current implementation we should never get here
   // throw new RuntimeException( "[BUG:FIXME] FLIP failed due to missing triangle");
@@ -776,7 +776,7 @@ void Sweep::FlipScanEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle&
   Triangle& ot = t.NeighborAcross(p);
   Point& op = *ot.OppositePoint(t, p);
 
-  //if (&t.NeighborAcross(p) == NULL) {
+  //if (&t.NeighborAcross(p) == nullptr) {
   //  If we want to integrate the fillEdgeEvent do it here
   //  With current implementation we should never get here
   //  throw new RuntimeException( "[BUG:FIXME] FLIP failed due to missing triangle");

--- a/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
@@ -177,7 +177,7 @@ void SweepContext::MeshClean(Triangle& triangle)
 	Triangle *t = triangles.back();
 	triangles.pop_back();
 
-    if (t != NULL && !t->IsInterior()) {
+    if (t != nullptr && !t->IsInterior()) {
       t->IsInterior(true);
       triangles_.push_back(t);
       for (int i = 0; i < 3; i++) {

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -280,7 +280,7 @@ namespace osmscout {
                                 const LabelData &label,
                                 const NativeLabel &/*layout*/)
   {
-    if (dynamic_cast<const TextStyle*>(label.style.get())!=NULL) {
+    if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
       const TextStyle* style=dynamic_cast<const TextStyle*>(label.style.get());
 
       // TODO: text x, y coordinate is text baseline, our placement is not precise
@@ -300,7 +300,7 @@ namespace osmscout {
       stream << StrEscape(label.text);
       stream << "</text>" << std::endl;
     }
-    else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=NULL) {
+    else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {
       const ShieldStyle* style=dynamic_cast<const ShieldStyle*>(label.style.get());
 
       // Shield background

--- a/libosmscout-map/include/osmscout/StyleDescription.h
+++ b/libosmscout-map/include/osmscout/StyleDescription.h
@@ -489,7 +489,7 @@ namespace osmscout {
         return result->second;
       }
       else {
-        return NULL;
+        return nullptr;
       }
     }
   };

--- a/libosmscout/include/osmscout/FeatureReader.h
+++ b/libosmscout/include/osmscout/FeatureReader.h
@@ -173,8 +173,8 @@ namespace osmscout {
      * @param buffer
      *    The FeatureValueBuffer instance
      * @return
-     *    A pointer to an instance if the Type and the instance do have the feature and its value is not NULL,
-     *    else NULL
+     *    A pointer to an instance if the Type and the instance do have the feature and its value is not nullptr,
+     *    else nullptr
      */
     V* GetValue(const FeatureValueBuffer& buffer) const;
   };
@@ -218,7 +218,7 @@ namespace osmscout {
       return dynamic_cast<V*>(buffer.GetValue(index));
     }
     else {
-      return NULL;
+      return nullptr;
     }
   }
 

--- a/libosmscout/include/osmscout/NumericIndex.h
+++ b/libosmscout/include/osmscout/NumericIndex.h
@@ -128,7 +128,7 @@ namespace osmscout {
      cacheSize(cacheSize),
      pageSize(0),
      levels(0),
-     buffer(NULL)
+     buffer(nullptr)
   {
     // no code
   }
@@ -379,7 +379,7 @@ namespace osmscout {
           auto cacheRef=simplePageCache[level].find(startId);
 
           if (cacheRef==simplePageCache[level].end()) {
-            pageRef=NULL; // Make sure, that we allocate a new page and not reuse an old one
+            pageRef=nullptr; // Make sure, that we allocate a new page and not reuse an old one
 
             ReadPage(offset,pageRef);
 

--- a/libosmscout/include/osmscout/TextSearchIndex.h
+++ b/libosmscout/include/osmscout/TextSearchIndex.h
@@ -51,7 +51,7 @@ namespace osmscout
       bool         isAvail;
 
       TrieInfo() :
-        trie(NULL),
+        trie(nullptr),
         isAvail(false)
       {
         // no code

--- a/libosmscout/include/osmscout/util/FileScanner.h
+++ b/libosmscout/include/osmscout/util/FileScanner.h
@@ -117,14 +117,14 @@ namespace osmscout {
 
     inline bool IsOpen() const
     {
-      return file!=NULL;
+      return file!=nullptr;
     }
 
     bool IsEOF() const;
 
     inline  bool HasError() const
     {
-      return file==NULL || hasError;
+      return file==nullptr || hasError;
     }
 
     std::string GetFilename() const;

--- a/libosmscout/src/osmscout/routing/RoutingProfile.cpp
+++ b/libosmscout/src/osmscout/routing/RoutingProfile.cpp
@@ -228,7 +228,7 @@ namespace osmscout {
 
     AccessFeatureValue *accessValue=accessReader.GetValue(way.GetFeatureValueBuffer());
 
-    if (accessValue!=NULL) {
+    if (accessValue!=nullptr) {
       switch (vehicle) {
       case vehicleFoot:
         return accessValue->CanRouteFoot();
@@ -268,7 +268,7 @@ namespace osmscout {
 
     AccessFeatureValue *accessValue=accessReader.GetValue(way.GetFeatureValueBuffer());
 
-    if (accessValue!=NULL) {
+    if (accessValue!=nullptr) {
       switch (vehicle) {
       case vehicleFoot:
         return accessValue->CanRouteFootForward();
@@ -308,7 +308,7 @@ namespace osmscout {
 
     AccessFeatureValue *accessValue=accessReader.GetValue(way.GetFeatureValueBuffer());
 
-    if (accessValue!=NULL) {
+    if (accessValue!=nullptr) {
       switch (vehicle) {
       case vehicleFoot:
         return accessValue->CanRouteFootBackward();

--- a/libosmscout/src/osmscout/util/FileScanner.cpp
+++ b/libosmscout/src/osmscout/util/FileScanner.cpp
@@ -441,7 +441,7 @@ namespace osmscout {
     }
 
 #if defined(HAVE_MMAP) || defined(_WIN32)
-    if (this->buffer!=NULL) {
+    if (this->buffer!=nullptr) {
       if (offset+(FileOffset)bytes-1>=size) {
         hasError=true;
         throw IOException(filename,"Cannot read byte array","Cannot read beyond end of file");


### PR DESCRIPTION
From C++11 `nullptr` keyword is preferred for null pointers instead of `NULL` macro. We are mixing both in library. It is not problem until it is not argument of template, but I think that we should use just one... 

I skip iOS/Mac code and OST parser...