### PR TITLE
replace some usages of QTime by QElapsedTimer

### DIFF
--- a/Demos/src/DrawMapQt.cpp
+++ b/Demos/src/DrawMapQt.cpp
@@ -26,6 +26,7 @@
 #include <QDesktopWidget>
 #include <QPixmap>
 #include <QScreen>
+#include <QGuiApplication>
 
 #include <osmscout/Database.h>
 #include <osmscout/MapService.h>
@@ -133,8 +134,9 @@ int main(int argc, char* argv[])
 {
   QApplication application(argc,argv,true);
 
+  assert(QGuiApplication::primaryScreen());
   DrawMapDemo drawDemo("DrawMapQt", argc, argv,
-                       application.screens().at(application.desktop()->primaryScreen())->physicalDotsPerInch());
+                       QGuiApplication::primaryScreen()->physicalDotsPerInch());
 
   if (!drawDemo.OpenDatabase()){
     return 2;

--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -18,19 +18,16 @@
 */
 
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QDesktopWidget>
 #include <QPixmap>
 #include <QScreen>
 #include <QDebug>
 
 #include <chrono>
-#include <cmath>
 #include <cstring>
 #include <iostream>
-#include <iomanip>
 #include <list>
-#include <sstream>
 
 #include <osmscout/Database.h>
 #include <osmscout/MapService.h>
@@ -509,9 +506,6 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-
-  QApplication application(argc,argv,true);
-
   osmscout::StyleConfigRef styleConfig(new osmscout::StyleConfig(database->GetTypeConfig()));
 
   if (!styleConfig->Load(args.style)) {
@@ -530,7 +524,7 @@ int main(int argc, char* argv[])
       osmscout::AreaSearchParameter searchParameter;
       osmscout::MapData             data;
       osmscout::MapPainterQt        mapPainter(styleConfig);
-      double                        dpi=application.screens().at(application.desktop()->primaryScreen())->physicalDotsPerInch();
+      double                        dpi=QGuiApplication::primaryScreen()->physicalDotsPerInch();
 
       drawParameter.SetFontSize(3.0);
 

--- a/Tests/include/DrawWindow.h
+++ b/Tests/include/DrawWindow.h
@@ -24,6 +24,7 @@
 #include <QDesktopWidget>
 #include <QPixmap>
 #include <QScreen>
+#include <QElapsedTimer>
 
 #include <osmscout/Database.h>
 #include <osmscout/MapService.h>
@@ -55,8 +56,8 @@ protected:
   std::vector<double>       sin;           //! Lookup table for sin calculation
   int                       sinCount;
   int                       cnt;
-  QTime                     timer;
-  QTime                     animTimer;
+  QElapsedTimer             timer;
+  QElapsedTimer             animTimer;
   int                       startOffset;
   double                    moveOffset;
 };

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -24,7 +24,7 @@
 #include <QVector2D>
 #include <QTouchEvent>
 #include <QTimer>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QQueue>
 
 #include <osmscout/util/Bearing.h>
@@ -115,7 +115,7 @@ signals:
 struct AccumulatorEvent
 {
   QPointF pos;
-  QTime time;
+  QElapsedTimer time;
 };
 
 /**
@@ -282,7 +282,7 @@ class OSMSCOUT_CLIENT_QT_API MoveHandler : public InputHandler {
     Q_OBJECT
 
 private:
-    QTime animationStart;
+    QElapsedTimer animationStart;
     QTimer timer;
     MapView startMapView;
     QVector2D _move;
@@ -328,7 +328,7 @@ class OSMSCOUT_CLIENT_QT_API JumpHandler : public InputHandler {
     Q_OBJECT
 
 private:
-    QTime animationStart;
+    QElapsedTimer animationStart;
     QTimer timer;
     MapView startMapView;
     MapView targetMapView;

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -113,7 +113,7 @@ private:
 
     /// input handler control
     bool follow{false};
-    QTime lastGesture; // when there is some gesture, we will not follow vehicle for some short time
+    QElapsedTimer lastGesture; // when there is some gesture, we will not follow vehicle for some short time
 
     QString standardIconFile{"vehicle.svg"}; // state == OnRoute | OffRoute
     QString noGpsSignalIconFile{"vehicle_not_fixed.svg"}; // state == NoGpsSignal

--- a/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscout/PlaneMapRenderer.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QSettings>
+#include <QElapsedTimer>
 
 #include <osmscout/DataTileCache.h>
 #include <osmscout/DBThread.h>
@@ -44,7 +45,7 @@ private:
 
   DBLoadJob                     *loadJob;
 
-  QTime                         lastRendering;
+  QElapsedTimer                 lastRendering;
   QTimer                        pendingRenderingTimer;
 
   QImage                        *currentImage;

--- a/libosmscout-client-qt/include/osmscout/TileCache.h
+++ b/libosmscout-client-qt/include/osmscout/TileCache.h
@@ -29,6 +29,7 @@
 #include <QMap>
 #include <QSet>
 #include <QTime>
+#include <QElapsedTimer>
 #include <QImage>
 #include <QPixmap>
 #include <QDebug>
@@ -68,7 +69,7 @@ QDebug& operator<<(QDebug &out, const TileCacheKey &key);
  */
 struct TileCacheVal
 {
-  QTime lastAccess;
+  QElapsedTimer lastAccess;
   QPixmap image;
   size_t epoch;
 };

--- a/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/AvailableMapsModel.cpp
@@ -178,6 +178,7 @@ void AvailableMapsModel::listDownloaded(const MapProvider &provider, QNetworkRep
     }
   }
 
+  // TODO: use std::sort after transition to c++17
   qSort(items.begin(), items.end(), itemLessThan);
   reply->deleteLater();
   

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -22,6 +22,8 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
+#include <QTime>
+#include <QElapsedTimer>
 
 #include <osmscout/InputHandler.h>
 #include <osmscout/OSMTile.h>
@@ -129,7 +131,7 @@ void TapRecognizer::touch(const QTouchEvent &event)
 
 MoveAccumulator& MoveAccumulator::operator+=(const QPointF p)
 {
-    AccumulatorEvent ev = {p, QTime()};
+    AccumulatorEvent ev = {p, QElapsedTimer()};
     ev.time.start();
     events.push_back(ev);
     // flush old events

--- a/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledMapsModel.cpp
@@ -40,6 +40,7 @@ void InstalledMapsModel::onDatabaseListChanged()
 {
   QList<MapDirectory> currentDirs=mapManager->getDatabaseDirectories();
 
+  // TODO: use std::stable_sort after transition to c++17
   qStableSort(currentDirs);
 
   // following process is little bit complicated, but we don't want to call

--- a/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
@@ -235,6 +235,7 @@ void LocationInfoModel::addToModel(const QString database,
   obj[AddressNumberRole] = addressNumber;
   
   model << obj;
+  // TODO: use std::sort after transition to c++17
   qSort(model.begin(),model.end(),distanceComparator);
   endResetModel();
 }
@@ -301,6 +302,7 @@ void LocationInfoModel::onLocationAdminRegions(const osmscout::GeoCoord location
 
   QMap<int, QVariant> obj;
 
+  // TODO: use std::sort after transition to c++17
   qSort(regions.begin(),regions.end(),adminRegionComparator);
 
   const AdminRegionInfoRef bottom=regions.first();
@@ -329,6 +331,7 @@ void LocationInfoModel::onLocationAdminRegions(const osmscout::GeoCoord location
   obj[AddressNumberRole] = "";
 
   model << obj;
+  // TODO: use std::sort after transition to c++17
   qSort(model.begin(),model.end(),distanceComparator);
   endResetModel();
 }

--- a/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
@@ -312,7 +312,8 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
 
     std::list<osmscout::TileRef> tileList;
     if (tiles.contains(db->path)){
-      tileList=tiles[db->path].values().toStdList();
+      auto list = tiles[db->path].values();
+      tileList=std::list<osmscout::TileRef>(list.begin(), list.end());
     }else{
       if (!last){
         osmscout::log.Debug() << "Skip database " << db->path.toStdString();

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -501,7 +501,7 @@ void MapWidget::setLockToPosition(bool lock){
 
 void MapWidget::setFollowVehicle(bool follow){
   vehicle.follow = follow;
-  vehicle.lastGesture = QTime(); // set to null
+  vehicle.lastGesture.invalidate(); // set to invalid state
   if (follow){
     if (!inputHandler->isFollowVehicle()){
       setupInputHandler(new VehicleFollowHandler(*view, QSizeF(width(), height())));
@@ -755,7 +755,7 @@ void MapWidget::SetVehiclePosition(QObject *o)
 
   if (vehicle.position != nullptr &&
       vehicle.follow &&
-      (vehicle.lastGesture.isNull() || vehicle.lastGesture.elapsed() > 4000) // there was no gesture event for 4s
+      ((!vehicle.lastGesture.isValid()) || vehicle.lastGesture.elapsed() > 4000) // there was no gesture event for 4s
       ) {
 
     if (!inputHandler->isFollowVehicle()){

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -28,10 +28,10 @@ namespace osmscout {
 // uncomment or define by compiler parameter to render various debug marks
 // #define DRAW_DEBUG
 
-// Timeout for the first rendering after rerendering was triggered (render what ever data is available)
+// Timeout [ms] for the first rendering after rerendering was triggered (render what ever data is available)
 static int INITIAL_DATA_RENDERING_TIMEOUT = 10;
 
-// Timeout for the updated rendering after rerendering was triggered (more rendering data is available)
+// Timeout [ms] for the updated rendering after rerendering was triggered (more rendering data is available)
 static int UPDATED_DATA_RENDERING_TIMEOUT = 200;
 
 PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
@@ -426,7 +426,7 @@ void PlaneMapRenderer::DrawMap()
       finishedMagnification=currentMagnification;
       finishedEpoch=currentEpoch;
 
-      lastRendering=QTime::currentTime();
+      lastRendering.restart();
     }
   }
   emit Redraw();
@@ -435,7 +435,7 @@ void PlaneMapRenderer::DrawMap()
 void PlaneMapRenderer::HandleTileStatusChanged(QString /*dbPath*/,const osmscout::TileRef /*changedTile*/)
 {
   QMutexLocker locker(&lock);
-  int elapsedTime=lastRendering.elapsed();
+  int elapsedTime=lastRendering.isValid() ? lastRendering.elapsed() : UPDATED_DATA_RENDERING_TIMEOUT;
 
   //qDebug() << "Relevant tile changed, elapsed:" << elapsedTime;
 

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -23,6 +23,7 @@
 #include <osmscout/OSMScoutQt.h>
 
 #include <QtQml>
+#include <QElapsedTimer>
 
 #include <iostream>
 
@@ -95,7 +96,7 @@ void LocationListModel::onSearchResult(const QString searchPattern,
     return; // result is not for us
   }
 
-  QTime timer;
+  QElapsedTimer timer;
   timer.start();
 
   QQmlEngine *engine = qmlEngine(this);

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -153,7 +153,7 @@ void SearchModule::SearchForLocations(const QString searchPattern,
   QMutexLocker locker(&mutex);
 
   osmscout::log.Debug() << "Searching for " << searchPattern.toStdString();
-  QTime timer;
+  QElapsedTimer timer;
   timer.start();
 
   OSMScoutQt::GetInstance().GetDBThread()->RunSynchronousJob(

--- a/libosmscout-client-qt/src/osmscout/TileCache.cpp
+++ b/libosmscout-client-qt/src/osmscout/TileCache.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <QDebug>
+#include <QElapsedTimer>
 
 #include <iostream>
 #include <algorithm>
@@ -176,7 +177,7 @@ TileCacheVal TileCache::get(uint32_t zoomLevel, uint32_t x, uint32_t y)
     TileCacheKey key = {zoomLevel, x, y};
     if (!tiles.contains(key)){
         qWarning() << this << "No tile in cache for key " << key;
-        return {QTime(), QPixmap(), epoch}; // throw std::underflow_error ?
+        return {QElapsedTimer(), QPixmap(), epoch}; // throw std::underflow_error ?
     }
     TileCacheVal val = tiles.value(key);
     val.lastAccess.start();
@@ -200,7 +201,7 @@ void TileCache::put(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, si
     QPixmap pixmap = QPixmap::fromImage(image);
     removeRequest(zoomLevel, x, y);
     TileCacheKey key = {zoomLevel, x, y};
-    QTime now;
+    QElapsedTimer now;
     now.start();
     TileCacheVal val = {now, pixmap, epoch};
 

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -167,7 +167,8 @@ void TiledMapRenderer::InvalidateVisualCache()
 bool TiledMapRenderer::RenderMap(QPainter& painter,
                                  const MapViewStruct& request)
 {
-  QTime start;
+  QElapsedTimer start;
+  start.start();
   QMutexLocker locker(&tileCacheMutex);
   int elapsed = start.elapsed();
   if (elapsed > 1){


### PR DESCRIPTION
QTime usage for measuring duration is deprecated in recent Qt.

Add note to `qSort` and `qStableSort` functions, it should
be replaced by `std::` variants when we upgrade to c++17.

These changes solve some warnings described in issue:
https://github.com/Framstag/libosmscout/issues/816