### PR TITLE
Lane turns

### DIFF
--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -174,6 +174,7 @@ namespace osmscout {
       const FeatureValueBuffer *buffer;         //!< Features of the line segment
       size_t                   transStart;      //!< Start of coordinates in transformation buffer
       size_t                   transEnd;        //!< End of coordinates in transformation buffer
+      double                   mainSlotWidth;   //!< Width of main slot, used for relative positioning
     };
 
     struct OSMSCOUT_MAP_API PolyData
@@ -615,7 +616,7 @@ namespace osmscout {
 
     //@}
 
-    std::vector<LineStyle::OffsetRel> ParseLaneTurns(const LanesFeatureValue&);
+    std::vector<OffsetRel> ParseLaneTurns(const LanesFeatureValue&);
 
   public:
     MapPainter(const StyleConfigRef& styleConfig,

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -615,6 +615,8 @@ namespace osmscout {
 
     //@}
 
+    std::vector<LineStyle::OffsetRel> ParseLaneTurns(const LanesFeatureValue&);
+
   public:
     MapPainter(const StyleConfigRef& styleConfig,
                CoordBuffer *buffer);

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -601,7 +601,7 @@ namespace osmscout {
 
     std::vector<LineStyleLookupTable>          wayLineStyleSelectors;
     PathTextStyleLookupTable                   wayPathTextStyleSelectors;
-    PathSymbolStyleLookupTable                 wayPathSymbolStyleSelectors;
+    std::vector<PathSymbolStyleLookupTable>    wayPathSymbolStyleSelectors;
     PathShieldStyleLookupTable                 wayPathShieldStyleSelectors;
 
     std::vector<TypeInfoSet>                   wayTypeSets;
@@ -740,10 +740,11 @@ namespace osmscout {
     void GetWayLineStyles(const FeatureValueBuffer& buffer,
                           const Projection& projection,
                           std::vector<LineStyleRef>& lineStyles) const;
+    void GetWayPathSymbolStyle(const FeatureValueBuffer& buffer,
+                               const Projection& projection,
+                               std::vector<PathSymbolStyleRef> &symbolStyles) const;
     PathTextStyleRef GetWayPathTextStyle(const FeatureValueBuffer& buffer,
                                          const Projection& projection) const;
-    PathSymbolStyleRef GetWayPathSymbolStyle(const FeatureValueBuffer& buffer,
-                                             const Projection& projection) const;
     PathShieldStyleRef GetWayPathShieldStyle(const FeatureValueBuffer& buffer,
                                              const Projection& projection) const;
 

--- a/libosmscout-map/include/osmscout/StyleDescription.h
+++ b/libosmscout-map/include/osmscout/StyleDescription.h
@@ -231,7 +231,7 @@ namespace osmscout {
   public:
     typedef std::unordered_map<std::string,int> EnumNameValueMap;
 
-  private:
+  protected:
     EnumNameValueMap enumMap;
 
   protected:

--- a/libosmscout-map/include/osmscout/Styles.h
+++ b/libosmscout-map/include/osmscout/Styles.h
@@ -53,6 +53,17 @@ namespace osmscout {
       leftOutline,
       rightOutline,
       laneDivider,
+
+      laneForwardLeft,
+      laneForwardThroughLeft,
+      laneForwardThrough,
+      laneForwardThroughRight,
+      laneForwardRight,
+      laneBackwardLeft,
+      laneBackwardThroughLeft,
+      laneBackwardThrough,
+      laneBackwardThroughRight,
+      laneBackwardRight,
     };
 
     enum Attribute {
@@ -222,6 +233,17 @@ namespace osmscout {
       AddEnumValue("leftOutline",LineStyle::leftOutline);
       AddEnumValue("rightOutline",LineStyle::rightOutline);
       AddEnumValue("laneDivider",LineStyle::laneDivider);
+
+      AddEnumValue("laneForwardLeft",LineStyle::laneForwardLeft);
+      AddEnumValue("laneForwardThroughLeft",LineStyle::laneForwardThroughLeft);
+      AddEnumValue("laneForwardThrough",LineStyle::laneForwardThrough);
+      AddEnumValue("laneForwardThroughRight",LineStyle::laneForwardThroughRight);
+      AddEnumValue("laneForwardRight",LineStyle::laneForwardRight);
+      AddEnumValue("laneBackwardLeft",LineStyle::laneBackwardLeft);
+      AddEnumValue("laneBackwardThroughLeft",LineStyle::laneBackwardThroughLeft);
+      AddEnumValue("laneBackwardThrough",LineStyle::laneBackwardThrough);
+      AddEnumValue("laneBackwardThroughRight",LineStyle::laneBackwardThroughRight);
+      AddEnumValue("laneBackwardRight",LineStyle::laneBackwardRight);
     }
   };
 

--- a/libosmscout-map/include/osmscout/Styles.h
+++ b/libosmscout-map/include/osmscout/Styles.h
@@ -34,6 +34,24 @@
 
 namespace osmscout {
 
+  enum class OffsetRel: int {
+    base,
+    leftOutline,
+    rightOutline,
+    laneDivider,
+
+    laneForwardLeft,
+    laneForwardThroughLeft,
+    laneForwardThrough,
+    laneForwardThroughRight,
+    laneForwardRight,
+    laneBackwardLeft,
+    laneBackwardThroughLeft,
+    laneBackwardThrough,
+    laneBackwardThroughRight,
+    laneBackwardRight,
+  };
+
   /**
    * \ingroup Stylesheet
    *
@@ -46,24 +64,6 @@ namespace osmscout {
       capButt,
       capRound,
       capSquare
-    };
-
-    enum OffsetRel {
-      base,
-      leftOutline,
-      rightOutline,
-      laneDivider,
-
-      laneForwardLeft,
-      laneForwardThroughLeft,
-      laneForwardThrough,
-      laneForwardThroughRight,
-      laneForwardRight,
-      laneBackwardLeft,
-      laneBackwardThroughLeft,
-      laneBackwardThrough,
-      laneBackwardThroughRight,
-      laneBackwardRight,
     };
 
     enum Attribute {
@@ -229,21 +229,27 @@ namespace osmscout {
       : StyleEnumAttributeDescriptor(name,
                                      attribute)
     {
-      AddEnumValue("base",LineStyle::base);
-      AddEnumValue("leftOutline",LineStyle::leftOutline);
-      AddEnumValue("rightOutline",LineStyle::rightOutline);
-      AddEnumValue("laneDivider",LineStyle::laneDivider);
+      AddEnumValue2("base",OffsetRel::base);
+      AddEnumValue2("leftOutline",OffsetRel::leftOutline);
+      AddEnumValue2("rightOutline",OffsetRel::rightOutline);
+      AddEnumValue2("laneDivider",OffsetRel::laneDivider);
 
-      AddEnumValue("laneForwardLeft",LineStyle::laneForwardLeft);
-      AddEnumValue("laneForwardThroughLeft",LineStyle::laneForwardThroughLeft);
-      AddEnumValue("laneForwardThrough",LineStyle::laneForwardThrough);
-      AddEnumValue("laneForwardThroughRight",LineStyle::laneForwardThroughRight);
-      AddEnumValue("laneForwardRight",LineStyle::laneForwardRight);
-      AddEnumValue("laneBackwardLeft",LineStyle::laneBackwardLeft);
-      AddEnumValue("laneBackwardThroughLeft",LineStyle::laneBackwardThroughLeft);
-      AddEnumValue("laneBackwardThrough",LineStyle::laneBackwardThrough);
-      AddEnumValue("laneBackwardThroughRight",LineStyle::laneBackwardThroughRight);
-      AddEnumValue("laneBackwardRight",LineStyle::laneBackwardRight);
+      AddEnumValue2("laneForwardLeft",OffsetRel::laneForwardLeft);
+      AddEnumValue2("laneForwardThroughLeft",OffsetRel::laneForwardThroughLeft);
+      AddEnumValue2("laneForwardThrough",OffsetRel::laneForwardThrough);
+      AddEnumValue2("laneForwardThroughRight",OffsetRel::laneForwardThroughRight);
+      AddEnumValue2("laneForwardRight",OffsetRel::laneForwardRight);
+      AddEnumValue2("laneBackwardLeft",OffsetRel::laneBackwardLeft);
+      AddEnumValue2("laneBackwardThroughLeft",OffsetRel::laneBackwardThroughLeft);
+      AddEnumValue2("laneBackwardThrough",OffsetRel::laneBackwardThrough);
+      AddEnumValue2("laneBackwardThroughRight",OffsetRel::laneBackwardThroughRight);
+      AddEnumValue2("laneBackwardRight",OffsetRel::laneBackwardRight);
+    }
+
+    void AddEnumValue2(const std::string& name,
+                       OffsetRel value)
+    {
+      AddEnumValue(name, static_cast<int>(value));
     }
   };
 
@@ -1212,14 +1218,17 @@ namespace osmscout {
       attrSymbol,
       attrSymbolSpace,
       attrDisplayOffset,
-      attrOffset
+      attrOffset,
+      attrOffsetRel
     };
 
   private:
-    SymbolRef symbol;
-    double    symbolSpace;
-    double    displayOffset;
-    double    offset;
+    std::string slot;
+    SymbolRef   symbol;
+    double      symbolSpace;
+    double      displayOffset;
+    double      offset;
+    OffsetRel   offsetRel{OffsetRel::base};
 
   public:
     PathSymbolStyle();
@@ -1227,15 +1236,24 @@ namespace osmscout {
 
     void SetDoubleValue(int attribute, double value) override;
     void SetSymbolValue(int attribute, const SymbolRef& value) override;
+    void SetIntValue(int attribute, int value) override;
+
+    PathSymbolStyle& SetSlot(const std::string& slot);
 
     PathSymbolStyle& SetSymbol(const SymbolRef& symbol);
     PathSymbolStyle& SetSymbolSpace(double space);
     PathSymbolStyle& SetDisplayOffset(double value);
     PathSymbolStyle& SetOffset(double value);
+    PathSymbolStyle& SetOffsetRel(OffsetRel offsetRel);
 
     inline bool IsVisible() const
     {
       return (bool)symbol;
+    }
+
+    inline const std::string& GetSlot() const
+    {
+      return slot;
     }
 
     inline const SymbolRef& GetSymbol() const
@@ -1256,6 +1274,11 @@ namespace osmscout {
     inline double GetOffset() const
     {
       return offset;
+    }
+
+    inline OffsetRel GetOffsetRel() const
+    {
+      return offsetRel;
     }
 
     static StyleDescriptorRef GetDescriptor();

--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -1070,7 +1070,12 @@ PRODUCTIONS
               = SYNC "SYMBOL"
                 (.
                   PathSymbolPartialStyle style;
+                  std::string      slot;
                 .)
+                [
+                "#"
+                  IDENT<slot> (. style.style->SetSlot(slot); .)
+                ]
                 SYNC "{"
                 {
                   PATHSYMBOLSTYLEATTR<style> WEAK ";"
@@ -1490,6 +1495,11 @@ PRODUCTIONS
                          else if (function=="darken") {
                            if (!errors->hasErrors) {
                              style.SetColorValue(descriptor.GetAttribute(),color.Darken(factor));
+                           }
+                         }
+                         else if (function=="alpha") {
+                           if (!errors->hasErrors) {
+                             style.SetColorValue(descriptor.GetAttribute(),color.Alpha(factor));
                            }
                          }
                          else {

--- a/libosmscout-map/parser/generate.sh
+++ b/libosmscout-map/parser/generate.sh
@@ -11,6 +11,8 @@ fi
 
 echo "Using Coco command '${COCO}'..."
 
+cd $(dirname $0)
+
 # OSS (aka OSMScout style)
 $COCO OSS/OSS.atg -namespace osmscout:oss -frames OSS -o OSS
 

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1031,41 +1031,91 @@ namespace osmscout {
                                      const MapParameter& parameter,
                                      const MapPainter::WayPathData& data)
   {
-    PathSymbolStyleRef pathSymbolStyle=styleConfig.GetWayPathSymbolStyle(*data.buffer,
-                                                                         projection);
+    std::vector<PathSymbolStyleRef> symbolStyles;
+    styleConfig.GetWayPathSymbolStyle(*data.buffer,
+                                      projection,
+                                      symbolStyles);
 
-    if (!pathSymbolStyle) {
+    if (symbolStyles.empty()) {
       return false;
     }
 
-    double lineOffset=0.0;
-    size_t transStart=data.transStart;
-    size_t transEnd=data.transEnd;
-    double symbolSpace=projection.ConvertWidthToPixel(pathSymbolStyle->GetSymbolSpace());
+    LanesFeatureValue  *lanesValue=nullptr;
+    std::vector<OffsetRel> laneTurns; // cached turns
 
-    if (pathSymbolStyle->GetOffset()!=0.0) {
-      lineOffset+=GetProjectedWidth(projection,
-                                    pathSymbolStyle->GetOffset());
+    for (const auto &pathSymbolStyle : symbolStyles) {
+      double lineOffset = 0.0;
+      size_t transStart = data.transStart;
+      size_t transEnd = data.transEnd;
+      double symbolSpace = projection.ConvertWidthToPixel(pathSymbolStyle->GetSymbolSpace());
+
+      if (pathSymbolStyle->GetOffsetRel() == OffsetRel::laneForwardLeft ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneForwardThroughLeft ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneForwardThrough ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneForwardThroughRight ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneForwardRight ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneBackwardLeft ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneBackwardThroughLeft ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneBackwardThrough ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneBackwardThroughRight ||
+          pathSymbolStyle->GetOffsetRel() == OffsetRel::laneBackwardRight ) {
+
+        if (lanesValue==nullptr) {
+          lanesValue=lanesReader.GetValue(*data.buffer);
+        }
+
+        if (lanesValue==nullptr || lanesValue->GetLanes()<1){
+          continue;
+        }
+
+        if (laneTurns.empty()) {
+          laneTurns=ParseLaneTurns(*lanesValue);
+        }
+
+        int lanes=lanesValue->GetLanes();
+        double lanesSpace=data.mainSlotWidth/lanes;
+        double laneOffset=-data.mainSlotWidth/2.0+lanesSpace/2.0;
+
+        for (const OffsetRel &laneTurn: laneTurns) {
+          if (pathSymbolStyle->GetOffsetRel() == laneTurn) {
+            coordBuffer->GenerateParallelWay(transStart,transEnd,
+                                             laneOffset,
+                                             transStart,transEnd);
+
+            DrawContourSymbol(projection,
+                              parameter,
+                              *pathSymbolStyle->GetSymbol(),
+                              symbolSpace,
+                              transStart, transEnd);
+          }
+          laneOffset+=lanesSpace;
+        }
+      } else {
+
+        if (pathSymbolStyle->GetOffset() != 0.0) {
+          lineOffset += GetProjectedWidth(projection,
+                                          pathSymbolStyle->GetOffset());
+        }
+
+        if (pathSymbolStyle->GetDisplayOffset() != 0.0) {
+          lineOffset += projection.ConvertWidthToPixel(pathSymbolStyle->GetDisplayOffset());
+        }
+
+        if (lineOffset != 0.0) {
+          coordBuffer->GenerateParallelWay(transStart,
+                                           transEnd,
+                                           lineOffset,
+                                           transStart,
+                                           transEnd);
+        }
+
+        DrawContourSymbol(projection,
+                          parameter,
+                          *pathSymbolStyle->GetSymbol(),
+                          symbolSpace,
+                          transStart, transEnd);
+      }
     }
-
-    if (pathSymbolStyle->GetDisplayOffset()!=0.0) {
-      lineOffset+=projection.ConvertWidthToPixel(pathSymbolStyle->GetDisplayOffset());
-    }
-
-    if (lineOffset!=0.0) {
-      coordBuffer->GenerateParallelWay(transStart,
-                                       transEnd,
-                                       lineOffset,
-                                       transStart,
-                                       transEnd);
-    }
-
-    DrawContourSymbol(projection,
-                      parameter,
-                      *pathSymbolStyle->GetSymbol(),
-                      symbolSpace,
-                      transStart,transEnd);
-
     return true;
   }
 
@@ -1436,9 +1486,9 @@ namespace osmscout {
     }
   }
 
-  std::vector<LineStyle::OffsetRel> MapPainter::ParseLaneTurns(const LanesFeatureValue &lanesValue)
+  std::vector<OffsetRel> MapPainter::ParseLaneTurns(const LanesFeatureValue &lanesValue)
   {
-    std::vector<LineStyle::OffsetRel> laneTurns;
+    std::vector<OffsetRel> laneTurns;
     laneTurns.reserve(lanesValue.GetLanes());
 
     // backward
@@ -1450,22 +1500,22 @@ namespace osmscout {
         break;
       }
       if (turn == "left" || turn == "merge_to_left") {
-        laneTurns.push_back(LineStyle::laneBackwardLeft);
+        laneTurns.push_back(OffsetRel::laneBackwardLeft);
       } else if (turn == "through;left" || turn == "through;slight_left" || turn == "through;sharp_left") {
-        laneTurns.push_back(LineStyle::laneBackwardThroughLeft);
+        laneTurns.push_back(OffsetRel::laneBackwardThroughLeft);
       } else if (turn == "through") {
-        laneTurns.push_back(LineStyle::laneBackwardThrough);
+        laneTurns.push_back(OffsetRel::laneBackwardThrough);
       } else if (turn == "through;right" || turn == "through;slight_right" || turn == "through;sharp_right") {
-        laneTurns.push_back(LineStyle::laneBackwardThroughRight);
+        laneTurns.push_back(OffsetRel::laneBackwardThroughRight);
       } else if (turn == "right" || turn == "merge_to_right") {
-        laneTurns.push_back(LineStyle::laneBackwardRight);
+        laneTurns.push_back(OffsetRel::laneBackwardRight);
       } else {
-        laneTurns.push_back(LineStyle::base);
+        laneTurns.push_back(OffsetRel::base);
       }
       lane++;
     }
     for (;lane<lanes;lane++){
-      laneTurns.push_back(LineStyle::base);
+      laneTurns.push_back(OffsetRel::base);
     }
 
     // forward
@@ -1477,22 +1527,22 @@ namespace osmscout {
         break;
       }
       if (turn == "left" || turn == "merge_to_left") {
-        laneTurns.push_back(LineStyle::laneForwardLeft);
+        laneTurns.push_back(OffsetRel::laneForwardLeft);
       } else if (turn == "through;left" || turn == "through;slight_left" || turn == "through;sharp_left") {
-        laneTurns.push_back(LineStyle::laneForwardThroughLeft);
+        laneTurns.push_back(OffsetRel::laneForwardThroughLeft);
       } else if (turn == "through") {
-        laneTurns.push_back(LineStyle::laneForwardThrough);
+        laneTurns.push_back(OffsetRel::laneForwardThrough);
       } else if (turn == "through;right" || turn == "through;slight_right" || turn == "through;sharp_right") {
-        laneTurns.push_back(LineStyle::laneForwardThroughRight);
+        laneTurns.push_back(OffsetRel::laneForwardThroughRight);
       } else if (turn == "right" || turn == "merge_to_right") {
-        laneTurns.push_back(LineStyle::laneForwardRight);
+        laneTurns.push_back(OffsetRel::laneForwardRight);
       } else {
-        laneTurns.push_back(LineStyle::base);
+        laneTurns.push_back(OffsetRel::base);
       }
       lane++;
     }
     for (;lane<lanes;lane++){
-      laneTurns.push_back(LineStyle::base);
+      laneTurns.push_back(OffsetRel::base);
     }
 
     return laneTurns;
@@ -1519,7 +1569,7 @@ namespace osmscout {
     double             mainSlotWidth=0.0;
     AccessFeatureValue *accessValue=nullptr;
     LanesFeatureValue  *lanesValue=nullptr;
-    std::vector<LineStyle::OffsetRel> laneTurns; // cached turns
+    std::vector<OffsetRel> laneTurns; // cached turns
 
     for (const auto& lineStyle : lineStyles) {
       double       lineWidth=0.0;
@@ -1552,16 +1602,16 @@ namespace osmscout {
       }
 
       switch (lineStyle->GetOffsetRel()) {
-      case LineStyle::base:
+      case OffsetRel::base:
         lineOffset=0.0;
         break;
-      case LineStyle::leftOutline:
+      case OffsetRel::leftOutline:
         lineOffset=-mainSlotWidth/2.0;
         break;
-      case LineStyle::rightOutline:
+      case OffsetRel::rightOutline:
         lineOffset=mainSlotWidth/2.0;
         break;
-      case LineStyle::laneDivider:
+      case OffsetRel::laneDivider:
         lineOffset=0.0;
         lanesValue=lanesReader.GetValue(buffer);
         accessValue=accessReader.GetValue(buffer);
@@ -1571,16 +1621,16 @@ namespace osmscout {
           continue;
         }
         break;
-      case LineStyle::laneForwardLeft:
-      case LineStyle::laneForwardThroughLeft:
-      case LineStyle::laneForwardThrough:
-      case LineStyle::laneForwardThroughRight:
-      case LineStyle::laneForwardRight:
-      case LineStyle::laneBackwardLeft:
-      case LineStyle::laneBackwardThroughLeft:
-      case LineStyle::laneBackwardThrough:
-      case LineStyle::laneBackwardThroughRight:
-      case LineStyle::laneBackwardRight:
+      case OffsetRel::laneForwardLeft:
+      case OffsetRel::laneForwardThroughLeft:
+      case OffsetRel::laneForwardThrough:
+      case OffsetRel::laneForwardThroughRight:
+      case OffsetRel::laneForwardRight:
+      case OffsetRel::laneBackwardLeft:
+      case OffsetRel::laneBackwardThroughLeft:
+      case OffsetRel::laneBackwardThrough:
+      case OffsetRel::laneBackwardThroughRight:
+      case OffsetRel::laneBackwardRight:
         lineOffset=0.0;
         lanesValue=lanesReader.GetValue(buffer);
         break;
@@ -1640,6 +1690,7 @@ namespace osmscout {
         pathData.buffer=&buffer;
         pathData.transStart=transStart;
         pathData.transEnd=transEnd;
+        pathData.mainSlotWidth=mainSlotWidth;
 
         wayPathData.push_back(pathData);
 
@@ -1670,7 +1721,7 @@ namespace osmscout {
         data.transEnd=transEnd;
       }
 
-      if (lineStyle->GetOffsetRel()==LineStyle::laneDivider) {
+      if (lineStyle->GetOffsetRel()==OffsetRel::laneDivider) {
         uint8_t lanes=0;
 
         if (lanesValue!=nullptr) {
@@ -1699,16 +1750,16 @@ namespace osmscout {
           laneOffset+=lanesSpace;
         }
       }
-      else if (lineStyle->GetOffsetRel() == LineStyle::laneForwardLeft ||
-               lineStyle->GetOffsetRel() == LineStyle::laneForwardThroughLeft ||
-               lineStyle->GetOffsetRel() == LineStyle::laneForwardThrough ||
-               lineStyle->GetOffsetRel() == LineStyle::laneForwardThroughRight ||
-               lineStyle->GetOffsetRel() == LineStyle::laneForwardRight ||
-               lineStyle->GetOffsetRel() == LineStyle::laneBackwardLeft ||
-               lineStyle->GetOffsetRel() == LineStyle::laneBackwardThroughLeft ||
-               lineStyle->GetOffsetRel() == LineStyle::laneBackwardThrough ||
-               lineStyle->GetOffsetRel() == LineStyle::laneBackwardThroughRight ||
-               lineStyle->GetOffsetRel() == LineStyle::laneBackwardRight ) {
+      else if (lineStyle->GetOffsetRel() == OffsetRel::laneForwardLeft ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneForwardThroughLeft ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneForwardThrough ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneForwardThroughRight ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneForwardRight ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneBackwardLeft ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneBackwardThroughLeft ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneBackwardThrough ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneBackwardThroughRight ||
+               lineStyle->GetOffsetRel() == OffsetRel::laneBackwardRight ) {
 
         if (lanesValue==nullptr || lanesValue->GetLanes()<1){
           continue;
@@ -1722,7 +1773,7 @@ namespace osmscout {
         double lanesSpace=mainSlotWidth/lanes;
         double laneOffset=-mainSlotWidth/2.0+lanesSpace/2.0;
 
-        for (const LineStyle::OffsetRel &laneTurn: laneTurns) {
+        for (const OffsetRel &laneTurn: laneTurns) {
           if (lineStyle->GetOffsetRel() == laneTurn) {
             coordBuffer->GenerateParallelWay(transStart, transEnd,
                                              laneOffset,

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1070,6 +1070,7 @@ namespace osmscout {
 
         if (laneTurns.empty()) {
           laneTurns=ParseLaneTurns(*lanesValue);
+          assert(laneTurns.size() <= lanesValue->GetLanes());
         }
 
         int lanes=lanesValue->GetLanes();
@@ -1078,7 +1079,7 @@ namespace osmscout {
 
         for (const OffsetRel &laneTurn: laneTurns) {
           if (pathSymbolStyle->GetOffsetRel() == laneTurn) {
-            coordBuffer->GenerateParallelWay(transStart,transEnd,
+            coordBuffer->GenerateParallelWay(data.transStart,data.transEnd,
                                              laneOffset,
                                              transStart,transEnd);
 
@@ -1102,11 +1103,9 @@ namespace osmscout {
         }
 
         if (lineOffset != 0.0) {
-          coordBuffer->GenerateParallelWay(transStart,
-                                           transEnd,
+          coordBuffer->GenerateParallelWay(data.transStart,data.transEnd,
                                            lineOffset,
-                                           transStart,
-                                           transEnd);
+                                           transStart,transEnd);
         }
 
         DrawContourSymbol(projection,
@@ -1767,6 +1766,7 @@ namespace osmscout {
 
         if (laneTurns.empty()) {
           laneTurns=ParseLaneTurns(*lanesValue);
+          assert(laneTurns.size() <= lanesValue->GetLanes());
         }
 
         int lanes=lanesValue->GetLanes();

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -56,7 +56,7 @@ namespace osmscout {
      endCap(capRound),
      priority(0),
      zIndex(0),
-     offsetRel(base)
+     offsetRel(OffsetRel::base)
   {
     // no code
   }
@@ -1845,7 +1845,7 @@ namespace osmscout {
       AddAttribute(std::make_shared<StyleUDisplayAttributeDescriptor>("symbolSpace",PathSymbolStyle::attrSymbolSpace));
       AddAttribute(std::make_shared<StyleDisplayAttributeDescriptor>("displayOffset",PathSymbolStyle::attrDisplayOffset));
       AddAttribute(std::make_shared<StyleUMapAttributeDescriptor>("offset",PathSymbolStyle::attrOffset));
-    }
+      AddAttribute(std::make_shared<OffsetRelAttributeDescriptor>("offsetRel",PathSymbolStyle::attrOffsetRel));    }
   };
 
   static StyleDescriptorRef pathSymbolStyleDescriptor=std::make_shared<PathSymbolStyleDescriptor>();
@@ -1862,9 +1862,17 @@ namespace osmscout {
   : symbol(style.symbol),
     symbolSpace(style.symbolSpace),
     displayOffset(style.displayOffset),
-    offset(style.offset)
+    offset(style.offset),
+    offsetRel(style.offsetRel)
   {
     // no code
+  }
+
+  PathSymbolStyle& PathSymbolStyle::SetSlot(const std::string& slot)
+  {
+    this->slot=slot;
+
+    return *this;
   }
 
   PathSymbolStyle& PathSymbolStyle::SetSymbol(const SymbolRef& symbol)
@@ -1895,6 +1903,13 @@ namespace osmscout {
     return *this;
   }
 
+  PathSymbolStyle& PathSymbolStyle::SetOffsetRel(OffsetRel offsetRel)
+  {
+    this->offsetRel=offsetRel;
+
+    return *this;
+  }
+
   StyleDescriptorRef PathSymbolStyle::GetDescriptor()
   {
     return pathSymbolStyleDescriptor;
@@ -1915,6 +1930,9 @@ namespace osmscout {
         displayOffset=other.displayOffset;
         break;
       case attrOffset:
+        offset=other.offset;
+        break;
+      case attrOffsetRel:
         offset=other.offset;
         break;
       }
@@ -1950,5 +1968,17 @@ namespace osmscout {
       assert(false);
     }
   }
+
+  void PathSymbolStyle::SetIntValue(int attribute, int value)
+  {
+    switch (attribute) {
+      case attrOffsetRel:
+        SetOffsetRel((OffsetRel)value);
+        break;
+      default:
+        assert(false);
+    }
+  }
+
 }
 

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1401,7 +1401,13 @@ void Parser::WAYPATHSYMBOLSTYLE(StyleFilter filter, bool state) {
 		while (!(la->kind == _EOF || la->kind == 21 /* "SYMBO" */)) {SynErr(108); Get();}
 		Expect(21 /* "SYMBO" */);
 		PathSymbolPartialStyle style;
+		std::string      slot;
 		
+		if (la->kind == 51 /* "#" */) {
+			Get();
+			IDENT(slot);
+			style.style->SetSlot(slot); 
+		}
 		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(109); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 57 /* "name" */) {

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -1838,7 +1838,7 @@ namespace osmscout {
   {
   private:
 
-    uint8_t     lanes;              //< // First two bits reserved, 3 bit for number of lanes in each direction
+    uint8_t     lanes;              //!< First two bits reserved, 3 bit for number of lanes in each direction
     std::string turnForward;
     std::string turnBackward;
     std::string destinationForward;

--- a/libosmscout/parser/OST/OST.atg
+++ b/libosmscout/parser/OST/OST.atg
@@ -157,7 +157,7 @@ PRODUCTIONS
 
   TYPE        = (.
                   std::string     name;
-                  TagConditionRef condition;
+                  TagConditionRef condition=nullptr;
                   TypeInfoRef     typeInfo;
                   unsigned char   types;
                 .)

--- a/libosmscout/parser/generate.sh
+++ b/libosmscout/parser/generate.sh
@@ -11,6 +11,8 @@ fi
 
 echo "Using Coco command '${COCO}'..."
 
+cd $(dirname $0)
+
 # OST (aka OSMScout types)
 $COCO OST/OST.atg -namespace osmscout:ost -frames OST -o OST 
 

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -2617,12 +2617,7 @@ namespace osmscout {
 
   uint8_t LanesFeatureValue::GetLanes() const
   {
-    if (lanes & 0x01) {
-      return 1;
-    }
-    else {
-      return GetForwardLanes() + GetBackwardLanes();
-    }
+    return GetForwardLanes() + GetBackwardLanes();
   }
 
   const char* const LanesFeature::NAME             = "Lanes";

--- a/libosmscout/src/osmscout/ost/Parser.cpp
+++ b/libosmscout/src/osmscout/ost/Parser.cpp
@@ -263,7 +263,7 @@ void Parser::FEATURE() {
 		
 		 SemErr(e.c_str());
 		
-		 // Avoid NULL-pointer further on
+		 // Avoid nullptr-pointer further on
 		 feature=std::make_shared<osmscout::NameFeature>();
 		}
 		
@@ -297,7 +297,7 @@ void Parser::FEATUREDESCS(Feature& feature) {
 
 void Parser::TYPE() {
 		std::string     name;
-		TagConditionRef condition=NULL;
+		TagConditionRef condition=nullptr;
 		TypeInfoRef     typeInfo;
 		unsigned char   types;
 		

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -355,7 +355,8 @@ CONST
 
   COLOR wallColor                  = #663e1b;
 
-  COLOR turnSymbolColor            = #ffffff80
+  COLOR turnSymbolColor            = #ffffff80;
+  COLOR turnSymbolOutlineColor     = #a0a0a080;
 
   SYMBOL viaFerrataEasyCross
     POLYGON -0.5,-0.5 0.5,0.5 {
@@ -565,53 +566,63 @@ CONST
     }
 
   SYMBOL turn_forward_left
-    POLYGON 2.04,1.92 2.65,1.38 2.98,1.57 3.01,0.60 2.04,0.90 2.36,1.14 1.93,1.52 -0.32,1.53 -0.33,1.93  {
+    POLYGON 2.04,1.92 2.65,1.38 2.98,1.57 3.01,0.60 2.04,0.90 2.36,1.14 1.93,1.52 -0.32,1.53 -0.33,1.93 2.04,1.92 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_forward_through_left
-    POLYGON 1.90,1.87 3.10,1.27 1.90,0.67 1.90,1.07 0.79,1.07 1.18,0.48 1.51,0.67 1.54,-0.30 0.61,0.08 0.90,0.29 0.40,1.07 -0.60,1.07 -0.60,1.47 1.90,1.47 {
+    POLYGON 1.90,1.87 3.10,1.27 1.90,0.67 1.90,1.07 0.79,1.07 1.18,0.48 1.51,0.67 1.54,-0.30 0.61,0.08 0.90,0.29 0.40,1.07 -0.60,1.07 -0.60,1.47 1.90,1.47 1.90,1.87 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_forward_through
     POLYGON 1.90,0.90 3.10,0.30 1.90,-0.30 1.90,0.10 -0.60,0.10 -0.60,0.50 1.90,0.50  {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_forward_through_right
-    POLYGON 1.90,0.30 3.10,0.90 1.90,1.50 1.90,1.10 0.79,1.10 1.18,1.69 1.51,1.50 1.54,2.47 0.61,2.10 0.90,1.88 0.40,1.10 -0.60,1.10 -0.60,0.70 1.90,0.70 {
+    POLYGON 1.90,0.30 3.10,0.90 1.90,1.50 1.90,1.10 0.79,1.10 1.18,1.69 1.51,1.50 1.54,2.47 0.61,2.10 0.90,1.88 0.40,1.10 -0.60,1.10 -0.60,0.70 1.90,0.70 1.90,0.30 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_forward_right
     POLYGON 2.04,-0.59 2.65,-0.05 2.98,-0.24 3.01,0.73 2.04,0.43 2.36,0.19 1.93,-0.19 -0.32,-0.20 -0.33,-0.60  {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_backward_left
-    POLYGON 1.31,1.92 0.69,1.38 0.36,1.57 0.33,0.60 1.30,0.90 0.98,1.14 1.41,1.52 3.66,1.53 3.67,1.93 {
+    POLYGON 1.31,1.92 0.69,1.38 0.36,1.57 0.33,0.60 1.30,0.90 0.98,1.14 1.41,1.52 3.66,1.53 3.67,1.93 1.31,1.92 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_backward_through_left
-    POLYGON 1.80,1.87 0.60,1.27 1.80,0.67 1.80,1.07 2.91,1.07 2.52,0.48 2.19,0.67 2.16,-0.30 3.09,0.08 2.80,0.29 3.30,1.07 4.30,1.07 4.30,1.47 1.80,1.47 {
+    POLYGON 1.80,1.87 0.60,1.27 1.80,0.67 1.80,1.07 2.91,1.07 2.52,0.48 2.19,0.67 2.16,-0.30 3.09,0.08 2.80,0.29 3.30,1.07 4.30,1.07 4.30,1.47 1.80,1.47 1.80,1.87 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_backward_through
-    POLYGON 1.80,0.90 0.60,0.30 1.80,-0.30 1.80,0.10 4.30,0.10 4.30,0.50 1.80,0.50 {
+    POLYGON 1.80,0.90 0.60,0.30 1.80,-0.30 1.80,0.10 4.30,0.10 4.30,0.50 1.80,0.50 1.80,0.90 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_backward_through_right
-    POLYGON 1.80,0.30 0.60,0.90 1.80,1.50 1.80,1.10 2.91,1.10 2.52,1.69 2.19,1.50 2.16,2.47 3.09,2.10 2.80,1.88 3.30,1.10 4.30,1.10 4.30,0.70 1.80,0.70 {
+    POLYGON 1.80,0.30 0.60,0.90 1.80,1.50 1.80,1.10 2.91,1.10 2.52,1.69 2.19,1.50 2.16,2.47 3.09,2.10 2.80,1.88 3.30,1.10 4.30,1.10 4.30,0.70 1.80,0.70 1.80,0.30 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
   SYMBOL turn_backward_right
-    POLYGON 1.31,-0.59 0.69,-0.05 0.36,-0.24 0.33,0.73 1.30,0.43 0.98,0.19 1.41,-0.19 3.66,-0.20 3.67,-0.60  {
+    POLYGON 1.31,-0.59 0.69,-0.05 0.36,-0.24 0.33,0.73 1.30,0.43 0.98,0.19 1.41,-0.19 3.66,-0.20 3.67,-0.60 1.31,-0.59 {
       AREA { color: @turnSymbolColor; }
+      AREA.BORDER { width: 0.1mm; color:  @turnSymbolOutlineColor; }
     }
 
 

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -355,6 +355,8 @@ CONST
 
   COLOR wallColor                  = #663e1b;
 
+  COLOR turnSymbolColor            = #ffffff80
+
   SYMBOL viaFerrataEasyCross
     POLYGON -0.5,-0.5 0.5,0.5 {
       AREA.BORDER { width: 0.1mm; color:  @viaFerrataEasyColor;  }
@@ -561,6 +563,57 @@ CONST
     CIRCLE 0,0 0.8 {
       AREA {color: #ff0000; }
     }
+
+  SYMBOL turn_forward_left
+    POLYGON 2.04,1.92 2.65,1.38 2.98,1.57 3.01,0.60 2.04,0.90 2.36,1.14 1.93,1.52 -0.32,1.53 -0.33,1.93  {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_forward_through_left
+    POLYGON 1.90,1.87 3.10,1.27 1.90,0.67 1.90,1.07 0.79,1.07 1.18,0.48 1.51,0.67 1.54,-0.30 0.61,0.08 0.90,0.29 0.40,1.07 -0.60,1.07 -0.60,1.47 1.90,1.47 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_forward_through
+    POLYGON 1.90,0.90 3.10,0.30 1.90,-0.30 1.90,0.10 -0.60,0.10 -0.60,0.50 1.90,0.50  {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_forward_through_right
+    POLYGON 1.90,0.30 3.10,0.90 1.90,1.50 1.90,1.10 0.79,1.10 1.18,1.69 1.51,1.50 1.54,2.47 0.61,2.10 0.90,1.88 0.40,1.10 -0.60,1.10 -0.60,0.70 1.90,0.70 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_forward_right
+    POLYGON 2.04,-0.59 2.65,-0.05 2.98,-0.24 3.01,0.73 2.04,0.43 2.36,0.19 1.93,-0.19 -0.32,-0.20 -0.33,-0.60  {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_backward_left
+    POLYGON 1.31,1.92 0.69,1.38 0.36,1.57 0.33,0.60 1.30,0.90 0.98,1.14 1.41,1.52 3.66,1.53 3.67,1.93 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_backward_through_left
+    POLYGON 1.80,1.87 0.60,1.27 1.80,0.67 1.80,1.07 2.91,1.07 2.52,0.48 2.19,0.67 2.16,-0.30 3.09,0.08 2.80,0.29 3.30,1.07 4.30,1.07 4.30,1.47 1.80,1.47 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_backward_through
+    POLYGON 1.80,0.90 0.60,0.30 1.80,-0.30 1.80,0.10 4.30,0.10 4.30,0.50 1.80,0.50 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_backward_through_right
+    POLYGON 1.80,0.30 0.60,0.90 1.80,1.50 1.80,1.10 2.91,1.10 2.52,1.69 2.19,1.50 2.16,2.47 3.09,2.10 2.80,1.88 3.30,1.10 4.30,1.10 4.30,0.70 1.80,0.70 {
+      AREA { color: @turnSymbolColor; }
+    }
+
+  SYMBOL turn_backward_right
+    POLYGON 1.31,-0.59 0.69,-0.05 0.36,-0.24 0.33,0.73 1.30,0.43 0.98,0.19 1.41,-0.19 3.66,-0.20 3.67,-0.60  {
+      AREA { color: @turnSymbolColor; }
+    }
+
 
 STYLE
   // -------------------------------------------------------
@@ -1335,6 +1388,33 @@ STYLE
     [TYPE highway_tertiary,
           highway_tertiary_link] {
       WAY#lanes { color: lighten(@tertiaryColor,0.1); displayWidth: 0.4mm; dash: 20,3; priority: 1; joinCap: butt; offsetRel: laneDivider; }
+    }
+
+    // lane turn symbols
+    [TYPE highway_motorway,
+          highway_motorway_link,
+          highway_trunk,
+          highway_trunk_link,
+          highway_motorway_trunk,
+          highway_primary,
+          highway_primary_link,
+          highway_motorway_primary,
+          highway_secondary,
+          highway_secondary_link,
+          highway_tertiary,
+          highway_tertiary_link] {
+
+      WAY.SYMBOL#laneForwardLeft           { symbol: turn_forward_left; symbolSpace: 10mm; offsetRel: laneForwardLeft; }
+      WAY.SYMBOL#laneForwardThroughLeft    { symbol: turn_forward_through_left; symbolSpace: 10mm; offsetRel: laneForwardThroughLeft; }
+      WAY.SYMBOL#laneForwardThrough        { symbol: turn_forward_through; symbolSpace: 10mm; offsetRel: laneForwardThrough; }
+      WAY.SYMBOL#laneForwardThroughRight   { symbol: turn_forward_through_right; symbolSpace: 10mm; offsetRel: laneForwardThroughRight; }
+      WAY.SYMBOL#laneForwardRight          { symbol: turn_forward_right; symbolSpace: 10mm; offsetRel: laneForwardRight; }
+      WAY.SYMBOL#laneBackwardLeft          { symbol: turn_backward_left; symbolSpace: 10mm; offsetRel: laneBackwardLeft; }
+      WAY.SYMBOL#laneBackwardThroughLeft   { symbol: turn_backward_through_left; symbolSpace: 10mm; offsetRel: laneBackwardThroughLeft; }
+      WAY.SYMBOL#laneBackwardThrough       { symbol: turn_backward_through; symbolSpace: 10mm; offsetRel: laneBackwardThrough; }
+      WAY.SYMBOL#laneBackwardThroughRight  { symbol: turn_backward_through_right; symbolSpace: 10mm; offsetRel: laneBackwardThroughRight; }
+      WAY.SYMBOL#laneBackwardRight         { symbol: turn_backward_right; symbolSpace: 10mm; offsetRel: laneBackwardRight; }
+
     }
   }
 


### PR DESCRIPTION
Hi. 

This is small addition to map renderer - support displaying of lane turns. Screenshot better than words:

![Screenshot_20200405_104127](https://user-images.githubusercontent.com/309458/78470498-5b298180-772a-11ea-8a6f-21c7e295c6c7.png)

To achieve it, I added:
 - support for relative offset for way icons
 - relative offset by turn type (laneForwardLeft, laneForwardThroughLeft, laneForwardThrough...), one offset may be multiple times on the way
 - symbols for turns, add it to ways