### PR TITLE
Cleanup database caches

### DIFF
--- a/StyleEditor/src/StyleAnalyser.cpp
+++ b/StyleEditor/src/StyleAnalyser.cpp
@@ -30,8 +30,9 @@ osmscout::TypeConfigRef getTypeConfig()
   OSMScoutQt::GetInstance().GetDBThread()->RunSynchronousJob(
       [&typeConfig](const std::list<DBInstanceRef>& databases) {
         for (auto &db:databases) {
-          if (db->database && db->database->IsOpen() && db->database->GetTypeConfig()){
-            typeConfig = db->database->GetTypeConfig();
+          auto database=db->GetDatabase();
+          if (database && database->IsOpen() && database->GetTypeConfig()){
+            typeConfig = database->GetTypeConfig();
             return;
           }
         }

--- a/libosmscout-client-qt/include/osmscout/DBInstance.h
+++ b/libosmscout-client-qt/include/osmscout/DBInstance.h
@@ -20,12 +20,6 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  */
 
-#include <QObject>
-#include <QMutex>
-#include <QDebug>
-#include <QMap>
-#include <QThread>
-
 #include <osmscout/Database.h>
 #include <osmscout/LocationService.h>
 #include <osmscout/LocationDescriptionService.h>
@@ -35,6 +29,14 @@
 #include <osmscout/util/Breaker.h>
 
 #include <osmscout/ClientQtImportExport.h>
+
+#include <QObject>
+#include <QMutex>
+#include <QDebug>
+#include <QMap>
+#include <QThread>
+#include <QElapsedTimer>
+#include <QMutexLocker>
 
 namespace osmscout {
 
@@ -95,22 +97,27 @@ class OSMSCOUT_CLIENT_QT_API DBInstance : public QObject
 {
   Q_OBJECT
 
-private:
-  QMutex                                  mutex;
-  QMap<QThread*,osmscout::MapPainterQt*>  painterHolder;
-public slots:
-  void onThreadFinished();
+public:
+  const QString                           path;
 
-public: // TODO: make it private, ensure thread safety
-  QString                                 path;
+private:
+  mutable QMutex                          mutex;
+  QMap<QThread*,osmscout::MapPainterQt*>  painterHolder; ///< thread-local cache of map painters, guarded by mutex
+  QElapsedTimer                           lastUsage; ///< last time when database was used, guarded by mutex
+
+  osmscout::GeoBox                        dbBox; ///< cached database GeoBox, may be accessed without lock and lastUsage update
   osmscout::DatabaseRef                   database;
 
   osmscout::LocationServiceRef            locationService;
   osmscout::LocationDescriptionServiceRef locationDescriptionService;
   osmscout::MapServiceRef                 mapService;
 
-  osmscout::StyleConfigRef          styleConfig;
+  osmscout::StyleConfigRef                styleConfig;
 
+public slots:
+  void onThreadFinished();
+
+public:
   inline DBInstance(QString path,
                     osmscout::DatabaseRef database,
                     osmscout::LocationServiceRef locationService,
@@ -124,12 +131,72 @@ public: // TODO: make it private, ensure thread safety
     mapService(mapService),
     styleConfig(styleConfig)
   {
+    if (!database->GetBoundingBox(dbBox)){
+      osmscout::log.Error() << "Failed to get database GeoBox: " << path.toStdString();
+    }
+    lastUsage.start();
   };
 
   inline ~DBInstance()
   {
     close();
   };
+
+  inline osmscout::GeoBox GetDBGeoBox() const
+  {
+    return dbBox;
+  }
+
+  /**
+   * return true if database is open
+   * lastUsage is not udpated
+   */
+  inline bool IsOpen() const
+  {
+    return database->IsOpen();
+  }
+
+  inline osmscout::DatabaseRef GetDatabase()
+  {
+    QMutexLocker locker(&mutex);
+    lastUsage.restart();
+    return database;
+  }
+
+  inline osmscout::MapServiceRef GetMapService()
+  {
+    QMutexLocker locker(&mutex);
+    lastUsage.restart();
+    return mapService;
+  }
+
+  inline osmscout::LocationDescriptionServiceRef GetLocationDescriptionService()
+  {
+    QMutexLocker locker(&mutex);
+    lastUsage.restart();
+    return locationDescriptionService;
+  }
+
+  inline osmscout::LocationServiceRef GetLocationService()
+  {
+    QMutexLocker locker(&mutex);
+    lastUsage.restart();
+    return locationService;
+  }
+
+  inline osmscout::StyleConfigRef GetStyleConfig()
+  {
+    return styleConfig;
+  }
+
+  /**
+   * Returns the number of milliseconds since last database usage
+   */
+  inline qint64 lastUsageMs() const
+  {
+    QMutexLocker locker(&mutex);
+    return lastUsage.elapsed();
+  }
 
   bool LoadStyle(QString stylesheetFilename,
                  std::unordered_map<std::string,bool> stylesheetFlags,

--- a/libosmscout-client-qt/include/osmscout/DBInstance.h
+++ b/libosmscout-client-qt/include/osmscout/DBInstance.h
@@ -108,7 +108,6 @@ public: // TODO: make it private, ensure thread safety
   osmscout::LocationServiceRef            locationService;
   osmscout::LocationDescriptionServiceRef locationDescriptionService;
   osmscout::MapServiceRef                 mapService;
-  osmscout::BreakerRef                    dataLoadingBreaker;
 
   osmscout::StyleConfigRef          styleConfig;
 
@@ -117,14 +116,12 @@ public: // TODO: make it private, ensure thread safety
                     osmscout::LocationServiceRef locationService,
                     osmscout::LocationDescriptionServiceRef locationDescriptionService,
                     osmscout::MapServiceRef mapService,
-                    osmscout::BreakerRef dataLoadingBreaker,
                     osmscout::StyleConfigRef styleConfig):
     path(path),
     database(database),
     locationService(locationService),
     locationDescriptionService(locationDescriptionService),
     mapService(mapService),
-    dataLoadingBreaker(dataLoadingBreaker),
     styleConfig(styleConfig)
   {
   };

--- a/libosmscout-client-qt/include/osmscout/DBThread.h
+++ b/libosmscout-client-qt/include/osmscout/DBThread.h
@@ -157,8 +157,6 @@ protected:
 
 protected:
 
-  void CancelCurrentDataLoading();
-
   bool isInitializedInternal();
 
 public:

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -341,19 +341,11 @@ void DBThread::onDatabaseListChanged(QList<QDir> databaseDirectories)
                                                      std::make_shared<osmscout::LocationService>(database),
                                                      std::make_shared<osmscout::LocationDescriptionService>(database),
                                                      mapService,
-                                                     std::make_shared<QBreaker>(),
                                                      styleConfig));
   }
 
   emit databaseLoadFinished(boundingBox);
   emit stylesheetFilenameChanged();
-}
-
-void DBThread::CancelCurrentDataLoading()
-{
-  for (auto db:databases){
-    db->dataLoadingBreaker->Break();
-  }
 }
 
 void DBThread::ToggleDaylight()

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -94,7 +94,7 @@ DBThread::~DBThread()
 bool DBThread::isInitializedInternal()
 {
   for (auto db:databases){
-    if (!db->database->IsOpen()){
+    if (!db->IsOpen()){
       return false;
     }
   }
@@ -120,13 +120,7 @@ const DatabaseLoadedResponse DBThread::loadedResponse() const {
   QReadLocker locker(&lock);
   DatabaseLoadedResponse response;
   for (auto db:databases){
-    if (response.boundingBox.IsValid()){
-      osmscout::GeoBox boundingBox;
-      db->database->GetBoundingBox(boundingBox);
-      response.boundingBox.Include(boundingBox);
-    }else{
-      db->database->GetBoundingBox(response.boundingBox);
-    }
+    response.boundingBox.Include(db->GetDBGeoBox());
   }
   return response;
 }
@@ -138,14 +132,7 @@ DatabaseCoverage DBThread::databaseCoverage(const osmscout::Magnification &magni
 
   osmscout::GeoBox boundingBox;
   for (const auto &db:databases){
-    if (boundingBox.IsValid()){
-      osmscout::GeoBox dbBox;
-      if (db->database->GetBoundingBox(dbBox)){
-        boundingBox.Include(dbBox);
-      }
-    }else{
-      db->database->GetBoundingBox(boundingBox);
-    }
+    boundingBox.Include(db->GetDBGeoBox());
   }
   if (boundingBox.IsValid()) {
     /*
@@ -162,7 +149,7 @@ DatabaseCoverage DBThread::databaseCoverage(const osmscout::Magnification &magni
       bool fullCoverage=false;
       for (const auto &db:databases){
         std::list<osmscout::GroundTile> groundTiles;
-        if (!db->mapService->GetGroundTiles(bbox,magnification,groundTiles)){
+        if (!db->GetMapService()->GetGroundTiles(bbox,magnification,groundTiles)){
           break;
         }
         bool mayContainsUnknown=false;
@@ -334,13 +321,11 @@ void DBThread::onDatabaseListChanged(QList<QDir> databaseDirectories)
       continue;
     }
 
-    osmscout::MapServiceRef mapService = std::make_shared<osmscout::MapService>(database);
-
     databases.push_back(std::make_shared<DBInstance>(databaseDirectory.absolutePath(),
                                                      database,
                                                      std::make_shared<osmscout::LocationService>(database),
                                                      std::make_shared<osmscout::LocationDescriptionService>(database),
-                                                     mapService,
+                                                     std::make_shared<osmscout::MapService>(database),
                                                      styleConfig));
   }
 
@@ -426,11 +411,11 @@ const QMap<QString,bool> DBThread::GetStyleFlags() const
 
   // add flags defined by stylesheet
   for (auto &db:databases){
-    if (!db->styleConfig) {
+    if (!db->GetStyleConfig()) {
       continue;
     }
 
-    auto styleFlags = db->styleConfig->GetFlags(); // iterate temporary container is UB!
+    auto styleFlags = db->GetStyleConfig()->GetFlags(); // iterate temporary container is UB!
     for (const auto& flag : styleFlags){
       if (!flags.contains(QString::fromStdString(flag.first))){
         flags[QString::fromStdString(flag.first)]=flag.second;

--- a/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapRenderer.cpp
@@ -250,8 +250,8 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
   if (drawCanvasBackground){
     for (auto &db:databases){
       // fill background with "unknown" color
-      if (!backgroundRendered && db->styleConfig){
-          osmscout::FillStyleRef unknownFillStyle=db->styleConfig->GetUnknownFillStyle(renderProjection);
+      if (!backgroundRendered && db->GetStyleConfig()){
+          osmscout::FillStyleRef unknownFillStyle=db->GetStyleConfig()->GetUnknownFillStyle(renderProjection);
           if (unknownFillStyle){
             osmscout::Color backgroundColor=unknownFillStyle->GetFillColor();
             p->fillRect(QRectF(0,0,renderProjection.GetWidth(),renderProjection.GetHeight()),
@@ -322,9 +322,9 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
     }
 
     osmscout::MapDataRef data=std::make_shared<osmscout::MapData>();
-    db->mapService->AddTileDataToMapData(tileList,*data);
+    db->GetMapService()->AddTileDataToMapData(tileList,*data);
     if (last){
-      osmscout::TypeConfigRef typeConfig=db->database->GetTypeConfig();
+      osmscout::TypeConfigRef typeConfig=db->GetDatabase()->GetTypeConfig();
       for (auto const &o:overlayObjects){
 
         if (o->getObjectType()==osmscout::RefType::refWay){
@@ -356,7 +356,7 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
     }
 
     if (drawParameter->GetRenderSeaLand()) {
-      db->mapService->GetGroundTiles(renderProjection,
+      db->GetMapService()->GetGroundTiles(renderProjection,
                                      data->groundTiles);
     }
 

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -76,11 +76,12 @@ QList<LocationEntry> POILookupModule::doPOIlookup(DBInstanceRef db,
   osmscout::TypeInfoSet areaTypes;
   std::vector<osmscout::AreaRef> areas;
 
-  if (!db->database){
+  auto database=db->GetDatabase();
+  if (!database){
     osmscout::log.Error() << "No database available";
     return result;
   }
-  osmscout::TypeConfigRef typeConfig=db->database->GetTypeConfig();
+  osmscout::TypeConfigRef typeConfig=database->GetTypeConfig();
   if (!typeConfig){
     osmscout::log.Error() << "No typeConfig available";
     return result;
@@ -105,7 +106,7 @@ QList<LocationEntry> POILookupModule::doPOIlookup(DBInstanceRef db,
   }
 
   // lookup objects
-  osmscout::POIService poiService(db->database);
+  osmscout::POIService poiService(database);
   try {
     poiService.GetPOIsInArea(searchBoundingBox,
                              nodeTypes,

--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -532,8 +532,9 @@ void PlaneMapRenderer::onStylesheetFilenameChanged()
     dbThread->RunSynchronousJob(
       [this](const std::list<DBInstanceRef>& databases) {
         for (auto &db:databases){
-          if (db->styleConfig){
-            finishedUnknownFillStyle=db->styleConfig->GetUnknownFillStyle(projection);
+          auto styleConfig=db->GetStyleConfig();
+          if (styleConfig){
+            finishedUnknownFillStyle=styleConfig->GetUnknownFillStyle(projection);
             if (finishedUnknownFillStyle){
               break;
             }

--- a/libosmscout-client-qt/src/osmscout/Router.cpp
+++ b/libosmscout-client-qt/src/osmscout/Router.cpp
@@ -111,8 +111,8 @@ osmscout::MultiDBRoutingServiceRef Router::MakeRoutingService(const std::list<DB
 
   std::vector<osmscout::DatabaseRef> dbs;
   dbs.reserve(databases.size());
-  for (const auto& instance:databases){
-    dbs.push_back(instance->database);
+  for (auto& instance:databases){
+    dbs.push_back(instance->GetDatabase());
   }
   osmscout::MultiDBRoutingServiceRef routingService=std::make_shared<osmscout::MultiDBRoutingService>(routerParameter,dbs);
   if (!routingService->Open(profileBuilder)){

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -129,8 +129,9 @@ void TiledMapRenderer::onStylesheetFilenameChanged()
     dbThread->RunSynchronousJob(
       [this,&unknownFillStyle,&projection](const std::list<DBInstanceRef>& databases) {
         for (auto &db:databases){
-          if (db->styleConfig) {
-            unknownFillStyle=db->styleConfig->GetUnknownFillStyle(projection);
+          auto styledConfig=db->GetStyleConfig();
+          if (styledConfig) {
+            unknownFillStyle=styledConfig->GetUnknownFillStyle(projection);
             if (unknownFillStyle) {
               osmscout::Color fillColor = unknownFillStyle->GetFillColor();
               unknownColor.setRgbF(fillColor.GetR(),

--- a/libosmscout/include/osmscout/AreaAreaIndex.h
+++ b/libosmscout/include/osmscout/AreaAreaIndex.h
@@ -96,12 +96,12 @@ namespace osmscout {
 
   private:
     std::string           datafilename;   //!< Full path and name of the data file
-    mutable FileScanner   scanner;        //!< Scanner instance for reading this file
+    mutable FileScanner   scanner;        //!< Scanner instance for reading this file, guarded by lookupMutex
 
     uint32_t              maxLevel;       //!< Maximum level in index
     FileOffset            topLevelOffset; //!< File offset of the top level index entry
 
-    mutable IndexCache    indexCache;     //!< Cached map of all index entries by file offset
+    mutable IndexCache    indexCache;     //!< Cached map of all index entries by file offset, guarded by lookupMutex
 
     mutable std::mutex    lookupMutex;
 
@@ -151,6 +151,8 @@ namespace osmscout {
                         TypeInfoSet& loadedTypes) const;
 
     void DumpStatistics();
+
+    void FlushCache();
   };
 
   typedef std::shared_ptr<AreaAreaIndex> AreaAreaIndexRef;

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -108,6 +108,8 @@ namespace osmscout {
     virtual bool IsOpen() const;
     virtual bool Close();
 
+    void FlushCache();
+
     inline std::string GetFilename() const
     {
       return datafilename;
@@ -257,6 +259,13 @@ namespace osmscout {
     }
 
     return true;
+  }
+
+  template <class N>
+  void DataFile<N>::FlushCache()
+  {
+    std::lock_guard<std::mutex> lock(accessMutex);
+    cache.Flush();
   }
 
   /**

--- a/libosmscout/include/osmscout/Database.h
+++ b/libosmscout/include/osmscout/Database.h
@@ -475,6 +475,8 @@ namespace osmscout {
                                            const GeoBox& boundingBox);
 
     void DumpStatistics();
+
+    void FlushCache();
   };
 
   //! Reference counted reference to an Database instance

--- a/libosmscout/src/osmscout/AreaAreaIndex.cpp
+++ b/libosmscout/src/osmscout/AreaAreaIndex.cpp
@@ -371,6 +371,13 @@ namespace osmscout {
 
   void AreaAreaIndex::DumpStatistics()
   {
+    std::lock_guard<std::mutex> guard(lookupMutex);
     indexCache.DumpStatistics(AREA_AREA_IDX,IndexCacheValueSizer());
+  }
+
+  void AreaAreaIndex::FlushCache()
+  {
+    std::lock_guard<std::mutex> guard(lookupMutex);
+    indexCache.Flush();
   }
 }

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -1003,6 +1003,38 @@ namespace osmscout {
     }
   }
 
+  void Database::FlushCache()
+  {
+    {
+      std::lock_guard<std::mutex> guard(nodeDataFileMutex);
+      if (nodeDataFile){
+        nodeDataFile->FlushCache();
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> guard(areaDataFileMutex);
+      if (areaDataFile){
+        areaDataFile->FlushCache();
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> guard(wayDataFileMutex);
+      if (wayDataFile){
+        wayDataFile->FlushCache();
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> guard(areaAreaIndexMutex);
+      if (areaAreaIndex){
+        areaAreaIndex->FlushCache();
+      }
+    }
+
+  }
+
   NodeRegionSearchResult Database::LoadNodesInRadius(const GeoCoord& location,
                                                      const TypeInfoSet& types,
                                                      Distance maxDistance)


### PR DESCRIPTION
This MR makes possible to determine time of the last access to specific database and flush data caches and area-area index cache. It will help to https://github.com/Framstag/libosmscout/issues/827 and https://github.com/Karry/osmscout-sailfish/issues/193 . 

I don't measure impact yet. Still plan to create some periodic task that will flush caches for database (and map service) that was not used for several minutes... Application may then decide how long the caches will be hold or flush them in some critical situations (when system memory is under pressure). 
