### PR TITLE
fix tag priority while parsing name* features

### DIFF
--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -94,14 +94,14 @@ namespace osmscout {
                           FeatureValueBuffer& buffer) const
   {
     std::string name;
-    uint32_t    namePriority=0;
+    uint32_t    namePriority=std::numeric_limits<uint32_t>::max();
 
     for (const auto &tag : tags) {
       uint32_t ntPrio;
       bool     isNameTag=tagRegistry.IsNameTag(tag.first,ntPrio);
 
       if (isNameTag &&
-          (name.empty() || ntPrio>namePriority)) {
+          (name.empty() || ntPrio<namePriority)) {
         name=tag.second;
         namePriority=ntPrio;
       }
@@ -180,14 +180,14 @@ namespace osmscout {
                              FeatureValueBuffer& buffer) const
   {
     std::string nameAlt;
-    uint32_t    nameAltPriority=0;
+    uint32_t    nameAltPriority=std::numeric_limits<uint32_t>::max();
 
     for (const auto &tag : tags) {
       uint32_t natPrio;
       bool     isNameAltTag=tagRegistry.IsNameAltTag(tag.first,natPrio);
 
       if (isNameAltTag &&
-          (nameAlt.empty() || natPrio>nameAltPriority)) {
+          (nameAlt.empty() || natPrio<nameAltPriority)) {
         nameAlt=tag.second;
         nameAltPriority=natPrio;
       }


### PR DESCRIPTION
Priority of name tags is increasing with its order.
When lang order is `fr,#`
```
 - tag name:fr has priority 0
 - tag place_name:fr     => 1
 - tag brand:fr          => 2
 - tag name              => 3
 - ...
```
It means that tag with lowest priority should win during parsing.
This commit fixes that.

@vyskocil  can you check that this branch is fixing your issue? https://github.com/Framstag/libosmscout/issues/777

@Framstag it is correct to prioritize `name` before `brand`? Makes it sense to you?