### PR TITLE
Qt RoutingModel: cancel current route computation on start/target update

### DIFF
--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -61,7 +61,8 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   } else if (vehicleStr=="foot"){
     vehicle=osmscout::Vehicle::vehicleFoot;
   }
-  clear();
+  cancel(); // cancel current computation
+  clear(); // clear model
   computing=true;
   breaker=std::make_shared<osmscout::ThreadedBreaker>();
   emit computingChanged();

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -66,7 +66,7 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   breaker=std::make_shared<osmscout::ThreadedBreaker>();
   emit computingChanged();
 
-  // make copy to shared ptr, remove owhership
+  // make copy to shared ptr, remove ownership
   LocationEntryRef startRef=std::make_shared<LocationEntry>(*start);
   startRef->setParent(Q_NULLPTR);
   LocationEntryRef targetRef=std::make_shared<LocationEntry>(*target);


### PR DESCRIPTION
It should speedup reaction to new start/target setup