### PR TITLE
Follow vehicle during navigation

### DIFF
--- a/OSMScout2/qml/NavigationSimulation.qml
+++ b/OSMScout2/qml/NavigationSimulation.qml
@@ -42,9 +42,9 @@ Window {
         }
 
         onPositionChanged: {
-            if (!map.lockToPosition){ // don't set again when it is true already
-                map.lockToPosition = true;
-            }
+            // if (!map.lockToPosition){ // don't set again when it is true already
+            //     map.lockToPosition = true;
+            // }
             map.locationChanged(true, // valid
                                 latitude, longitude,
                                 horizontalAccuracyValid, horizontalAccuracy);
@@ -86,6 +86,7 @@ Window {
         anchors.fill: parent
         showCurrentPosition: true
         vehiclePosition: navigationModel.vehiclePosition
+        followVehicle: true
 
         focus: true
 

--- a/OSMScout2/qml/NavigationSimulation.qml
+++ b/OSMScout2/qml/NavigationSimulation.qml
@@ -32,9 +32,6 @@ Window {
         Component.onCompleted: {
             console.log("PositionSimulationTrack: "+PositionSimulationTrack)
         }
-        onStartChanged: {
-            map.showCoordinates(latitude, longitude);
-        }
         onEndChanged: {
             var startLoc = routingModel.locationEntryFromPosition(simulator.startLat, simulator.startLon);
             var destinationLoc = routingModel.locationEntryFromPosition(simulator.endLat, simulator.endLon);

--- a/OSMScout2/src/AppSettings.cpp
+++ b/OSMScout2/src/AppSettings.cpp
@@ -39,7 +39,7 @@ MapView *AppSettings::GetMapView()
     double mag   = settings.value("settings/map/mag",   pow(2.0,osmscout::Magnification::magContinent.Get())).toDouble();
     view = new MapView(this,
               osmscout::GeoCoord(lat, lon),
-              angle,
+              Bearing::Radians(angle),
               osmscout::Magnification(mag),
               OSMScoutQt::GetInstance().GetSettings()->GetMapDPI()
               );
@@ -57,16 +57,15 @@ void AppSettings::SetMapView(QObject *o)
   bool changed = false;
   if (view == nullptr){
     view = new MapView(this,
-              osmscout::GeoCoord(updated->GetLat(), updated->GetLon()),
-              updated->GetAngle(),
-              osmscout::Magnification(updated->GetMag()),
-              updated->GetMapDpi()
-              );
+                       updated->center,
+                       updated->angle,
+                       updated->magnification,
+                       updated->mapDpi);
     changed = true;
   }else{
     changed = *view != *updated;
     if (changed){
-        view->operator =( *updated );
+        *view = *updated;
     }
   }
   if (changed){

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -51,7 +51,7 @@ namespace osmscout {
 struct MapViewStruct
 {
   osmscout::GeoCoord      coord;
-  double                  angle;
+  osmscout::Bearing       angle;
   osmscout::Magnification magnification;
   size_t                  width;
   size_t                  height;

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -51,7 +51,7 @@ namespace osmscout {
 struct MapViewStruct
 {
   osmscout::GeoCoord      coord;
-  osmscout::Bearing       angle;
+  osmscout::Bearing       angle; // canvas clockwise
   osmscout::Magnification magnification;
   size_t                  width;
   size_t                  height;

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -258,11 +258,12 @@ public:
     virtual bool rotateTo(double angle);
     virtual bool rotateBy(double angleChange);
     virtual bool touch(QTouchEvent *event);
-    virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition, double moveTolerance);
+    virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);
     virtual bool vehiclePosition(VehiclePosition* /*vehiclePosition*/);
     virtual bool isLockedToPosition();
     virtual bool isFollowVehicle();
     virtual bool focusOutEvent(QFocusEvent *event);
+    virtual void widgetResized(const QSizeF &widgetSize);
 
 signals:
     void viewChanged(const MapView &view);
@@ -415,14 +416,17 @@ private:
 class OSMSCOUT_CLIENT_QT_API LockHandler : public JumpHandler {
     Q_OBJECT
 public:
-    inline LockHandler(const MapView &view):
-      JumpHandler(view)
+    inline LockHandler(const MapView &view, const QSizeF &widgetSize):
+      JumpHandler(view), window(widgetSize)
     {};
 
-    virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition, double moveTolerance);
+    virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);
     virtual bool showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification);
     virtual bool isLockedToPosition();
     virtual bool focusOutEvent(QFocusEvent *event);
+    virtual void widgetResized(const QSizeF &widgetSize);
+private:
+    QSizeF window;
 };
 
 /**
@@ -440,6 +444,7 @@ public:
   virtual bool vehiclePosition(VehiclePosition* /*vehiclePosition*/);
   virtual bool isLockedToPosition();
   virtual bool isFollowVehicle();
+  virtual void widgetResized(const QSizeF &widgetSize);
 
 private:
   QSizeF window;

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -335,14 +335,20 @@ private:
     MapView targetMapView;
     double angleDiff; // radians
 
-    const int ANIMATION_DURATION = 1000; // ms
-    const int ANIMATION_TICK = 16;
+    double moveAnimationDuration;
+    double zoomAnimationDuration;
+
+    static constexpr int ANIMATION_DURATION = 1000; // ms
+    static constexpr int ANIMATION_TICK = 16; // ms
 
 private slots:
     void onTimeout();
 
 public:
-    JumpHandler(const MapView &view);
+    JumpHandler(const MapView &view,
+                double moveAnimationDuration = (double)ANIMATION_DURATION,
+                double zoomAnimationDuration = (double)ANIMATION_DURATION);
+
     virtual ~JumpHandler();
 
     virtual bool animationInProgress();
@@ -438,9 +444,7 @@ private:
 class OSMSCOUT_CLIENT_QT_API VehicleFollowHandler : public JumpHandler {
 Q_OBJECT
 public:
-  inline VehicleFollowHandler(const MapView &view, const QSizeF &widgetSize):
-      JumpHandler(view), window(widgetSize)
-  {};
+  VehicleFollowHandler(const MapView &view, const QSizeF &widgetSize);
 
   virtual bool vehiclePosition(const VehiclePosition &vehiclePosition);
   virtual bool isLockedToPosition();

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -212,7 +212,7 @@ public:
   }
 
   osmscout::GeoCoord           center;
-  Bearing                      angle;
+  Bearing                      angle; // canvas clockwise
   osmscout::Magnification      magnification;
   double                       mapDpi{0};
 };
@@ -259,7 +259,7 @@ public:
     virtual bool rotateBy(double angleChange);
     virtual bool touch(QTouchEvent *event);
     virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);
-    virtual bool vehiclePosition(VehiclePosition* /*vehiclePosition*/);
+    virtual bool vehiclePosition(const VehiclePosition &vehiclePosition);
     virtual bool isLockedToPosition();
     virtual bool isFollowVehicle();
     virtual bool focusOutEvent(QFocusEvent *event);
@@ -333,6 +333,7 @@ private:
     QTimer timer;
     MapView startMapView;
     MapView targetMapView;
+    double angleDiff; // radians
 
     const int ANIMATION_DURATION = 1000; // ms
     const int ANIMATION_TICK = 16;
@@ -345,7 +346,7 @@ public:
     virtual ~JumpHandler();
 
     virtual bool animationInProgress();
-    virtual bool showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification);
+    virtual bool showCoordinates(const osmscout::GeoCoord &coord, const osmscout::Magnification &magnification, const osmscout::Bearing &bearing);
 };
 
 /**
@@ -441,7 +442,7 @@ public:
       JumpHandler(view), window(widgetSize)
   {};
 
-  virtual bool vehiclePosition(VehiclePosition* /*vehiclePosition*/);
+  virtual bool vehiclePosition(const VehiclePosition &vehiclePosition);
   virtual bool isLockedToPosition();
   virtual bool isFollowVehicle();
   virtual void widgetResized(const QSizeF &widgetSize);

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -252,7 +252,7 @@ public:
     virtual void painted();
     virtual bool animationInProgress();
 
-    virtual bool showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification);
+    virtual bool showCoordinates(const osmscout::GeoCoord &coord, const osmscout::Magnification &magnification, const osmscout::Bearing &bearing);
     virtual bool zoom(double zoomFactor, const QPoint widgetPosition, const QRect widgetDimension);
     virtual bool move(QVector2D vector); // move vector in pixels
     virtual bool rotateTo(double angle);
@@ -428,7 +428,7 @@ public:
     {};
 
     virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);
-    virtual bool showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification);
+    virtual bool showCoordinates(const osmscout::GeoCoord &coord, const osmscout::Magnification &magnification, const osmscout::Bearing &bearing);
     virtual bool isLockedToPosition();
     virtual bool focusOutEvent(QFocusEvent *event);
     virtual void widgetResized(const QSizeF &widgetSize);

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -111,6 +111,10 @@ private:
 
     double iconSize{16}; // icon size [mm]
 
+    /// input handler control
+    bool follow{false};
+    QTime lastGesture; // when there is some gesture, we will not follow vehicle for some short time
+
     QString standardIconFile{"vehicle.svg"}; // state == OnRoute | OffRoute
     QString noGpsSignalIconFile{"vehicle_not_fixed.svg"}; // state == NoGpsSignal
     QString inTunnelIconFile{"vehicle_tunnel.svg"}; // state == EstimateInTunnel
@@ -381,7 +385,7 @@ public:
 
   inline bool isFollowVehicle() const
   {
-    return inputHandler->isFollowVehicle();
+    return vehicle.follow;
   }
 
   void setFollowVehicle(bool);

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -234,7 +234,9 @@ private slots:
   virtual void onLongTap(const QPoint p);
   virtual void onTapLongTap(const QPoint p);
   
-  void onMapDPIChange(double dpi);  
+  void onMapDPIChange(double dpi);
+
+  void onResize();
   
 private:
   void setupInputHandler(InputHandler *newGesture);

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -67,6 +67,7 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_PROPERTY(bool     finished READ IsFinished  NOTIFY finishedChanged)
   Q_PROPERTY(bool     showCurrentPosition READ getShowCurrentPosition WRITE setShowCurrentPosition)
   Q_PROPERTY(bool     lockToPosition READ isLockedToPosition WRITE setLockToPosition NOTIFY lockToPossitionChanged)
+  Q_PROPERTY(bool     followVehicle READ isFollowVehicle WRITE setFollowVehicle NOTIFY followVehicleChanged)
   Q_PROPERTY(QString  stylesheetFilename READ GetStylesheetFilename NOTIFY stylesheetFilenameChanged)
   Q_PROPERTY(QString  renderingType READ GetRenderingType WRITE SetRenderingType NOTIFY renderingTypeChanged)
   
@@ -138,6 +139,7 @@ private:
 signals:
   void viewChanged();
   void lockToPossitionChanged();
+  void followVehicleChanged();
   void finishedChanged(bool finished);
 
   void mouseMove(const int screenX, const int screenY, const double lat, const double lon, const Qt::KeyboardModifiers modifiers);
@@ -368,13 +370,20 @@ public:
       redraw();
   };
   
-  inline bool isLockedToPosition()
+  inline bool isLockedToPosition() const
   {
       return inputHandler->isLockedToPosition();
   };
-  
+
   void setLockToPosition(bool);
-  
+
+  inline bool isFollowVehicle() const
+  {
+    return inputHandler->isFollowVehicle();
+  }
+
+  void setFollowVehicle(bool);
+
   inline osmscout::MercatorProjection getProjection() const
   {
     osmscout::MercatorProjection projection;
@@ -382,12 +391,12 @@ public:
     size_t w=width();
     size_t h=height();
     projection.Set(GetCenter(),
-               view->angle,
-               view->magnification,
-               view->mapDpi,
-               // to avoid invalid projection when scene is not finished yet
-               w==0? 100:w,
-               h==0? 100:h);
+                   view->angle.AsRadians(),
+                   view->magnification,
+                   view->mapDpi,
+                   // to avoid invalid projection when scene is not finished yet
+                   w==0? 100:w,
+                   h==0? 100:h);
     return projection;
   }
 

--- a/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
@@ -51,7 +51,7 @@ private:
   size_t                        currentWidth;
   size_t                        currentHeight;
   osmscout::GeoCoord            currentCoord;
-  double                        currentAngle;
+  double                        currentAngle;   // radians
   osmscout::Magnification       currentMagnification;
 
   mutable QMutex                finishedMutex;  // mutex protecting access to finished* variables

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -212,7 +212,7 @@ bool InputHandler::touch(QTouchEvent* /*event*/)
 {
     return false;
 }
-bool InputHandler::currentPosition(bool /*locationValid*/, osmscout::GeoCoord /*currentPosition*/, double /*moveTolerance*/)
+bool InputHandler::currentPosition(bool /*locationValid*/, osmscout::GeoCoord /*currentPosition*/)
 {
     return false;
 }
@@ -231,6 +231,10 @@ bool InputHandler::isFollowVehicle()
 bool InputHandler::focusOutEvent(QFocusEvent* /*event*/)
 {
     return false;
+}
+void InputHandler::widgetResized(const QSizeF &/*widgetSize*/)
+{
+  // no code
 }
 
 MoveHandler::MoveHandler(const MapView &view): InputHandler(view)
@@ -691,7 +695,7 @@ bool MultitouchHandler::touch(QTouchEvent *event)
     return true;
 }
 
-bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord currentPosition, double moveTolerance)
+bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord currentPosition)
 {
     if (locationValid){
         osmscout::MercatorProjection projection;
@@ -704,6 +708,7 @@ bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord current
         double y;
         projection.GeoToPixel(currentPosition, x, y);
         double distanceFromCenter = sqrt(pow(std::abs(500.0 - x), 2) + pow(std::abs(500.0 - y), 2));
+        double moveTolerance = std::min(window.width(), window.height()) / 4;
         if (distanceFromCenter > moveTolerance){
             JumpHandler::showCoordinates(currentPosition, view.magnification);
         }
@@ -723,6 +728,10 @@ bool LockHandler::focusOutEvent(QFocusEvent* /*event*/)
 {
     return true;
 }
+void LockHandler::widgetResized(const QSizeF &widgetSize)
+{
+    window=widgetSize;
+}
 
 bool VehicleFollowHandler::vehiclePosition(VehiclePosition* vehiclePosition)
 {
@@ -739,5 +748,8 @@ bool VehicleFollowHandler::isFollowVehicle()
 {
   return true;
 }
-
+void VehicleFollowHandler::widgetResized(const QSizeF &widgetSize)
+{
+  window=widgetSize;
+}
 }

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -187,7 +187,7 @@ bool InputHandler::animationInProgress()
 {
     return false;
 }
-bool InputHandler::showCoordinates(osmscout::GeoCoord /*coord*/, osmscout::Magnification /*magnification*/)
+bool InputHandler::showCoordinates(const osmscout::GeoCoord &/*coord*/, const osmscout::Magnification &/*magnification*/, const osmscout::Bearing &bearing)
 {
     return false;
 }
@@ -734,7 +734,7 @@ bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord current
     return true;
 }
 
-bool LockHandler::showCoordinates(osmscout::GeoCoord /*coord*/, osmscout::Magnification /*magnification*/){
+bool LockHandler::showCoordinates(const osmscout::GeoCoord &/*coord*/, const osmscout::Magnification &/*magnification*/, const osmscout::Bearing &/*bearing*/){
     return false; // lock handler can't handle it, we are locked on "currentPosition"
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -484,7 +484,7 @@ void MapWidget::reloadTmpStyle() {
 void MapWidget::setLockToPosition(bool lock){
     if (lock){
         if (!inputHandler->currentPosition(currentPosition.valid, currentPosition.coord)){
-            setupInputHandler(new LockHandler(*view, size()));
+            setupInputHandler(new LockHandler(*view, QSizeF(width(), height())));
             inputHandler->currentPosition(currentPosition.valid, currentPosition.coord);
         }
     }else{
@@ -495,7 +495,7 @@ void MapWidget::setLockToPosition(bool lock){
 void MapWidget::setFollowVehicle(bool follow){
   if (follow){
     if (!isFollowVehicle()){
-      setupInputHandler(new VehicleFollowHandler(*view, size()));
+      setupInputHandler(new VehicleFollowHandler(*view, QSizeF(width(), height())));
     }
   }else{
     setupInputHandler(new InputHandler(*view));
@@ -720,7 +720,7 @@ void MapWidget::onMapDPIChange(double dpi)
 
 void MapWidget::onResize()
 {
-    inputHandler->widgetResized(size());
+    inputHandler->widgetResized(QSizeF(width(), height()));
 }
 
 void MapWidget::SetVehiclePosition(QObject *o)

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -504,9 +504,10 @@ void MapWidget::setFollowVehicle(bool follow){
 
 void MapWidget::showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification)
 {
-    if (!inputHandler->showCoordinates(coord, magnification)){
+    assert(view);
+    if (!inputHandler->showCoordinates(coord, magnification, view->angle)){
         setupInputHandler(new JumpHandler(*view));
-        inputHandler->showCoordinates(coord, magnification);
+        inputHandler->showCoordinates(coord, magnification, view->angle);
     }
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -67,7 +67,7 @@ MapWidget::MapWidget(QQuickItem* parent)
     // TODO, open last position, move to current position or get as constructor argument...
     view = new MapView(this,
                        osmscout::GeoCoord(0.0, 0.0),
-                       /*angle*/ 0,
+                       /*angle*/ Bearing(),
                        Magnification(Magnification::magContinent),
                        settings->GetMapDPI());
     setupInputHandler(new InputHandler(*view));
@@ -185,7 +185,6 @@ void MapWidget::touchEvent(QTouchEvent *event)
 
     event->accept();
 
-    /*
     qDebug() << "touchEvent:";
     QList<QTouchEvent::TouchPoint> relevantTouchPoints;
     for (QTouchEvent::TouchPoint tp: event->touchPoints()){
@@ -194,7 +193,6 @@ void MapWidget::touchEvent(QTouchEvent *event)
               " pos " << tp.pos().x() << "x" << tp.pos().y() <<
               " @ " << tp.pressure();
     }
-    */
  }
 
 void MapWidget::focusOutEvent(QFocusEvent *event)
@@ -489,6 +487,16 @@ void MapWidget::setLockToPosition(bool lock){
     }else{
         setupInputHandler(new InputHandler(*view));
     }
+}
+
+void MapWidget::setFollowVehicle(bool follow){
+  if (follow){
+    if (!isFollowVehicle()){
+      setupInputHandler(new VehicleFollowHandler(*view, size()));
+    }
+  }else{
+    setupInputHandler(new InputHandler(*view));
+  }
 }
 
 void MapWidget::showCoordinates(osmscout::GeoCoord coord, osmscout::Magnification magnification)

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -64,6 +64,9 @@ MapWidget::MapWidget(QQuickItem* parent)
     connect(&tapRecognizer, &TapRecognizer::longTap,    this, &MapWidget::onLongTap);
     connect(&tapRecognizer, &TapRecognizer::tapLongTap, this, &MapWidget::onTapLongTap);
 
+    connect(this, &QQuickItem::widthChanged, this, &MapWidget::onResize);
+    connect(this, &QQuickItem::heightChanged, this, &MapWidget::onResize);
+
     // TODO, open last position, move to current position or get as constructor argument...
     view = new MapView(this,
                        osmscout::GeoCoord(0.0, 0.0),
@@ -480,9 +483,9 @@ void MapWidget::reloadTmpStyle() {
 
 void MapWidget::setLockToPosition(bool lock){
     if (lock){
-        if (!inputHandler->currentPosition(currentPosition.valid, currentPosition.coord, std::min(width(), height()) / 3)){
-            setupInputHandler(new LockHandler(*view));
-            inputHandler->currentPosition(currentPosition.valid, currentPosition.coord, std::min(width(), height()) / 3);
+        if (!inputHandler->currentPosition(currentPosition.valid, currentPosition.coord)){
+            setupInputHandler(new LockHandler(*view, size()));
+            inputHandler->currentPosition(currentPosition.valid, currentPosition.coord);
         }
     }else{
         setupInputHandler(new InputHandler(*view));
@@ -592,7 +595,7 @@ void MapWidget::locationChanged(bool locationValid,
     this->currentPosition.horizontalAccuracyValid = horizontalAccuracyValid;
     this->currentPosition.horizontalAccuracy = horizontalAccuracy;
 
-    inputHandler->currentPosition(locationValid, currentPosition.coord, std::min(width(), height()) / 3);
+    inputHandler->currentPosition(locationValid, currentPosition.coord);
 
     redraw();
 }
@@ -712,6 +715,11 @@ void MapWidget::onMapDPIChange(double dpi)
     // discard current input handler
     setupInputHandler(new InputHandler(*view));
     emit viewChanged();
+}
+
+void MapWidget::onResize()
+{
+    inputHandler->widgetResized(size());
 }
 
 void MapWidget::SetVehiclePosition(QObject *o)

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -741,8 +741,13 @@ void MapWidget::SetVehiclePosition(QObject *o)
     *vehicle.position = *updated;
   }
 
-  inputHandler->vehiclePosition(vehicle.position);
-  redraw();
+  if (vehicle.position != nullptr) {
+    // TODO use timer
+    setFollowVehicle(true);
+
+    inputHandler->vehiclePosition(*vehicle.position);
+    redraw();
+  }
 }
 
 QImage MapWidget::loadSVGIcon(const QString &directory, const QString fileName, double iconPixelSize)

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -136,7 +136,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
   osmscout::MercatorProjection requestProjection;
 
   if (!requestProjection.Set(request.coord,
-                             request.angle,
+                             request.angle.AsRadians(),
                              request.magnification,
                              mapDpi,
                              request.width,
@@ -255,7 +255,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
   bool needsNoRepaint=finishedImage->width()==(int) extendedRequest.width &&
                       finishedImage->height()==(int) extendedRequest.height &&
                       finishedCoord==request.coord &&
-                      finishedAngle==request.angle &&
+                      finishedAngle==request.angle.AsRadians() &&
                       finishedMagnification==request.magnification;
 
   if (!needsNoRepaint){
@@ -476,7 +476,7 @@ void PlaneMapRenderer::TriggerMapRendering(const MapViewStruct& request)
     currentWidth=request.width;
     currentHeight=request.height;
     currentCoord=request.coord;
-    currentAngle=request.angle;
+    currentAngle=request.angle.AsRadians();
     currentMagnification=request.magnification;
 
     projection.Set(currentCoord,

--- a/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledRenderingHelper.cpp
@@ -39,22 +39,22 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
   // compute canvas transformation from angle
   double width, height;
   QPointF translateVector;
-  if (request.angle==0) {
+  if (request.angle==Bearing()) {
     width = request.width;
     height = request.height;
   } else {
-    double cosAlpha=cos(request.angle);
-    double cosBeta=cos(M_PI_2 - request.angle);
+    double cosAlpha=cos(request.angle.AsRadians());
+    double cosBeta=cos(M_PI_2 - request.angle.AsRadians());
     double rw=request.width;
     double rh=request.height;
     height=std::abs(rw*cosBeta)+std::abs(rh*cosAlpha);
     width=std::abs(rw*cosAlpha)+std::abs(rh*cosBeta);
-    if (request.angle>0 && request.angle<=M_PI_2) {
+    if (request.angle.AsRadians()>0 && request.angle.AsRadians()<=M_PI_2) {
       translateVector.setY(cosBeta*rw*-1);
-    } else if (request.angle<=M_PI) {
+    } else if (request.angle.AsRadians()<=M_PI) {
       translateVector.setY(height*-1);
       translateVector.setX(cosAlpha * rw);
-    } else if (request.angle<=M_PI+M_PI_2) {
+    } else if (request.angle.AsRadians()<=M_PI+M_PI_2) {
       translateVector.setX(width*-1);
       translateVector.setY(height*-1 - cosBeta*rw);
     } else {
@@ -117,8 +117,8 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
   double y;
 
   painter.save();
-  if (request.angle!=0) {
-    painter.rotate(qRadiansToDegrees(request.angle));
+  if (request.angle!=Bearing()) {
+    painter.rotate(request.angle.AsDegrees());
     painter.translate(translateVector);
   }
 

--- a/libosmscout/include/osmscout/util/Bearing.h
+++ b/libosmscout/include/osmscout/util/Bearing.h
@@ -95,6 +95,16 @@ namespace osmscout {
       return Bearing(radians+d.radians);
     }
 
+    inline Bearing operator*(const double &d) const
+    {
+      return Bearing(radians * d);
+    }
+
+    inline Bearing operator/(const double &d) const
+    {
+      return Bearing(radians / d);
+    }
+
     /**
      * Convert the bearing to a direction description in relation to the compass (4 points).
      * One from the options: N, E, S, W

--- a/libosmscout/include/osmscout/util/Bearing.h
+++ b/libosmscout/include/osmscout/util/Bearing.h
@@ -107,6 +107,16 @@ namespace osmscout {
      */
     std::string LongDisplayString() const;
 
+    inline bool operator==(const Bearing& o) const
+    {
+      return radians == o.radians;
+    }
+
+    inline bool operator!=(const Bearing& o) const
+    {
+      return radians != o.radians;
+    }
+
     static inline Bearing Radians(double radians)
     {
       return Bearing(radians);
@@ -120,7 +130,7 @@ namespace osmscout {
   private:
     static double Normalise(double radians);
   };
-  
+
 }
 
 #endif //LIBOSMSCOUT_BEARING_H

--- a/libosmscout/include/osmscout/util/Projection.h
+++ b/libosmscout/include/osmscout/util/Projection.h
@@ -45,7 +45,7 @@ namespace osmscout {
   protected:
     double        lon;            //!< Longitude coordinate of the center of the image
     double        lat;            //!< Latitude coordinate of the center of the image
-    double        angle;          //!< Display rotation angle in radians
+    double        angle;          //!< Display rotation angle in radians, canvas clockwise
     Magnification magnification;  //!< Current magnification
     double        dpi;            //!< Screen DPI
     size_t        width;          //!< Width of image


### PR DESCRIPTION
Initial implementation for input handler (Qt MapWidget) that is following vehicle. It moves and rotate map based on car position and changing magnification level based on distance to next routing step...

Solution is not final. There is missing interaction with usual user gestures. My idea is to use delay (4 seconds?) when `VehicleFollowHandler` will be inactive after user input (gesture). But I need to test on the phone first. Do this complex UX properly is hard :-)