### PR TITLE
multiple elevation label variants in stylesheet

### DIFF
--- a/libosmscout-map/include/osmscout/LabelProvider.h
+++ b/libosmscout-map/include/osmscout/LabelProvider.h
@@ -130,8 +130,8 @@ namespace osmscout {
      *   Reference to the current type configuration
      * @param featureName
      *   Name of the feature which must be valid and must support labels
-     * @param labelIndex
-     *   The index of the labels to use (a feature might support multiple labels)
+     * @param labelName
+     *   The name of the label to use (a feature might support multiple labels)
      */
     DynamicFeatureLabelReader(const TypeConfig& typeConfig,
                               const std::string& featureName,

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1145,6 +1145,12 @@ namespace osmscout {
     /** Name of this feature */
     static const char* const NAME;
 
+    /** Name of the "name" label */
+    static const char* const NAME_LABEL;
+
+    /** Index of the 'name' label */
+    static const size_t      NAME_LABEL_INDEX;
+
   public:
     PostalCodeFeature();
 
@@ -1475,8 +1481,11 @@ namespace osmscout {
     /** Name of this feature */
     static const char* const NAME;
 
-    /** Name of the "name" label */
-    static const char* const NAME_LABEL;
+    /** Name of the "url" label */
+    static const char* const URL_LABEL;
+
+    /** Index of the 'url' label */
+    static const size_t      URL_LABEL_INDEX;
 
   public:
     WebsiteFeature();
@@ -1543,6 +1552,12 @@ namespace osmscout {
   public:
     /** Name of this feature */
     static const char* const NAME;
+
+    /** Name of the "number" label */
+    static const char* const NUMBER_LABEL;
+
+    /** Index of the 'number' label */
+    static const size_t      NUMBER_LABEL_INDEX;
 
   public:
     PhoneFeature();
@@ -1685,6 +1700,12 @@ namespace osmscout {
   public:
     /** Name of this feature */
     static const char* const NAME;
+
+    /** Name of the "year" label */
+    static const char* const YEAR_LABEL;
+
+    /** Index of the 'year' label */
+    static const size_t      YEAR_LABEL_INDEX;
 
   public:
     ConstructionYearFeature();

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1279,26 +1279,7 @@ namespace osmscout {
       return ele;
     }
 
-    inline std::string GetLabel(const Locale &locale, size_t /*labelIndex*/) const override
-    {
-      int value;
-      std::string unitsStr;
-      if (locale.GetDistanceUnits()==Units::Imperial){
-        value=std::round(Meters(ele).As<Feet>());
-        unitsStr="ft";
-      }else{
-        value=ele;
-        unitsStr="m";
-      }
-      std::string valueStr;
-      if (value < 1000 || locale.GetThousandsSeparator().empty()){
-        valueStr=std::to_string(value);
-      }else{
-        // not expecting that value will be bigger than million
-        valueStr=std::to_string(value/1000) + locale.GetThousandsSeparator() + std::to_string(value%1000);
-      }
-      return valueStr + locale.GetUnitsSeparator() + unitsStr;
-    }
+    std::string GetLabel(const Locale &locale, size_t labelIndex) const override;
 
     void Read(FileScanner& scanner) override;
     void Write(FileWriter& writer) override;
@@ -1316,11 +1297,23 @@ namespace osmscout {
     /** Name of this feature */
     static const char* const NAME;
 
-    /** Name of the "name" label */
-    static const char* const NAME_LABEL;
+    /** Name of the "inMeter" label */
+    static const char* const IN_METER_LABEL;
 
-    /** Index of the 'name' label */
-    static const size_t      NAME_LABEL_INDEX;
+    /** Index of the 'inMeter' label */
+    static const size_t      IN_METER_LABEL_INDEX;
+
+    /** Name of the "inFeet" label */
+    static const char* const IN_FEET_LABEL;
+
+    /** Index of the 'inFeet' label */
+    static const size_t      IN_FEET_LABEL_INDEX;
+
+    /** Name of the "inLocaleUnit" label */
+    static const char* const IN_LOCALE_UNIT_LABEL;
+
+    /** Index of the 'inLocaleUnit' label */
+    static const size_t      IN_LOCALE_UNIT_LABEL_INDEX;
 
   public:
     EleFeature();

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -1871,6 +1871,39 @@ namespace osmscout {
     return *this;
   }
 
+  std::string EleFeatureValue::GetLabel(const Locale &locale, size_t labelIndex) const
+  {
+    Units units;
+    if (labelIndex==EleFeature::IN_LOCALE_UNIT_LABEL_INDEX){
+      units=locale.GetDistanceUnits();
+    } else if (labelIndex==EleFeature::IN_METER_LABEL_INDEX){
+      units=Units::Metrics;
+    } else {
+      assert(labelIndex==EleFeature::IN_FEET_LABEL_INDEX);
+      units=Units::Imperial;
+    }
+
+    int value;
+    std::string unitsStr;
+    if (units==Units::Imperial){
+      value=std::round(Meters(ele).As<Feet>());
+      unitsStr="ft";
+    }else{
+      value=ele;
+      unitsStr="m";
+    }
+
+    std::string valueStr;
+    if (value < 1000 || locale.GetThousandsSeparator().empty()){
+      valueStr=std::to_string(value);
+    }else{
+      // not expecting that value will be bigger than million
+      valueStr=std::to_string(value/1000) + locale.GetThousandsSeparator() + std::to_string(value%1000);
+    }
+
+    return valueStr + locale.GetUnitsSeparator() + unitsStr;
+  }
+
   bool EleFeatureValue::operator==(const FeatureValue& other) const
   {
     const auto& otherValue=static_cast<const EleFeatureValue&>(other);
@@ -1878,15 +1911,26 @@ namespace osmscout {
     return ele==otherValue.ele;
   }
 
-  const char* const EleFeature::NAME             = "Ele";
-  const char* const EleFeature::NAME_LABEL       = "inMeter";
-  const size_t      EleFeature::NAME_LABEL_INDEX = 0;
+  const char* const EleFeature::NAME = "Ele";
+
+  const char* const EleFeature::IN_METER_LABEL       = "inMeter";
+  const size_t      EleFeature::IN_METER_LABEL_INDEX = 0;
+
+  const char* const EleFeature::IN_FEET_LABEL       = "inFeet";
+  const size_t      EleFeature::IN_FEET_LABEL_INDEX = 1;
+
+  const char* const EleFeature::IN_LOCALE_UNIT_LABEL       = "inLocaleUnit";
+  const size_t      EleFeature::IN_LOCALE_UNIT_LABEL_INDEX = 2;
 
   EleFeature::EleFeature()
   : tagEle(0)
   {
-    RegisterLabel(NAME_LABEL_INDEX,
-                  NAME_LABEL);
+    RegisterLabel(IN_METER_LABEL_INDEX,
+                  IN_METER_LABEL);
+    RegisterLabel(IN_FEET_LABEL_INDEX,
+                  IN_FEET_LABEL);
+    RegisterLabel(IN_LOCALE_UNIT_LABEL_INDEX,
+                  IN_LOCALE_UNIT_LABEL);
   }
 
   void EleFeature::Initialize(TagRegistry& tagRegistry)

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -1493,10 +1493,12 @@ namespace osmscout {
   }
 
   const char* const PostalCodeFeature::NAME = "PostalCode";
+  const char* const PostalCodeFeature::NAME_LABEL = "name";
+  const size_t      PostalCodeFeature::NAME_LABEL_INDEX = 0;
 
   PostalCodeFeature::PostalCodeFeature()
   {
-    RegisterLabel(0,NAME);
+    RegisterLabel(NAME_LABEL_INDEX,NAME_LABEL);
   }
 
   void PostalCodeFeature::Initialize(TagRegistry& tagRegistry)
@@ -1583,10 +1585,12 @@ namespace osmscout {
   }
 
   const char* const WebsiteFeature::NAME = "Website";
+  const char* const WebsiteFeature::URL_LABEL = "url";
+  const size_t      WebsiteFeature::URL_LABEL_INDEX = 0;
 
   WebsiteFeature::WebsiteFeature()
   {
-    RegisterLabel(0,NAME);
+    RegisterLabel(URL_LABEL_INDEX,URL_LABEL);
   }
 
   void WebsiteFeature::Initialize(TagRegistry& tagRegistry)
@@ -1671,10 +1675,12 @@ namespace osmscout {
   }
 
   const char* const PhoneFeature::NAME = "Phone";
+  const char* const PhoneFeature::NUMBER_LABEL = "number";
+  const size_t      PhoneFeature::NUMBER_LABEL_INDEX = 0;
 
   PhoneFeature::PhoneFeature()
   {
-    RegisterLabel(0,NAME);
+    RegisterLabel(NUMBER_LABEL_INDEX,NUMBER_LABEL);
   }
 
   void PhoneFeature::Initialize(TagRegistry& tagRegistry)
@@ -2231,10 +2237,12 @@ namespace osmscout {
   }
 
   const char* const ConstructionYearFeature::NAME = "ConstructionYear";
+  const char* const ConstructionYearFeature::YEAR_LABEL = "year";
+  const size_t      ConstructionYearFeature::YEAR_LABEL_INDEX = 0;
 
   ConstructionYearFeature::ConstructionYearFeature()
   {
-    RegisterLabel(0,NAME);
+    RegisterLabel(YEAR_LABEL_INDEX,YEAR_LABEL);
   }
 
   void ConstructionYearFeature::Initialize(TagRegistry& tagRegistry)

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -601,14 +601,14 @@ STYLE
     [MAG suburb-] {
       [TYPE elevation_contour_major] {
         WAY {color: @majorContourColor; displayWidth: 0.150mm; }
-        WAY.TEXT { label: Ele.inMeter; priority: @labelPrioElevationContour; }
+        WAY.TEXT { label: Ele.inLocaleUnit; priority: @labelPrioElevationContour; }
       }
     }
 
     [MAG detail-] {
       [TYPE elevation_contour_medium] {
         WAY {color: @mediumContourColor; displayWidth: 0.100mm; }
-        WAY.TEXT { label: Ele.inMeter; priority: @labelPrioElevationContour; }
+        WAY.TEXT { label: Ele.inLocaleUnit; priority: @labelPrioElevationContour; }
       }
 
       [TYPE elevation_contour_minor] {
@@ -655,7 +655,7 @@ STYLE
 
       [TYPE natural_peak] {
         NODE.TEXT#peakName { label: Name.name; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 1; }
-        NODE.TEXT#ele { label: Ele.inMeter; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 2;}
+        NODE.TEXT#ele { label: Ele.inLocaleUnit; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 2;}
       }
     }
 

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -524,14 +524,14 @@ STYLE
     [MAG suburb-] {
       [TYPE elevation_contour_major] {
         WAY {color: @majorContourColor; displayWidth: 0.150mm; }
-        WAY.TEXT { label: Ele.inMeter; color: @contourLabelColor; size: 0.7; priority: @labelPrioElevationContour; }
+        WAY.TEXT { label: Ele.inLocaleUnit; color: @contourLabelColor; size: 0.7; priority: @labelPrioElevationContour; }
       }
     }
 
     [MAG detail-] {
       [TYPE elevation_contour_medium] {
         WAY {color: @mediumContourColor; displayWidth: 0.100mm; }
-        WAY.TEXT { label: Ele.inMeter; color: @contourLabelColor; size: 0.8; priority: @labelPrioElevationContour; }
+        WAY.TEXT { label: Ele.inLocaleUnit; color: @contourLabelColor; size: 0.8; priority: @labelPrioElevationContour; }
       }
 
       [TYPE elevation_contour_minor] {
@@ -578,7 +578,7 @@ STYLE
 
       [TYPE natural_peak] {
         NODE.TEXT#peakName { label: Name.name; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 1; }
-        NODE.TEXT#ele { label: Ele.inMeter; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 2;}
+        NODE.TEXT#ele { label: Ele.inLocaleUnit; style: emphasize; color: @peakLabelColor; priority: @labelPrioPeak; size: 0.9; position: 2;}
       }
     }
 

--- a/webpage/content/documentation/stylesheet.md
+++ b/webpage/content/documentation/stylesheet.md
@@ -246,7 +246,15 @@ with values ("`<attributeName> : <value> ;`") and a closing
   
 `FeatureAttr`
 : Name of a feature followed by a point followed by the name of the feature
-attribute that holds the to be evaluated value. Example: `Name.name`
+  attribute that holds the to be evaluated value. Possible values:
+  `Name.name`, `NameAlt.name`, `Ref.name`, `Address.name`, `PostalCode.name`,
+  `Website.url`, `Phone.number`, `Ele.inMeter`, `Ele.inFeet`, `Ele.inLocaleUnit`,
+  `Destination.label`, `ConstructionYear.year` and `Lanes.label`.
+
+`LabelProvider`
+: Name of label provider. The only label provider is `IName` now. 
+  It allows to choose between `Name.name` and `NameAlt.name` feature properties
+  based on runtime property `MapParameter::showAltLanguage`.
 
 `OffsetRel`
 : Position of a way in relation to the original way. Possible values are
@@ -335,15 +343,15 @@ Currently allowed instances:
 
 The text style for point labels has the following attributes:
 
-Name         |Type         |Description
--------------|-------------|-----------
-label        |FeatureAttr  |The name of the feature attribute to be rendered.
-style        |TextStyle    |Depending on the value (normal or emphasize) the label is either drawn normal or (depending on the backend the visualisation may be different) somehow emphasized.
-color        |Color        |The color of the text
-size         |Int          |The size of the text relative to the standard text size. 2.0 for example generates a text twice as height as normal.
-scaleMag     |Magnification|Starting with the given magnification in the label is drawn bigger but on the same time with increasing transparency with increasing magnification, genrating an overlay-like effect.
-priority     |Int          |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value. Note that labels with a certain alpha value will be ignored (so giant scaleMag labels will not "kill" all other labels beneeth).
-autoSize     |Bool         |The size of the label is automatically scaled to fit the height of the area itself. Thus bigger areas will get bigger labels, label with not be higher than the actual area.
+Name         |Type                         |Description
+-------------|-----------------------------|-----------
+label        |FeatureAttr or LabelProvider |The name of the feature attribute to be rendered or name of label provider.
+style        |TextStyle                    |Depending on the value (normal or emphasize) the label is either drawn normal or (depending on the backend the visualisation may be different) somehow emphasized.
+color        |Color                        |The color of the text
+size         |Int                          |The size of the text relative to the standard text size. 2.0 for example generates a text twice as height as normal.
+scaleMag     |Magnification                |Starting with the given magnification in the label is drawn bigger but on the same time with increasing transparency with increasing magnification, genrating an overlay-like effect.
+priority     |Int                          |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value. Note that labels with a certain alpha value will be ignored (so giant scaleMag labels will not "kill" all other labels beneeth).
+autoSize     |Bool                         |The size of the label is automatically scaled to fit the height of the area itself. Thus bigger areas will get bigger labels, label with not be higher than the actual area.
 
 ### PathTextStyle - Draw labels onto ways and area borders
 
@@ -354,14 +362,14 @@ Currently allowed instances:
 
 The text style for contour labels has the following attributes:
 
-Name         |Type         |Description
--------------|-------------|-----------
-label        |FeatureAttr  |The name of the feature attribute to be rendered.
-color        |Color        |The color of the text
-size         |Int          |The size of the text relative to the standard text size. 2.0 for example genrates a text twice as height as normal.
-displayOffset|ScreenSize   |Offset of drawn text in relation to the actual path.
-offset       |GroundSize   |Offset of the drawn text in relation to the actual path.
-priority     |Int          |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value.
+Name         |Type                         |Description
+-------------|-----------------------------|-----------
+label        |FeatureAttr or LabelProvider |The name of the feature attribute to be rendered or name of label provider.
+color        |Color                        |The color of the text
+size         |Int                          |The size of the text relative to the standard text size. 2.0 for example genrates a text twice as height as normal.
+displayOffset|ScreenSize                   |Offset of drawn text in relation to the actual path.
+offset       |GroundSize                   |Offset of the drawn text in relation to the actual path.
+priority     |Int                          |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value.
 
 ### IconStyle - Drawing icons for nodes and areas
 
@@ -386,15 +394,15 @@ Currently allowed instances:
 
 The shield style has the following attributes:
 
-Name           |Type         |Description
----------------|-------------|-----------
-label          |FeatureAttr  |The name of the feature attribute to be rendered.
-color          |Color        |The color of the text
-backgroundColor|Color        |The color of the shield itself
-borderColor    |Color        |The color of the border.
-size           |Int          |The size of the text relative to the standard text size. 2.0 for example genrates a text twice as height as normal.
-priority       |Int          |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value. Note that labels with a certain alpha value will be ignored (so giant scaleMag labels will not "kill" all other labels beneeth).
-shieldSpace    |ScreenSize   |Space between each shield on a path.
+Name           |Type                          |Description
+---------------|------------------------------|-----------
+label          |FeatureAttr or LabelProvider  |The name of the feature attribute to be rendered or name of label provider.
+color          |Color                         |The color of the text
+backgroundColor|Color                         |The color of the shield itself
+borderColor    |Color                         |The color of the border.
+size           |Int                           |The size of the text relative to the standard text size. 2.0 for example genrates a text twice as height as normal.
+priority       |Int                           |numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value. Note that labels with a certain alpha value will be ignored (so giant scaleMag labels will not "kill" all other labels beneeth).
+shieldSpace    |ScreenSize                    |Space between each shield on a path.
 
 ### PathSymbolStyle - Drawing symbols onto paths
 


### PR DESCRIPTION
This is continuation of https://github.com/Framstag/libosmscout/pull/792

Stylesheet author may choose one from elevation variants:
Ele.inMeter, Ele.inFeet, Ele.inLocaleUnit

In our stylesheets, I changed all usages to `inLocaleUnit`...