### PR TITLE
remove std::move for temporary object

### DIFF
--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -381,7 +381,7 @@ namespace osmscout {
       const agg::glyph_cache *glyph = fontCacheManager->glyph(i);
       assert(glyph);
       fontCacheManager->add_kerning(&x, &y);
-      label.glyphs.emplace_back(std::move(MapPainterAgg::NativeGlyph{x, y, glyph}));
+      label.glyphs.emplace_back(MapPainterAgg::NativeGlyph{x, y, glyph});
 
       w += glyph->advance_x;
 


### PR DESCRIPTION
it fixes following clang warning:
`warning: moving a temporary object prevents copy elision [-Wpessimizing-move]`