### PR TITLE
make NaN as valid bearing

### DIFF
--- a/Tests/src/Bearing.cpp
+++ b/Tests/src/Bearing.cpp
@@ -26,6 +26,16 @@ TEST_CASE("Normalise") {
   REQUIRE(bearing.AsDegrees()==270);
 }
 
+TEST_CASE("NaN") {
+  auto nan=osmscout::Bearing::Radians(NAN);
+  REQUIRE(nan.DisplayString() == "?");
+  REQUIRE(nan.LongDisplayString() == "?");
+
+  auto inf=osmscout::Bearing::Radians(INFINITY);
+  REQUIRE(inf.DisplayString() == "?");
+  REQUIRE(inf.LongDisplayString() == "?");
+}
+
 TEST_CASE("North") {
   osmscout::GeoCoord a(-1.0,0.0);
   osmscout::GeoCoord b(1.0,0.0);

--- a/libosmscout/src/osmscout/util/Bearing.cpp
+++ b/libosmscout/src/osmscout/util/Bearing.cpp
@@ -34,7 +34,7 @@ namespace osmscout {
 
   std::string Bearing::DisplayString() const
   {
-    int grad=(int)round(AsDegrees());
+    double grad=round(AsDegrees());
 
     if (grad>=0 && grad<=45) {
       return "N";
@@ -50,6 +50,9 @@ namespace osmscout {
     }
     else if (grad>315 && grad<=360) {
       return "N";
+    }
+    else if (std::isnan(grad)){
+      return "?";
     }
 
     assert(false);
@@ -86,6 +89,9 @@ namespace osmscout {
     }
     else if (grad>327.5 && grad<=360) {
       return "N";
+    }
+    else if (std::isnan(grad)){
+      return "?";
     }
 
     assert(false);


### PR DESCRIPTION
As reported here: https://github.com/Karry/osmscout-sailfish/issues/159 QML sometimes provides NaN values in location. To avoid similar crashed in the future, allow this bearing value.