### PR TITLE
avoid infinite screen coordinates with mercator projection

### DIFF
--- a/libosmscout/src/osmscout/util/Projection.cpp
+++ b/libosmscout/src/osmscout/util/Projection.cpp
@@ -248,7 +248,11 @@ namespace osmscout {
       y=(coord.GetLat()-this->lat)*scaledLatDeriv;
     }
     else {
-      y=(atanh(sin(coord.GetLat()*gradtorad))-latOffset)*scale;
+      // Mercator is defined just for latitude +-85.0511
+      // For values outside this range is better to result projection border
+      // than some invalid coordinate, like INFINITY
+      double lat = std::min(std::max(coord.GetLat(), MinLat), MaxLat);
+      y=(atanh(sin(lat*gradtorad))-latOffset)*scale;
     }
 
     if (angle!=0.0) {


### PR DESCRIPTION
it fixes these artefacts:
![obrazek](https://user-images.githubusercontent.com/309458/60398904-d471c380-9b5d-11e9-8777-855038cc337a.png)
