### PR TITLE
fix computation of nearest routable object

### DIFF
--- a/libosmscout/src/osmscout/navigation/PositionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/PositionAgent.cpp
@@ -138,6 +138,7 @@ namespace osmscout {
               }
             }
             if (distance<nearest){
+              nearest=distance;
               position.coord=nearestPoint;
               position.databaseId=dbId;
               position.typeConfig=objs.typeConfig;


### PR DESCRIPTION
When current position is off planned route, position agent tries
to find nearest routable object and pin estimated position on it.
This commit fixes this search.