### PR TITLE
Fix low zoom

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
@@ -237,11 +237,13 @@ namespace osmscout
             }
           }
         }
+        newRings.back().bbox.Invalidate();
+        newRings.back().segments.clear();
 
         r++;
       }
 
-      // MAster ring can have nodes, but does not need to have
+      // Master ring can have nodes, but does not need to have
       if (area->rings.front().IsMasterRing()) {
         if (area->rings.front().nodes.empty()) {
           if (newRings.size()==1) {

--- a/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
@@ -271,6 +271,8 @@ namespace osmscout
                 }
 
                 way->nodes=newNodes;
+                way->segments.clear();
+                way->bbox.Invalidate();
               }
               else {
                 for (const auto& node : (*otherWay)->nodes) {
@@ -282,6 +284,8 @@ namespace osmscout
                 }
 
                 way->nodes=newNodes;
+                way->segments.clear();
+                way->bbox.Invalidate();
               }
 
               usedWays.insert((*otherWay)->GetFileOffset());
@@ -471,6 +475,8 @@ namespace osmscout
       WayRef copiedWay=std::make_shared<Way>(*way);
 
       copiedWay->nodes=newNodes;
+      copiedWay->bbox.Invalidate();
+      copiedWay->segments.clear();
 
       if (!IsValidToWrite(copiedWay->nodes)) {
         progress.Error("Way coordinates are not dense enough to be written for way "+

--- a/libosmscout/include/osmscout/Way.h
+++ b/libosmscout/include/osmscout/Way.h
@@ -48,7 +48,7 @@ namespace osmscout {
 
   public:
     /**
-     * Note that ring nodes, bbox and segments fields are public for simple manipulation.
+     * Note that way nodes, bbox and segments fields are public for simple manipulation.
      * User that modify it is responsible to keep these values in sync!
      * You should not rely on segments and bbox, it is just a cache used some algorithms.
      * It may be empty/invalid!


### PR DESCRIPTION
Fix for https://github.com/Framstag/libosmscout/issues/771 . Problem is in the case when two ways are merged - internal (cached) bounding box have to be invalidated. Area index may provide incomplete results otherwise...