### PR TITLE
mark immutable properties as constant

### DIFF
--- a/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
+++ b/libosmscout-client-qt/include/osmscout/AvailableMapsModel.h
@@ -37,10 +37,10 @@ namespace osmscout {
 class OSMSCOUT_CLIENT_QT_API AvailableMapsModelItem : public QObject {
   Q_OBJECT
 
-  Q_PROPERTY(bool valid READ isValid())
-  Q_PROPERTY(QString name READ getName())
-  Q_PROPERTY(QStringList path READ getPath())
-  Q_PROPERTY(QString description READ getDescription())
+  Q_PROPERTY(bool valid READ isValid() CONSTANT)
+  Q_PROPERTY(QString name READ getName() CONSTANT)
+  Q_PROPERTY(QStringList path READ getPath() CONSTANT)
+  Q_PROPERTY(QString description READ getDescription() CONSTANT)
 
 private:
   bool valid{false};
@@ -121,11 +121,11 @@ public:
 class OSMSCOUT_CLIENT_QT_API AvailableMapsModelMap : public AvailableMapsModelItem {
   Q_OBJECT
 
-  Q_PROPERTY(quint64 byteSize READ getSize())
-  Q_PROPERTY(QString size READ getSizeHuman())
-  Q_PROPERTY(QString serverDirectory READ getServerDirectory())
-  Q_PROPERTY(QDateTime time READ getCreation())
-  Q_PROPERTY(int version READ getVersion())
+  Q_PROPERTY(quint64 byteSize READ getSize() CONSTANT)
+  Q_PROPERTY(QString size READ getSizeHuman() CONSTANT)
+  Q_PROPERTY(QString serverDirectory READ getServerDirectory() CONSTANT)
+  Q_PROPERTY(QDateTime time READ getCreation() CONSTANT)
+  Q_PROPERTY(int version READ getVersion() CONSTANT)
 
 private:
   MapProvider provider;

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -161,12 +161,12 @@ class OSMSCOUT_CLIENT_QT_API MapView: public QObject
 {
   Q_OBJECT
 
-  Q_PROPERTY(double   lat       READ GetLat)
-  Q_PROPERTY(double   lon       READ GetLon)
-  Q_PROPERTY(double   angle     READ GetAngle)
-  Q_PROPERTY(double   mag       READ GetMag)
-  Q_PROPERTY(uint32_t magLevel  READ GetMagLevel)
-  Q_PROPERTY(double   mapDpi    READ GetMapDpi)
+  Q_PROPERTY(double   lat       READ GetLat       CONSTANT)
+  Q_PROPERTY(double   lon       READ GetLon       CONSTANT)
+  Q_PROPERTY(double   angle     READ GetAngle     CONSTANT)
+  Q_PROPERTY(double   mag       READ GetMag       CONSTANT)
+  Q_PROPERTY(uint32_t magLevel  READ GetMagLevel  CONSTANT)
+  Q_PROPERTY(double   mapDpi    READ GetMapDpi    CONSTANT)
 
 public:
   inline MapView(QObject *parent=0): QObject(parent) {}

--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -42,11 +42,11 @@ namespace osmscout {
 class OSMSCOUT_CLIENT_QT_API LocationEntry : public QObject
 {
   Q_OBJECT
-  Q_PROPERTY(QString label      READ getLabel)
-  Q_PROPERTY(QString type       READ getTypeString)
-  Q_PROPERTY(QString objectType READ getObjectType)
-  Q_PROPERTY(double  lat        READ getLat)
-  Q_PROPERTY(double  lon        READ getLon)
+  Q_PROPERTY(QString label      READ getLabel      CONSTANT)
+  Q_PROPERTY(QString type       READ getTypeString CONSTANT)
+  Q_PROPERTY(QString objectType READ getObjectType CONSTANT)
+  Q_PROPERTY(double  lat        READ getLat        CONSTANT)
+  Q_PROPERTY(double  lon        READ getLon        CONSTANT)
 
 public:
   enum Type {

--- a/libosmscout-client-qt/include/osmscout/VehiclePosition.h
+++ b/libosmscout-client-qt/include/osmscout/VehiclePosition.h
@@ -40,9 +40,9 @@ class OSMSCOUT_CLIENT_QT_API VehiclePosition: public QObject
 {
   Q_OBJECT
 
-  Q_PROPERTY(double   lat       READ getLat)
-  Q_PROPERTY(double   lon       READ getLon)
-  Q_PROPERTY(double   bearing   READ getBearingRadians)
+  Q_PROPERTY(double   lat       READ getLat             CONSTANT)
+  Q_PROPERTY(double   lon       READ getLon             CONSTANT)
+  Q_PROPERTY(double   bearing   READ getBearingRadians  CONSTANT)
 
 public:
   inline explicit VehiclePosition(QObject *parent = 0) :


### PR DESCRIPTION
It supress runtime QML warning: "XXX depends on non-NOTIFYable properties"