### PR TITLE
fix elevation formating

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -127,6 +127,12 @@ set_property(TARGET EncodeNumber PROPERTY CXX_STANDARD 14)
 target_link_libraries(EncodeNumber OSMScout)
 add_test(NAME EncodeNumber COMMAND EncodeNumber)
 
+#---- FeatureLabelTest
+add_executable(FeatureLabelTest src/FeatureLabelTest.cpp)
+set_property(TARGET FeatureLabelTest PROPERTY CXX_STANDARD 14)
+target_link_libraries(FeatureLabelTest OSMScout)
+add_test(NAME FeatureLabelTest COMMAND FeatureLabelTest)
+
 #---- FileScannerWriter
 add_executable(FileScannerWriter src/FileScannerWriter.cpp)
 set_property(TARGET FileScannerWriter PROPERTY CXX_STANDARD 14)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -130,6 +130,7 @@ add_test(NAME EncodeNumber COMMAND EncodeNumber)
 #---- FeatureLabelTest
 add_executable(FeatureLabelTest src/FeatureLabelTest.cpp)
 set_property(TARGET FeatureLabelTest PROPERTY CXX_STANDARD 14)
+target_include_directories(FeatureLabelTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(FeatureLabelTest OSMScout)
 add_test(NAME FeatureLabelTest COMMAND FeatureLabelTest)
 

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -82,6 +82,13 @@ EncodeNumber = executable('EncodeNumber',
              link_with: [osmscout],
              install: false)
 
+FeatureLabelTest = executable('FeatureLabelTest',
+             'src/FeatureLabelTest.cpp',
+             include_directories: [osmscoutIncDir],
+             dependencies: [mathDep, openmpDep],
+             link_with: [osmscout],
+             install: false)
+
 FileScannerWriter = executable('FileScannerWriter',
              'src/FileScannerWriter.cpp',
              include_directories: [osmscoutIncDir],
@@ -248,6 +255,7 @@ test('Check encoding of numbers', BitsAndBytesNeeded)
 test('Check parsing of command line args', CmdLineParsing)
 test('Check parsing of colors', ColorParse)
 test('Check encoding of numbers', EncodeNumber)
+test('Check label formatting', FeatureLabelTest)
 test('Check File access implementation', FileScannerWriter)
 test('Check parsing of geo box intersection', GeoBox)
 test('Check parsing of geo coordinates', GeoCoordParse)

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -84,7 +84,7 @@ EncodeNumber = executable('EncodeNumber',
 
 FeatureLabelTest = executable('FeatureLabelTest',
              'src/FeatureLabelTest.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)

--- a/Tests/src/FeatureLabelTest.cpp
+++ b/Tests/src/FeatureLabelTest.cpp
@@ -1,0 +1,30 @@
+
+#include <osmscout/TypeFeatures.h>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+using namespace osmscout;
+
+TEST_CASE("Elevation label formatting")
+{
+  EleFeatureValue ele;
+  ele.SetEle(1000);
+
+  Locale locale; // C locale
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_METER_LABEL_INDEX) == "1000\xE2\x80\xAFm");
+
+  locale.SetThousandsSeparator(",");
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_METER_LABEL_INDEX) == "1,000\xE2\x80\xAFm");
+
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_LOCALE_UNIT_LABEL_INDEX) == "1,000\xE2\x80\xAFm");
+
+  locale.SetUnitsSeparator(" ");
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_FEET_LABEL_INDEX) == "3,281 ft");
+
+  locale.SetUnitsSeparator("");
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_FEET_LABEL_INDEX) == "3,281ft");
+
+  locale.SetDistanceUnits(Units::Imperial);
+  REQUIRE(ele.GetLabel(locale, EleFeature::IN_LOCALE_UNIT_LABEL_INDEX) == "3,281ft");
+}

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -24,6 +24,9 @@
 #include <osmscout/util/String.h>
 
 #include <iostream>
+#include <sstream>
+#include <iomanip>
+
 namespace osmscout {
 
   void NameFeatureValue::Read(FileScanner& scanner)
@@ -1899,15 +1902,19 @@ namespace osmscout {
       unitsStr="m";
     }
 
-    std::string valueStr;
+    std::stringstream ss;
     if (value < 1000 || locale.GetThousandsSeparator().empty()){
-      valueStr=std::to_string(value);
+      ss << value;
     }else{
       // not expecting that value will be bigger than million
-      valueStr=std::to_string(value/1000) + locale.GetThousandsSeparator() + std::to_string(value%1000);
+      ss << (value/1000);
+      ss << locale.GetThousandsSeparator();
+      ss << std::setw(3) << std::setfill('0') << (value%1000);
     }
 
-    return valueStr + locale.GetUnitsSeparator() + unitsStr;
+    ss << locale.GetUnitsSeparator();
+    ss << unitsStr;
+    return ss.str();
   }
 
   bool EleFeatureValue::operator==(const FeatureValue& other) const


### PR DESCRIPTION
When printing number with thousand separator,
we cannot forget to print leading zeros before second part.

For example number number 1010 should be printed as "1 010" not "1 10"