### PR TITLE
Node index mutex

### DIFF
--- a/libosmscout/include/osmscout/AreaNodeIndex.h
+++ b/libosmscout/include/osmscout/AreaNodeIndex.h
@@ -74,7 +74,8 @@ namespace osmscout {
 
   private:
     std::string           datafilename;   //!< Full path and name of the data file
-    mutable FileScanner   scanner;        //!< Scanner instance for reading this file
+    mutable FileScanner   scanner;        //!< Scanner instance for reading this file,
+                                          //!< guarded by lookupMutex (Open and Close method are not guarded!)
 
     MagnificationLevel    gridMag;
     std::vector<TypeData> nodeTypeData;

--- a/libosmscout/include/osmscout/AreaNodeIndex.h
+++ b/libosmscout/include/osmscout/AreaNodeIndex.h
@@ -73,7 +73,6 @@ namespace osmscout {
     };
 
   private:
-    std::string           datafilename;   //!< Full path and name of the data file
     mutable FileScanner   scanner;        //!< Scanner instance for reading this file,
                                           //!< guarded by lookupMutex (Open and Close method are not guarded!)
 
@@ -109,7 +108,7 @@ namespace osmscout {
 
     inline std::string GetFilename() const
     {
-      return datafilename;
+      return scanner.GetFilename();
     }
 
     bool GetOffsets(const GeoBox& boundingBox,

--- a/libosmscout/src/osmscout/AreaNodeIndex.cpp
+++ b/libosmscout/src/osmscout/AreaNodeIndex.cpp
@@ -55,7 +55,7 @@ namespace osmscout {
   bool AreaNodeIndex::Open(const std::string& path,
                            bool memoryMappedData)
   {
-    datafilename=AppendFileToDir(path,AREA_NODE_IDX);
+    std::string datafilename=AppendFileToDir(path,AREA_NODE_IDX);
 
     try {
       scanner.Open(datafilename,

--- a/libosmscout/src/osmscout/AreaNodeIndex.cpp
+++ b/libosmscout/src/osmscout/AreaNodeIndex.cpp
@@ -165,6 +165,8 @@ namespace osmscout {
                                      const GeoBox& boundingBox,
                                      std::vector<FileOffset>& offsets) const
   {
+    std::lock_guard<std::mutex> guard(lookupMutex);
+
     scanner.SetPos(typeData.indexOffset);
 
     FileOffset previousOffset=0;
@@ -192,6 +194,8 @@ namespace osmscout {
                                          const GeoBox& boundingBox,
                                          std::vector<FileOffset>& offsets) const
   {
+    std::lock_guard<std::mutex> guard(lookupMutex);
+
     TileIdBox tileBox(TileId::GetTile(gridMag,boundingBox.GetMinCoord()),
                       TileId::GetTile(gridMag,boundingBox.GetMaxCoord()));
 


### PR DESCRIPTION
Hi. 

I was investigating weird coredump and only explanation was race condition during reading node area index... It seems that some code blocks that modifies scanner state are not guarded by mutex!