### PR TITLE
clear caches and medata on database file close

### DIFF
--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -243,6 +243,7 @@ namespace osmscout {
   bool DataFile<N>::Close()
   {
     typeConfig=nullptr;
+    cache.Flush();
 
     try  {
       if (scanner.IsOpen()) {

--- a/libosmscout/include/osmscout/OptimizeWaysLowZoom.h
+++ b/libosmscout/include/osmscout/OptimizeWaysLowZoom.h
@@ -67,7 +67,7 @@ namespace osmscout {
     };
 
   private:
-    TypeConfigRef                              typeConfig;    //!< Metadata information for loading the actual obejcts
+    TypeConfigRef                              typeConfig;    //!< Metadata information for loading the actual objects
     std::string                                datafilename;  //!< complete filename for data file
     mutable FileScanner                        scanner;       //!< File stream to the data file
 

--- a/libosmscout/src/osmscout/AreaAreaIndex.cpp
+++ b/libosmscout/src/osmscout/AreaAreaIndex.cpp
@@ -48,6 +48,7 @@ namespace osmscout {
 
   void AreaAreaIndex::Close()
   {
+    indexCache.Flush();
     try {
       if (scanner.IsOpen()) {
         scanner.Close();

--- a/libosmscout/src/osmscout/AreaWayIndex.cpp
+++ b/libosmscout/src/osmscout/AreaWayIndex.cpp
@@ -62,6 +62,7 @@ namespace osmscout {
 
   void AreaWayIndex::Close()
   {
+    wayTypeData.clear();
     try {
       if (scanner.IsOpen()) {
         scanner.Close();

--- a/libosmscout/src/osmscout/OptimizeAreasLowZoom.cpp
+++ b/libosmscout/src/osmscout/OptimizeAreasLowZoom.cpp
@@ -126,6 +126,8 @@ namespace osmscout
 
   bool OptimizeAreasLowZoom::Close()
   {
+    typeConfig=nullptr;
+    areaTypesData.clear();
     try  {
       if (scanner.IsOpen()) {
         scanner.Close();

--- a/libosmscout/src/osmscout/OptimizeWaysLowZoom.cpp
+++ b/libosmscout/src/osmscout/OptimizeWaysLowZoom.cpp
@@ -125,6 +125,8 @@ namespace osmscout
 
   bool OptimizeWaysLowZoom::Close()
   {
+    typeConfig=nullptr;
+    wayTypesData.clear();
     try  {
       if (scanner.IsOpen()) {
         scanner.Close();

--- a/libosmscout/src/osmscout/WaterIndex.cpp
+++ b/libosmscout/src/osmscout/WaterIndex.cpp
@@ -106,6 +106,7 @@ namespace osmscout {
 
   void WaterIndex::Close()
   {
+    levels.clear();
     try  {
       if (scanner.IsOpen()) {
         scanner.Close();


### PR DESCRIPTION
Flush file caches on Close(). It is not needed when it is used from `Database` class, because database destructs whole object in Close() method.

```
    if (nodeDataFile &&
        nodeDataFile->IsOpen()) {
      nodeDataFile->Close();
      nodeDataFile=nullptr;
    }
```
But it may be useful when someone is using data files directly.