### PR TITLE
Fix area node index

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenAreaNodeIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenAreaNodeIndex.cpp
@@ -422,7 +422,9 @@ namespace osmscout {
     FileOffset previousOffset=0;
 
     for (const auto& tileEntry : tileData) {
-      //writer.WriteCoord(tileEntry.first);
+      if (storeGeoCoord) {
+        writer.WriteCoord(tileEntry.first);
+      }
       writer.WriteNumber(tileEntry.second-previousOffset);
 
       previousOffset=tileEntry.second;

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -52,6 +52,8 @@ namespace osmscout {
    */
   extern OSMSCOUT_API const double latConversionFactor;
 
+  constexpr uint32_t maxRawCoordValue = 0x7FFFFFF; // 134217727
+
   /**
    * \ingroup Util
    * Number of bytes needed to store a lat,lon coordinate pair.

--- a/libosmscout/include/osmscout/util/FileScanner.h
+++ b/libosmscout/include/osmscout/util/FileScanner.h
@@ -108,7 +108,9 @@ namespace osmscout {
     /**
      * Set coordinates using raw data from file.
      *
-     * Check if GeoCoord is normalised, throw IO exception otherwise
+     * When NDEBUG macro is not defined,
+     * check if GeoCoord is normalised,
+     * throw IO exception otherwise
      *
      * @param latDat raw latitude data
      * @param lonDat raw longitude data
@@ -118,11 +120,13 @@ namespace osmscout {
                          const uint32_t &lonDat,
                          GeoCoord &coord)
     {
+#ifndef NDEBUG
       if (latDat > maxRawCoordValue ||
           lonDat > maxRawCoordValue){
         hasError=true;
         throw IOException(filename,"Cannot read coordinate","Coordinate is not normalised");
       }
+#endif
 
       coord.Set(latDat/latConversionFactor-90.0,
                 lonDat/lonConversionFactor-180.0);
@@ -131,7 +135,9 @@ namespace osmscout {
     /**
      * Set coordinates using raw data from file.
      *
-     * Check if GeoCoord is normalised, throw IO exception otherwise
+     * When NDEBUG macro is not defined,
+     * check if GeoCoord is normalised,
+     * throw IO exception otherwise
      *
      * @param latDat raw latitude data
      * @param lonDat raw longitude data
@@ -141,11 +147,13 @@ namespace osmscout {
                          const uint32_t &lonDat,
                          Point &point)
     {
+#ifndef NDEBUG
       if (latDat > maxRawCoordValue ||
           lonDat > maxRawCoordValue){
         hasError=true;
         throw IOException(filename,"Cannot read coordinate","Coordinate is not normalised");
       }
+#endif
 
       point.SetCoord(GeoCoord(latDat/latConversionFactor-90.0,
                               lonDat/lonConversionFactor-180.0));
@@ -154,17 +162,21 @@ namespace osmscout {
     /**
      * Covert raw data to boolean
      *
-     * Check if value is normalised, throw IO exception otherwise
+     * When NDEBUG macro is not defined,
+     * check if value is normalised,
+     * throw IO exception otherwise
      *
      * @param value
      * @return boolean value
      */
     inline bool ConvertBool(const char &value)
     {
+#ifndef NDEBUG
       if (value != 0 && value != 1){
         hasError=true;
         throw IOException(filename,"Cannot read bool","Bool value is not normalised");
       }
+#endif
       return value!=0;
     }
 

--- a/libosmscout/include/osmscout/util/FileScanner.h
+++ b/libosmscout/include/osmscout/util/FileScanner.h
@@ -105,6 +105,69 @@ namespace osmscout {
      */
     char* ReadInternal(size_t bytes);
 
+    /**
+     * Set coordinates using raw data from file.
+     *
+     * Check if GeoCoord is normalised, throw IO exception otherwise
+     *
+     * @param latDat raw latitude data
+     * @param lonDat raw longitude data
+     * @param coord output
+     */
+    inline void SetCoord(const uint32_t &latDat,
+                         const uint32_t &lonDat,
+                         GeoCoord &coord)
+    {
+      if (latDat > maxRawCoordValue ||
+          lonDat > maxRawCoordValue){
+        hasError=true;
+        throw IOException(filename,"Cannot read coordinate","Coordinate is not normalised");
+      }
+
+      coord.Set(latDat/latConversionFactor-90.0,
+                lonDat/lonConversionFactor-180.0);
+    }
+
+    /**
+     * Set coordinates using raw data from file.
+     *
+     * Check if GeoCoord is normalised, throw IO exception otherwise
+     *
+     * @param latDat raw latitude data
+     * @param lonDat raw longitude data
+     * @param coord output
+     */
+    inline void SetCoord(const uint32_t &latDat,
+                         const uint32_t &lonDat,
+                         Point &point)
+    {
+      if (latDat > maxRawCoordValue ||
+          lonDat > maxRawCoordValue){
+        hasError=true;
+        throw IOException(filename,"Cannot read coordinate","Coordinate is not normalised");
+      }
+
+      point.SetCoord(GeoCoord(latDat/latConversionFactor-90.0,
+                              lonDat/lonConversionFactor-180.0));
+    }
+
+    /**
+     * Covert raw data to boolean
+     *
+     * Check if value is normalised, throw IO exception otherwise
+     *
+     * @param value
+     * @return boolean value
+     */
+    inline bool ConvertBool(const char &value)
+    {
+      if (value != 0 && value != 1){
+        hasError=true;
+        throw IOException(filename,"Cannot read bool","Bool value is not normalised");
+      }
+      return value!=0;
+    }
+
   public:
     FileScanner();
     virtual ~FileScanner();

--- a/libosmscout/src/osmscout/GeoCoord.cpp
+++ b/libosmscout/src/osmscout/GeoCoord.cpp
@@ -26,8 +26,8 @@
 
 namespace osmscout {
 
-  const double latConversionFactor=134217727.0/180.0; // 27 Bit
-  const double lonConversionFactor=134217727.0/360.0; // 27 Bit
+  const double latConversionFactor=(double)maxRawCoordValue/180.0; // 27 Bit
+  const double lonConversionFactor=(double)maxRawCoordValue/360.0; // 27 Bit
 
   Id GeoCoord::GetId() const
   {

--- a/libosmscout/src/osmscout/util/FileScanner.cpp
+++ b/libosmscout/src/osmscout/util/FileScanner.cpp
@@ -552,6 +552,8 @@ namespace osmscout {
       throw IOException(filename,"Cannot read bool","File already in error state");
     }
 
+    char value;
+
 #if defined(HAVE_MMAP) || defined(_WIN32)
     if (buffer!=nullptr) {
       if (offset>=size) {
@@ -559,7 +561,8 @@ namespace osmscout {
         throw IOException(filename,"Cannot read bool","Cannot read beyond end of file");
       }
 
-      boolean=buffer[offset]!=0;
+      value=buffer[offset];
+      boolean=ConvertBool(value);
 
       offset++;
 
@@ -567,15 +570,13 @@ namespace osmscout {
     }
 #endif
 
-    char value;
-
     hasError=fread(&value,1,1,file)!=1;
 
     if (hasError) {
       throw IOException(filename,"Cannot read bool");
     }
 
-    boolean=value!=0;
+    boolean=ConvertBool(value);
   }
 
   void FileScanner::Read(int8_t& number)
@@ -2112,9 +2113,7 @@ namespace osmscout {
 
       offset+=coordByteSize;
 
-      coord.Set(latDat/latConversionFactor-90.0,
-                lonDat/lonConversionFactor-180.0);
-
+      SetCoord(latDat, lonDat, coord);
       return;
     }
 #endif
@@ -2137,8 +2136,7 @@ namespace osmscout {
            | (buffer[5] << 16)
            | ((buffer[6] & 0xf0) << 20);
 
-    coord.Set(latDat/latConversionFactor-90.0,
-              lonDat/lonConversionFactor-180.0);
+    SetCoord(latDat, lonDat, coord);
   }
 
   void FileScanner::ReadConditionalCoord(GeoCoord& coord,
@@ -2178,8 +2176,7 @@ namespace osmscout {
         isSet=false;
       }
       else  {
-        coord.Set(latDat/latConversionFactor-90.0,
-                  lonDat/lonConversionFactor-180.0);
+        SetCoord(latDat, lonDat, coord);
         isSet=true;
       }
 
@@ -2210,8 +2207,7 @@ namespace osmscout {
       isSet=false;
     }
     else  {
-      coord.Set(latDat/latConversionFactor-90.0,
-                lonDat/lonConversionFactor-180.0);
+      SetCoord(latDat, lonDat, coord);
       isSet=true;
     }
   }
@@ -2326,8 +2322,7 @@ namespace osmscout {
         latValue+=latDelta;
         lonValue+=lonDelta;
 
-        nodes[currentCoordPos].SetCoord(GeoCoord(latValue/latConversionFactor-90.0,
-                                                 lonValue/lonConversionFactor-180.0));
+        SetCoord(latValue,lonValue,nodes[currentCoordPos]);
 
         currentCoordPos++;
       }
@@ -2359,8 +2354,7 @@ namespace osmscout {
 
         lonValue+=lonDelta;
 
-        nodes[currentCoordPos].SetCoord(GeoCoord(latValue/latConversionFactor-90.0,
-                                                 lonValue/lonConversionFactor-180.0));
+        SetCoord(latValue,lonValue,nodes[currentCoordPos]);
 
         currentCoordPos++;
       }
@@ -2392,10 +2386,7 @@ namespace osmscout {
 
         lonValue+=lonDelta;
 
-        //setCoord(currentCoordPos, latValue, lonValue);
-        nodes[currentCoordPos].SetCoord(GeoCoord(latValue/latConversionFactor-90.0,
-                                                 lonValue/lonConversionFactor-180.0));
-
+        SetCoord(latValue,lonValue,nodes[currentCoordPos]);
 
         currentCoordPos++;
       }

--- a/libosmscout/src/osmscout/util/FileWriter.cpp
+++ b/libosmscout/src/osmscout/util/FileWriter.cpp
@@ -724,6 +724,12 @@ namespace osmscout {
     if (HasError()) {
       throw IOException(filename,"Cannot write coordinate","File already in error state");
     }
+    if (coord.GetLat() > 90 ||
+        coord.GetLat() < -90 ||
+        coord.GetLon() > 180 ||
+        coord.GetLon() < -180){
+      throw IOException(filename,"Cannot write coordinate","Coordinate is not normalised");
+    }
 
     uint32_t latValue=(uint32_t)round((coord.GetLat()+90.0)*latConversionFactor);
     uint32_t lonValue=(uint32_t)round((coord.GetLon()+180.0)*lonConversionFactor);


### PR DESCRIPTION
Hi Tim. 

I found out that many towns in Czechia disappear from the map. When I was investigating the issue, found a bug in area node index - It expects that tile contains node coordinates in some conditions. But these coordinates was never written to file. As a result, file scanner read garbage. Fix was simple, just write coordinates (in `GenAreaNodeIndex`) when `storeGeoCoord` flag is set. 

To found these bugs early, I added additional validity checks for GeoCoord and boolean to file scanner to make sure that it don't read total garbage from position where is stored different data type. I hope that these checks don't affect performance too much. I made it similar to standard asserts, just disable it when NDEBUB macro is defined to get maximum performance. Or do you have better idea howto check sanity of read data? It would be great to have unittests for all data files that would check compatibility of importer and reader, but it would be huge amount of work :-/