### PR TITLE
Waterindex coastlines in land

### DIFF
--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -616,9 +616,28 @@ namespace osmscout {
                              std::map<Pixel,std::list<GroundTile> >& cellGroundTileMap,
                              Data& data);
 
-    /**
-     * Comparator of coastline size (GeoBox::GetSize) for descending sort
-     */
+    void TransformCoastlines(Progress& progress,
+                             TransPolygon::OptimizeMethod optimizationMethod,
+                             double tolerance,
+                             double minObjectDimension,
+                             const Projection& projection,
+                             const std::list<CoastRef>& coastlines,
+                             std::vector<CoastlineDataRef> &transformedCoastlines);
+
+    void FilterIntersectCoastlines(Progress& progress,
+                                   std::vector<CoastlineDataRef> &transformedCoastlines);
+
+    void FilterEncapsulatedCoastlines(Progress& progress,
+                                      std::vector<CoastlineDataRef> &transformedCoastlines);
+
+    void ComputeCoveredTiles(Progress& progress,
+                           const StateMap& stateMap,
+                           Data& data,
+                           std::vector<CoastlineDataRef> &transformedCoastlines);
+
+      /**
+       * Comparator of coastline size (GeoBox::GetSize) for descending sort
+       */
     static bool CoastlineGeoSizeSorter(const CoastlineDataRef &a, const CoastlineDataRef &b);
 
 public:

--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -592,7 +592,7 @@ namespace osmscout {
 
     /**
      * Take the given coastlines and bounding polygons and create a list of synthesized
-     * coastlines that fuly encircle the imported region. Coastlines are either
+     * coastlines that fully encircle the imported region. Coastlines are either
      * real-life coastlines or emulated coastlines based on the bounding
      * polygons.
      *
@@ -684,8 +684,8 @@ public:
      * @param boundingPolygons
      */
     void SynthesizeCoastlines(Progress& progress,
-                            std::list<CoastRef>& coastlines,
-                            std::list<CoastRef>& boundingPolygons);
+                              std::list<CoastRef>& coastlines,
+                              std::list<CoastRef>& boundingPolygons);
 
     /**
      * Collects, calculates and generates a number of data about a coastline.

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -1220,10 +1220,8 @@ namespace osmscout {
      * It may cause problems in following computation, that strongly rely
      * on the fact that coastlines don't intersect.
      *
-     * For that reason, we will try to detect such intersections between land
-     * (line coastlines) and islands (area coastlines) to remove the most visible
-     * errors. Just biggest coastlines (top 100) will be considered, detecting
-     * intersections between all islands is too expensive.
+     * For that reason, we will try to detect such intersections
+     * and remove smaller objects (islands) that intersects.
      */
 
     // sort by the size (GeoBox::GetSize, descending)
@@ -1231,7 +1229,7 @@ namespace osmscout {
               transformedCoastlines.end(),
               CoastlineGeoSizeSorter);
 
-    progress.Info("Filter intersecting islands");
+    progress.Info("Filter intersecting coastlines");
 
     for (size_t i=0; i<transformedCoastlines.size(); i++) {
       progress.SetProgress(i,transformedCoastlines.size());
@@ -1284,6 +1282,9 @@ namespace osmscout {
         }
       }
     }
+
+    progress.Info("Filter encapsulated coastlines");
+    // TODO
 
     progress.Info("Calculate covered tiles");
     size_t curCoast=0;

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -262,17 +262,11 @@ namespace osmscout {
     for (const auto& tileEntry : cellGroundTileMap) {
       Pixel coord=tileEntry.first;
       State  state[4];      // type of the neighbouring cells: top, right, bottom, left
-      size_t coordCount[4]; // number of coords on the given line (top, right, bottom, left)
 
       state[0]=unknown;
       state[1]=unknown;
       state[2]=unknown;
       state[3]=unknown;
-
-      coordCount[0]=0;
-      coordCount[1]=0;
-      coordCount[2]=0;
-      coordCount[3]=0;
 
       // Preset top
       if (coord.y<stateMap.GetYCount()-1) {
@@ -312,27 +306,6 @@ namespace osmscout {
             break;
         }
         for (size_t c=0; c<tile.coords.size()-1;c++) {
-
-          //
-          // Count number of coords *on* the border
-          //
-
-          // top
-          if (tile.coords[c].y==GroundTile::Coord::CELL_MAX) {
-            coordCount[0]++;
-          }
-          // right
-          else if (tile.coords[c].x==GroundTile::Coord::CELL_MAX) {
-            coordCount[1]++;
-          }
-          // bottom
-          else if (tile.coords[c].y==0) {
-            coordCount[2]++;
-          }
-          // left
-          else if (tile.coords[c].x==0) {
-            coordCount[3]++;
-          }
 
           //
           // Detect fills over a complete border


### PR DESCRIPTION
Hi Tim, @vyskocil . I found recently that California is still flooded by sea with water index level 6. And the problem was not caused by OSM data. On higher zooms, it looks fine:

![obrazek](https://user-images.githubusercontent.com/309458/64922101-93d42e80-d7cb-11e9-9abb-db560bd05b9b.png)

Problem was with the coastline simplification for low zoom. Some islands becomes encapsulated by land:

![obrazek](https://user-images.githubusercontent.com/309458/64922098-80c15e80-d7cb-11e9-8955-59c873364b3d.png)

...and it is problem later for algorithm that works just with single tile and is not considering "big picture". For that reason, I added another filtering that tries to detect such cases and remove small islands that may cause this issue.

California is fine now, and it may also help to issues with world coastlines https://github.com/Framstag/libosmscout/issues/754