### PR TITLE
File downloader cleanup

### DIFF
--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -78,6 +78,7 @@ private:
   QFile file;
 
   bool isOk{true};
+  bool finishedSuccessfully{false};
 
   uint64_t downloaded{0};
 

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -39,20 +39,16 @@ namespace osmscout {
 ///
 /// Downloads a file as specified by URL and stores in a given path.
 /// If the required directories do not exist, creates all parent directories
-/// as needed. If specified that the format is BZ2, the downloader pipes
-/// the internet stream through a process running bunzip2.
+/// as needed.
 class OSMSCOUT_CLIENT_QT_API FileDownloader : public QObject
 {
   Q_OBJECT
 
-public:
-  enum Type { Plain=0, BZ2=1 };
 
 public:
   explicit FileDownloader(QNetworkAccessManager *manager,
                           QString url,
                           QString path,
-                          const Type mode = Plain,
                           QObject *parent = 0);
   ~FileDownloader();
 
@@ -75,15 +71,7 @@ protected slots:
   void onDownloaded();
   void onNetworkError(QNetworkReply::NetworkError code);
 
-  void onProcessStarted();
-  void onProcessRead();
-  void onProcessStopped(int exitCode); ///< Called on error while starting or when process has stopped
-  void onBytesWritten(qint64);
-
 protected:
-  void onProcessStateChanged(QProcess::ProcessState newState); ///< Called when state of the process has changed
-  void onProcessReadError();
-
   void onFinished();
   void onError(const QString &err);
 
@@ -98,26 +86,11 @@ protected:
 
   QNetworkReply *reply{nullptr};
 
-  QProcess *process{nullptr};
-  bool processStarted{false};
-
   QFile file;
 
-  bool pipeToProcess{false};
   bool isOk{true};
 
-  QByteArray cacheSafe;
-  QByteArray cacheCurrent;
-  bool clearAllCaches{false};
-  bool pauseNetworkIo{false};
-
   uint64_t downloaded{0};
-  uint64_t written{0};
-  uint64_t downloadedGui{0};
-
-  uint64_t downloadThrottleBytes{0};
-  QTime downloadThrottleTimeStart;
-  double downloadThrottleMaxSpeed{0};
 
   uint64_t downloadedLastError{0};
   size_t downloadRetries{0};
@@ -127,12 +100,7 @@ protected:
   const size_t maxDownloadRetries{5};          ///< Maximal number of download retries before cancelling download
   const double downloadRetrySleepTime{30.0};  ///< Time between retries in seconds
 
-  const qint64 cacheSizeBeforeSwap{1024*1024*1}; ///< Size at which cache is promoted from network to file/process
-  const qint64 bufferSizeIO{1024*1024*3};         ///< Size of the buffers that should not be significantly exceeded
   const qint64 bufferNetwork{1024*1024*1};         ///< Size of network ring buffer
-
-  /// \brief Factor determining whether cancel download when network buffer is too large
-  const qint64 bufferNetworkMaxFactorBeforeCancel{10};
 
   const int downloadTimeout{60};                ///< Download timeout in seconds
 };

--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -56,9 +56,9 @@ public:
                           QObject *parent = 0);
   ~FileDownloader();
 
-  operator bool() const { return m_isok; }
-  QString getFileName() const { return QFileInfo(m_path).fileName(); }
-  QString getFilePath() const { return m_path; }
+  operator bool() const { return isOk; }
+  QString getFileName() const { return QFileInfo(path).fileName(); }
+  QString getFilePath() const { return path; }
   uint64_t getBytesDownloaded() const;
 
 signals:
@@ -92,49 +92,49 @@ protected:
   virtual void timerEvent(QTimerEvent *event);
 
 protected:
-  QNetworkAccessManager *m_manager;
-  QUrl m_url;
-  QString m_path;
+  QNetworkAccessManager *manager;
+  QUrl url;
+  QString path;
 
-  QNetworkReply *m_reply{nullptr};
+  QNetworkReply *reply{nullptr};
 
-  QProcess *m_process{nullptr};
-  bool m_process_started{false};
+  QProcess *process{nullptr};
+  bool processStarted{false};
 
-  QFile m_file;
+  QFile file;
 
-  bool m_pipe_to_process{false};
-  bool m_isok{true};
+  bool pipeToProcess{false};
+  bool isOk{true};
 
-  QByteArray m_cache_safe;
-  QByteArray m_cache_current;
-  bool m_clear_all_caches{false};
-  bool m_pause_network_io{false};
+  QByteArray cacheSafe;
+  QByteArray cacheCurrent;
+  bool clearAllCaches{false};
+  bool pauseNetworkIo{false};
 
-  uint64_t m_downloaded{0};
-  uint64_t m_written{0};
-  uint64_t m_downloaded_gui{0};
+  uint64_t downloaded{0};
+  uint64_t written{0};
+  uint64_t downloadedGui{0};
 
-  uint64_t m_download_throttle_bytes{0};
-  QTime m_download_throttle_time_start;
-  double m_download_throttle_max_speed{0};
+  uint64_t downloadThrottleBytes{0};
+  QTime downloadThrottleTimeStart;
+  double downloadThrottleMaxSpeed{0};
 
-  uint64_t m_downloaded_last_error{0};
-  size_t m_download_retries{0};
-  QTime m_download_last_read_time;
-  int m_timeout_timer_id{-1};
+  uint64_t downloadedLastError{0};
+  size_t downloadRetries{0};
+  QTime downloadLastReadTime;
+  int timeoutTimerId{-1};
 
-  const size_t const_max_download_retries{5};          ///< Maximal number of download retries before cancelling download
-  const double const_download_retry_sleep_time{30.0};  ///< Time between retries in seconds
+  const size_t maxDownloadRetries{5};          ///< Maximal number of download retries before cancelling download
+  const double downloadRetrySleepTime{30.0};  ///< Time between retries in seconds
 
-  const qint64 const_cache_size_before_swap{1024*1024*1}; ///< Size at which cache is promoted from network to file/process
-  const qint64 const_buffer_size_io{1024*1024*3};         ///< Size of the buffers that should not be significantly exceeded
-  const qint64 const_buffer_network{1024*1024*1};         ///< Size of network ring buffer
+  const qint64 cacheSizeBeforeSwap{1024*1024*1}; ///< Size at which cache is promoted from network to file/process
+  const qint64 bufferSizeIO{1024*1024*3};         ///< Size of the buffers that should not be significantly exceeded
+  const qint64 bufferNetwork{1024*1024*1};         ///< Size of network ring buffer
 
   /// \brief Factor determining whether cancel download when network buffer is too large
-  const qint64 const_buffer_network_max_factor_before_cancel{10};
+  const qint64 bufferNetworkMaxFactorBeforeCancel{10};
 
-  const int const_download_timeout{60};                ///< Download timeout in seconds
+  const int downloadTimeout{60};                ///< Download timeout in seconds
 };
 
 }

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -81,7 +81,7 @@ FileDownloader::~FileDownloader()
   if (reply) {
     reply->deleteLater();
   }
-  if (file.exists()) {
+  if (file.exists() && !finishedSuccessfully) {
     file.close();
     file.remove();
   }
@@ -127,7 +127,7 @@ void FileDownloader::onFinished()
   }
 
   qDebug() << "Downloaded" << downloaded << "bytes";
-  file.rename(path);
+  finishedSuccessfully = file.rename(path);
 
   if (reply) {
     reply->deleteLater();

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -35,7 +35,6 @@ namespace osmscout {
 
 FileDownloader::FileDownloader(QNetworkAccessManager *manager,
                                QString urlStr, QString path,
-                               const Type mode,
                                QObject *parent):
   QObject(parent),
   manager(manager),
@@ -61,59 +60,13 @@ FileDownloader::FileDownloader(QNetworkAccessManager *manager,
     return;
   }
 
-  connect(&file, &QFile::bytesWritten,
-          this, &FileDownloader::onBytesWritten);
-
-  // start data processor if requested
-  QString command;
-  QStringList arguments;
-  if (mode == BZ2) {
-    command = "bunzip2";
-    arguments << "-c";
-  } else if (mode == Plain) {
-    // nothing to do
-  } else {
-    std::cerr << "FileDownloader: unknown mode: " << mode << std::endl;
-    isOk = false;
-    return;
-  }
-
-  if (!command.isEmpty()) {
-    pipeToProcess = true;
-    process = new QProcess(this);
-
-    connect( process, &QProcess::started,
-             this, &FileDownloader::onProcessStarted );
-
-    connect( process, SIGNAL(finished(int)),
-             this, SLOT(onProcessStopped(int)) );
-
-    connect( process, &QProcess::stateChanged,
-             this, &FileDownloader::onProcessStateChanged);
-
-    connect( process, &QProcess::readyReadStandardOutput,
-             this, &FileDownloader::onProcessRead);
-
-    connect( process, &QProcess::readyReadStandardError,
-             this, &FileDownloader::onProcessReadError);
-
-    connect( process, &QProcess::bytesWritten,
-             this, &FileDownloader::onBytesWritten);
-
-    process->start(command, arguments);
-  }
-
   downloadLastReadTime.start();
-  downloadThrottleTimeStart.start();
 }
 
 FileDownloader::~FileDownloader()
 {
   if (reply) {
     reply->deleteLater();
-  }
-  if (process) {
-    process->deleteLater();
   }
 }
 
@@ -125,12 +78,11 @@ void FileDownloader::startDownload()
                     OSMScoutQt::GetInstance().GetUserAgent());
   request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 
-  if (downloaded > 0)
-    {
-      // TODO: Range header don't have to be supported by server, we should handle such case
-      QByteArray range_header = "bytes=" + QByteArray::number((qulonglong)downloaded) + "-";
-      request.setRawHeader("Range",range_header);
-    }
+  if (downloaded > 0) {
+    // TODO: Range header don't have to be supported by server, we should handle such case
+    QByteArray range_header = "bytes=" + QByteArray::number((qulonglong)downloaded) + "-";
+    request.setRawHeader("Range",range_header);
+  }
 
   reply = manager->get(request);
   reply->setReadBufferSize(bufferNetwork);
@@ -143,10 +95,8 @@ void FileDownloader::startDownload()
           this, SLOT(onNetworkError(QNetworkReply::NetworkError)));
 
   downloadLastReadTime.restart();
-  downloadThrottleTimeStart.restart();
-  downloadThrottleBytes = 0;
 
-  timeoutTimerId=startTimer(1000); // used to check for timeouts and in throttling network speed
+  timeoutTimerId=startTimer(1000); // used to check for timeouts
 }
 
 void FileDownloader::onFinished()
@@ -161,11 +111,6 @@ void FileDownloader::onFinished()
 
   file.rename(path);
 
-  if (process) {
-    process->deleteLater();
-    process = nullptr;
-  }
-
   if (reply) {
     reply->deleteLater();
     reply = nullptr;
@@ -179,17 +124,10 @@ void FileDownloader::onError(const QString &err)
   file.close();
   file.remove();
 
-  if (process)
-    {
-      process->deleteLater();
-      process = nullptr;
-    }
-
-  if (reply)
-    {
-      reply->deleteLater();
-      reply = nullptr;
-    }
+  if (reply){
+    reply->deleteLater();
+    reply = nullptr;
+  }
 
   isOk = false;
   emit error(err, false);
@@ -199,95 +137,20 @@ void FileDownloader::onNetworkReadyRead()
 {
   downloadLastReadTime.restart();
 
-  if (!reply ||
-      (pipeToProcess && !processStarted) ) {
-    // too early, haven't started yet
-    return;
-  }
+  assert(reply);
 
-  double speed = downloadThrottleBytes /
-      (downloadThrottleTimeStart.elapsed() * 1e-3) / 1024.0;
+  QByteArray chunk = reply->readAll();
+  downloaded += chunk.size();
 
-  //  qDebug() << "Buffers: "
-  //           << m_reply->bytesAvailable() << " [network] / "
-  //           << m_reply->readBufferSize() << " [network max] / "
-  //           << (m_pipe_to_process ? m_process->bytesToWrite() : -1)
-  //           << " [process] / " << m_file.bytesToWrite() << " [file]; "
-  //           << "speed [kb/s]: " << speed
-  //           << " / clear: " << m_clear_all_caches;
+  emit downloadedBytes(downloaded);
 
-  // check if the network has to be throttled due to excessive
-  // non-writen buffers. check is skipped on the last read called
-  // with m_clear_all_caches
-  if (!clearAllCaches) {
-    /// It seems that sometimes Qt heavily overshoots the requested network buffer size. In
-    /// particular it has been usual for the first download from start of the server. On the second try,
-    /// it's usually OK (seen on SFOS 2.0 series)
-    if ( reply->bytesAvailable() > bufferNetworkMaxFactorBeforeCancel*bufferNetwork ) {
-      restartDownload(true);
-      return;
-    }
-
-    if ( (pipeToProcess && process->bytesToWrite() > bufferSizeIO) ||
-         (file.bytesToWrite() > bufferSizeIO) ) {
-      pauseNetworkIo = true;
-      return;
-    }
-
-    // check if requested speed has been exceeded
-    if (downloadThrottleMaxSpeed > 0) {
-      if (speed > downloadThrottleMaxSpeed) {
-        //              qDebug() << "Going too fast: " << speed;
-        pauseNetworkIo = true;
-        return;
-      }
-    }
-  }
-
-  pauseNetworkIo = false;
-
-  QByteArray data_current;
-  if (clearAllCaches) {
-    data_current = reply->readAll();
-  } else {
-    data_current = reply->read( std::min(cacheSizeBeforeSwap, bufferNetwork) );
-  }
-
-  cacheCurrent.append(data_current);
-  downloadedGui += data_current.size();
-  downloadThrottleBytes += data_current.size();
-
-  emit downloadedBytes(downloadedGui);
-
-  // check if caches are full or whether they have to be
-  // filled before writing to file/process
-  if (!clearAllCaches && cacheCurrent.size() < cacheSizeBeforeSwap) {
-    return;
-  }
-
-  QByteArray data(cacheSafe);
-  if (clearAllCaches) {
-    data.append(cacheCurrent);
-    cacheCurrent.clear();
-    cacheSafe.clear();
-  } else {
-    cacheSafe = cacheCurrent;
-    cacheCurrent.clear();
-  }
-
-  downloaded += data.size();
-
-  if (pipeToProcess) {
-    process->write(data);
-  } else {
-    file.write(data);
-    emit writtenBytes(downloaded);
-  }
+  file.write(chunk);
+  emit writtenBytes(downloaded);
 }
 
 uint64_t FileDownloader::getBytesDownloaded() const
 {
-  return downloadedGui;
+  return downloaded;
 }
 
 void FileDownloader::onDownloaded()
@@ -300,25 +163,14 @@ void FileDownloader::onDownloaded()
     return;
   }
 
-  if (pipeToProcess && !processStarted) {
-    return;
-  }
-
-  clearAllCaches = true;
   onNetworkReadyRead(); // update all data if needed
-
-  if (pipeToProcess && process) {
-    process->closeWriteChannel();
-  }
 
   if (reply) {
     reply->deleteLater();
   }
   reply = nullptr;
 
-  if (!pipeToProcess) {
-    onFinished();
-  }
+  onFinished();
 }
 
 bool FileDownloader::restartDownload(bool force)
@@ -336,8 +188,7 @@ bool FileDownloader::restartDownload(bool force)
   if (reply &&
       downloadRetries < maxDownloadRetries &&
       (downloaded > 0 || force) ) {
-    cacheSafe.clear();
-    cacheCurrent.clear();
+
     reply->deleteLater();
     reply = nullptr;
 
@@ -345,7 +196,7 @@ bool FileDownloader::restartDownload(bool force)
                        this, SLOT(startDownload()));
 
     downloadRetries++;
-    downloadedGui = downloaded;
+    downloaded = downloaded;
     downloadedLastError = downloaded;
     downloadLastReadTime.restart();
 
@@ -369,81 +220,14 @@ void FileDownloader::onNetworkError(QNetworkReply::NetworkError /*code*/)
 
 void FileDownloader::timerEvent(QTimerEvent * /*event*/)
 {
-  if (pauseNetworkIo) {
-    onNetworkReadyRead();
-  }
 
   if (downloadLastReadTime.elapsed()*1e-3 > downloadTimeout) {
     if (restartDownload()){
       emit error("Timeout", true);
       return;
-    };
+    }
     onError("Timeout");
   }
 }
 
-void FileDownloader::onBytesWritten(qint64)
-{
-  if (pauseNetworkIo) {
-    onNetworkReadyRead();
-  }
-}
-
-void FileDownloader::onProcessStarted()
-{
-  processStarted = true;
-  onNetworkReadyRead(); // pipe all data in that has been collected already
-}
-
-void FileDownloader::onProcessRead()
-{
-  downloadLastReadTime.restart();
-
-  if (!process) {
-    return;
-  }
-
-  QByteArray data = process->readAllStandardOutput();
-  file.write(data);
-  written += data.size();
-  emit writtenBytes(written);
-}
-
-void FileDownloader::onProcessStopped(int exitCode)
-{
-  if (exitCode != 0){
-    QString err = osmscout::FileDownloader::tr("Error in processing downloaded data");
-    isOk = false;
-    emit error(err, false);
-    return;
-  }
-
-  if (!process){
-    return;
-  }
-
-  onProcessRead();
-  onFinished();
-}
-
-void FileDownloader::onProcessReadError()
-{
-  if (!process){
-    // should not happen
-    return;
-  }
-
-  QByteArray data = process->readAllStandardError();
-  if (data.size() > 0){
-    onError("Error in processing downloaded data");
-  }
-}
-
-void FileDownloader::onProcessStateChanged(QProcess::ProcessState state)
-{
-  if ( !processStarted && state == QProcess::NotRunning ) {
-    QString err = osmscout::FileDownloader::tr("Error in processing downloaded data: could not start the program") + " " + process->program();
-    onError(err);
-  }
-}
 }


### PR DESCRIPTION
Hi. 

I found some strange results with map downloader. For example downloaded file that was bigger on the device than on the server and was leading to crashes... I was not able to reproduce this, but for simpler debugging, I decided to simplify FileDownloader class. I removed support for on-the-fly decompression, that is not used in libosmscout and rewrite downloading restart after error - now it is using exponential backoff...