### PR TITLE
use build-in compiler macros as cppcheck include

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -372,4 +372,4 @@ endif
 
 run_target('cppcheck', command : ['scripts/cppcheck.sh',
   meson.build_root(),
-  '--project=' +join_paths(meson.build_root(),'compile_commands.json')])
+  join_paths(meson.build_root(),'compile_commands.json')])


### PR DESCRIPTION
Some libraries (like QT) needs build-in compiler macros
to detect architecture endianity, operating system type and other stufs.
Cppcheck pre-processor fails with these libraries,
see the issue https://trac.cppcheck.net/ticket/8956

To workaround that cppcheck wrapper script create header file with compiler macros
and use it as cppcheck include.