### PR TITLE
navigation: add unitialised position state

### DIFF
--- a/libosmscout-client-qt/include/osmscout/NavigationModel.h
+++ b/libosmscout-client-qt/include/osmscout/NavigationModel.h
@@ -135,7 +135,7 @@ public:
 
   inline VehiclePosition* getVehiclePosition() const
   {
-    if (!route){
+    if (!route || vehicleState==PositionAgent::Uninitialised){
       return nullptr;
     }
     return new VehiclePosition(vehicle, vehicleState, vehicleCoord, vehicleBearing,
@@ -167,7 +167,7 @@ private:
   QtRouteData       route;
 
   Vehicle vehicle;
-  PositionAgent::PositionState vehicleState;
+  PositionAgent::PositionState vehicleState{PositionAgent::Uninitialised};
   GeoCoord vehicleCoord;
   std::shared_ptr<osmscout::Bearing> vehicleBearing;
 

--- a/libosmscout-client-qt/src/osmscout/NavigationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModel.cpp
@@ -168,6 +168,8 @@ void NavigationModel::setRoute(QObject *o)
 
   beginResetModel();
   routeSteps.clear();
+  nextRouteStep=RouteStep();
+  vehicleState=PositionAgent::Uninitialised;
   if (route) {
     auto steps = route.routeSteps();
     routeSteps.reserve(steps.size());

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -70,6 +70,7 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
     if (dynamic_cast<PositionAgent::PositionMessage *>(message.get()) != nullptr) {
       auto positionMessage=static_cast<PositionAgent::PositionMessage*>(message.get());
       auto &position=positionMessage->position;
+      assert(position.state!=PositionAgent::Uninitialised);
       emit positionEstimate(position.state, position.coord, lastBearing);
     }
     else if (dynamic_cast<osmscout::BearingChangedMessage*>(message.get())!=nullptr) {

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -70,7 +70,7 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
     if (dynamic_cast<PositionAgent::PositionMessage *>(message.get()) != nullptr) {
       auto positionMessage=static_cast<PositionAgent::PositionMessage*>(message.get());
       auto &position=positionMessage->position;
-      assert(position.state!=PositionAgent::Uninitialised);
+      assert(position.state!=PositionAgent::Uninitialised); // unitialised position newer should be used in UI
       emit positionEstimate(position.state, position.coord, lastBearing);
     }
     else if (dynamic_cast<osmscout::BearingChangedMessage*>(message.get())!=nullptr) {

--- a/libosmscout/include/osmscout/navigation/PositionAgent.h
+++ b/libosmscout/include/osmscout/navigation/PositionAgent.h
@@ -55,14 +55,15 @@ namespace osmscout {
     };
 
     enum PositionState {
-      NoGpsSignal,
-      OnRoute,
-      OffRoute,
-      EstimateInTunnel
+      Uninitialised, // position is uninitialised yet
+      NoGpsSignal, // last know position is used, may be inaccurate
+      OnRoute, // vehicle is on the planned route
+      OffRoute, // vehicle is out off planned route, route should be re-computed
+      EstimateInTunnel // vehicle positin is estimated in tunnel
     };
 
     struct OSMSCOUT_API Position {
-      PositionState state{PositionState::NoGpsSignal};
+      PositionState state{PositionState::Uninitialised};
       GeoCoord coord;
       std::list<RouteDescription::Node>::const_iterator routeNode; // last passed node on the route
 

--- a/libosmscout/include/osmscout/navigation/PositionAgent.h
+++ b/libosmscout/include/osmscout/navigation/PositionAgent.h
@@ -59,7 +59,7 @@ namespace osmscout {
       NoGpsSignal, // last know position is used, may be inaccurate
       OnRoute, // vehicle is on the planned route
       OffRoute, // vehicle is out off planned route, route should be re-computed
-      EstimateInTunnel // vehicle positin is estimated in tunnel
+      EstimateInTunnel // vehicle position is estimated in tunnel
     };
 
     struct OSMSCOUT_API Position {


### PR DESCRIPTION
Greetings from quarantine!

Here is fix for one annoying bug - "random" jumps to zero-island (gps coordinates 0,0) during navigation, when route is re-computed... I just added "uninitialised" entry to position state enum, logic is now following:

 - `Unitialised`, position newer should be used in UI
 - `NoGpsSignal` now means that last know position is used, may be inaccurate

other enum entries are unchanged:

 - `OnRoute`, vehicle is on the planned route
 - `OffRoute`, vehicle is out off planned route, route should be re-computed
 - `EstimateInTunnel`, vehicle position is estimated in tunnel
