### PR TITLE
fix animation computation in LockHandler

### DIFF
--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -725,7 +725,9 @@ bool LockHandler::currentPosition(bool locationValid, osmscout::GeoCoord current
         double x;
         double y;
         projection.GeoToPixel(currentPosition, x, y);
-        double distanceFromCenter = sqrt(pow(std::abs(500.0 - x), 2) + pow(std::abs(500.0 - y), 2));
+        double distanceFromCenter = sqrt(pow(std::abs(projection.GetWidth()/2 - x), 2) +
+                                         pow(std::abs(projection.GetHeight()/2 - y), 2));
+
         double moveTolerance = std::min(window.width(), window.height()) / 4;
         if (distanceFromCenter > moveTolerance){
             JumpHandler::showCoordinates(currentPosition, view.magnification, view.angle);


### PR DESCRIPTION
Computation of current possition distance from the display
center was wrong. This error was not visible on UI,
but animation in input handler was running all the
time when LockHandler was active. For that reason,
application could cause high battery consumption.