### PR TITLE
allow http(s) redirects

### DIFF
--- a/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
@@ -205,7 +205,7 @@ signals:
   void loadingChanged();
 
 public slots:
-  void listDownloaded(QNetworkReply*);
+  void listDownloaded(const MapProvider &provider, QNetworkReply*);
   void reload();
 
 public:
@@ -250,7 +250,7 @@ public:
    Q_INVOKABLE QObject* mapByPath(QStringList path);
 
   inline bool isLoading(){
-    return !requests.isEmpty();
+    return requests>0;
   }
 
   inline QString getFetchError(){
@@ -264,7 +264,7 @@ private:
   QNetworkAccessManager     webCtrl; 
   QNetworkDiskCache         diskCache;
   QList<MapProvider>        mapProviders;
-  QHash<QUrl,MapProvider>   requests;
+  size_t                    requests{0};
   QList<AvailableMapsModelItem*> items;
   QString                   fetchError;
 };

--- a/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
@@ -55,12 +55,11 @@ signals:
   void failed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange);
 
 private slots:
-  void fileDownloaded(QNetworkReply* pReply);
+  void fileDownloaded(const TileCacheKey &key, QNetworkReply *reply);
  
 private:
   int                       serverNumber;
   QNetworkAccessManager     webCtrl;
-  QHash<QUrl,TileCacheKey>  requests;
   QNetworkDiskCache         diskCache;
   OnlineTileProvider        tileProvider;
 

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -123,6 +123,7 @@ void FileDownloader::startDownload()
   QNetworkRequest request(m_url);
   request.setHeader(QNetworkRequest::UserAgentHeader,
                     OSMScoutQt::GetInstance().GetUserAgent());
+  request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 
   if (m_downloaded > 0)
     {


### PR DESCRIPTION
Request url cannot be compared with the response url anymore,
because when request is redirected, final url may be different.
To solve this, finish signal is connected to lambda that provides
pairing responses to requests via captured variables.