### PR TITLE
Area refactoring

### DIFF
--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -783,7 +783,7 @@ static void DumpArea(const osmscout::AreaRef& area,
     std::cout << std::endl;
 
     size_t ident;
-    if (area->rings[r].IsMasterRing()) {
+    if (area->rings[r].IsMaster()) {
       ident=IDENT;
     }
     else {
@@ -791,11 +791,11 @@ static void DumpArea(const osmscout::AreaRef& area,
       ident=IDENT+2;
     }
 
-    if (area->rings[r].IsMasterRing()) {
+    if (area->rings[r].IsMaster()) {
       DumpIndent(ident);
       std::cout << "master" << std::endl;
     }
-    else if (area->rings[r].IsOuterRing()) {
+    else if (area->rings[r].IsTopOuter()) {
       DumpIndent(ident);
       std::cout << "outer" << std::endl;
       DumpIndent(ident);
@@ -833,7 +833,7 @@ static void DumpArea(const osmscout::AreaRef& area,
       }
     }
 
-    if (!area->rings[r].IsMasterRing()) {
+    if (!area->rings[r].IsMaster()) {
       ident-=2;
       DumpIndent(ident);
       std::cout << "}" << std::endl;

--- a/libosmscout-client-qt/include/osmscout/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/LookupModule.h
@@ -148,24 +148,23 @@ public:
 
 private:
 
-  template<class T> void addObjectInfo(QList<ObjectInfo> &objectList, // output
-                                       QString type,
-                                       const ObjectFileRef &ref,
-                                       const std::vector<osmscout::Point> &points,
-                                       const osmscout::GeoCoord &center,
-                                       const T &o,
-                                       const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
-                                       LocationServiceRef &locationService,
-                                       std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
+  void addObjectInfo(QList<ObjectInfo> &objectList, // output
+                     QString type,
+                     const ObjectFileRef &ref,
+                     const std::vector<osmscout::Point> &points,
+                     const osmscout::GeoCoord &center,
+                     const osmscout::TypeInfoRef &objectType,
+                     const osmscout::FeatureValueBuffer &features,
+                     const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
+                     LocationServiceRef &locationService,
+                     std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
   {
     ObjectInfo info;
     //std::cout << " - "<<type.toStdString()<<": " << o->GetType()->GetName() << " " << ref.GetName();
 
     info.type=type;
-    info.objectType=QString::fromStdString(o->GetType()->GetName());
+    info.objectType=QString::fromStdString(objectType->GetName());
     info.id=ref.GetFileOffset();
-
-    const osmscout::FeatureValueBuffer &features=o->GetFeatureValueBuffer();
 
     const osmscout::NameFeatureValue *name=features.findValue<osmscout::NameFeatureValue>();
     if (name!=nullptr){
@@ -192,6 +191,19 @@ private:
     info.points=points;
 
     objectList << info;
+  }
+
+  template<class T> void addObjectInfo(QList<ObjectInfo> &objectList, // output
+                                       QString type,
+                                       const ObjectFileRef &ref,
+                                       const std::vector<osmscout::Point> &points,
+                                       const osmscout::GeoCoord &center,
+                                       const T &o,
+                                       const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
+                                       LocationServiceRef &locationService,
+                                       std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
+  {
+    addObjectInfo(objectList,type,ref,points,center,o->GetType(),o->GetFeatureValueBuffer(),reverseLookupMap,locationService,regionMap);
   }
 
   void addObjectInfo(QList<ObjectInfo> &objectList, // output

--- a/libosmscout-client-qt/src/osmscout/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/LookupModule.cpp
@@ -111,23 +111,28 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
 
 void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                                  const AreaRef &a,
-                   const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
-                   LocationServiceRef &locationService,
-                   std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
+                                 const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
+                                 LocationServiceRef &locationService,
+                                 std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
 {
   for (const auto &ring:a->rings) {
-    if (!ring.GetType()->GetIgnore()) {
-      addObjectInfo(objectList,
-                    "area",
-                    a->GetObjectFileRef(),
-                    ring.nodes,
-                    // Master ring don't contains nodes! Use intersection of all outer rings instead
-                    (ring.nodes.empty() ? a->GetBoundingBox() : ring.GetBoundingBox()).GetCenter(),
-                    &ring,
-                    reverseLookupMap,
-                    locationService,
-                    regionMap);
+    TypeInfoRef type=a->GetRingType(ring);
+    if (type->GetIgnore()) {
+      continue;
     }
+    // Master ring don't contains nodes! Use intersection of all outer rings instead
+    osmscout::GeoBox bbox=(ring.nodes.empty() ? a->GetBoundingBox() : ring.GetBoundingBox());
+
+    addObjectInfo(objectList,
+                  "area",
+                  a->GetObjectFileRef(),
+                  ring.nodes,
+                  bbox.GetCenter(),
+                  type,
+                  ring.GetFeatureValueBuffer(),
+                  reverseLookupMap,
+                  locationService,
+                  regionMap);
   }
 }
 

--- a/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapObjectInfoModel.cpp
@@ -120,6 +120,8 @@ QObject* MapObjectInfoModel::createOverlayObject(int row) const
         o->addPoint(p.GetLat(), p.GetLon());
       }
     }
+  } else {
+    qWarning() << "Object " << obj.name << " (" << obj.type << " / " << obj.objectType << ") has no points!";
   }
 
   return o;

--- a/libosmscout-import/src/osmscout/import/GenAreaAreaIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenAreaAreaIndex.cpp
@@ -153,10 +153,10 @@ namespace osmscout {
           continue;
         }
 
-        if (ring.IsMasterRing() &&
+        if (ring.IsMaster() &&
             ring.nodes.empty()) {
           for (const auto& r : area.rings) {
-            if (r.IsOuterRing()) {
+            if (r.IsTopOuter()) {
               writer.WriteFileOffset(offset);
               writer.WriteNumber(ring.GetType()->GetAreaId());
 
@@ -345,7 +345,7 @@ namespace osmscout {
 
           if (area.rings.empty() ||
               (area.rings.size()==1 &&
-               area.rings[0].IsMasterRing())) {
+                  area.rings[0].IsMaster())) {
             save=false;
             return true;
           }

--- a/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenLocationIndex.cpp
@@ -993,7 +993,7 @@ namespace osmscout {
         }
 
         for (const auto& ring : area.rings) {
-          if (ring.IsOuterRing()) {
+          if (ring.IsTopOuter()) {
             std::vector<GeoCoord> coords;
 
             for (const auto& node : ring.nodes) {
@@ -1104,7 +1104,7 @@ namespace osmscout {
         }
 
         for (const auto& ring : area.rings) {
-          if (ring.IsOuterRing()) {
+          if (ring.IsTopOuter()) {
             std::vector<GeoCoord> coords;
 
             for (const auto& node : ring.nodes) {
@@ -1378,10 +1378,10 @@ namespace osmscout {
                                                        const std::string& postalCode,
                                                        const RegionIndex& regionIndex)
   {
-    if (ring.IsMasterRing() &&
+    if (ring.IsMaster() &&
         ring.nodes.empty()) {
       for (const auto& r : area.rings) {
-        if (r.IsOuterRing()) {
+        if (r.IsTopOuter()) {
           GeoBox boundingBox;
 
           r.GetBoundingBox(boundingBox);

--- a/libosmscout-import/src/osmscout/import/GenMergeAreas.cpp
+++ b/libosmscout-import/src/osmscout/import/GenMergeAreas.cpp
@@ -60,7 +60,7 @@ namespace osmscout {
                                                       Id id) const
   {
     for (size_t r = 0; r<area.rings.size(); r++) {
-      if (area.rings[r].IsOuterRing()) {
+      if (area.rings[r].IsTopOuter()) {
         for (const auto& node : area.rings[r].nodes) {
           if (node.GetId()==id) {
             return r;
@@ -79,7 +79,7 @@ namespace osmscout {
                                              std::unordered_map<Id,std::set<AreaRef> >& idAreaMap)
   {
     for (const auto& ring: area->rings) {
-      if (ring.IsOuterRing()) {
+      if (ring.IsTopOuter()) {
         for (const auto node : ring.nodes) {
           Id id=node.GetId();
 
@@ -134,7 +134,7 @@ namespace osmscout {
       std::unordered_set<Id> nodeIds;
 
       for (const auto& ring: data.rings) {
-        if (!ring.IsOuterRing()) {
+        if (!ring.IsTopOuter()) {
           continue;
         }
 
@@ -227,7 +227,7 @@ namespace osmscout {
       bool isMergeCandidate=false;
 
       for (const auto& ring: area->rings) {
-        if (!ring.IsOuterRing()) {
+        if (!ring.IsTopOuter()) {
           continue;
         }
 
@@ -294,7 +294,7 @@ namespace osmscout {
       std::unordered_set<Id> nodeIds;
 
       for (const auto& ring: area->rings) {
-        if (ring.IsOuterRing()) {
+        if (ring.IsTopOuter()) {
           for (const auto node : ring.nodes) {
             Id id=node.GetId();
 
@@ -316,7 +316,7 @@ namespace osmscout {
                                      std::unordered_set<FileOffset>& mergedAway)
   {
     for (const auto& ring: area.rings) {
-      if (!ring.IsOuterRing()) {
+      if (!ring.IsTopOuter()) {
         continue;
       }
 

--- a/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
@@ -198,7 +198,7 @@ namespace osmscout
 
       size_t r=0;
       while (r<area->rings.size()) {
-        if (!(area->rings[r].IsMasterRing() &&
+        if (!(area->rings[r].IsMaster() &&
               area->rings[r].nodes.empty())) {
           polygon.TransformArea(projection,
                                 optimizeAreaMethod,
@@ -225,7 +225,7 @@ namespace osmscout
 
         newRings.push_back(area->rings[r]);
 
-        if (!(area->rings[r].IsMasterRing() &&
+        if (!(area->rings[r].IsMaster() &&
               area->rings[r].nodes.empty())) {
           newRings.back().nodes.clear();
 
@@ -244,7 +244,7 @@ namespace osmscout
       }
 
       // Master ring can have nodes, but does not need to have
-      if (area->rings.front().IsMasterRing()) {
+      if (area->rings.front().IsMaster()) {
         if (area->rings.front().nodes.empty()) {
           if (newRings.size()==1) {
             // Master ring is empty and the only one left => skip

--- a/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRelAreaDat.cpp
@@ -885,7 +885,7 @@ namespace osmscout {
 
     // Count the occurence of outer types and store the last outer ring found for each type
     for (auto ring=parts.begin(); ring!=parts.end(); ++ring) {
-      if (ring->role.IsOuterRing() &&
+      if (ring->role.IsTopOuter() &&
           ring->IsArea() &&
           ring->role.GetType()!=typeConfig.typeInfoIgnore) {
         typeCount[ring->role.GetType()->GetIndex()]++;
@@ -1059,7 +1059,7 @@ namespace osmscout {
       size_t outerRingCount=0;
 
       for (const auto& ring : parts) {
-        if (ring.role.IsOuterRing()) {
+        if (ring.role.IsTopOuter()) {
           outerRingCount++;
 
           if (outerRingCount>1) {
@@ -1072,7 +1072,7 @@ namespace osmscout {
         optimizeAwayMaster=true;
 
         for (auto& ring : parts) {
-          if (ring.role.IsOuterRing()) {
+          if (ring.role.IsTopOuter()) {
             ring.role.SetFeatures(masterRing.GetFeatureValueBuffer());
             break;
           }
@@ -1084,7 +1084,7 @@ namespace osmscout {
       bool outerRingsClean=true;
 
       for (const auto& ring : parts) {
-        if (ring.role.IsOuterRing() &&
+        if (ring.role.IsTopOuter() &&
             ring.role.GetType()!=masterRing.GetType()) {
           outerRingsClean=false;
           break;
@@ -1110,7 +1110,7 @@ namespace osmscout {
 
     if (!optimizeAwayMaster) {
       for (auto& ring : relation.rings) {
-        if (ring.IsOuterRing() &&
+        if (ring.IsTopOuter() &&
             ring.GetType()==masterRing.GetType()) {
           ring.SetType(typeConfig.typeInfoIgnore);
         }
@@ -1269,7 +1269,7 @@ namespace osmscout {
         bool big=false;
 
         for (const auto& ring : rel.rings) {
-          if (!ring.IsMasterRing()) {
+          if (!ring.IsMaster()) {
             if (ring.nodes.size()<3) {
               valid=false;
               break;
@@ -1316,7 +1316,7 @@ namespace osmscout {
 
         areaTypeCount[rel.GetType()->GetIndex()]++;
         for (const auto& ring: rel.rings) {
-          if (ring.IsOuterRing()) {
+          if (ring.IsTopOuter()) {
             areaNodeTypeCount[rel.GetType()->GetIndex()]+=ring.nodes.size();
           }
         }

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -306,7 +306,7 @@ namespace osmscout {
         for (size_t i = 0; i < area->rings.size(); i++) {
           const Area::Ring &ring = area->rings[i];
 
-          if (ring.IsMasterRing()) {
+          if (ring.IsMaster()) {
             continue;
           }
 
@@ -314,19 +314,19 @@ namespace osmscout {
             continue;
           }
 
-          if (!ring.IsOuterRing() &&
+          if (!ring.IsTopOuter() &&
               ring.GetType()->GetIgnore()) {
             continue;
           }
 
-          if (!ring.IsOuterRing() && ring.GetType()->GetIgnore())
+          if (!ring.IsTopOuter() && ring.GetType()->GetIgnore())
             continue;
 
           TypeInfoRef type;
           FillStyleRef fillStyle;
           std::vector<BorderStyleRef> borderStyles;
 
-          if (ring.IsOuterRing()) {
+          if (ring.IsTopOuter()) {
             type = area->GetType();
           } else {
             type = ring.GetType();

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1296,6 +1296,9 @@ namespace osmscout {
     }
 
     size_t ringId=Area::outerRingId;
+
+    // found the ring on this (ringId) depth in hierarchy (and is big enough to render),
+    // we are going deeper in the hierarchy
     bool foundRing=true;
 
     while (foundRing) {
@@ -1308,8 +1311,11 @@ namespace osmscout {
           continue;
         }
 
-        if (!ring.IsOuterRing() &&
+        if (!ring.IsSomeOuterRing() &&
             ring.GetType()->GetIgnore()) {
+          // clipping inner ring, we will not render it, but still go deeper,
+          // there may be inner outer rings
+          foundRing = true;
           continue;
         }
 
@@ -1318,7 +1324,7 @@ namespace osmscout {
         std::vector<BorderStyleRef> borderStyles;
         BorderStyleRef              borderStyle;
 
-        if (ring.IsOuterRing()) {
+        if (ring.IsSomeOuterRing() && ring.GetType()->GetIgnore()) {
           type=area->GetType();
         }
         else {
@@ -1354,19 +1360,19 @@ namespace osmscout {
           borderStyleIndex++;
         }
 
-        foundRing=true;
-
         AreaData a;
         double   borderWidth=borderStyle ? borderStyle->GetWidth() : 0.0;
 
         a.boundingBox=ring.GetBoundingBox();
-        a.isOuter = ring.IsOuterRing();
+        a.isOuter = ring.IsSomeOuterRing();
 
         if (!IsVisibleArea(projection,
                            a.boundingBox,
                            borderWidth/2.0)) {
           continue;
         }
+
+        foundRing=true;
 
         // Collect possible clippings. We only take into account inner rings of the next level
         // that do not have a type and thus act as a clipping region. If a inner ring has a type,

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -313,7 +313,7 @@ namespace osmscout {
         entry.coordCount+=ring.nodes.size();
 
         if (parameter.IsDebugData()) {
-          if (ring.IsMasterRing()) {
+          if (ring.IsMaster()) {
             IconStyleRef iconStyle=styleConfig->GetAreaIconStyle(area->GetType(),
                                                                  ring.GetFeatureValueBuffer(),
                                                                  projection);
@@ -341,7 +341,7 @@ namespace osmscout {
         entry.coordCount+=ring.nodes.size();
 
         if (parameter.IsDebugData()) {
-          if (ring.IsMasterRing()) {
+          if (ring.IsMaster()) {
             IconStyleRef iconStyle=styleConfig->GetAreaIconStyle(area->GetType(),
                                                                  ring.GetFeatureValueBuffer(),
                                                                  projection);
@@ -1266,7 +1266,7 @@ namespace osmscout {
       const Area::Ring &ring = area->rings[i];
       // The master ring does not have any nodes, so we skip it
       // Rings with less than 3 nodes should be skipped, too (no area)
-      if (ring.IsMasterRing() || ring.nodes.size()<3) {
+      if (ring.IsMaster() || ring.nodes.size() < 3) {
         continue;
       }
 
@@ -1311,7 +1311,7 @@ namespace osmscout {
           continue;
         }
 
-        if (!ring.IsSomeOuterRing() &&
+        if (!ring.IsOuter() &&
             ring.GetType()->GetIgnore()) {
           // clipping inner ring, we will not render it, but still go deeper,
           // there may be inner outer rings
@@ -1324,7 +1324,7 @@ namespace osmscout {
         std::vector<BorderStyleRef> borderStyles;
         BorderStyleRef              borderStyle;
 
-        if (ring.IsSomeOuterRing() && ring.GetType()->GetIgnore()) {
+        if (ring.IsOuter() && ring.GetType()->GetIgnore()) {
           type=area->GetType();
         }
         else {
@@ -1364,7 +1364,7 @@ namespace osmscout {
         double   borderWidth=borderStyle ? borderStyle->GetWidth() : 0.0;
 
         a.boundingBox=ring.GetBoundingBox();
-        a.isOuter = ring.IsSomeOuterRing();
+        a.isOuter = ring.IsOuter();
 
         if (!IsVisibleArea(projection,
                            a.boundingBox,

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1380,13 +1380,15 @@ namespace osmscout {
         // not required.
         // Since we know that rings are created deep first, we only take into account direct followers
         // in the list with ring+1.
-        size_t j=i+1;
-        while (j<area->rings.size() &&
-               area->rings[j].GetRing()==ringId+1 &&
-               area->rings[j].GetType()->GetIgnore()) {
-          a.clippings.push_back(td[j]);
-
-          j++;
+        // Note that inner rings may have nested islands with ( > ringId+1), we skip them but continue
+        // iterating.
+        for (size_t j=i+1;
+             j<area->rings.size() && area->rings[j].GetRing()>=ringId+1;
+             j++) {
+          if (area->rings[j].GetRing()==ringId+1 &&
+              area->rings[j].GetType()->GetIgnore()) {
+            a.clippings.push_back(td[j]);
+          }
         }
 
         a.ref=area->GetObjectFileRef();

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -146,19 +146,19 @@ namespace osmscout {
         return featureValueBuffer;
       }
 
-      inline bool IsMasterRing() const
+      inline bool IsMaster() const
       {
         return ring==masterRingId;
       }
 
       // top level outer ring
-      inline bool IsOuterRing() const
+      inline bool IsTopOuter() const
       {
         return ring==outerRingId;
       }
 
       // ring level is odd, it is some outer ring
-      inline bool IsSomeOuterRing() const
+      inline bool IsOuter() const
       {
         return (ring & outerRingId) == outerRingId;
       }

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -157,6 +157,12 @@ namespace osmscout {
         return ring==outerRingId;
       }
 
+      // ring level is odd, it is some outer ring
+      inline bool IsSomeOuterRing() const
+      {
+        return (ring & outerRingId) == outerRingId;
+      }
+
       inline uint8_t GetRing() const
       {
         return ring;

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -270,6 +270,16 @@ namespace osmscout {
       return rings.front().GetType();
     }
 
+    inline TypeInfoRef GetRingType(const Ring &ring) const
+    {
+      if (ring.IsTopOuter() ||
+          (ring.IsOuter() && ring.GetType()->GetIgnore())) {
+        return GetType();
+      } else {
+        return ring.GetType();
+      }
+    }
+
     inline const FeatureValueBuffer& GetFeatureValueBuffer() const
     {
       return rings.front().GetFeatureValueBuffer();

--- a/libosmscout/include/osmscout/Area.h
+++ b/libosmscout/include/osmscout/Area.h
@@ -234,6 +234,8 @@ namespace osmscout {
       friend class Area;
     };
 
+    using RingVisitor = std::function<bool(size_t i, const Ring&, const TypeInfoRef&)>;
+
   private:
     FileOffset        fileOffset;
     FileOffset        nextFileOffset;
@@ -335,6 +337,19 @@ namespace osmscout {
      */
     void WriteOptimized(const TypeConfig& typeConfig,
                         FileWriter& writer) const;
+
+    /**
+     * Visit rings in breadth-first manner.
+     * When visitor return true for some ring,
+     * algorithm will continue deeper in hierarchy.
+     */
+    void VisitRings(RingVisitor visitor) const;
+
+    /**
+     * Visit possible clippings of ring specified by index.
+     * We only take into account rings of the next level.
+     */
+    void VisitClippingRings(size_t index, RingVisitor visitor) const;
   };
 
   typedef std::shared_ptr<Area> AreaRef;

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -155,7 +155,7 @@ namespace osmscout {
     bool   start=true;
 
     for (const auto& ring : rings) {
-      if (ring.IsOuterRing()) {
+      if (ring.IsTopOuter()) {
         for (const auto& node : ring.nodes) {
           if (start) {
             minLat=node.GetLat();
@@ -196,7 +196,7 @@ namespace osmscout {
     GeoBox boundingBox;
 
     for (const auto& ring : rings) {
-      if (ring.IsOuterRing()) {
+      if (ring.IsTopOuter()) {
         if (!boundingBox.IsValid()) {
           ring.GetBoundingBox(boundingBox);
         }
@@ -440,7 +440,7 @@ namespace osmscout {
   {
     auto ring=rings.cbegin();
     bool multipleRings=rings.size()>1;
-    bool hasMaster=rings[0].IsMasterRing();
+    bool hasMaster= rings[0].IsMaster();
 
     // TODO: We would like to have a bit flag here, if we have a simple area,
     // an area with one master (and multiple rings) or an area with
@@ -496,7 +496,7 @@ namespace osmscout {
   {
     auto ring=rings.cbegin();
     bool multipleRings=rings.size()>1;
-    bool hasMaster=ring->IsMasterRing();
+    bool hasMaster= ring->IsMaster();
 
     // Master/Outer ring
 
@@ -545,7 +545,7 @@ namespace osmscout {
   {
     auto ring=rings.cbegin();
     bool multipleRings=rings.size()>1;
-    bool hasMaster=rings[0].IsMasterRing();
+    bool hasMaster= rings[0].IsMaster();
 
     // Outer ring
 

--- a/libosmscout/src/osmscout/Area.cpp
+++ b/libosmscout/src/osmscout/Area.cpp
@@ -585,8 +585,6 @@ namespace osmscout {
 
   void Area::VisitRings(RingVisitor visitor) const
   {
-    TypeInfoRef areaType=GetType();
-
     size_t ringId=Area::outerRingId;
 
     // found the ring on this (ringId) depth in hierarchy (and visitor wants to continue),
@@ -603,13 +601,7 @@ namespace osmscout {
           continue;
         }
 
-        TypeInfoRef type;
-        if (ring.IsTopOuter() ||
-            (ring.IsOuter() && ring.GetType()->GetIgnore())) {
-          type=areaType;
-        } else {
-          type=ring.GetType();
-        }
+        TypeInfoRef type=GetRingType(ring);
         foundRing |= visitor(i, ring, type);
       }
       ringId++;
@@ -621,8 +613,6 @@ namespace osmscout {
     assert(i<rings.size());
     uint8_t ringId=rings[i].GetRing();
 
-    TypeInfoRef areaType=GetType();
-
     // Since we know that rings are created deep first, we only take into account direct followers
     // in the list with ring+1.
     // Note that inner rings may have nested islands with ( > ringId+1), we skip them but continue
@@ -631,13 +621,7 @@ namespace osmscout {
          j<rings.size() && rings[j].GetRing()>=ringId+1;
          j++) {
       const Ring &ring=rings[j];
-      TypeInfoRef type;
-      if (ring.IsTopOuter() ||
-          (ring.IsOuter() && ring.GetType()->GetIgnore())) {
-        type=areaType;
-      } else {
-        type=ring.GetType();
-      }
+      TypeInfoRef type=GetRingType(ring);
       if (ring.GetRing()==ringId+1) {
         visitor(j,ring,type);
       }

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -1189,7 +1189,7 @@ namespace osmscout {
           break;
         }
 
-        if (ring.IsOuterRing()) {
+        if (ring.IsTopOuter()) {
           if (IsCoordInArea(location,
                             ring.nodes)) {
             distance=Distance::Of<Meter>(0.0);
@@ -1421,7 +1421,7 @@ namespace osmscout {
           break;
         }
 
-        if (ring.IsOuterRing()) {
+        if (ring.IsTopOuter()) {
           if (IsCoordInArea(center,
                             ring.nodes)) {
             distance=Distance::Of<Meter>(0.0);

--- a/libosmscout/src/osmscout/LocationDescriptionService.cpp
+++ b/libosmscout/src/osmscout/LocationDescriptionService.cpp
@@ -386,7 +386,7 @@ namespace osmscout {
     // Test for inclusion
     bool candidate=false;
     for (const auto& ring : area->rings) {
-      if (!ring.IsOuterRing()) {
+      if (!ring.IsTopOuter()) {
         continue;
       }
 
@@ -671,7 +671,7 @@ namespace osmscout {
         }
 
         for (auto& ring : area->rings) {
-          if (ring.IsOuterRing()) {
+          if (ring.IsTopOuter()) {
             AdminRegionReverseLookupVisitor::SearchEntry searchEntry;
 
             searchEntry.object=object;


### PR DESCRIPTION
Continuation of https://github.com/Framstag/libosmscout/pull/802

It is refactoring how rings are iterated in `MapPainter` and Qt `LookupModule`

 - render nested outer rings properly
 - fix clipping for areas with nested rings
 - provide utility for visiting rings in breadth-first manner
 - use this visitor pattern in MapPainter to separate complicated ring iteration and painter code

Right now, this ruin seems to be rendered properly: https://www.openstreetmap.org/relation/7281899

![Screenshot_20191217_074040](https://user-images.githubusercontent.com/309458/70971136-8b2c1680-20a0-11ea-80ea-04867dc57b5e.png)

