### PR TITLE
Add support for Imperial units (elevation label)

### DIFF
--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -67,7 +67,7 @@ void DumpFeatures(const osmscout::FeatureValueBuffer &features, const std::strin
         if (feature->HasValue()) {
           osmscout::FeatureValue *value=features.GetValue(featureInstance.GetIndex());
           if (feature->HasLabel()) {
-            std::string label=value->GetLabel(osmscout::Units::Metrics, 0);
+            std::string label=value->GetLabel(osmscout::Locale(), 0);
             if (!label.empty()) {
               std::cout << ": " << osmscout::UTF8StringToLocaleString(label);
             }

--- a/Demos/src/LocationDescription.cpp
+++ b/Demos/src/LocationDescription.cpp
@@ -67,8 +67,9 @@ void DumpFeatures(const osmscout::FeatureValueBuffer &features, const std::strin
         if (feature->HasValue()) {
           osmscout::FeatureValue *value=features.GetValue(featureInstance.GetIndex());
           if (feature->HasLabel()) {
-            if (!value->GetLabel(0).empty()) {
-              std::cout << ": " << osmscout::UTF8StringToLocaleString(value->GetLabel(0));
+            std::string label=value->GetLabel(osmscout::Units::Metrics, 0);
+            if (!label.empty()) {
+              std::cout << ": " << osmscout::UTF8StringToLocaleString(label);
             }
           }
           else {

--- a/Demos/src/LookupText.cpp
+++ b/Demos/src/LookupText.cpp
@@ -47,11 +47,13 @@ void printDetails(const osmscout::FeatureValueBuffer& features)
 
       if (feature->HasValue() && feature->HasLabel()) {
         osmscout::FeatureValue *value=features.GetValue(featureInstance.GetIndex());
-        if (value->GetLabel(0).empty()) {
+        if (value->GetLabel(osmscout::Units::Metrics, 0).empty()) {
           std::cout << "   + feature " << feature->GetName() << std::endl;
         }
         else {
-          std::cout << "   + feature " << feature->GetName() << ": " << osmscout::UTF8StringToLocaleString(value->GetLabel(0)) << std::endl;
+          std::cout << "   + feature " << feature->GetName() << ": "
+                    << osmscout::UTF8StringToLocaleString(value->GetLabel(osmscout::Units::Metrics, 0))
+                    << std::endl;
         }
       }
       else {

--- a/Demos/src/LookupText.cpp
+++ b/Demos/src/LookupText.cpp
@@ -47,12 +47,12 @@ void printDetails(const osmscout::FeatureValueBuffer& features)
 
       if (feature->HasValue() && feature->HasLabel()) {
         osmscout::FeatureValue *value=features.GetValue(featureInstance.GetIndex());
-        if (value->GetLabel(osmscout::Units::Metrics, 0).empty()) {
+        if (value->GetLabel(osmscout::Locale(), 0).empty()) {
           std::cout << "   + feature " << feature->GetName() << std::endl;
         }
         else {
           std::cout << "   + feature " << feature->GetName() << ": "
-                    << osmscout::UTF8StringToLocaleString(value->GetLabel(osmscout::Units::Metrics, 0))
+                    << osmscout::UTF8StringToLocaleString(value->GetLabel(osmscout::Locale(), 0))
                     << std::endl;
         }
       }

--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -660,7 +660,7 @@ static void DumpFeatureValueBuffer(const osmscout::FeatureValueBuffer& buffer,
         else if (meta.GetFeature()->HasLabel()) {
           DumpIndent(indent);
           std::cout << meta.GetFeature()->GetName() << ": ";
-          std::cout << value->GetLabel(osmscout::Units::Metrics, 0);
+          std::cout << value->GetLabel(osmscout::Locale(), 0);
           std::cout << std::endl;
         }
         else {

--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -660,7 +660,7 @@ static void DumpFeatureValueBuffer(const osmscout::FeatureValueBuffer& buffer,
         else if (meta.GetFeature()->HasLabel()) {
           DumpIndent(indent);
           std::cout << meta.GetFeature()->GetName() << ": ";
-          std::cout << value->GetLabel(0);
+          std::cout << value->GetLabel(osmscout::Units::Metrics, 0);
           std::cout << std::endl;
         }
         else {

--- a/libosmscout-client-qt/include/osmscout/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/LookupModule.h
@@ -169,7 +169,7 @@ private:
 
     const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
     if (name!=nullptr){
-      info.name=QString::fromStdString(name->GetLabel(0));
+      info.name=QString::fromStdString(name->GetLabel(Units::Metrics, 0));
     }
     const osmscout::PhoneFeatureValue *phone=features.findValue<osmscout::PhoneFeatureValue>();
     if (phone!=nullptr){

--- a/libosmscout-client-qt/include/osmscout/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/LookupModule.h
@@ -169,7 +169,7 @@ private:
 
     const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
     if (name!=nullptr){
-      info.name=QString::fromStdString(name->GetLabel(Units::Metrics, 0));
+      info.name=QString::fromStdString(name->GetLabel(Locale(), 0));
     }
     const osmscout::PhoneFeatureValue *phone=features.findValue<osmscout::PhoneFeatureValue>();
     if (phone!=nullptr){

--- a/libosmscout-client-qt/include/osmscout/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/MapRenderer.h
@@ -85,6 +85,7 @@ protected:
   double      fontSize;
   QString     iconDirectory;
   bool        showAltLanguage{false};
+  QString     units;
 
   mutable QMutex                 overlayLock;
   std::map<int,OverlayObjectRef> overlayObjectMap; // <! map guarded by overlayLock, OverlayWay object is multithread
@@ -104,6 +105,7 @@ public slots:
   virtual void onFontNameChanged(const QString);
   virtual void onFontSizeChanged(double);
   virtual void onShowAltLanguageChanged(bool);
+  virtual void onUnitsChanged(const QString);
 
 protected:
   MapRenderer(QThread *thread,

--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -50,7 +50,7 @@ namespace osmscout {
  *     ":/resources/online-tile-providers.json");
  * ```
  * 
- * Before program exit, resources shoudl be released by calling Settings::FreeInstance.
+ * Before program exit, resources should be released by calling Settings::FreeInstance.
  */
 class OSMSCOUT_CLIENT_QT_API Settings: public QObject
 {
@@ -65,6 +65,8 @@ class OSMSCOUT_CLIENT_QT_API Settings: public QObject
   Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
   Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
   Q_PROPERTY(bool     showAltLanguage READ GetShowAltLanguage WRITE SetShowAltLanguage NOTIFY ShowAltLanguageChanged)
+  /// metrics or imperial
+  Q_PROPERTY(QString  units       READ GetUnits               WRITE SetUnits        NOTIFY UnitsChanged)
 
 signals:
   void MapDPIChange(double dpi);
@@ -78,6 +80,7 @@ signals:
   void FontNameChanged(const QString fontName);
   void FontSizeChanged(double fontSize);
   void ShowAltLanguageChanged(bool showAltLanguage);
+  void UnitsChanged(const QString units);
 
 private:
   QSettings *storage;
@@ -143,6 +146,9 @@ public:
   
   const QByteArray GetCookieData() const;
   void SetCookieData(QByteArray data);
+
+  QString GetUnits() const;
+  void SetUnits(const QString units);
 };
 
 /**
@@ -180,6 +186,8 @@ class OSMSCOUT_CLIENT_QT_API QmlSettings: public QObject{
   Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
   Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
   Q_PROPERTY(bool     showAltLanguage READ GetShowAltLanguage WRITE SetShowAltLanguage NOTIFY ShowAltLanguageChanged)
+  /// metrics or imperial
+  Q_PROPERTY(QString  units       READ GetUnits               WRITE SetUnits        NOTIFY UnitsChanged)
 
 private:
   SettingsRef settings;
@@ -193,6 +201,7 @@ signals:
   void FontNameChanged(const QString fontName);
   void FontSizeChanged(double fontSize);
   void ShowAltLanguageChanged(bool showAltLanguage);
+  void UnitsChanged(const QString units);
 
 public:
   QmlSettings();
@@ -226,6 +235,9 @@ public:
 
   bool GetShowAltLanguage() const;
   void SetShowAltLanguage(bool showAltLanguage);
+
+  QString GetUnits() const;
+  void SetUnits(const QString units);
 };
 
 }

--- a/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
@@ -39,6 +39,7 @@ MapRenderer::MapRenderer(QThread *thread,
   fontName=settings->GetFontName();
   fontSize=settings->GetFontSize();
   showAltLanguage=settings->GetShowAltLanguage();
+  units=settings->GetUnits();
 
   connect(settings.get(), &Settings::MapDPIChange,
           this, &MapRenderer::onMapDPIChange,
@@ -54,6 +55,9 @@ MapRenderer::MapRenderer(QThread *thread,
           Qt::QueuedConnection);
   connect(settings.get(), &Settings::ShowAltLanguageChanged,
           this, &MapRenderer::onShowAltLanguageChanged,
+          Qt::QueuedConnection);
+  connect(settings.get(), &Settings::UnitsChanged,
+          this, &MapRenderer::onUnitsChanged,
           Qt::QueuedConnection);
   connect(thread, &QThread::started,
           this, &MapRenderer::Initialize);
@@ -122,6 +126,16 @@ void MapRenderer::onShowAltLanguageChanged(bool showAltLanguage)
   {
     QMutexLocker locker(&lock);
     this->showAltLanguage=showAltLanguage;
+  }
+  InvalidateVisualCache();
+  emit Redraw();
+}
+
+void MapRenderer::onUnitsChanged(const QString units)
+{
+  {
+    QMutexLocker locker(&lock);
+    this->units=units;
   }
   InvalidateVisualCache();
   emit Redraw();

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -52,7 +52,7 @@ LocationEntry buildLocationEntry(T obj,
   const osmscout::FeatureValueBuffer &features=obj->GetFeatureValueBuffer();
   const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
   if (name!=nullptr){
-    title=QString::fromStdString(name->GetLabel(osmscout::Units::Metrics, 0));
+    title=QString::fromStdString(name->GetLabel(osmscout::Locale(), 0));
     //std::cout << " \"" << name->GetLabel() << "\"";
   }
 

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -52,7 +52,7 @@ LocationEntry buildLocationEntry(T obj,
   const osmscout::FeatureValueBuffer &features=obj->GetFeatureValueBuffer();
   const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
   if (name!=nullptr){
-    title=QString::fromStdString(name->GetLabel(0));
+    title=QString::fromStdString(name->GetLabel(osmscout::Units::Metrics, 0));
     //std::cout << " \"" << name->GetLabel() << "\"";
   }
 

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -359,7 +359,7 @@ void PlaneMapRenderer::DrawMap()
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight())/canvasOverrun);
 
-    drawParameter.SetUnits(units=="imperial" ? osmscout::MapParameter::Units::Imperial : osmscout::MapParameter::Units::Metrics);
+    drawParameter.SetUnits(units=="imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
 
     // create copy of projection
     osmscout::MercatorProjection renderProjection;

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -359,6 +359,8 @@ void PlaneMapRenderer::DrawMap()
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight())/canvasOverrun);
 
+    drawParameter.SetUnits(units=="imperial" ? osmscout::MapParameter::Units::Imperial : osmscout::MapParameter::Units::Metrics);
+
     // create copy of projection
     osmscout::MercatorProjection renderProjection;
 

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -359,7 +359,7 @@ void PlaneMapRenderer::DrawMap()
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(projection.GetWidth(), projection.GetHeight())/canvasOverrun);
 
-    drawParameter.SetUnits(units=="imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
+    drawParameter.GetLocaleRef().SetDistanceUnits(units == "imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
 
     // create copy of projection
     osmscout::MercatorProjection renderProjection;

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -319,6 +319,19 @@ void Settings::SetCookieData(const QByteArray data)
   storage->setValue("OSMScoutLib/General/Cookies", data);
 }
 
+QString Settings::GetUnits() const
+{
+  return storage->value("OSMScoutLib/General/Units", "metrics").toString();
+}
+
+void Settings::SetUnits(const QString units)
+{
+  if (GetUnits()!=units){
+    storage->setValue("OSMScoutLib/General/Units", units);
+    emit UnitsChanged(units);
+  }
+}
+
 QmlSettings::QmlSettings()
 {
     settings=OSMScoutQt::GetInstance().GetSettings();
@@ -339,6 +352,8 @@ QmlSettings::QmlSettings()
             this, &QmlSettings::FontSizeChanged);
     connect(settings.get(), &Settings::ShowAltLanguageChanged,
             this, &QmlSettings::ShowAltLanguageChanged);
+    connect(settings.get(), &Settings::UnitsChanged,
+            this, &QmlSettings::UnitsChanged);
 }
 
 double QmlSettings::GetPhysicalDPI() const
@@ -425,5 +440,13 @@ bool QmlSettings::GetShowAltLanguage() const
 void QmlSettings::SetShowAltLanguage(bool showAltLanguage)
 {
     settings->SetShowAltLanguage(showAltLanguage);
+}
+QString QmlSettings::GetUnits() const
+{
+    return settings->GetUnits();
+}
+void QmlSettings::SetUnits(const QString units)
+{
+    settings->SetUnits(units);
 }
 }

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -17,6 +17,9 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <osmscout/Settings.h>
+#include <osmscout/OSMScoutQt.h>
+
 #include <QScreen>
 #include <QGuiApplication>
 #include <QStandardPaths>
@@ -24,13 +27,8 @@
 #include <QObject>
 #include <QDebug>
 #include <QFileInfo>
-
 #include <QJsonDocument>
-#include <QJsonArray>
-#include <QJsonObject>
-
-#include <osmscout/Settings.h>
-#include <osmscout/OSMScoutQt.h>
+#include <QLocale>
 
 namespace osmscout {
 
@@ -321,7 +319,18 @@ void Settings::SetCookieData(const QByteArray data)
 
 QString Settings::GetUnits() const
 {
-  return storage->value("OSMScoutLib/General/Units", "metrics").toString();
+  QLocale locale;
+  QString defaultUnits;
+  switch (locale.measurementSystem()){
+    case QLocale::ImperialUSSystem:
+    case QLocale::ImperialUKSystem:
+      defaultUnits="imperial";
+      break;
+    case QLocale::MetricSystem:
+    default:
+      defaultUnits="metrics";
+  }
+  return storage->value("OSMScoutLib/General/Units", defaultUnits).toString();
 }
 
 void Settings::SetUnits(const QString units)

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -452,7 +452,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     // of other than the current tile, too.
     drawParameter.SetDropNotVisiblePointLabels(loadZ.Get() >= 14);
 
-    drawParameter.SetUnits(units=="imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
+    drawParameter.GetLocaleRef().SetDistanceUnits(units == "imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
 
     // setup projection for these tiles
     osmscout::MercatorProjection projection;

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -452,7 +452,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     // of other than the current tile, too.
     drawParameter.SetDropNotVisiblePointLabels(loadZ.Get() >= 14);
 
-    drawParameter.SetUnits(units=="imperial" ? osmscout::MapParameter::Units::Imperial : osmscout::MapParameter::Units::Metrics);
+    drawParameter.SetUnits(units=="imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
 
     // setup projection for these tiles
     osmscout::MercatorProjection projection;

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -452,6 +452,8 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     // of other than the current tile, too.
     drawParameter.SetDropNotVisiblePointLabels(loadZ.Get() >= 14);
 
+    drawParameter.SetUnits(units=="imperial" ? osmscout::MapParameter::Units::Imperial : osmscout::MapParameter::Units::Metrics);
+
     // setup projection for these tiles
     osmscout::MercatorProjection projection;
     osmscout::Magnification magnification(loadZ);

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -108,7 +108,7 @@ namespace osmscout {
 
     bool                                showAltLanguage;           //!< if true, display alternative language (needs support by style sheet and import)
 
-    Units                               units;                     //!< Units used by the renderer, for example peak elevation
+    Locale                              locale;                     //!< Locale used by the renderer, for example peak elevation
 
     std::vector<FillStyleProcessorRef > fillProcessors;            //!< List of processors for FillStyles for types
 
@@ -169,7 +169,7 @@ namespace osmscout {
 
     void SetShowAltLanguage(bool showAltLanguage);
 
-    void SetUnits(Units units);
+    void SetLocale(const Locale &locale);
 
     void RegisterFillStyleProcessor(size_t typeIndex,
                                     const FillStyleProcessorRef& processor);
@@ -359,9 +359,14 @@ namespace osmscout {
       return showAltLanguage;
     }
 
-    inline Units GetUnits() const
+    inline Locale GetLocale() const
     {
-      return units;
+      return locale;
+    }
+
+    inline Locale& GetLocaleRef()
+    {
+      return locale;
     }
 
     bool IsAborted() const

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -54,12 +54,6 @@ namespace osmscout {
       Scalable          // !< vector pattern should be used, it will be scaled to patternSize
     };
 
-    enum class Units
-    {
-      Metrics,
-      Imperial
-    };
-
   private:
     std::string                         fontName;                  //!< Name of the font to use
     double                              fontSize;                  //!< Metric size of base font (aka font size 100%) in millimeter
@@ -96,8 +90,6 @@ namespace osmscout {
 
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
 
-    Units                               units;                     //!< Units used by the renderer, for example peak elevation
-
   private:
 // Contour labels
     double                              contourLabelOffset;        //!< Offset in mm for beginning and end of an contour label in relation to contour begin and end
@@ -115,6 +107,8 @@ namespace osmscout {
     size_t                              warnCoordCountLimit;       //!< Limit for coords/type. If limit is reached a warning is created
 
     bool                                showAltLanguage;           //!< if true, display alternative language (needs support by style sheet and import)
+
+    Units                               units;                     //!< Units used by the renderer, for example peak elevation
 
     std::vector<FillStyleProcessorRef > fillProcessors;            //!< List of processors for FillStyles for types
 

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -54,6 +54,12 @@ namespace osmscout {
       Scalable          // !< vector pattern should be used, it will be scaled to patternSize
     };
 
+    enum class Units
+    {
+      Metrics,
+      Imperial
+    };
+
   private:
     std::string                         fontName;                  //!< Name of the font to use
     double                              fontSize;                  //!< Metric size of base font (aka font size 100%) in millimeter
@@ -89,6 +95,8 @@ namespace osmscout {
     double                              patternSize;               //!< Size of pattern image in mm (default 3.7)
 
     bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
+
+    Units                               units;                     //!< Units used by the renderer, for example peak elevation
 
   private:
 // Contour labels
@@ -166,6 +174,8 @@ namespace osmscout {
     void SetWarningCoordCountLimit(size_t limit);
 
     void SetShowAltLanguage(bool showAltLanguage);
+
+    void SetUnits(Units units);
 
     void RegisterFillStyleProcessor(size_t typeIndex,
                                     const FillStyleProcessorRef& processor);
@@ -353,6 +363,11 @@ namespace osmscout {
     inline bool GetShowAltLanguage() const
     {
       return showAltLanguage;
+    }
+
+    inline Units GetUnits() const
+    {
+      return units;
     }
 
     bool IsAborted() const

--- a/libosmscout-map/src/osmscout/LabelProvider.cpp
+++ b/libosmscout-map/src/osmscout/LabelProvider.cpp
@@ -66,7 +66,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(parameter.GetUnits(), 0);
+          return value->GetLabel(parameter.GetLocale(), 0);
         }
       }
 
@@ -77,7 +77,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(parameter.GetUnits(), 0);
+          return value->GetLabel(parameter.GetLocale(), 0);
         }
       }
 
@@ -91,7 +91,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(parameter.GetUnits(), 0);
+          return value->GetLabel(parameter.GetLocale(), 0);
         }
       }
 
@@ -149,7 +149,7 @@ namespace osmscout {
       FeatureValue *value=buffer.GetValue(index);
 
       if (value!=nullptr) {
-        return value->GetLabel(parameter.GetUnits(), labelIndex);
+        return value->GetLabel(parameter.GetLocale(), labelIndex);
       }
     }
 

--- a/libosmscout-map/src/osmscout/LabelProvider.cpp
+++ b/libosmscout-map/src/osmscout/LabelProvider.cpp
@@ -66,7 +66,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(0);
+          return value->GetLabel(parameter.GetUnits(), 0);
         }
       }
 
@@ -77,7 +77,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(0);
+          return value->GetLabel(parameter.GetUnits(), 0);
         }
       }
 
@@ -91,7 +91,7 @@ namespace osmscout {
         FeatureValue *value=buffer.GetValue(index);
 
         if (value!=nullptr) {
-          return value->GetLabel(0);
+          return value->GetLabel(parameter.GetUnits(), 0);
         }
       }
 
@@ -139,7 +139,7 @@ namespace osmscout {
     }
   }
 
-  std::string DynamicFeatureLabelReader::GetLabel(const MapParameter& /*parameter*/,
+  std::string DynamicFeatureLabelReader::GetLabel(const MapParameter& parameter,
                                                   const FeatureValueBuffer& buffer) const
   {
     size_t index=lookupTable[buffer.GetType()->GetIndex()];
@@ -149,7 +149,7 @@ namespace osmscout {
       FeatureValue *value=buffer.GetValue(index);
 
       if (value!=nullptr) {
-        return value->GetLabel(labelIndex);
+        return value->GetLabel(parameter.GetUnits(), labelIndex);
       }
     }
 

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -56,7 +56,7 @@ namespace osmscout {
     warnObjectCountLimit(0),
     warnCoordCountLimit(0),
     showAltLanguage(false),
-    units{Units::Metrics}
+    locale{Locale::ByEnvironment()}
   {
     // no code
   }
@@ -241,9 +241,9 @@ namespace osmscout {
     this->showAltLanguage=showAltLanguage;
   }
 
-  void MapParameter::SetUnits(Units units)
+  void MapParameter::SetLocale(const Locale &locale)
   {
-    this->units=units;
+    this->locale=locale;
   }
 
   void MapParameter::SetBreaker(const BreakerRef& breaker)

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -55,7 +55,8 @@ namespace osmscout {
     debugPerformance(false),
     warnObjectCountLimit(0),
     warnCoordCountLimit(0),
-    showAltLanguage(false)
+    showAltLanguage(false),
+    units{Units::Metrics}
   {
     // no code
   }
@@ -238,6 +239,11 @@ namespace osmscout {
   void MapParameter::SetShowAltLanguage(bool showAltLanguage)
   {
     this->showAltLanguage=showAltLanguage;
+  }
+
+  void MapParameter::SetUnits(Units units)
+  {
+    this->units=units;
   }
 
   void MapParameter::SetBreaker(const BreakerRef& breaker)

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEADER_FILES_UTIL
     include/osmscout/util/FileScanner.h
     include/osmscout/util/FileWriter.h
     include/osmscout/util/HTMLWriter.h
+    include/osmscout/util/Locale.h
     include/osmscout/util/GeoBox.h
     include/osmscout/util/Geometry.h
     include/osmscout/util/Logger.h
@@ -140,6 +141,7 @@ set(SOURCE_FILES
     src/osmscout/util/FileScanner.cpp
     src/osmscout/util/FileWriter.cpp
     src/osmscout/util/HTMLWriter.cpp
+    src/osmscout/util/Locale.cpp
     src/osmscout/util/GeoBox.cpp
     src/osmscout/util/Geometry.cpp
     src/osmscout/util/Logger.cpp

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -17,6 +17,7 @@ osmscoutHeader = [
             'osmscout/util/FileScanner.h',
             'osmscout/util/FileWriter.h',
             'osmscout/util/HTMLWriter.h',
+            'osmscout/util/Locale.h',
             'osmscout/util/GeoBox.h',
             'osmscout/util/Geometry.h',
             'osmscout/util/Logger.h',

--- a/libosmscout/include/osmscout/FeatureReader.h
+++ b/libosmscout/include/osmscout/FeatureReader.h
@@ -299,7 +299,7 @@ namespace osmscout {
       V* value=dynamic_cast<V*>(buffer.GetValue(index));
 
       if (value!=nullptr) {
-        return value->GetLabel(Units::Metrics, 0);
+        return value->GetLabel(Locale(), 0);
       }
     }
 

--- a/libosmscout/include/osmscout/FeatureReader.h
+++ b/libosmscout/include/osmscout/FeatureReader.h
@@ -299,7 +299,7 @@ namespace osmscout {
       V* value=dynamic_cast<V*>(buffer.GetValue(index));
 
       if (value!=nullptr) {
-        return value->GetLabel(0);
+        return value->GetLabel(Units::Metrics, 0);
       }
     }
 

--- a/libosmscout/include/osmscout/TypeFeature.h
+++ b/libosmscout/include/osmscout/TypeFeature.h
@@ -29,6 +29,7 @@
 
 #include <osmscout/util/FileScanner.h>
 #include <osmscout/util/FileWriter.h>
+#include <osmscout/util/Locale.h>
 
 #include <osmscout/util/TagErrorReporter.h>
 
@@ -43,7 +44,7 @@ namespace osmscout {
 
     virtual ~FeatureValue()=default;
 
-    inline virtual std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const
+    inline virtual std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const
     {
       return "";
     }

--- a/libosmscout/include/osmscout/TypeFeature.h
+++ b/libosmscout/include/osmscout/TypeFeature.h
@@ -43,7 +43,7 @@ namespace osmscout {
 
     virtual ~FeatureValue()=default;
 
-    inline virtual std::string GetLabel(size_t /*labelIndex*/) const
+    inline virtual std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const
     {
       return "";
     }

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -56,7 +56,7 @@ namespace osmscout {
       return name;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return name;
     }
@@ -124,7 +124,7 @@ namespace osmscout {
       return nameAlt;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return nameAlt;
     }
@@ -192,7 +192,7 @@ namespace osmscout {
       return ref;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return ref;
     }
@@ -261,7 +261,7 @@ namespace osmscout {
       return location;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return location;
     }
@@ -339,7 +339,7 @@ namespace osmscout {
       return address;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return address;
     }
@@ -1123,7 +1123,7 @@ namespace osmscout {
       return postalCode;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return postalCode;
     }
@@ -1279,17 +1279,18 @@ namespace osmscout {
       return ele;
     }
 
-    inline std::string GetLabel(Units units, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &locale, size_t /*labelIndex*/) const override
     {
-      if (units==Units::Imperial){
-        int eleFeet=std::round(Meters(ele).As<Feet>());
-        // use tiny, unbreakable space between value and unit.
-        // U+202F unicode is encoded as 0xE280AF in utf-8
-        // because unicode support in C++ is poor and platform dependent,
-        // we will use utf-8 bytes directly
-        return std::to_string(eleFeet)+"\xE2\x80\xAF"+"ft";
+      int value;
+      std::string unitsStr;
+      if (locale.GetDistanceUnits()==Units::Imperial){
+        value=std::round(Meters(ele).As<Feet>());
+        unitsStr="ft";
+      }else{
+        value=ele;
+        unitsStr="m";
       }
-      return std::to_string(ele)+"\xE2\x80\xAF"+"m";
+      return std::to_string(value) + locale.GetUnitsSeparator() + unitsStr;
     }
 
     void Read(FileScanner& scanner) override;
@@ -1358,7 +1359,7 @@ namespace osmscout {
       return destination;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return destination;
     }
@@ -1453,7 +1454,7 @@ namespace osmscout {
       return website;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return website;
     }
@@ -1522,7 +1523,7 @@ namespace osmscout {
       return phone;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       return phone;
     }
@@ -1658,7 +1659,7 @@ namespace osmscout {
       return endYear;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       if (startYear==endYear) {
         return std::to_string(startYear);
@@ -1888,7 +1889,7 @@ namespace osmscout {
       this->destinationBackward=destinationBawckard;
     }
 
-    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
+    inline std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override
     {
       if (HasSingleLane()) {
         return "1";

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1283,9 +1283,13 @@ namespace osmscout {
     {
       if (units==Units::Imperial){
         int eleFeet=std::round(Meters(ele).As<Feet>());
-        return std::to_string(eleFeet)+"\u202Fft"; // use tiny, unbreakable space between value and unit
+        // use tiny, unbreakable space between value and unit.
+        // U+202F unicode is encoded as 0xE280AF in utf-8
+        // because unicode support in C++ is poor and platform dependent,
+        // we will use utf-8 bytes directly
+        return std::to_string(eleFeet)+"\xE2\x80\xAF"+"ft";
       }
-      return std::to_string(ele)+"\u202Fm";
+      return std::to_string(ele)+"\xE2\x80\xAF"+"m";
     }
 
     void Read(FileScanner& scanner) override;

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1283,9 +1283,9 @@ namespace osmscout {
     {
       if (units==Units::Imperial){
         int eleFeet=std::round(Meters(ele).As<Feet>());
-        return std::to_string(eleFeet)+"ft";
+        return std::to_string(eleFeet)+"\u202Fft"; // use tiny, unbreakable space between value and unit
       }
-      return std::to_string(ele)+"m";
+      return std::to_string(ele)+"\u202Fm";
     }
 
     void Read(FileScanner& scanner) override;

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1290,7 +1290,14 @@ namespace osmscout {
         value=ele;
         unitsStr="m";
       }
-      return std::to_string(value) + locale.GetUnitsSeparator() + unitsStr;
+      std::string valueStr;
+      if (value < 1000 || locale.GetThousandsSeparator().empty()){
+        valueStr=std::to_string(value);
+      }else{
+        // not expecting that value will be bigger than million
+        valueStr=std::to_string(value/1000) + locale.GetThousandsSeparator() + std::to_string(value%1000);
+      }
+      return valueStr + locale.GetUnitsSeparator() + unitsStr;
     }
 
     void Read(FileScanner& scanner) override;

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -56,7 +56,7 @@ namespace osmscout {
       return name;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return name;
     }
@@ -124,7 +124,7 @@ namespace osmscout {
       return nameAlt;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return nameAlt;
     }
@@ -192,7 +192,7 @@ namespace osmscout {
       return ref;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return ref;
     }
@@ -261,7 +261,7 @@ namespace osmscout {
       return location;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return location;
     }
@@ -339,7 +339,7 @@ namespace osmscout {
       return address;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return address;
     }
@@ -1123,7 +1123,7 @@ namespace osmscout {
       return postalCode;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return postalCode;
     }
@@ -1279,8 +1279,12 @@ namespace osmscout {
       return ele;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units units, size_t /*labelIndex*/) const override
     {
+      if (units==Units::Imperial){
+        int eleFeet=std::round(Meters(ele).As<Feet>());
+        return std::to_string(eleFeet)+"ft";
+      }
       return std::to_string(ele)+"m";
     }
 
@@ -1350,7 +1354,7 @@ namespace osmscout {
       return destination;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return destination;
     }
@@ -1445,7 +1449,7 @@ namespace osmscout {
       return website;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return website;
     }
@@ -1514,7 +1518,7 @@ namespace osmscout {
       return phone;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       return phone;
     }
@@ -1650,7 +1654,7 @@ namespace osmscout {
       return endYear;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       if (startYear==endYear) {
         return std::to_string(startYear);
@@ -1880,7 +1884,7 @@ namespace osmscout {
       this->destinationBackward=destinationBawckard;
     }
 
-    inline std::string GetLabel(size_t /*labelIndex*/) const override
+    inline std::string GetLabel(Units /*units*/, size_t /*labelIndex*/) const override
     {
       if (HasSingleLane()) {
         return "1";

--- a/libosmscout/include/osmscout/util/Distance.h
+++ b/libosmscout/include/osmscout/util/Distance.h
@@ -31,6 +31,12 @@
 
 namespace osmscout {
 
+  enum class Units
+  {
+    Metrics,
+    Imperial
+  };
+
   struct OSMSCOUT_API Meter
   {
     static inline double ToMeter(double m)
@@ -54,6 +60,19 @@ namespace osmscout {
     static inline double FromMeter(double m)
     {
       return m/1000.0;
+    }
+  };
+
+  struct OSMSCOUT_API Feet
+  {
+    static inline double ToMeter(double feet)
+    {
+      return feet * 0.3048;
+    }
+
+    static inline double FromMeter(double m)
+    {
+      return m/0.3048;
     }
   };
 

--- a/libosmscout/include/osmscout/util/Locale.h
+++ b/libosmscout/include/osmscout/util/Locale.h
@@ -1,0 +1,104 @@
+#ifndef OSMSCOUT_LOCALE_H
+#define OSMSCOUT_LOCALE_H
+
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2019 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/CoreImportExport.h>
+#include <osmscout/system/Compiler.h>
+
+#include <osmscout/util/Distance.h>
+
+#include <string>
+
+namespace osmscout {
+
+  class OSMSCOUT_API Locale CLASS_FINAL
+  {
+  private:
+    Units distanceUnits{Units::Metrics};
+    std::string decimalSeparator{"."}; //!<  UTF-8 encoded string with decimal separator
+    std::string thousandsSeparator; //!< UTF-8 encoded string with thousands separator
+    std::string unitsSeparator{"\xE2\x80\xAF"}; //!< UTF-8 encoded string with unit separator (character between number and unit). Unbreakable space by default
+
+  public:
+    /**
+     * Default constructor initialise locale with default locale.
+     * It is equivalent to LC_ALL=C
+     *
+     * To initialise locale by environment, use static method ByEnvironment
+     */
+    Locale() = default;
+
+    Locale(const Units &distanceUnits,
+           const std::string &decimalSeparator,
+           const std::string &thousandsSeparator);
+
+    Locale(const Locale&) = default;
+    Locale(Locale&&) = default;
+    ~Locale() = default;
+    Locale &operator=(const Locale &) = default;
+    Locale &operator=(Locale &&) = default;
+
+    Units GetDistanceUnits() const
+    {
+      return distanceUnits;
+    }
+
+    void SetDistanceUnits(const Units &units)
+    {
+      this->distanceUnits = units;
+    }
+
+    std::string GetDecimalSeparator() const
+    {
+      return decimalSeparator;
+    }
+
+    void SetDecimalSeparator(const std::string &separator)
+    {
+      this->decimalSeparator = separator;
+    }
+
+    std::string GetThousandsSeparator() const
+    {
+      return thousandsSeparator;
+    }
+
+    void SetThousandsSeparator(const std::string &separator)
+    {
+      this->thousandsSeparator = separator;
+    }
+
+    std::string GetUnitsSeparator() const
+    {
+      return unitsSeparator;
+    }
+
+    void SetUnitsSeparator(const std::string &separator)
+    {
+      this->unitsSeparator = separator;
+    }
+
+  public:
+    static Locale ByEnvironment(std::locale locale = std::locale(""));
+  };
+}
+
+#endif // OSMSCOUT_LOCALE_H

--- a/libosmscout/include/osmscout/util/Locale.h
+++ b/libosmscout/include/osmscout/util/Locale.h
@@ -35,6 +35,11 @@ namespace osmscout {
     Units distanceUnits{Units::Metrics};
     std::string decimalSeparator{"."}; //!<  UTF-8 encoded string with decimal separator
     std::string thousandsSeparator; //!< UTF-8 encoded string with thousands separator
+
+    // use tiny, unbreakable space between value and unit.
+    // U+202F unicode is encoded as 0xE280AF in utf-8
+    // because unicode support in C++ is poor and platform dependent,
+    // we will use utf-8 bytes directly
     std::string unitsSeparator{"\xE2\x80\xAF"}; //!< UTF-8 encoded string with unit separator (character between number and unit). Unbreakable space by default
 
   public:

--- a/libosmscout/src/meson.build
+++ b/libosmscout/src/meson.build
@@ -14,6 +14,7 @@ osmscoutSrc = [
             'src/osmscout/util/FileScanner.cpp',
             'src/osmscout/util/FileWriter.cpp',
             'src/osmscout/util/HTMLWriter.cpp',
+            'src/osmscout/util/Locale.cpp',
             'src/osmscout/util/GeoBox.cpp',
             'src/osmscout/util/Geometry.cpp',
             'src/osmscout/util/Logger.cpp',

--- a/libosmscout/src/osmscout/util/Locale.cpp
+++ b/libosmscout/src/osmscout/util/Locale.cpp
@@ -1,0 +1,61 @@
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2019 Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/util/Locale.h>
+#include <osmscout/util/String.h>
+
+namespace osmscout {
+
+  namespace { // anonymous namespace
+
+  std::string GetCountryCode(std::string localeName) {
+    if (localeName.size()>=5 && localeName[2]=='_'  &&
+        localeName[3]>='A' && localeName[3]<='Z' &&
+        localeName[4]>='A' && localeName[4]<='Z'){
+      // locale starts with lang_COUNTRY
+      return localeName.substr(3,2);
+    }
+    return "";
+  }
+  }
+
+  Locale Locale::ByEnvironment(std::locale cppLocale)
+  {
+    Locale locale;
+
+    std::string country=GetCountryCode(cppLocale.name());
+    if (country=="US" || // USA
+        country=="GB" || // Britain
+        country=="LR" || // Liberia
+        country=="MM"  // Myanmar
+    ){
+      locale.SetDistanceUnits(Units::Imperial);
+    }
+
+    using Facet = std::numpunct<wchar_t>;
+
+    wchar_t thousandSep = std::use_facet<Facet>(cppLocale).thousands_sep();
+    wchar_t decimalSep = std::use_facet<Facet>(cppLocale).decimal_point();
+
+    locale.SetThousandsSeparator(WStringToUTF8String(std::wstring() + thousandSep));
+    locale.SetDecimalSeparator(WStringToUTF8String(std::wstring() + decimalSep));
+
+    return locale;
+  }
+}


### PR DESCRIPTION
Hi.

I was expecting that this request will arrive some day https://github.com/Karry/osmscout-sailfish/issues/174 :-)

Question is if would like to add Metrics to `FeatureValue::GetLabel` (that I did) or create `LabelProvider` that will handel Units just fro elevation...