### PR TITLE
remove performance limit, test intersection for all coastlines

### DIFF
--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -1260,8 +1260,8 @@ namespace osmscout {
 
     progress.Info("Filter intersecting islands");
 
-    for (size_t i=0; i<std::min(transformedCoastlines.size(), static_cast<size_t>(100)); i++) {
-      progress.SetProgress(i,std::min(transformedCoastlines.size(), static_cast<size_t>(100)));
+    for (size_t i=0; i<transformedCoastlines.size(); i++) {
+      progress.SetProgress(i,transformedCoastlines.size());
 
       for (size_t j=i+1; j<transformedCoastlines.size(); j++) {
         assert(i!=j);


### PR DESCRIPTION
It seems that intersection check is not so expensive that I expected with the current code. Computing water index for Canada took 2,1 hours without this limit and 2.0 hours with it (7 minute difference). There is no reason for that limit anymore, water index should be more robust...