### PR TITLE
WaterIndexProcessor fixes

### DIFF
--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -295,7 +295,7 @@ namespace osmscout {
       Id                                         id;                 //! The id of the coastline
       bool                                       isArea;             //! true,if the boundary forms an area
       bool                                       isCompletelyInCell; //! true, if the complete coastline is within one cell
-      GeoBox                                     boundingBox;        //! GeoBox of original Coast
+      GeoBox                                     boundingBox;        //! GeoBox from points (already transformed)
       Pixel                                      cell;               //! The cell that completely contains the coastline
       std::vector<GeoCoord>                      points;             //! The points of the coastline
       std::map<Pixel,std::list<IntersectionRef>> cellIntersections;  //! All intersections for each cell

--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -295,6 +295,7 @@ namespace osmscout {
       Id                                         id;                 //! The id of the coastline
       bool                                       isArea;             //! true,if the boundary forms an area
       bool                                       isCompletelyInCell; //! true, if the complete coastline is within one cell
+      GeoBox                                     boundingBox;        //! GeoBox of original Coast
       Pixel                                      cell;               //! The cell that completely contains the coastline
       std::vector<GeoCoord>                      points;             //! The points of the coastline
       std::map<Pixel,std::list<IntersectionRef>> cellIntersections;  //! All intersections for each cell
@@ -598,6 +599,11 @@ namespace osmscout {
                              const StateMap& stateMap,
                              std::map<Pixel,std::list<GroundTile> >& cellGroundTileMap,
                              Data& data);
+
+    /**
+     * Comparator of coastline size (GeoBox::GetSize) for descending sort
+     */
+    static bool CoastlineGeoSizeSorter(const CoastlineDataRef &a, const CoastlineDataRef &b);
 
 public:
     /**

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -801,9 +801,9 @@ namespace osmscout {
       if (coastline->left==CoastState::unknown) {
         type=GroundTile::unknown;
       }
-      else if (coastline->left==CoastState::water) {
-        type=GroundTile::water; // should not happen on the Earth
-      }
+      // coastline->left==CoastState::water should not happen with OSM data,
+      // but it may happen with basemap import from shapefile, it has reverse coastline direction...
+      // for that case always consider island as land type
 
       GroundTile groundTile(type);
 

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -1240,8 +1240,8 @@ namespace osmscout {
 
     progress.Info("Filter intersecting islands");
 
-    for (size_t i=0; i<std::min(transformedCoastlines.size(), 100lu); i++) {
-      progress.SetProgress(i,std::min(transformedCoastlines.size(), 100lu));
+    for (size_t i=0; i<std::min(transformedCoastlines.size(), static_cast<size_t>(100)); i++) {
+      progress.SetProgress(i,std::min(transformedCoastlines.size(), static_cast<size_t>(100)));
 
       for (size_t j=i+1; j<transformedCoastlines.size(); j++) {
         assert(i!=j);


### PR DESCRIPTION
solution for most visible problems with waterindex - https://github.com/Framstag/libosmscout/issues/754#issuecomment-505658824

explanation in code:

 > In some countries are islands too close to land or other islands
 > that its coastlines intersect after polygon optimisation.
 >
 > It may cause problems in following computation, that strongly rely
 > on the fact that coastlines don't intersect.
 >
 > For that reason, we will try to detect such intersections between land
 > (line coastlines) and islands (area coastlines) to remove the most visible
 > errors. Detecting intersections between all islands is too expensive.
 > errors. Just biggest coastlines (top 100) will be considered, detecting
 > intersections between all islands is too expensive.
