### PR TITLE
Use C locale for numbers in OpenStreetMap links

### DIFF
--- a/libosmscout/src/osmscout/util/HTMLWriter.cpp
+++ b/libosmscout/src/osmscout/util/HTMLWriter.cpp
@@ -21,6 +21,7 @@
 
 #include <osmscout/system/Assert.h>
 #include <osmscout/util/Logger.h>
+#include <locale>
 
 namespace osmscout {
 
@@ -312,25 +313,27 @@ namespace osmscout {
                                       const std::string& name)
   {
     try {
-      // TODO: Call WriteLink
+      std::stringstream url;
+      url.imbue(std::locale("C")); // number in link should be locale independent (without thousand delimiter)
 
-      file << "<a href=\"https://www.openstreetmap.org/";
+      url << "https://www.openstreetmap.org/";
 
       switch (object.GetType()) {
       case osmRefNone:
         assert(false);
       case osmRefNode:
-        file << "node";
+        url << "node";
         break;
       case osmRefWay:
-        file << "way";
+        url << "way";
         break;
       case osmRefRelation:
-        file << "relation";
+        url << "relation";
         break;
       }
 
-      file << "/" << std::to_string(object.GetId()) << "\">" << Sanitize(name) << "</a>";
+      url << "/" << std::to_string(object.GetId());
+      WriteLink(url.str(), name);
     }
     catch (std::ifstream::failure& e) {
       throw IOException(filename,"Cannot write object link",e);


### PR DESCRIPTION
Hi. When I am importing database on my computer with `LANG=cs_CZ.UTF-8`, it generates invalid links where are numbers with thousand delimiter. See http://osmscout.karry.cz/europe/czech-republic-10-20161203/way.html

This change should fix it.