### PR TITLE
Area import improvements

### DIFF
--- a/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
+++ b/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
@@ -158,6 +158,18 @@ namespace osmscout {
         }
       }
 
+      inline std::string GetRelationRoleStr() const
+      {
+        switch (relationRole){
+          case outer:
+            return "outer";
+          case inner:
+            return "inner";
+          default:
+            return "none";
+        }
+      }
+
       inline void SetId(OSMId id)
       {
         this->id = id;

--- a/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
+++ b/libosmscout-import/include/osmscout/import/GenRelAreaDat.h
@@ -127,6 +127,15 @@ namespace osmscout {
       Area::Ring           role;
       std::list<RawWayRef> ways;
 
+      // diagnostics data
+      enum RelationRole {
+        none,
+        inner,
+        outer
+      } relationRole{none};
+
+      OSMId id{0};
+
       inline bool IsArea() const
       {
         if (ways.size()==1) {
@@ -136,6 +145,22 @@ namespace osmscout {
         else {
           return false;
         }
+      }
+
+      inline void SetRelationRole(const std::string &role)
+      {
+        if (role=="outer") {
+          relationRole=outer;
+        } else if (role=="inner") {
+          relationRole=inner;
+        } else {
+          relationRole=none;
+        }
+      }
+
+      inline void SetId(OSMId id)
+      {
+        this->id = id;
       }
     };
 
@@ -149,7 +174,8 @@ namespace osmscout {
                                                         const GroupingState& state,
                                                         size_t& subIndex);
 
-    void ConsumeSubs(const std::list<MultipolygonPart>& rings,
+    void ConsumeSubs(Progress& progress,
+                     const std::list<MultipolygonPart>& rings,
                      std::list<MultipolygonPart>& groups,
                      GroupingState& state,
                      size_t topIndex,

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -119,7 +119,8 @@ namespace osmscout {
     Recursively consume all direct children and all direct children of that children)
     of the given role.
    */
-  void RelAreaDataGenerator::ConsumeSubs(const std::list<MultipolygonPart>& rings,
+  void RelAreaDataGenerator::ConsumeSubs(Progress& progress,
+                                         const std::list<MultipolygonPart>& rings,
                                          std::list<MultipolygonPart>& groups,
                                          GroupingState& state,
                                          size_t topIndex,
@@ -128,15 +129,25 @@ namespace osmscout {
     std::list<MultipolygonPart>::const_iterator sub;
     size_t                                      subIndex;
 
-    sub=FindSub(rings,topIndex,state,subIndex);
-    while (sub!=rings.end()) {
+
+    for (sub=FindSub(rings,topIndex,state,subIndex);
+         sub!=rings.end();
+         sub=FindSub(rings,topIndex,state,subIndex)) {
+
       state.SetUsed(subIndex);
+
+      if (sub->relationRole!=MultipolygonPart::none){
+        MultipolygonPart::RelationRole expectedRole = id % 2 == 0 ? MultipolygonPart::inner : MultipolygonPart::outer;
+        if (sub->relationRole != expectedRole) {
+          progress.Error("Ring " + std::to_string(sub->id) + " has invalid role, continue");
+          continue;
+        }
+      }
+
       groups.push_back(*sub);
       groups.back().role.SetRing(id);
 
-      ConsumeSubs(rings,groups,state,subIndex,id+1);
-
-      sub=FindSub(rings,topIndex,state,subIndex);
+      ConsumeSubs(progress,rings,groups,state,subIndex,id+1);
     }
   }
 
@@ -221,6 +232,9 @@ namespace osmscout {
 
         ring.role.SetType(typeConfig.typeInfoIgnore);
         ring.ways=part->ways;
+        assert(!part->ways.empty());
+        ring.SetId(part->ways.front()->GetId());
+        ring.relationRole=part->relationRole;
 
         ringParts.push_back(part);
         nodeCount=part->role.nodes.size();
@@ -384,13 +398,17 @@ namespace osmscout {
       }
 
       state.SetUsed(topIndex);
+      if (top->relationRole!=MultipolygonPart::none && top->relationRole!=MultipolygonPart::outer) {
+        progress.Error("Ring " + std::to_string(top->id) + " is not outer, continue");
+        continue;
+      }
 
       groups.push_back(*top);
 
       groups.back().role.MarkAsOuterRing();
 
       if (state.HasIncludes(topIndex)) {
-        ConsumeSubs(parts,groups,state,topIndex,Area::outerRingId+1/*groups.back().role.GetRing()+1*/);
+        ConsumeSubs(progress,parts,groups,state,topIndex,Area::outerRingId+1/*groups.back().role.GetRing()+1*/);
       }
     }
 
@@ -448,6 +466,8 @@ namespace osmscout {
         part.role.SetType(typeConfig.typeInfoIgnore);
         part.role.MarkAsMasterRing();
         part.role.nodes.resize(way->GetNodeCount());
+        part.SetRelationRole(member.role);
+        part.SetId(member.id);
 
         for (size_t n=0; n<way->GetNodeCount(); n++) {
           OSMId osmId=way->GetNodeId(n);
@@ -553,6 +573,8 @@ namespace osmscout {
         part.role.SetType(typeConfig.typeInfoIgnore);
         part.role.MarkAsMasterRing();
         part.role.nodes.resize(way->GetNodeCount());
+        part.SetId(way->GetId());
+        part.SetRelationRole(member.role);
 
         for (size_t n=0; n<way->GetNodeCount(); n++) {
           OSMId osmId=way->GetNodeId(n);

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -735,7 +735,7 @@ namespace osmscout {
                                  std::to_string(member.id)+
                                  " is referenced multiple times within relation "+
                                  std::to_string(rawRelation.GetId())+" "+name);
-                continue;;
+                continue;
               }
 
               if (resolvedRelations.find(member.id)!=resolvedRelations.end()) {

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -362,21 +362,32 @@ namespace osmscout {
 
     GroupingState state(parts.size());
 
-    size_t ix=0;
+    size_t i1=0;
     for (const auto& r1 : parts) {
-      size_t jx=0;
+      size_t i2=0;
       for (const auto& r2 : parts) {
-        if (ix!=jx) {
-          if (IsAreaSubOfArea(r2.role.nodes,
-                              r1.role.nodes)) {
-            state.SetIncluded(ix,jx);
+        if (i1 != i2) {
+          if (IsAreaSubOfArea(r2.role.nodes, r1.role.nodes)) {
+            if (!IsAreaCompletelyInArea(r2.role.nodes, r1.role.nodes)) {
+              // ring r2 is not included in r1 completely, but at least
+              // one its node is included => rings are intersecting!
+              progress.Warning("Rings " + std::to_string(r1.id) + " (" + r1.GetRelationRoleStr() + "), " +
+                               std::to_string(r2.id) + " (" + r2.GetRelationRoleStr() + "), " +
+                               "in relation " + std::to_string(id) + " are intersecting!");
+              // in such case, setup inclusion only when r1 is outer and r2 inner
+              if (r1.relationRole!=MultipolygonPart::outer || r2.relationRole!=MultipolygonPart::inner){
+                continue;
+              }
+            }
+
+            state.SetIncluded(i1, i2);
           }
         }
 
-        jx++;
+        i2++;
       }
 
-      ix++;
+      i1++;
     }
 
     //

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -696,7 +696,8 @@ namespace osmscout {
           pendingRelationIds.insert(member.id);
         }
         else {
-          progress.Warning("Unsupported relation reference in relation "+
+          progress.Warning("Unsupported relation ("+std::to_string(member.id)+") "+
+                           "reference in relation "+
                            std::to_string(rawRelation.GetId())+" "+
                            rawRelation.GetType()->GetName()+" "+
                            name);

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -47,31 +47,36 @@ namespace osmscout {
    *    -- nested outer rings (odd ring number >= 3)
    *  - inner ring(s) (even ring number)
    *
-   *  This hierarchy may be presented as a tree, where ring number represent depth.
-   *  Master ring is first and the rest of rings are ordered deep-first fashion in Area::rings vector
-   *  (top-level outer rings are on the top of the tree).
+   * This hierarchy may be presented as a tree, where ring number represent depth.
+   * Master ring is first and the rest of rings are ordered deep-first fashion in Area::rings vector
+   * (top-level outer rings are on the top of the tree).
    *
-   *  When object consists just from single outline (simple building for example),
-   *  Area contains just one (top level) outer ring
+   * When object consists just from single outline (simple building for example),
+   * Area contains just one (top level) outer ring
    *
-   *  When area is multipolygon relation (in OSM words), type and features of such relation
-   *  are stored in master ring. Every outer ring may have its own type and features.
+   * When area is multipolygon relation (in OSM words), type and features of such relation
+   * are stored in master ring. Every outer ring may have its own type and features.
    *
-   *  When outer ring has not type (GetType()->GetIgnore()), type of master ring
-   *  or nearest (upper) master ring should be used.
+   * When outer ring has not type (GetType()->GetIgnore()), type of master ring should be used.
    *
-   *  When inner ring has no type (GetType()->GetIgnore())
-   *  it is used as simple clipping of containing (upper) outer ring.
+   * When inner ring has no type (GetType()->GetIgnore())
+   * it is used as simple clipping of containing (upper) outer ring.
    *
-   *  For example this ruin: https://www.openstreetmap.org/relation/7281899
-   *  Will have seven rings:
-   *   [0] master (number 0) with type "building", without nodes
-   *   [1] outer (number 1) without type, OSM id 295845013
-   *   [2] inner (number 2) without type, OSM id 495919001
-   *   [3] outer (number 3) without type, OSM id 495919003
-   *   [4] outer (number 3) without type, OSM id 495919002
-   *   [5] inner (number 2) without type, OSM id 495919008
-   *   [6] inner (number 2) without type, OSM id 495919006
+   * For example this ruin: https://www.openstreetmap.org/relation/7281899
+   * Will have seven rings:
+   *  [0] master (number 0) with type "building", without nodes
+   *  [1] outer (number 1) without type, OSM id 295845013
+   *  [2] inner (number 2) without type, OSM id 495919001
+   *  [3] outer (number 3) without type, OSM id 495919003
+   *  [4] outer (number 3) without type, OSM id 495919002
+   *  [5] inner (number 2) without type, OSM id 495919008
+   *  [6] inner (number 2) without type, OSM id 495919006
+   *
+   * Nested relations (member type=relation, role=inner|outer) are not supported for areas now.
+   * See RelAreaDataGenerator::ResolveMultipolygonMembers code for the details.
+   * For example relation https://www.openstreetmap.org/relation/7751062 will be created
+   * just with master and one outer ring. Its nested relation (inner role)
+   * https://www.openstreetmap.org/relation/7074095 will be imported as a separate Area.
    */
   class OSMSCOUT_API Area CLASS_FINAL
   {

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -37,8 +37,42 @@
 
 namespace osmscout {
   /**
-    Representation of an (complex/multipolygon) area
-    */
+   * Representation of an (complex/multipolygon) area.
+   *
+   * It consists from hierarchy of rings:
+   *
+   *  - optional master ring (ring number 0)
+   *  - outer ring(s) (odd ring number)
+   *    -- top level outer rings (ring number == 1)
+   *    -- nested outer rings (odd ring number >= 3)
+   *  - inner ring(s) (even ring number)
+   *
+   *  This hierarchy may be presented as a tree, where ring number represent depth.
+   *  Master ring is first and the rest of rings are ordered deep-first fashion in Area::rings vector
+   *  (top-level outer rings are on the top of the tree).
+   *
+   *  When object consists just from single outline (simple building for example),
+   *  Area contains just one (top level) outer ring
+   *
+   *  When area is multipolygon relation (in OSM words), type and features of such relation
+   *  are stored in master ring. Every outer ring may have its own type and features.
+   *
+   *  When outer ring has not type (GetType()->GetIgnore()), type of master ring
+   *  or nearest (upper) master ring should be used.
+   *
+   *  When inner ring has no type (GetType()->GetIgnore())
+   *  it is used as simple clipping of containing (upper) outer ring.
+   *
+   *  For example this ruin: https://www.openstreetmap.org/relation/7281899
+   *  Will have seven rings:
+   *   [0] master (number 0) with type "building", without nodes
+   *   [1] outer (number 1) without type, OSM id 295845013
+   *   [2] inner (number 2) without type, OSM id 495919001
+   *   [3] outer (number 3) without type, OSM id 495919003
+   *   [4] outer (number 3) without type, OSM id 495919002
+   *   [5] inner (number 2) without type, OSM id 495919008
+   *   [6] inner (number 2) without type, OSM id 495919006
+   */
   class OSMSCOUT_API Area CLASS_FINAL
   {
   public:
@@ -107,6 +141,7 @@ namespace osmscout {
         return ring==masterRingId;
       }
 
+      // top level outer ring
       inline bool IsOuterRing() const
       {
         return ring==outerRingId;

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -57,7 +57,12 @@ namespace osmscout {
    * When area is multipolygon relation (in OSM words), type and features of such relation
    * are stored in master ring. Every outer ring may have its own type and features.
    *
-   * When outer ring has not type (GetType()->GetIgnore()), type of master ring should be used.
+   * When outer ring has not type (GetType()->GetIgnore()), type of relation (master ring) should be used.
+   * But OSM documentation is not clear what type should be used when outer ring has different type than relation.
+   * For example this relation: https://www.openstreetmap.org/relation/7826515
+   *  - master ring has type "leisure_park" and outer ring "place_islet".
+   * OSM Scout library don't support multiple types for object, so in such cases,
+   * we are using relation type for top-level outer ring and ring type for nested outer rings.
    *
    * When inner ring has no type (GetType()->GetIgnore())
    * it is used as simple clipping of containing (upper) outer ring.

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -447,7 +447,7 @@ namespace osmscout {
     // multiple outer but no master
     //
     // Also for each ring we would like to have a bit flag, if
-    // we stor eids or not
+    // we store ids or not
 
     // Outer ring
 


### PR DESCRIPTION
Hi Tim.

Here is initial batch for Area refactoring / improvements. 

First four commits extends import part: I just store OSM id and relation role to `MultipolygonPart`. OSM id is used just for debugging. Relation role is used to clarification what to do with the rings that are intersecting each other and then for validation that odd rings (odd ring number) are outer and even rings are inner.

The last commit adds documentation of Area and its rings. We recently discuss what to do with nested outer rings without type... I think that we should use type from relation itself (master ring) or nearest (upper) outer ring, like Mapnik does and I believe that it corresponds with documentation... Take a look to this building: https://www.openstreetmap.org/relation/7281899 how Mapnik handle it...
