### PR TITLE
Navigation tunnel improvements

### DIFF
--- a/libosmscout/include/osmscout/navigation/DataAgent.h
+++ b/libosmscout/include/osmscout/navigation/DataAgent.h
@@ -99,6 +99,10 @@ namespace osmscout {
           return result; // no route yet
         }
         auto requestMessage=dynamic_cast<RoutableObjectsRequestMessage*>(message.get());
+        if (GetSphericalDistance(requestMessage->bbox.GetMinCoord(),
+                                 requestMessage->bbox.GetMaxCoord()) > Kilometers(2)){
+          log.Warn() << "Requested routable data from huge region: " << requestMessage->bbox.GetDisplayText();
+        }
 
         auto msg=std::make_shared<RoutableObjectsMessage>(requestMessage->timestamp, std::make_shared<RoutableObjects>());
 

--- a/libosmscout/src/osmscout/navigation/PositionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/PositionAgent.cpp
@@ -192,14 +192,13 @@ namespace osmscout {
 
         if (!Includes(routableObjects,gps.GetGeoBox())){
           // we don't have routable data for current position, request data
-          GeoBox requestBox = gps.GetGeoBox();
-          requestBox.Include(GeoBox::BoxByCenterAndRadius(gps.position, Meters(200)));
+          GeoBox requestBox = GeoBox::BoxByCenterAndRadius(gps.position, std::max(Meters(200), gps.horizontalAccuracy));
           result.push_back(std::make_shared<RoutableObjectsRequestMessage>(now, requestBox));
         }
       }
     } else if (dynamic_cast<RoutableObjectsMessage*>(message.get())!=nullptr){
       auto msg=dynamic_cast<RoutableObjectsMessage*>(message.get());
-      if (gps.GetState(now)==Good && Includes(msg->data,gps.GetGeoBox())){
+      if (Includes(msg->data,gps.GetGeoBox())){
         this->routableObjects = msg->data;
       }
     } else if (dynamic_cast<RouteUpdateMessage*>(message.get())!=nullptr) {


### PR DESCRIPTION
Next round of fixes for estimated position in tunnel: 

 - it doesn't make sense to show current speed when position is estimated
 - load "routable data" around estimated position to make sure that estimation works even in long tunnels
 - use "routable data" even when gps position has poor accuracy