### PR TITLE
add tunnel feature to waterway_stream type

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -445,7 +445,7 @@ TYPES
 
   TYPE waterway_stream
     = WAY ("waterway"=="stream")
-      {Name, NameAlt, Width}
+      {Name, NameAlt, Width, Tunnel}
       OPTIMIZE_LOW_ZOOM IGNORESEALAND PIN_WAY
 
   TYPE waterway_river

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -723,6 +723,10 @@ STYLE
       [TYPE waterway_stream] {
         [SIZE 2m 0.25mm:3px<] WAY {color: @waterColor; width: 2m;}
         [SIZE 2m <0.25mm:3px] WAY {color: @waterColor; displayWidth: 0.25mm;}
+
+        [FEATURE Tunnel] {
+          WAY { dash: 0.4,4;}
+        }
       }
     }
 

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -639,6 +639,10 @@ STYLE
       [TYPE waterway_stream] {
         [SIZE 2m 0.25mm:3px<] WAY {color: @waterColor; width: 2m;}
         [SIZE 2m <0.25mm:3px] WAY {color: @waterColor; displayWidth: 0.25mm;}
+
+        [FEATURE Tunnel] {
+          WAY { dash: 0.4,4;}
+        }
       }
     }
 


### PR DESCRIPTION
...and define dashed line for such streams in stylesheets

Streams are often hidden in cannals in cities.
When such streams are rendered with the full line,
it may be confusing.