### PR TITLE
Downloader write errors

### DIFF
--- a/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
@@ -129,7 +129,7 @@ class OSMSCOUT_CLIENT_QT_API AvailableMapsModelMap : public AvailableMapsModelIt
 
 private:
   MapProvider provider;
-  size_t size{0};
+  uint64_t size{0};
   QString serverDirectory;
   QDateTime creation;
   int version{-1};
@@ -138,7 +138,7 @@ public:
   inline AvailableMapsModelMap():AvailableMapsModelItem(){};
 
   inline AvailableMapsModelMap(QString name, QList<QString> path, QString description, MapProvider provider,
-                               size_t size, QString serverDirectory, QDateTime creation, int version):
+                               uint64_t size, QString serverDirectory, QDateTime creation, int version):
     AvailableMapsModelItem(name, path, description), provider(provider), size(size), serverDirectory(serverDirectory), 
     creation(creation), version(version) {};
 

--- a/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
@@ -121,7 +121,7 @@ public:
 class OSMSCOUT_CLIENT_QT_API AvailableMapsModelMap : public AvailableMapsModelItem {
   Q_OBJECT
 
-  Q_PROPERTY(qint64 byteSize READ getSize())
+  Q_PROPERTY(quint64 byteSize READ getSize())
   Q_PROPERTY(QString size READ getSizeHuman())
   Q_PROPERTY(QString serverDirectory READ getServerDirectory())
   Q_PROPERTY(QDateTime time READ getCreation())
@@ -165,7 +165,7 @@ public:
   }
 
   MapProvider getProvider() const;
-  size_t getSize() const;
+  uint64_t getSize() const;
   QString getSizeHuman() const;
   QString getServerDirectory() const;
   QDateTime getCreation() const;

--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -109,6 +109,11 @@ public:
     return done;
   }
 
+  inline bool isSuccessful() const
+  {
+    return successful;
+  }
+
   inline bool isDownloading() const
   {
     return started && !done;

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -33,7 +33,7 @@ MapProvider AvailableMapsModelMap::getProvider() const
   return provider;
 }
 
-size_t AvailableMapsModelMap::getSize() const
+uint64_t AvailableMapsModelMap::getSize() const
 {
   return size;
 }

--- a/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/FileDownloader.cpp
@@ -163,8 +163,18 @@ void FileDownloader::onNetworkReadyRead()
 
   emit downloadedBytes(downloaded);
 
-  file.write(chunk);
-  emit writtenBytes(downloaded);
+  // TODO: is there any case when writeRes != chunk.size() and it is not error?
+  qint64 writeRes = file.write(chunk);
+  if (writeRes < 0 || writeRes != chunk.size()){
+    qWarning() << "Writing to file return with:" << writeRes << ", chunk size:" << chunk.size() << ", error:" << file.errorString();
+    QString error = file.errorString();
+    if (error.isEmpty()){
+      error = "Writing to file failed";
+    }
+    onError(error);
+  }else {
+    emit writtenBytes(downloaded);
+  }
 }
 
 uint64_t FileDownloader::getBytesDownloaded() const

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -57,7 +57,7 @@ MapDownloadJob::~MapDownloadJob()
 void MapDownloadJob::start()
 {
   QStorageInfo storage=QStorageInfo(target);
-  if (storage.bytesAvailable() > 0 && (size_t)storage.bytesAvailable() < map.getSize()){
+  if (storage.bytesAvailable() > 0 && (uint64_t)storage.bytesAvailable() < map.getSize()){
     qWarning() << "Free space" << storage.bytesAvailable() << "bytes is less than map size (" << map.getSize() << ")!";
     onJobFailed("Not enough space", false);
     return;

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -56,6 +56,13 @@ MapDownloadJob::~MapDownloadJob()
 
 void MapDownloadJob::start()
 {
+  QStorageInfo storage=QStorageInfo(target);
+  if (storage.bytesAvailable() > 0 && (size_t)storage.bytesAvailable() < map.getSize()){
+    qWarning() << "Free space" << storage.bytesAvailable() << "bytes is less than map size (" << map.getSize() << ")!";
+    onJobFailed("Not enough space", false);
+    return;
+  }
+
   QJsonObject mapMetadata;
   mapMetadata["name"] = map.getName();
   mapMetadata["map"] = map.getPath().join("/");
@@ -349,11 +356,6 @@ void MapManager::downloadMap(AvailableMapsModelMap map, QDir dir, bool replaceEx
       emit mapDownloadFails("Can't create directory");
       return;
     }
-  }
-
-  QStorageInfo storage=QStorageInfo(dir);
-  if (storage.bytesAvailable()<(double)map.getSize()){
-    qWarning() << "Free space" << storage.bytesAvailable() << "bytes is less than map size ("<<map.getSize()<<")!";
   }
 
   auto job=new MapDownloadJob(&webCtrl, map, dir, replaceExisting);

--- a/libosmscout-client-qt/src/osmscout/MapManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapManager.cpp
@@ -389,17 +389,17 @@ void MapManager::onJobFinished()
   QList<MapDownloadJob*> finished;
   for (auto job:downloadJobs){
     if (job->isDone()){
-      finished<<job;
+      finished << job;
 
-      if (job->isReplaceExisting()){
+      if (job->isReplaceExisting() && job->isSuccessful()){
         // if there is upgrade requested, delete old database with same (logical) path
         for (auto &mapDir:databaseDirectories) {
           if (mapDir.hasMetadata() &&
               mapDir.getPath() == job->getMapPath() &&
               mapDir.getDir().canonicalPath() != job->getDestinationDirectory().canonicalPath()) {
 
-            osmscout::log.Debug() << "deleting map database" << mapDir.getName().toStdString() << "after upgrade:"
-                     << mapDir.getDir().canonicalPath().toStdString();
+            osmscout::log.Debug() << "deleting map database " << mapDir.getName().toStdString() << " after upgrade: "
+                                  << mapDir.getDir().canonicalPath().toStdString();
             mapDir.deleteDatabase();
           }
         }


### PR DESCRIPTION
Right now, map downloader fails silently when there is disk error, without reporting errors to UI. These commits improves it.