### PR TITLE
return result structure from GetClosestRoutableNode

### DIFF
--- a/Demos/src/Navigation.cpp
+++ b/Demos/src/Navigation.cpp
@@ -558,28 +558,29 @@ int main(int argc, char *argv[]){
             break;
     }
 
-    osmscout::RoutePosition start=router->GetClosestRoutableNode(osmscout::GeoCoord(startLat,startLon),
-                                                                 *routingProfile,
-                                                                 osmscout::Distance::Of<osmscout::Kilometer>(1));
-
-    if (!start.IsValid()) {
+    auto startResult=router->GetClosestRoutableNode(osmscout::GeoCoord(startLat,startLon),
+                                                    *routingProfile,
+                                                    osmscout::Kilometers(1));
+    if (!startResult.IsValid()) {
         std::cerr << "Error while searching for routing node near start location!" << std::endl;
         return 1;
     }
 
+    osmscout::RoutePosition start=startResult.GetRoutePosition();
     if (start.GetObjectFileRef().GetType()==osmscout::refNode) {
         std::cerr << "Cannot find start node for start location!" << std::endl;
     }
 
-    osmscout::RoutePosition target=router->GetClosestRoutableNode(osmscout::GeoCoord(targetLat,targetLon),
-                                                                  *routingProfile,
-                                                                  osmscout::Distance::Of<osmscout::Kilometer>(1));
+    auto targetResult=router->GetClosestRoutableNode(osmscout::GeoCoord(targetLat,targetLon),
+                                                     *routingProfile,
+                                                     osmscout::Kilometers(1));
 
-    if (!target.IsValid()) {
+    if (!targetResult.IsValid()) {
         std::cerr << "Error while searching for routing node near target location!" << std::endl;
         return 1;
     }
 
+    osmscout::RoutePosition target=targetResult.GetRoutePosition();
     if (target.GetObjectFileRef().GetType()==osmscout::refNode) {
         std::cerr << "Cannot find start node for target location!" << std::endl;
     }

--- a/Demos/src/NavigationSimulator.cpp
+++ b/Demos/src/NavigationSimulator.cpp
@@ -631,28 +631,30 @@ int main(int argc, char* argv[])
     break;
   }
 
-  osmscout::RoutePosition start=router->GetClosestRoutableNode(args.start,
+  auto startResult=router->GetClosestRoutableNode(args.start,
                                                                *routingProfile,
                                                                osmscout::Distance::Of<osmscout::Kilometer>(1));
 
-  if (!start.IsValid()) {
+  if (!startResult.IsValid()) {
     std::cerr << "Error while searching for routing node near start location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition start=startResult.GetRoutePosition();
   if (start.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for start location!" << std::endl;
   }
 
-  osmscout::RoutePosition target=router->GetClosestRoutableNode(args.target,
-                                                                *routingProfile,
-                                                                osmscout::Distance::Of<osmscout::Kilometer>(1));
+  auto targetResult=router->GetClosestRoutableNode(args.target,
+                                                   *routingProfile,
+                                                   osmscout::Distance::Of<osmscout::Kilometer>(1));
 
-  if (!target.IsValid()) {
+  if (!targetResult.IsValid()) {
     std::cerr << "Error while searching for routing node near target location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition target=targetResult.GetRoutePosition();
   if (target.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for target location!" << std::endl;
   }

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -683,28 +683,30 @@ int main(int argc, char* argv[])
     break;
   }
 
-  osmscout::RoutePosition start=router->GetClosestRoutableNode(args.start,
-                                                               *routingProfile,
-                                                               osmscout::Distance::Of<osmscout::Kilometer>(1));
+  auto startResult=router->GetClosestRoutableNode(args.start,
+                                                  *routingProfile,
+                                                  osmscout::Kilometers(1));
 
-  if (!start.IsValid()) {
+  if (!startResult.IsValid()) {
     std::cerr << "Error while searching for routing node near start location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition start=startResult.GetRoutePosition();
   if (start.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for start location!" << std::endl;
   }
 
-  osmscout::RoutePosition target=router->GetClosestRoutableNode(args.target,
-                                                               *routingProfile,
-                                                                osmscout::Distance::Of<osmscout::Kilometer>(1));
+  auto targetResult=router->GetClosestRoutableNode(args.target,
+                                                   *routingProfile,
+                                                   osmscout::Kilometers(1));
 
-  if (!target.IsValid()) {
+  if (!targetResult.IsValid()) {
     std::cerr << "Error while searching for routing node near target location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition target=targetResult.GetRoutePosition();
   if (target.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for target location!" << std::endl;
   }

--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -624,28 +624,30 @@ int main(int argc, char* argv[])
     break;
   }
 
-  osmscout::RoutePosition start=router->GetClosestRoutableNode(args.start,
-                                                               routingProfile,
-                                                               osmscout::Distance::Of<osmscout::Kilometer>(1));
+  auto startResult=router->GetClosestRoutableNode(args.start,
+                                                  routingProfile,
+                                                  osmscout::Distance::Of<osmscout::Kilometer>(1));
 
-  if (!start.IsValid()) {
+  if (!startResult.IsValid()) {
     std::cerr << "Error while searching for routing node near start location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition start=startResult.GetRoutePosition();
   if (start.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for start location!" << std::endl;
   }
 
-  osmscout::RoutePosition target=router->GetClosestRoutableNode(args.target,
-                                                                routingProfile,
-                                                                osmscout::Distance::Of<osmscout::Kilometer>(1));
+  auto targetResult=router->GetClosestRoutableNode(args.target,
+                                                   routingProfile,
+                                                   osmscout::Distance::Of<osmscout::Kilometer>(1));
 
-  if (!target.IsValid()) {
+  if (!targetResult.IsValid()) {
     std::cerr << "Error while searching for routing node near target location!" << std::endl;
     return 1;
   }
 
+  osmscout::RoutePosition target=targetResult.GetRoutePosition();
   if (target.GetObjectFileRef().GetType()==osmscout::refNode) {
     std::cerr << "Cannot find start node for target location!" << std::endl;
   }

--- a/Tests/src/MultiDBRouting.cpp
+++ b/Tests/src/MultiDBRouting.cpp
@@ -155,20 +155,22 @@ int main(int argc, char* argv[])
   std::cout << "Done." << std::endl;
 
   std::cout << "Retrieve routing node next to start..." << std::endl;
-  osmscout::RoutePosition startNode=router->GetClosestRoutableNode(args.start);
+  auto startResult=router->GetClosestRoutableNode(args.start);
 
-  if (!startNode.IsValid()){
+  if (!startResult.IsValid()){
     std::cerr << "Can't found route node near start coord " << args.start.GetDisplayText() << std::endl;
     return 1;
   }
+  osmscout::RoutePosition startNode=startResult.GetRoutePosition();
 
   std::cout << "Retrieve routing node next to target..." << std::endl;
-  osmscout::RoutePosition targetNode=router->GetClosestRoutableNode(args.target);
+  auto targetResult=router->GetClosestRoutableNode(args.target);
 
-  if (!targetNode.IsValid()){
+  if (!targetResult.IsValid()){
     std::cerr << "Can't found route node near target coord " << args.target.GetDisplayText() << std::endl;
     return 1;
   }
+  osmscout::RoutePosition targetNode=targetResult.GetRoutePosition();
 
   std::cout << "Calculate route..." << std::endl;
 

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -201,25 +201,27 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
                                  int requestId,
                                  const osmscout::BreakerRef &breaker)
 {
-  osmscout::RoutePosition startNode=routingService->GetClosestRoutableNode(
+  auto startResult=routingService->GetClosestRoutableNode(
                                 start->getCoord(),
-                                /*radius*/ Distance::Of<Kilometer>(1));
-  if (!startNode.IsValid()){
+                                /*radius*/ Kilometers(1));
+  if (!startResult.IsValid()){
     osmscout::log.Warn() << "Can't found route node near start coord " << start->getCoord().GetDisplayText();
     emit routeFailed(QString("Can't found route node near start coord %1").arg(QString::fromStdString(start->getCoord().GetDisplayText())),
                      requestId);
     return;
   }
+  osmscout::RoutePosition startNode=startResult.GetRoutePosition();
 
-  osmscout::RoutePosition targetNode=routingService->GetClosestRoutableNode(
+  auto targetResult=routingService->GetClosestRoutableNode(
                                 target->getCoord(),
-                                /*radius*/ Distance::Of<Kilometer>(1));
-  if (!targetNode.IsValid()){
+                                /*radius*/ Kilometers(1));
+  if (!targetResult.IsValid()){
     osmscout::log.Warn() << "Can't found route node near target coord " << target->getCoord().GetDisplayText();
     emit routeFailed(QString("Can't found route node near target coord %1").arg(QString::fromStdString(target->getCoord().GetDisplayText())),
                      requestId);
     return;
   }
+  osmscout::RoutePosition targetNode=targetResult.GetRoutePosition();
 
   osmscout::RouteData routeData;
   if (!CalculateRoute(routingService,

--- a/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
+++ b/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
@@ -126,8 +126,8 @@ namespace osmscout {
 
     void Close();
 
-    RoutePosition GetClosestRoutableNode(const GeoCoord &coord,
-                                         Distance radius=Distance::Of<Kilometer>(1)) const;
+    RoutePositionResult GetClosestRoutableNode(const GeoCoord &coord,
+                                               const Distance &radius=Kilometers(1)) const;
 
     RoutingResult CalculateRoute(const RoutePosition &start,
                                  const RoutePosition &target,

--- a/libosmscout/include/osmscout/routing/RoutingService.h
+++ b/libosmscout/include/osmscout/routing/RoutingService.h
@@ -95,6 +95,34 @@ namespace osmscout {
     }
   };
 
+  class OSMSCOUT_API RoutePositionResult CLASS_FINAL
+  {
+  private:
+    RoutePosition routePosition;
+    Distance distance;
+
+  public:
+    RoutePositionResult();
+
+    RoutePositionResult(const RoutePosition &routePosition, const Distance &distance);
+
+    inline RoutePosition GetRoutePosition() const
+    {
+      return routePosition;
+    }
+
+    inline Distance GetDistance() const
+    {
+      return distance;
+    }
+
+    inline bool IsValid() const
+    {
+      return routePosition.IsValid();
+    }
+  };
+
+
   /**
    * \ingroup Routing
    *

--- a/libosmscout/include/osmscout/routing/SimpleRoutingService.h
+++ b/libosmscout/include/osmscout/routing/SimpleRoutingService.h
@@ -200,9 +200,9 @@ namespace osmscout {
                                           const Distance &radius,
                                           const RoutingParameter& parameter);
 
-    RoutePosition GetClosestRoutableNode(const GeoCoord& coord,
-                                         const RoutingProfile& profile,
-                                         const Distance &radius) const;
+    RoutePositionResult GetClosestRoutableNode(const GeoCoord& coord,
+                                               const RoutingProfile& profile,
+                                               const Distance &radius) const;
 
     ClosestRoutableObjectResult GetClosestRoutableObject(const GeoCoord& location,
                                                          Vehicle vehicle,

--- a/libosmscout/src/osmscout/routing/RoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/RoutingService.cpp
@@ -37,6 +37,19 @@ namespace osmscout {
     // no code
   }
 
+  RoutePositionResult::RoutePositionResult()
+    : distance(Distance::Max())
+  {
+    // no code
+  }
+
+  RoutePositionResult::RoutePositionResult(const RoutePosition &routePosition, const Distance &distance)
+    : routePosition(routePosition),
+      distance(distance)
+  {
+    // no code
+  }
+
   RouterParameter::RouterParameter()
   : debugPerformance(false)
   {


### PR DESCRIPTION
This structure contains distance from lookup point beside RoutePosition.
Distance is necessary in multi-database variant (MultiDBRoutingService),
it was broken and provided invalid results near boundary of two databases.
Only first possible result was used, not the closest.

Btw, I plan to update `GetClosestRoutableNode` method in future to respect 
car bearing. Because router often calculate path to opposite direction 
in situations where is not possible turn around...