### PR TITLE
New qt signals

### DIFF
--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -86,7 +86,7 @@ public:
           moveTolerance(15)
   {
     timer.setSingleShot(true);
-    connect(&timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+    connect(&timer, &QTimer::timeout, this, &TapRecognizer::onTimeout);
   }
 
   virtual inline ~TapRecognizer()

--- a/libosmscout-client-qt/include/osmscout/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/LookupModule.h
@@ -95,7 +95,7 @@ public slots:
   void requestObjectsOnView(const MapViewStruct&);
   void requestObjects(const LocationEntry&);
   void onDatabaseLoaded(QString dbPath,QList<osmscout::TileRef> tiles);
-  void onLoadJobFinished(QMap<QString,QMap<osmscout::TileId,osmscout::TileRef>> tiles);
+  void onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>> tiles);
 
   /**
    * Start retrieving place information based on objects on or near the location.

--- a/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscout/MapObjectInfoModel.h
@@ -65,7 +65,7 @@ public:
 
 signals:
   void readyChange(bool ready);
-  void objectsRequested(const MapViewStruct &view);
+  void objectsOnViewRequested(const MapViewStruct &view);
   void objectsRequested(const LocationEntry &entry);
 
 public slots:

--- a/libosmscout-client-qt/include/osmscout/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscout/NearPOIModel.h
@@ -94,11 +94,11 @@ signals:
 
   void SearchingChanged(bool);
 
-  void lookupPOI(int requestId,
-                 osmscout::BreakerRef breaker,
-                 osmscout::GeoCoord searchCenter,
-                 QStringList types,
-                 double maxDistance);
+  void lookupPOIRequest(int requestId,
+                        osmscout::BreakerRef breaker,
+                        osmscout::GeoCoord searchCenter,
+                        QStringList types,
+                        double maxDistance);
 
 public slots:
   void onLookupFinished(int requestId);

--- a/libosmscout-client-qt/include/osmscout/POILookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/POILookupModule.h
@@ -56,10 +56,10 @@ public:
   virtual ~POILookupModule();
 
 private:
-  QList<LocationEntry> lookupPOIRequest(DBInstanceRef database,
-                                        osmscout::GeoBox searchBoundingBox,
-                                        osmscout::BreakerRef breaker,
-                                        QStringList types);
+  QList<LocationEntry> doPOIlookup(DBInstanceRef db,
+                                   osmscout::GeoBox searchBoundingBox,
+                                   osmscout::BreakerRef breaker,
+                                   QStringList types);
 
 };
 

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -63,7 +63,9 @@ AvailableMapsModel::AvailableMapsModel()
   SettingsRef settings = OSMScoutQt::GetInstance().GetSettings();
   mapProviders = settings->GetMapProviders();
 
-  connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT(listDownloaded(QNetworkReply*)));
+  connect(&webCtrl, &QNetworkAccessManager::finished,
+          this, &AvailableMapsModel::listDownloaded);
+
   diskCache.setCacheDirectory(settings->GetHttpCacheDir());
   webCtrl.setCache(&diskCache);
   webCtrl.setCookieJar(new PersistentCookieJar(settings));

--- a/libosmscout-client-qt/src/osmscout/DBInstance.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBInstance.cpp
@@ -149,8 +149,8 @@ osmscout::MapPainterQt* DBInstance::GetPainter()
 
   if (!painterHolder.contains(QThread::currentThread())){
     painterHolder[QThread::currentThread()]=new osmscout::MapPainterQt(styleConfig);
-    connect(QThread::currentThread(),SIGNAL(finished()),
-            this,SLOT(onThreadFinished()));
+    connect(QThread::currentThread(), &QThread::finished,
+            this, &DBInstance::onThreadFinished);
   }
   return painterHolder[QThread::currentThread()];
 }

--- a/libosmscout-client-qt/src/osmscout/DBJob.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBJob.cpp
@@ -78,8 +78,8 @@ DBLoadJob::DBLoadJob(osmscout::MercatorProjection lookupProjection,
   searchParameter.SetUseLowZoomOptimization(lowZoomOptimization);
   searchParameter.SetBreaker(breaker);
 
-  connect(this,SIGNAL(tileStateChanged(QString,const osmscout::TileRef)),
-          this,SLOT(onTileStateChanged(QString,const osmscout::TileRef)),
+  connect(this, &DBLoadJob::tileStateChanged,
+          this, &DBLoadJob::onTileStateChanged,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -60,12 +60,12 @@ DBThread::DBThread(QThread *backgroundThread,
   stylesheetFlags=settings->GetStyleSheetFlags();
   osmscout::log.Debug() << "Using stylesheet: " << stylesheetFilename.toStdString();
 
-  connect(settings.get(), SIGNAL(MapDPIChange(double)),
-          this, SLOT(onMapDPIChange(double)),
+  connect(settings.get(), &Settings::MapDPIChange,
+          this, &DBThread::onMapDPIChange,
           Qt::QueuedConnection);
 
-  connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
-          this, SLOT(onDatabaseListChanged(QList<QDir>)),
+  connect(mapManager.get(), &MapManager::databaseListChanged,
+          this, &DBThread::onDatabaseListChanged,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -61,8 +61,8 @@ FileDownloader::FileDownloader(QNetworkAccessManager *manager,
     return;
   }
 
-  connect( &m_file, SIGNAL(bytesWritten(qint64)),
-           this, SLOT(onBytesWritten(qint64)) );
+  connect(&m_file, &QFile::bytesWritten,
+          this, &FileDownloader::onBytesWritten);
 
   // start data processor if requested
   QString command;
@@ -82,23 +82,23 @@ FileDownloader::FileDownloader(QNetworkAccessManager *manager,
     m_pipe_to_process = true;
     m_process = new QProcess(this);
 
-    connect( m_process, SIGNAL(started()),
-             this, SLOT(onProcessStarted()) );
+    connect( m_process, &QProcess::started,
+             this, &FileDownloader::onProcessStarted );
 
     connect( m_process, SIGNAL(finished(int)),
              this, SLOT(onProcessStopped(int)) );
 
-    connect( m_process, SIGNAL(stateChanged(QProcess::ProcessState)),
-             this, SLOT(onProcessStateChanged(QProcess::ProcessState)) );
+    connect( m_process, &QProcess::stateChanged,
+             this, &FileDownloader::onProcessStateChanged);
 
-    connect( m_process, SIGNAL(readyReadStandardOutput()),
-             this, SLOT(onProcessRead()) );
+    connect( m_process, &QProcess::readyReadStandardOutput,
+             this, &FileDownloader::onProcessRead);
 
-    connect( m_process, SIGNAL(readyReadStandardError()),
-             this, SLOT(onProcessReadError()) );
+    connect( m_process, &QProcess::readyReadStandardError,
+             this, &FileDownloader::onProcessReadError);
 
-    connect( m_process, SIGNAL(bytesWritten(qint64)),
-             this, SIGNAL(onBytesWritten(qint64)) );
+    connect( m_process, &QProcess::bytesWritten,
+             this, &FileDownloader::onBytesWritten);
 
     m_process->start(command, arguments);
   }
@@ -134,10 +134,10 @@ void FileDownloader::startDownload()
   m_reply = m_manager->get(request);
   m_reply->setReadBufferSize(const_buffer_network);
 
-  connect(m_reply, SIGNAL(readyRead()),
-          this, SLOT(onNetworkReadyRead()));
-  connect(m_reply, SIGNAL(finished()),
-          this, SLOT(onDownloaded()));
+  connect(m_reply, &QNetworkReply::readyRead,
+          this, &FileDownloader::onNetworkReadyRead);
+  connect(m_reply, &QNetworkReply::finished,
+          this, &FileDownloader::onDownloaded);
   connect(m_reply, SIGNAL(error(QNetworkReply::NetworkError)),
           this, SLOT(onNetworkError(QNetworkReply::NetworkError)));
 

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -227,7 +227,7 @@ bool InputHandler::focusOutEvent(QFocusEvent* /*event*/)
 
 MoveHandler::MoveHandler(MapView view): InputHandler(view)
 {
-    connect(&timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+    connect(&timer, &QTimer::timeout, this, &MoveHandler::onTimeout);
     timer.setSingleShot(false);
 }
 
@@ -444,7 +444,7 @@ bool MoveHandler::rotateBy(double angleChange)
 JumpHandler::JumpHandler(MapView view):
     InputHandler(view)
 {
-    connect(&timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+    connect(&timer, &QTimer::timeout, this, &JumpHandler::onTimeout);
     timer.setSingleShot(false);
 }
 

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -25,10 +25,10 @@ namespace osmscout {
 InstalledMapsModel::InstalledMapsModel()
 {
   mapManager=OSMScoutQt::GetInstance().GetMapManager();
-  connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
-          this, SLOT(onDatabaseListChanged()));
-  connect(mapManager.get(), SIGNAL(databaseListChanged(QList<QDir>)),
-          this, SIGNAL(databaseListChanged()));
+  connect(mapManager.get(), &MapManager::databaseListChanged,
+          this, &InstalledMapsModel::onDatabaseListChanged);
+  connect(mapManager.get(), &MapManager::databaseListChanged,
+          this, &InstalledMapsModel::databaseListChanged);
   onDatabaseListChanged();
 }
 

--- a/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
@@ -30,32 +30,32 @@ LocationInfoModel::LocationInfoModel():
 {
     lookupModule=OSMScoutQt::GetInstance().MakeLookupModule();
 
-    connect(lookupModule, SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)),
-            this, SLOT(dbInitialized(const DatabaseLoadedResponse&)),
+    connect(lookupModule, &LookupModule::initialisationFinished,
+            this, &LocationInfoModel::dbInitialized,
             Qt::QueuedConnection);
     
-    connect(this, SIGNAL(locationDescriptionRequested(const osmscout::GeoCoord)), 
-            lookupModule, SLOT(requestLocationDescription(const osmscout::GeoCoord)),
+    connect(this, &LocationInfoModel::locationDescriptionRequested,
+            lookupModule, &LookupModule::requestLocationDescription,
             Qt::QueuedConnection);
     
-    connect(lookupModule, SIGNAL(locationDescription(const osmscout::GeoCoord, const QString, const osmscout::LocationDescription, const QStringList)),
-            this, SLOT(onLocationDescription(const osmscout::GeoCoord, const QString, const osmscout::LocationDescription, const QStringList)),
+    connect(lookupModule, &LookupModule::locationDescription,
+            this, &LocationInfoModel::onLocationDescription,
             Qt::QueuedConnection);
     
-    connect(lookupModule, SIGNAL(locationDescriptionFinished(const osmscout::GeoCoord)),
-            this, SLOT(onLocationDescriptionFinished(const osmscout::GeoCoord)),
+    connect(lookupModule, &LookupModule::locationDescriptionFinished,
+            this, &LocationInfoModel::onLocationDescriptionFinished,
             Qt::QueuedConnection);
 
-    connect(this, SIGNAL(regionLookupRequested(osmscout::GeoCoord)),
-            lookupModule, SLOT(requestRegionLookup(osmscout::GeoCoord)),
+    connect(this, &LocationInfoModel::regionLookupRequested,
+            lookupModule, &LookupModule::requestRegionLookup,
             Qt::QueuedConnection);
 
-    connect(lookupModule, SIGNAL(locationAdminRegions(const osmscout::GeoCoord,QList<AdminRegionInfoRef>)),
-              this, SLOT(onLocationAdminRegions(const osmscout::GeoCoord,QList<AdminRegionInfoRef>)),
-              Qt::QueuedConnection);
+    connect(lookupModule, &LookupModule::locationAdminRegions,
+            this, &LocationInfoModel::onLocationAdminRegions,
+            Qt::QueuedConnection);
 
-    connect(lookupModule, SIGNAL(locationAdminRegionFinished(const osmscout::GeoCoord)),
-            this, SLOT(onLocationAdminRegionFinished(const osmscout::GeoCoord)),
+    connect(lookupModule, &LookupModule::locationAdminRegionFinished,
+            this, &LocationInfoModel::onLocationAdminRegionFinished,
             Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/LookupModule.cpp
@@ -124,7 +124,7 @@ void LookupModule::onDatabaseLoaded(QString dbPath,QList<osmscout::TileRef> tile
   emit viewObjectsLoaded(view, data);
 }
 
-void LookupModule::onLoadJobFinished(QMap<QString,QMap<osmscout::TileId,osmscout::TileRef>> /*tiles*/)
+void LookupModule::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>> /*tiles*/)
 {
   emit viewObjectsLoaded(view, osmscout::MapData());
 }

--- a/libosmscout-client-qt/src/osmscout/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/LookupModule.cpp
@@ -30,8 +30,8 @@ LookupModule::LookupModule(QThread *thread,DBThreadRef dbThread):
   loadJob(nullptr)
 {
 
-  connect(dbThread.get(), SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)),
-          this, SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)));
+  connect(dbThread.get(), &DBThread::initialisationFinished,
+          this, &LookupModule::initialisationFinished);
 }
 
 LookupModule::~LookupModule()
@@ -65,10 +65,10 @@ void LookupModule::requestObjectsOnView(const MapViewStruct &view)
   loadJob=new DBLoadJob(lookupProjection,maximumAreaLevel,/* lowZoomOptimization */ true);
   this->view=view;
 
-  connect(loadJob, SIGNAL(databaseLoaded(QString,QList<osmscout::TileRef>)),
-          this, SLOT(onDatabaseLoaded(QString,QList<osmscout::TileRef>)));
-  connect(loadJob, SIGNAL(finished(QMap<QString,QMap<osmscout::TileId,osmscout::TileRef>>)),
-          this, SLOT(onLoadJobFinished(QMap<QString,QMap<osmscout::TileId,osmscout::TileRef>>)));
+  connect(loadJob, &DBLoadJob::databaseLoaded,
+          this, &LookupModule::onDatabaseLoaded);
+  connect(loadJob, &DBLoadJob::finished,
+          this, &LookupModule::onLoadJobFinished);
 
   dbThread->RunJob(loadJob);
 }

--- a/libosmscout-client-qt/src/osmscout/MapDownloadsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapDownloadsModel.cpp
@@ -27,8 +27,8 @@ MapDownloadsModel::MapDownloadsModel(QObject *parent):
   QAbstractListModel(parent){
 
   mapManager=OSMScoutQt::GetInstance().GetMapManager();
-  connect(mapManager.get(), SIGNAL(downloadJobsChanged()), this, SLOT(onDownloadJobsChanged()));
-  connect(mapManager.get(), SIGNAL(mapDownloadFails(QString)), this, SIGNAL(mapDownloadFails(QString)));
+  connect(mapManager.get(), &MapManager::downloadJobsChanged, this, &MapDownloadsModel::onDownloadJobsChanged);
+  connect(mapManager.get(), &MapManager::mapDownloadFails, this, &MapDownloadsModel::mapDownloadFails);
   onDownloadJobsChanged();
 }
 
@@ -89,7 +89,7 @@ void MapDownloadsModel::onDownloadJobsChanged()
 {
   beginResetModel();
   for (auto job:mapManager->getDownloadJobs()){
-    connect(job, SIGNAL(downloadProgress()), this, SLOT(onDownloadProgress()));
+    connect(job, &MapDownloadJob::downloadProgress, this, &MapDownloadsModel::onDownloadProgress);
   }
   endResetModel();
 }

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -98,10 +98,10 @@ void MapDownloadJob::start()
 
   for (auto fileName:fileNames){
     auto job=new FileDownloader(webCtrl, map.getProvider().getUri()+"/"+map.getServerDirectory()+"/"+fileName, target.filePath(fileName));
-    connect(job, SIGNAL(finished(QString)), this, SLOT(onJobFinished()));
-    connect(job, SIGNAL(error(QString, bool)), this, SLOT(onJobFailed(QString, bool)));
-    connect(job, SIGNAL(writtenBytes(uint64_t)), this, SIGNAL(downloadProgress()));
-    connect(job, SIGNAL(writtenBytes(uint64_t)), this, SLOT(onDownloadProgress(uint64_t)));
+    connect(job, &FileDownloader::finished, this, &MapDownloadJob::onJobFinished);
+    connect(job, &FileDownloader::error, this, &MapDownloadJob::onJobFailed);
+    connect(job, &FileDownloader::writtenBytes, this, &MapDownloadJob::downloadProgress);
+    connect(job, &FileDownloader::writtenBytes, this, &MapDownloadJob::onDownloadProgress);
     jobs << job;
   }
   started=true;
@@ -337,8 +337,8 @@ void MapManager::downloadMap(AvailableMapsModelMap map, QDir dir, bool replaceEx
 #endif
   
   auto job=new MapDownloadJob(&webCtrl, map, dir, replaceExisting);
-  connect(job, SIGNAL(finished()), this, SLOT(onJobFinished()));
-  connect(job, SIGNAL(failed(QString)), this, SLOT(onJobFailed(QString)));
+  connect(job, &MapDownloadJob::finished, this, &MapManager::onJobFinished);
+  connect(job, &MapDownloadJob::failed, this, &MapManager::onJobFailed);
   downloadJobs<<job;
   emit downloadJobsChanged();
   downloadNext();

--- a/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
@@ -33,24 +33,24 @@ ready(false), setup(false), view(), lookupModule(nullptr)
   lookupModule=OSMScoutQt::GetInstance().MakeLookupModule();
   this->mapDpi=OSMScoutQt::GetInstance().GetSettings()->GetMapDPI();
 
-  connect(lookupModule, SIGNAL(initialisationFinished(const DatabaseLoadedResponse)),
-          this, SLOT(dbInitialized(const DatabaseLoadedResponse)),
+  connect(lookupModule, &LookupModule::initialisationFinished,
+          this, &MapObjectInfoModel::dbInitialized,
           Qt::QueuedConnection);
 
-  connect(this, SIGNAL(objectsOnViewRequested(const MapViewStruct&)),
-          lookupModule, SLOT(requestObjectsOnView(const MapViewStruct&)),
+  connect(this, &MapObjectInfoModel::objectsOnViewRequested,
+          lookupModule, &LookupModule::requestObjectsOnView,
           Qt::QueuedConnection);
 
-  connect(lookupModule, SIGNAL(viewObjectsLoaded(const MapViewStruct&, const osmscout::MapData&)),
-          this, SLOT(onViewObjectsLoaded(const MapViewStruct&, const osmscout::MapData&)),
+  connect(lookupModule, &LookupModule::viewObjectsLoaded,
+          this, &MapObjectInfoModel::onViewObjectsLoaded,
           Qt::QueuedConnection);
 
-  connect(this, SIGNAL(objectsRequested(const LocationEntry &)),
-          lookupModule, SLOT(requestObjects(const LocationEntry&)),
+  connect(this, &MapObjectInfoModel::objectsRequested,
+          lookupModule, &LookupModule::requestObjects,
           Qt::QueuedConnection);
 
-  connect(lookupModule, SIGNAL(objectsLoaded(const LocationEntry&, const osmscout::MapData&)),
-          this, SLOT(onObjectsLoaded(const LocationEntry&, const osmscout::MapData&)),
+  connect(lookupModule, &LookupModule::objectsLoaded,
+          this, &MapObjectInfoModel::onObjectsLoaded,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
@@ -37,7 +37,7 @@ ready(false), setup(false), view(), lookupModule(nullptr)
           this, SLOT(dbInitialized(const DatabaseLoadedResponse)),
           Qt::QueuedConnection);
 
-  connect(this, SIGNAL(objectsRequested(const MapViewStruct&)),
+  connect(this, SIGNAL(objectsOnViewRequested(const MapViewStruct&)),
           lookupModule, SLOT(requestObjectsOnView(const MapViewStruct&)),
           Qt::QueuedConnection);
 
@@ -65,7 +65,7 @@ MapObjectInfoModel::~MapObjectInfoModel()
 void MapObjectInfoModel::dbInitialized(const DatabaseLoadedResponse&)
 {
   if (setup){
-    emit objectsRequested(view);
+    emit objectsOnViewRequested(view);
   }
 }
 
@@ -178,7 +178,7 @@ void MapObjectInfoModel::setPosition(QObject *o,
     model.clear();
     mapData.clear();
     endResetModel();
-    emit objectsRequested(view);
+    emit objectsOnViewRequested(view);
   }else{
     update();
   }

--- a/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
@@ -39,22 +39,22 @@ MapRenderer::MapRenderer(QThread *thread,
   fontName=settings->GetFontName();
   fontSize=settings->GetFontSize();
 
-  connect(settings.get(), SIGNAL(MapDPIChange(double)),
-          this, SLOT(onMapDPIChange(double)),
+  connect(settings.get(), &Settings::MapDPIChange,
+          this, &MapRenderer::onMapDPIChange,
           Qt::QueuedConnection);
-  connect(settings.get(), SIGNAL(RenderSeaChanged(bool)),
-          this, SLOT(onRenderSeaChanged(bool)),
+  connect(settings.get(), &Settings::RenderSeaChanged,
+          this, &MapRenderer::onRenderSeaChanged,
           Qt::QueuedConnection);
-  connect(settings.get(), SIGNAL(FontNameChanged(const QString)),
-          this, SLOT(onFontNameChanged(const QString)),
+  connect(settings.get(), &Settings::FontNameChanged,
+          this, &MapRenderer::onFontNameChanged,
           Qt::QueuedConnection);
-  connect(settings.get(), SIGNAL(FontSizeChanged(double)),
-          this, SLOT(onFontSizeChanged(double)),
+  connect(settings.get(), &Settings::FontSizeChanged,
+          this, &MapRenderer::onFontSizeChanged,
           Qt::QueuedConnection);
-  connect(thread, SIGNAL(started()),
-          this, SLOT(Initialize()));
-  connect(dbThread.get(), SIGNAL(stylesheetFilenameChanged()),
-          this, SLOT(onStylesheetFilenameChanged()),
+  connect(thread, &QThread::started,
+          this, &MapRenderer::Initialize);
+  connect(dbThread.get(), &DBThread::stylesheetFilenameChanged,
+          this, &MapRenderer::onStylesheetFilenameChanged,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapStyleModel.cpp
@@ -28,11 +28,13 @@ MapStyleModel::MapStyleModel():
   QAbstractListModel()
 {
   styleModule=OSMScoutQt::GetInstance().MakeStyleModule();
-  connect(styleModule,SIGNAL(stylesheetFilenameChanged()),
-          this,SIGNAL(styleChanged()),
+
+  connect(styleModule, &StyleModule::stylesheetFilenameChanged,
+          this, &MapStyleModel::styleChanged,
           Qt::QueuedConnection);
-  connect(this,SIGNAL(loadStyleRequested(QString,std::unordered_map<std::string,bool>)),
-          styleModule,SLOT(loadStyle(QString,std::unordered_map<std::string,bool>)),
+
+  connect(this, &MapStyleModel::loadStyleRequested,
+          styleModule, &StyleModule::loadStyle,
           Qt::QueuedConnection);
 
   SettingsRef settings=OSMScoutQt::GetInstance().GetSettings();

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -49,24 +49,24 @@ MapWidget::MapWidget(QQuickItem* parent)
 
     DBThreadRef dbThread = OSMScoutQt::GetInstance().GetDBThread();
 
-    connect(settings.get(), SIGNAL(MapDPIChange(double)),
-            this, SLOT(onMapDPIChange(double)));
+    connect(settings.get(), &Settings::MapDPIChange,
+            this, &MapWidget::onMapDPIChange);
 
     tapRecognizer.setPhysicalDpi(dbThread->GetPhysicalDpi());
 
-    connect(renderer,SIGNAL(Redraw()),
-            this,SLOT(redraw()));
-    connect(dbThread.get(),SIGNAL(stylesheetFilenameChanged()),
-            this,SIGNAL(stylesheetFilenameChanged()));
-    connect(dbThread.get(),SIGNAL(styleErrorsChanged()),
-            this,SIGNAL(styleErrorsChanged()));
-    connect(dbThread.get(),SIGNAL(databaseLoadFinished(osmscout::GeoBox)),
-            this,SIGNAL(databaseLoaded(osmscout::GeoBox)));
+    connect(renderer, &MapRenderer::Redraw,
+            this, &MapWidget::redraw);
+    connect(dbThread.get(), &DBThread::stylesheetFilenameChanged,
+            this, &MapWidget::stylesheetFilenameChanged);
+    connect(dbThread.get(), &DBThread::styleErrorsChanged,
+            this, &MapWidget::styleErrorsChanged);
+    connect(dbThread.get(), &DBThread::databaseLoadFinished,
+            this, &MapWidget::databaseLoaded);
 
-    connect(&tapRecognizer, SIGNAL(tap(const QPoint)),        this, SLOT(onTap(const QPoint)));
-    connect(&tapRecognizer, SIGNAL(doubleTap(const QPoint)),  this, SLOT(onDoubleTap(const QPoint)));
-    connect(&tapRecognizer, SIGNAL(longTap(const QPoint)),    this, SLOT(onLongTap(const QPoint)));
-    connect(&tapRecognizer, SIGNAL(tapLongTap(const QPoint)), this, SLOT(onTapLongTap(const QPoint)));
+    connect(&tapRecognizer, &TapRecognizer::tap,        this, &MapWidget::onTap);
+    connect(&tapRecognizer, &TapRecognizer::doubleTap,  this, &MapWidget::onDoubleTap);
+    connect(&tapRecognizer, &TapRecognizer::longTap,    this, &MapWidget::onLongTap);
+    connect(&tapRecognizer, &TapRecognizer::tapLongTap, this, &MapWidget::onTapLongTap);
 
     // TODO, open last position, move to current position or get as constructor argument...
     view = new MapView(this,
@@ -141,8 +141,8 @@ void MapWidget::setupInputHandler(InputHandler *newGesture)
     }
     inputHandler = newGesture;
 
-    connect(inputHandler, SIGNAL(viewChanged(const MapView&)),
-            this, SLOT(changeView(const MapView&)));
+    connect(inputHandler, &InputHandler::viewChanged,
+            this, &MapWidget::changeView);
 
     if (locked != inputHandler->isLockedToPosition()){
         emit lockToPossitionChanged();
@@ -759,8 +759,8 @@ void MapWidget::SetRenderingType(QString strType)
     for (auto &p:overlayWays){
       renderer->addOverlayObject(p.first, p.second);
     }
-    connect(renderer,SIGNAL(Redraw()),
-            this,SLOT(redraw()));
+    connect(renderer, &MapRenderer::Redraw,
+            this, &MapWidget::redraw);
     emit renderingTypeChanged(GetRenderingType());
   }
 }

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -28,7 +28,7 @@ NavigationModule::NavigationModule(QThread *thread,
   thread(thread), settings(settings), dbThread(dbThread)
 {
   timer.moveToThread(thread); // constructor is called from different thread!
-  connect(&timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+  connect(&timer, &QTimer::timeout, this, &NavigationModule::onTimeout);
 }
 
 NavigationModule::~NavigationModule()

--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -26,18 +26,18 @@ NearPOIModel::NearPOIModel()
 {
   poiModule=OSMScoutQt::GetInstance().MakePOILookupModule();
 
-  connect(this, SIGNAL(lookupPOIRequest(int, osmscout::BreakerRef, osmscout::GeoCoord, QStringList, double)),
-          poiModule, SLOT(lookupPOIRequest(int, osmscout::BreakerRef, osmscout::GeoCoord, QStringList, double)),
+  connect(this, &NearPOIModel::lookupPOIRequest,
+          poiModule, &POILookupModule::lookupPOIRequest,
           Qt::QueuedConnection);
 
-  connect(poiModule, SIGNAL(lookupAborted(int)),
-          this, SLOT(onLookupFinished(int)),
+  connect(poiModule, &POILookupModule::lookupAborted,
+          this, &NearPOIModel::onLookupFinished,
           Qt::QueuedConnection);
-  connect(poiModule, SIGNAL(lookupFinished(int)),
-          this, SLOT(onLookupFinished(int)),
+  connect(poiModule, &POILookupModule::lookupFinished,
+          this, &NearPOIModel::onLookupFinished,
           Qt::QueuedConnection);
-  connect(poiModule, SIGNAL(lookupResult(int, QList<LocationEntry>)),
-          this, SLOT(onLookupResult(int, QList<LocationEntry>)),
+  connect(poiModule, &POILookupModule::lookupResult,
+          this, &NearPOIModel::onLookupResult,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -26,7 +26,7 @@ NearPOIModel::NearPOIModel()
 {
   poiModule=OSMScoutQt::GetInstance().MakePOILookupModule();
 
-  connect(this, SIGNAL(lookupPOI(int, osmscout::BreakerRef, osmscout::GeoCoord, QStringList, double)),
+  connect(this, SIGNAL(lookupPOIRequest(int, osmscout::BreakerRef, osmscout::GeoCoord, QStringList, double)),
           poiModule, SLOT(lookupPOIRequest(int, osmscout::BreakerRef, osmscout::GeoCoord, QStringList, double)),
           Qt::QueuedConnection);
 
@@ -212,7 +212,7 @@ void NearPOIModel::lookupPOI()
     breaker=std::make_shared<osmscout::ThreadedBreaker>();
     searching=true;
     // TODO: use resultLimit
-    emit lookupPOI(++currentRequest, breaker, searchCenter, types, maxDistance.AsMeter());
+    emit lookupPOIRequest(++currentRequest, breaker, searchCenter, types, maxDistance.AsMeter());
   }else{
     searching=false;
   }

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -229,7 +229,9 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
                                       mapManager,
                                       customPoiTypeVector);
 
-  dbThread->connect(thread, SIGNAL(started()), SLOT(Initialize()));
+  connect(thread, &QThread::started,
+          dbThread.get(), &DBThread::Initialize);
+
   dbThread->moveToThread(thread);
 
   thread->start();
@@ -275,10 +277,10 @@ QThread *OSMScoutQt::makeThread(QString name)
 {
   QThread *thread=new QThread();
   thread->setObjectName(name);
-  QObject::connect(thread, SIGNAL(finished()),
-                   thread, SLOT(deleteLater()));
-  connect(thread, SIGNAL(finished()),
-          this, SLOT(threadFinished()));
+  QObject::connect(thread, &QThread::finished,
+                   thread, &QThread::deleteLater);
+  connect(thread, &QThread::finished,
+          this, &OSMScoutQt::threadFinished);
 
   liveBackgroundThreads++;
   return thread;

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -32,7 +32,8 @@ OsmTileDownloader::OsmTileDownloader(QString diskCacheDir,
   serverNumber(qrand()),
   tileProvider(provider)
 {
-  connect(&webCtrl, SIGNAL (finished(QNetworkReply*)),  this, SLOT (fileDownloaded(QNetworkReply*)));
+  connect(&webCtrl, &QNetworkAccessManager::finished,
+          this, &OsmTileDownloader::fileDownloaded);
  
   /** http://wiki.openstreetmap.org/wiki/Tile_usage_policy
    * 

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -62,10 +62,10 @@ LocationEntry buildLocationEntry(T obj,
   return location;
 }
 
-QList<LocationEntry> POILookupModule::lookupPOIRequest(DBInstanceRef db,
-                                                       osmscout::GeoBox searchBoundingBox,
-                                                       osmscout::BreakerRef /*breaker*/,
-                                                       QStringList types)
+QList<LocationEntry> POILookupModule::doPOIlookup(DBInstanceRef db,
+                                                  osmscout::GeoBox searchBoundingBox,
+                                                  osmscout::BreakerRef /*breaker*/,
+                                                  QStringList types)
 {
   QList<LocationEntry> result;
 
@@ -162,7 +162,7 @@ void POILookupModule::lookupPOIRequest(int requestId,
         break;
       }
       emit lookupResult(requestId,
-                        lookupPOIRequest(db, searchBoundingBox, breaker, types));
+                        doPOIlookup(db, searchBoundingBox, breaker, types));
     }
   });
 

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -58,18 +58,18 @@ PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
   // else we might get into a dead lock
   //
 
-  connect(this,SIGNAL(TriggerMapRenderingSignal(const MapViewStruct&)),
-          this,SLOT(TriggerMapRendering(const MapViewStruct&)),
+  connect(this, &PlaneMapRenderer::TriggerMapRenderingSignal,
+          this, &PlaneMapRenderer::TriggerMapRendering,
           Qt::QueuedConnection);
 
-  connect(this,SIGNAL(TriggerInitialRendering()),
-          this,SLOT(HandleInitialRenderingRequest()));
+  connect(this, &PlaneMapRenderer::TriggerInitialRendering,
+          this, &PlaneMapRenderer::HandleInitialRenderingRequest);
 
-  connect(&pendingRenderingTimer,SIGNAL(timeout()),
-          this,SLOT(DrawMap()));
+  connect(&pendingRenderingTimer, &QTimer::timeout,
+          this, &PlaneMapRenderer::DrawMap);
 
-  connect(this,SIGNAL(TriggerDrawMap()),
-          this,SLOT(DrawMap()),
+  connect(this, &PlaneMapRenderer::TriggerDrawMap,
+          this, &PlaneMapRenderer::DrawMap,
           Qt::QueuedConnection);
 }
 
@@ -494,11 +494,11 @@ void PlaneMapRenderer::TriggerMapRendering(const MapViewStruct& request)
                           /* lowZoomOptimization */ true,
                           /* closeOnFinish */ false);
 
-    connect(loadJob, SIGNAL(tileStateChanged(QString,const osmscout::TileRef)),
-            this, SLOT(HandleTileStatusChanged(QString,const osmscout::TileRef)),
+    connect(loadJob, &DBLoadJob::tileStateChanged,
+            this, &PlaneMapRenderer::HandleTileStatusChanged,
             Qt::QueuedConnection);
-    connect(loadJob, SIGNAL(finished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>>)),
-            this, SLOT(onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>>)));
+    connect(loadJob, &DBLoadJob::finished,
+            this, &PlaneMapRenderer::onLoadJobFinished);
 
     dbThread->RunJob(loadJob);
   }

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -36,8 +36,8 @@ Router::Router(QThread *thread,
   settings(settings),
   dbThread(dbThread)
 {
-  connect(thread, SIGNAL(started()),
-          this, SLOT(Initialize()));
+  connect(thread, &QThread::started,
+          this, &Router::Initialize);
 }
 
 Router::~Router()

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -28,18 +28,18 @@ RoutingListModel::RoutingListModel(QObject* parent)
 {
   router=OSMScoutQt::GetInstance().MakeRouter();
 
-  connect(this,SIGNAL(routeRequest(LocationEntryRef,LocationEntryRef,osmscout::Vehicle,int,osmscout::BreakerRef)),
-          router,SLOT(onRouteRequest(LocationEntryRef,LocationEntryRef,osmscout::Vehicle,int,osmscout::BreakerRef)),
+  connect(this, &RoutingListModel::routeRequest,
+          router, &Router::onRouteRequest,
           Qt::QueuedConnection);
 
-  connect(router,SIGNAL(routeComputed(QtRouteData,int)),
-          this,SLOT(onRouteComputed(QtRouteData,int)),
+  connect(router, &Router::routeComputed,
+          this, &RoutingListModel::onRouteComputed,
           Qt::QueuedConnection);
-  connect(router,SIGNAL(routeFailed(QString,int)),
-          this,SLOT(onRouteFailed(QString,int)),
+  connect(router, &Router::routeFailed,
+          this, &RoutingListModel::onRouteFailed,
           Qt::QueuedConnection);
-  connect(router,SIGNAL(routingProgress(int,int)),
-          this,SLOT(onRoutingProgress(int,int)),
+  connect(router, &Router::routingProgress,
+          this, &RoutingListModel::onRoutingProgress,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -36,28 +36,28 @@ LocationListModel::LocationListModel(QObject* parent)
   searchModule=OSMScoutQt::GetInstance().MakeSearchModule();
   lookupModule=OSMScoutQt::GetInstance().MakeLookupModule();
 
-  connect(this, SIGNAL(SearchRequested(const QString, int, osmscout::GeoCoord, AdminRegionInfoRef, osmscout::BreakerRef)),
-          searchModule, SLOT(SearchForLocations(const QString, int, osmscout::GeoCoord, AdminRegionInfoRef, osmscout::BreakerRef)),
+  connect(this, &LocationListModel::SearchRequested,
+          searchModule, &SearchModule::SearchForLocations,
           Qt::QueuedConnection);
 
-  connect(searchModule, SIGNAL(searchResult(const QString, const QList<LocationEntry>)),
-          this, SLOT(onSearchResult(const QString, const QList<LocationEntry>)),
+  connect(searchModule, &SearchModule::searchResult,
+          this, &LocationListModel::onSearchResult,
           Qt::QueuedConnection);
 
-  connect(searchModule, SIGNAL(searchFinished(const QString, bool)),
-          this, SLOT(onSearchFinished(const QString, bool)),
+  connect(searchModule, &SearchModule::searchFinished,
+          this, &LocationListModel::onSearchFinished,
           Qt::QueuedConnection);
 
-  connect(this, SIGNAL(regionLookupRequested(osmscout::GeoCoord)),
-          lookupModule, SLOT(requestRegionLookup(osmscout::GeoCoord)),
+  connect(this, &LocationListModel::regionLookupRequested,
+          lookupModule, &LookupModule::requestRegionLookup,
           Qt::QueuedConnection);
 
-  connect(lookupModule, SIGNAL(locationAdminRegions(const osmscout::GeoCoord,QList<AdminRegionInfoRef>)),
-          this, SLOT(onLocationAdminRegions(const osmscout::GeoCoord,QList<AdminRegionInfoRef>)),
+  connect(lookupModule, &LookupModule::locationAdminRegions,
+          this, &LocationListModel::onLocationAdminRegions,
           Qt::QueuedConnection);
 
-  connect(lookupModule, SIGNAL(locationAdminRegionFinished(const osmscout::GeoCoord)),
-          this, SLOT(onLocationAdminRegionFinished(const osmscout::GeoCoord)),
+  connect(lookupModule, &LookupModule::locationAdminRegionFinished,
+          this, &LocationListModel::onLocationAdminRegionFinished,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -311,20 +311,20 @@ QmlSettings::QmlSettings()
 {
     settings=OSMScoutQt::GetInstance().GetSettings();
 
-    connect(settings.get(), SIGNAL(MapDPIChange(double)),
-            this, SIGNAL(MapDPIChange(double)));
-    connect(settings.get(), SIGNAL(OnlineTilesEnabledChanged(bool)),
-            this, SIGNAL(OnlineTilesEnabledChanged(bool)));
-    connect(settings.get(), SIGNAL(OnlineTileProviderIdChanged(const QString)),
-            this, SIGNAL(OnlineTileProviderIdChanged(const QString)));
-    connect(settings.get(), SIGNAL(OfflineMapChanged(bool)),
-            this, SIGNAL(OfflineMapChanged(bool)));
-    connect(settings.get(), SIGNAL(RenderSeaChanged(bool)),
-            this, SIGNAL(RenderSeaChanged(bool)));
-    connect(settings.get(), SIGNAL(FontNameChanged(const QString)),
-            this, SIGNAL(FontNameChanged(const QString)));
-    connect(settings.get(), SIGNAL(FontSizeChanged(double)),
-            this, SIGNAL(FontSizeChanged(double)));
+    connect(settings.get(), &Settings::MapDPIChange,
+            this, &QmlSettings::MapDPIChange);
+    connect(settings.get(), &Settings::OnlineTilesEnabledChanged,
+            this, &QmlSettings::OnlineTilesEnabledChanged);
+    connect(settings.get(), &Settings::OnlineTileProviderIdChanged,
+            this, &QmlSettings::OnlineTileProviderIdChanged);
+    connect(settings.get(), &Settings::OfflineMapChanged,
+            this, &QmlSettings::OfflineMapChanged);
+    connect(settings.get(), &Settings::RenderSeaChanged,
+            this, &QmlSettings::RenderSeaChanged);
+    connect(settings.get(), &Settings::FontNameChanged,
+            this, &QmlSettings::FontNameChanged);
+    connect(settings.get(), &Settings::FontSizeChanged,
+            this, &QmlSettings::FontSizeChanged);
 }
 
 double QmlSettings::GetPhysicalDPI() const

--- a/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/StyleFlagsModel.cpp
@@ -28,17 +28,17 @@ StyleFlagsModel::StyleFlagsModel():
 {
   styleModule=OSMScoutQt::GetInstance().MakeStyleModule();
 
-  connect(styleModule,SIGNAL(styleFlagsChanged(QMap<QString,bool>)),
-          this,SLOT(onStyleFlagsChanged(QMap<QString,bool>)),
+  connect(styleModule, &StyleModule::styleFlagsChanged,
+          this, &StyleFlagsModel::onStyleFlagsChanged,
           Qt::QueuedConnection);
-  connect(this,SIGNAL(styleFlagsRequested()),
-          styleModule,SLOT(onStyleFlagsRequested()),
+  connect(this, &StyleFlagsModel::styleFlagsRequested,
+          styleModule, &StyleModule::onStyleFlagsRequested,
           Qt::QueuedConnection);
-  connect(this,SIGNAL(setFlagRequest(QString,bool)),
-          styleModule,SLOT(onSetFlagRequest(QString,bool)),
+  connect(this, &StyleFlagsModel::setFlagRequest,
+          styleModule, &StyleModule::onSetFlagRequest,
           Qt::QueuedConnection);
-  connect(styleModule,SIGNAL(flagSet(QString,bool)),
-          this,SLOT(onFlagSet(QString,bool)),
+  connect(styleModule, &StyleModule::flagSet,
+          this, &StyleFlagsModel::onFlagSet,
           Qt::QueuedConnection);
 
   emit styleFlagsRequested();

--- a/libosmscout-client-qt/src/osmscout/StyleModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/StyleModule.cpp
@@ -28,12 +28,12 @@ StyleModule::StyleModule(QThread *thread,DBThreadRef dbThread):
     dbThread(dbThread)
 {
 
-  connect(dbThread.get(), SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)),
-          this, SIGNAL(initialisationFinished(const DatabaseLoadedResponse&)));
-  connect(dbThread.get(), SIGNAL(stylesheetFilenameChanged()),
-          this, SIGNAL(stylesheetFilenameChanged()));
-  connect(dbThread.get(),SIGNAL(stylesheetFilenameChanged()),
-          this,SLOT(onStyleChanged()),
+  connect(dbThread.get(), &DBThread::initialisationFinished,
+          this, &StyleModule::initialisationFinished);
+  connect(dbThread.get(), &DBThread::stylesheetFilenameChanged,
+          this, &StyleModule::stylesheetFilenameChanged);
+  connect(dbThread.get(), &DBThread::stylesheetFilenameChanged,
+          this, &StyleModule::onStyleChanged,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapOverlay.cpp
@@ -49,15 +49,15 @@ void TileLoaderThread::init()
   QString tileCacheDirectory=OSMScoutQt::GetInstance().GetCacheLocation();
   tileDownloader = new OsmTileDownloader(tileCacheDirectory,provider);
 
-  connect(tileDownloader, SIGNAL(failed(uint32_t, uint32_t, uint32_t, bool)),
-          this, SLOT(tileDownloadFailed(uint32_t, uint32_t, uint32_t, bool)),
+  connect(tileDownloader, &OsmTileDownloader::failed,
+          this, &TileLoaderThread::tileDownloadFailed,
           Qt::QueuedConnection);
-  connect(tileDownloader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
-          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t, QImage, QByteArray)),
+  connect(tileDownloader, &OsmTileDownloader::downloaded,
+          this, &TileLoaderThread::tileDownloaded,
           Qt::QueuedConnection);
 
-  connect(&onlineTileCache,SIGNAL(tileRequested(uint32_t, uint32_t, uint32_t)),
-          this,SLOT(download(uint32_t, uint32_t, uint32_t)),
+  connect(&onlineTileCache, &TileCache::tileRequested,
+          this, &TileLoaderThread::download,
           Qt::QueuedConnection);
 }
 
@@ -135,16 +135,16 @@ TiledMapOverlay::TiledMapOverlay(QQuickItem* parent):
 
   loader=new TileLoaderThread(thread);
   loader->moveToThread(thread);
-  connect(thread, SIGNAL(started()),
-          loader, SLOT(init()));
+  connect(thread, &QThread::started,
+          loader, &TileLoaderThread::init);
   thread->start();
 
-  connect(this, SIGNAL(providerChanged(const OnlineTileProvider &)),
-          loader, SLOT(onProviderChanged(const OnlineTileProvider &)),
+  connect(this, &TiledMapOverlay::providerChanged,
+          loader, &TileLoaderThread::onProviderChanged,
           Qt::QueuedConnection);
 
-  connect(loader, SIGNAL(downloaded(uint32_t, uint32_t, uint32_t)),
-          this, SLOT(tileDownloaded(uint32_t, uint32_t, uint32_t)),
+  connect(loader, &TileLoaderThread::downloaded,
+          this, &TiledMapOverlay::tileDownloaded,
           Qt::QueuedConnection);
 }
 


### PR DESCRIPTION
Hi Tim. 

While I was reviewing this merge request: https://github.com/Karry/osmscout-sailfish/pull/136, I just found out that Qt 5 supports [new signal/slot connection syntax](https://wiki.qt.io/New_Signal_Slot_Syntax). It is not using macros that leads to string representation that is compared in runtime, but it is using function pointers that allows static check for signal/slots compatibility! I really like this syntax, so I updated (almost) all signals in client-qt library using it...