### PR TITLE
navigation SpeedAgent: ignore too fast position updates

### DIFF
--- a/libosmscout/src/osmscout/navigation/SpeedAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/SpeedAgent.cpp
@@ -52,7 +52,9 @@ std::list<NavigationMessageRef> SpeedAgent::Process(const NavigationMessageRef &
   if (gpsUpdateMsg &&
       gpsUpdateMsg->horizontalAccuracy < Meters(100)){
 
-    if (lastPosition){
+    if (lastPosition &&
+        (gpsUpdateMsg->timestamp-lastPosition.time) >= seconds(1)){
+
       segmentFifo.push_back({GetEllipsoidalDistance(lastPosition.coord,gpsUpdateMsg->currentPosition),
                              gpsUpdateMsg->timestamp-lastPosition.time});
       Timestamp::duration fifoDuration{Timestamp::duration::zero()};


### PR DESCRIPTION
Navigation is using device clock as event time source.
For that reason, when position source emits multiple events
in batch (it may happen when system is under load),
speed agent evaluate huge jump in short time.
It results unrealistic high values.