### PR TITLE
Cppcheck

### DIFF
--- a/Demos/src/ElevationProfile.cpp
+++ b/Demos/src/ElevationProfile.cpp
@@ -46,7 +46,7 @@ private:
   double millis{0};
 
 public:
-  DataLoader(osmscout::DatabaseRef &database):
+  explicit DataLoader(osmscout::DatabaseRef &database):
     database(database),
     reader(*(database->GetTypeConfig()))
   {

--- a/Demos/src/NavigationSimulator.cpp
+++ b/Demos/src/NavigationSimulator.cpp
@@ -266,7 +266,7 @@ private:
   osmscout::DatabaseRef   database;
   osmscout::MapServiceRef mapService;
 public:
-  DataLoader(const osmscout::DatabaseRef &database):
+  explicit DataLoader(const osmscout::DatabaseRef &database):
     database(database),
     mapService{std::make_shared<osmscout::MapService>(database)}
   {}

--- a/libosmscout-gpx/include/osmscout/gpx/TrackPoint.h
+++ b/libosmscout-gpx/include/osmscout/gpx/TrackPoint.h
@@ -35,7 +35,7 @@ namespace gpx {
 class OSMSCOUT_GPX_API TrackPoint {
 public:
 
-  inline TrackPoint(const GeoCoord coord) :
+  inline explicit TrackPoint(const GeoCoord coord) :
       coord(coord) {
   }
 

--- a/libosmscout-gpx/include/osmscout/gpx/Waypoint.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Waypoint.h
@@ -34,7 +34,7 @@ namespace gpx {
 
 class OSMSCOUT_GPX_API Waypoint {
 public:
-  Waypoint(GeoCoord coord) :
+  explicit Waypoint(GeoCoord coord) :
       coord(coord) {
   }
 

--- a/libosmscout-import/include/osmscout/import/GenLocationIndex.h
+++ b/libosmscout-import/include/osmscout/import/GenLocationIndex.h
@@ -136,7 +136,7 @@ namespace osmscout {
       FileOffset                           dataOffsetOffset; //!< Offset into the index file
       std::map<std::string,RegionLocation> locations;        //!< list of indexed objects in this region
 
-      PostalArea(const std::string& name)
+      explicit PostalArea(const std::string& name)
       : name(name)
       {
         // no code

--- a/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
+++ b/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
@@ -63,7 +63,7 @@ namespace osmscout {
       bool   *hasIncludes;
 
     public:
-      GroupingState(size_t rings)
+      explicit GroupingState(size_t rings)
       {
         this->rings=rings;
 

--- a/libosmscout-import/include/osmscout/import/ShapeFileScanner.h
+++ b/libosmscout-import/include/osmscout/import/ShapeFileScanner.h
@@ -66,7 +66,7 @@ namespace osmscout {
     double ReadDoubleLE();
 
   public:
-    ShapeFileScanner(const std::string& filename);
+    explicit ShapeFileScanner(const std::string& filename);
     ~ShapeFileScanner();
 
     void Open();

--- a/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscout/import/WaterIndexProcessor.h
@@ -53,7 +53,7 @@ namespace osmscout {
     * and check the result...
     */
   template<typename InputIterator>
-  void WriteGpx(InputIterator begin, InputIterator end, const std::string name)
+  void WriteGpx(InputIterator begin, InputIterator end, const std::string &name)
   {
     std::ofstream gpxFile;
 

--- a/libosmscout-map-opengl/include/poly2tri/sweep/advancing_front.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/advancing_front.h
@@ -48,7 +48,7 @@ struct Node {
 
   double value;
 
-  Node(Point& p) : point(&p), triangle(nullptr), next(nullptr), prev(nullptr), value(p.x)
+  explicit Node(Point& p) : point(&p), triangle(nullptr), next(nullptr), prev(nullptr), value(p.x)
   {
   }
 

--- a/libosmscout-map-opengl/include/poly2tri/sweep/cdt.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/cdt.h
@@ -53,7 +53,7 @@ public:
    * 
    * @param polyline
    */
-  CDT(std::vector<Point*> polyline);
+  explicit CDT(std::vector<Point*> polyline);
   
    /**
    * Destructor - clean up memory

--- a/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
@@ -52,7 +52,7 @@ class SweepContext {
 public:
 
 /// Constructor
-explicit SweepContext(std::vector<Point*> polyline);
+explicit SweepContext(const std::vector<Point*> &polyline);
 /// Destructor
 ~SweepContext();
 

--- a/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
@@ -52,7 +52,7 @@ class SweepContext {
 public:
 
 /// Constructor
-SweepContext(std::vector<Point*> polyline);
+explicit SweepContext(std::vector<Point*> polyline);
 /// Destructor
 ~SweepContext();
 

--- a/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
@@ -34,7 +34,7 @@
 
 namespace p2t {
 
-SweepContext::SweepContext(std::vector<Point*> polyline) :
+SweepContext::SweepContext(const std::vector<Point*> &polyline) :
   front_(0),
   head_(0),
   tail_(0),

--- a/libosmscout-map/include/osmscout/LabelLayouter.h
+++ b/libosmscout-map/include/osmscout/LabelLayouter.h
@@ -202,7 +202,7 @@ namespace osmscout {
   class Mask
   {
   public:
-    Mask(size_t rowSize) : d(rowSize)
+    explicit Mask(size_t rowSize) : d(rowSize)
     {
     };
 

--- a/libosmscout/include/osmscout/ElevationService.h
+++ b/libosmscout/include/osmscout/ElevationService.h
@@ -53,8 +53,8 @@ private:
   MagnificationLevel loadTileMag;
 
 public:
-  ElevationService(DataLoader &dataLoader,
-                   MagnificationLevel loadTileMag = Magnification::magSuburb):
+  explicit ElevationService(DataLoader &dataLoader,
+                            MagnificationLevel loadTileMag = Magnification::magSuburb):
       dataLoader(dataLoader), loadTileMag(loadTileMag)
   {}
 

--- a/libosmscout/include/osmscout/GroundTile.h
+++ b/libosmscout/include/osmscout/GroundTile.h
@@ -63,10 +63,7 @@ namespace osmscout {
       uint16_t y;
       bool     coast;
 
-      inline Coord()
-      {
-        // no code
-      }
+      inline Coord() = default;
 
       inline Coord(uint16_t x,
                    uint16_t y,
@@ -101,10 +98,7 @@ namespace osmscout {
     double             cellHeight;    //!< Height of cell
     std::vector<Coord> coords;        //!< Optional coordinates for coastline
 
-    inline GroundTile()
-    {
-      // no code
-    }
+    inline GroundTile() = default;
 
     inline explicit GroundTile(Type type)
     : type(type)

--- a/libosmscout/include/osmscout/POIService.h
+++ b/libosmscout/include/osmscout/POIService.h
@@ -44,10 +44,8 @@ namespace osmscout {
   private:
     DatabaseRef database;
 
-
-
   public:
-    POIService(const DatabaseRef& database);
+    explicit POIService(const DatabaseRef& database);
     virtual ~POIService();
 
     void GetPOIsInArea(const GeoBox& boundingBox,

--- a/libosmscout/include/osmscout/Pixel.h
+++ b/libosmscout/include/osmscout/Pixel.h
@@ -47,10 +47,7 @@ namespace osmscout {
     /**
      * The default constructor creates an uninitialized instance (for performance reasons).
      */
-    inline Pixel()
-    {
-      // no code
-    }
+    inline Pixel() = default;
 
     inline Pixel(uint32_t x, uint32_t y)
      :x(x),y(y)

--- a/libosmscout/include/osmscout/Pixel.h
+++ b/libosmscout/include/osmscout/Pixel.h
@@ -109,7 +109,7 @@ namespace osmscout {
       // no code
     }
 
-    inline Vertex2D(const Vertex2D& other)
+    inline Vertex2D(const Vertex2D& other) noexcept
     {
       coords[0]=other.coords[0];
       coords[1]=other.coords[1];

--- a/libosmscout/include/osmscout/SRTM.h
+++ b/libosmscout/include/osmscout/SRTM.h
@@ -61,7 +61,7 @@ namespace osmscout {
         unsigned char   *heights;
 
     public:
-        SRTM(const std::string &path);
+        explicit SRTM(const std::string &path);
         virtual ~SRTM();
         const std::string& srtmFilename(int patchLat, int patchLon);
         int heightAtLocation(double latitude, double longitude);

--- a/libosmscout/include/osmscout/navigation/Engine.h
+++ b/libosmscout/include/osmscout/navigation/Engine.h
@@ -91,7 +91,7 @@ namespace osmscout {
     std::vector<NavigationAgentRef> agents;
 
   public:
-    NavigationEngine(std::initializer_list<NavigationAgentRef> agents);
+    explicit NavigationEngine(std::initializer_list<NavigationAgentRef> agents);
     std::list<NavigationMessageRef> Process(const NavigationMessageRef& message);
   };
 }

--- a/libosmscout/include/osmscout/navigation/Navigation.h
+++ b/libosmscout/include/osmscout/navigation/Navigation.h
@@ -108,7 +108,7 @@ namespace osmscout {
      * outputDescr pointer is not owned, it should not be destroyed before Navigation,
      * caller is responsible for deleting it.
      */
-    Navigation(OutputDescription<NodeDescriptionTmpl>* outputDescr)
+    explicit Navigation(OutputDescription<NodeDescriptionTmpl>* outputDescr)
       : route(nullptr),
         outputDescription(outputDescr),
         snapDistanceInMeters(Distance::Of<Meter>(25.0))

--- a/libosmscout/include/osmscout/navigation/PositionAgent.h
+++ b/libosmscout/include/osmscout/navigation/PositionAgent.h
@@ -83,7 +83,7 @@ namespace osmscout {
       RouteDescriptionRef route;
       Position position;
 
-      PositionMessage(const Timestamp& timestamp, const RouteDescriptionRef &route, const Position position);
+      PositionMessage(const Timestamp& timestamp, const RouteDescriptionRef &route, const Position &position);
     };
 
     using PositionMessageRef=std::shared_ptr<PositionMessage>;

--- a/libosmscout/include/osmscout/navigation/RouteInstructionAgent.h
+++ b/libosmscout/include/osmscout/navigation/RouteInstructionAgent.h
@@ -32,7 +32,7 @@ struct RouteInstructionsMessage CLASS_FINAL : public NavigationMessage
 public:
   std::list<RouteInstruction> instructions;
 
-  inline RouteInstructionsMessage(const Timestamp& timestamp, std::list<RouteInstruction> instructions):
+  inline RouteInstructionsMessage(const Timestamp& timestamp, const std::list<RouteInstruction> &instructions):
     NavigationMessage(timestamp), instructions(instructions)
   {}
 };

--- a/libosmscout/include/osmscout/util/Bearing.h
+++ b/libosmscout/include/osmscout/util/Bearing.h
@@ -55,7 +55,7 @@ namespace osmscout {
       return *this;
     }
 
-    inline Bearing(Bearing &&d)
+    inline Bearing(Bearing &&d) noexcept
     {
       std::swap(radians, d.radians);
     }

--- a/libosmscout/include/osmscout/util/Distance.h
+++ b/libosmscout/include/osmscout/util/Distance.h
@@ -101,7 +101,7 @@ namespace osmscout {
       return *this;
     }
 
-    inline Distance(Distance &&d)
+    inline Distance(Distance &&d) noexcept
     {
       std::swap(meters, d.meters);
     }

--- a/libosmscout/src/osmscout/navigation/PositionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/PositionAgent.cpp
@@ -82,7 +82,7 @@ namespace osmscout {
 
   PositionAgent::PositionMessage::PositionMessage(const Timestamp& timestamp,
                                                   const RouteDescriptionRef &route,
-                                                  const Position position):
+                                                  const Position &position):
                                                   NavigationMessage(timestamp),
                                                   route(route),
                                                   position(position)

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -28,7 +28,7 @@ fi
 
 cd $BUILDDIR
 echo "Calling cppcheck..."
-cppcheck -q --force --enable=all --std=c++11 --xml-version=2 --include="$MACROS" --xml --project="$PROJECT" 2>cppcheck.xml
+cppcheck -q --force --enable=all --std=c++14 --xml-version=2 --include="$MACROS" --xml --project="$PROJECT" 2>cppcheck.xml
 echo "Calling cppcheck-htmlreport..."
 cppcheck-htmlreport --file cppcheck.xml --report-dir=cppcheck
 


### PR DESCRIPTION
update cppcheck standard to c++14 and fixes for few reported errors and warnings

 - mark move constructors as `noexcept`
 - replace empty constructors with default one
 - mark constructors with one argument as explicit 