### PR TITLE
fix crash in lookup module

### DIFF
--- a/libosmscout-client-qt/src/osmscout/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/LookupModule.cpp
@@ -121,7 +121,8 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                     "area",
                     a->GetObjectFileRef(),
                     ring.nodes,
-                    ring.GetBoundingBox().GetCenter(),
+                    // Master ring don't contains nodes! Use intersection of all outer rings instead
+                    (ring.nodes.empty() ? a->GetBoundingBox() : ring.GetBoundingBox()).GetCenter(),
                     &ring,
                     reverseLookupMap,
                     locationService,


### PR DESCRIPTION
Lookup module evaluates center of Area rings, but master ring
don't contains nodes. In that case, bounding box computation hits assert!

As a solution is used area center for master ring. It is computed
as center of intersection bounding boxes from all outer rings.