### PR TITLE
 navigation bearing agent: avoid random turnaround

### DIFF
--- a/libosmscout/include/osmscout/navigation/BearingAgent.h
+++ b/libosmscout/include/osmscout/navigation/BearingAgent.h
@@ -39,6 +39,7 @@ namespace osmscout {
   {
   private:
     GeoCoord previousPoint;
+    Bearing previousBearing;
     bool previousPointValid{false};
     Timestamp lastUpdate;
 

--- a/libosmscout/include/osmscout/navigation/BearingAgent.h
+++ b/libosmscout/include/osmscout/navigation/BearingAgent.h
@@ -38,7 +38,7 @@ namespace osmscout {
   class OSMSCOUT_API BearingAgent CLASS_FINAL : public NavigationAgent
   {
   private:
-    GeoCoord previousPoing;
+    GeoCoord previousPoint;
     bool previousPointValid{false};
     Timestamp lastUpdate;
 

--- a/libosmscout/src/osmscout/navigation/BearingAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/BearingAgent.cpp
@@ -47,12 +47,12 @@ namespace osmscout {
 
       if (!previousPointValid){
         previousPointValid=true;
-        previousPoing=coord;
+        previousPoint=coord;
         lastUpdate=now;
-      }else if (GetSphericalDistance(previousPoing,coord) > Meters(2)){
-        result.push_back(std::make_shared<BearingChangedMessage>(now, GetSphericalBearingInitial(previousPoing, coord)));
+      }else if (GetSphericalDistance(previousPoint, coord) > Meters(2)){
+        result.push_back(std::make_shared<BearingChangedMessage>(now, GetSphericalBearingInitial(previousPoint, coord)));
         previousPointValid=true;
-        previousPoing=coord;
+        previousPoint=coord;
         lastUpdate=now;
       }
     } else if (previousPointValid &&

--- a/libosmscout/src/osmscout/navigation/BearingAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/BearingAgent.cpp
@@ -50,7 +50,23 @@ namespace osmscout {
         previousPoint=coord;
         lastUpdate=now;
       }else if (GetSphericalDistance(previousPoint, coord) > Meters(2)){
-        result.push_back(std::make_shared<BearingChangedMessage>(now, GetSphericalBearingInitial(previousPoint, coord)));
+        Bearing currentBearing = GetSphericalBearingInitial(previousPoint, coord);
+
+        // angle diff [0..M_PI)
+        Bearing bearingDiffAbs = previousBearing - currentBearing;
+        if (bearingDiffAbs.AsRadians() > M_PI) {
+          bearingDiffAbs = Bearing::Radians((2 * M_PI) - bearingDiffAbs.AsRadians());
+        }
+
+        if (bearingDiffAbs.AsRadians() > (M_PI*0.75) &&
+            GetSphericalDistance(previousPoint, coord) < Meters(15)){
+          // to make big bearing change, we have to be sure
+          // we want to avoid turnaround when GPS is just jumping around
+          return result;
+        }
+
+        result.push_back(std::make_shared<BearingChangedMessage>(now, currentBearing));
+        previousBearing=currentBearing;
         previousPointValid=true;
         previousPoint=coord;
         lastUpdate=now;


### PR DESCRIPTION
> We want to avoid turnaround when GPS is just jumping around.
> To make big bearing change, we have to be sure.
> So we will ignore small position changes (< 15 meters)
> that may cause big bearing change (> 135 degrees).

This simple approach seems to be effective during initial tests...