### PR TITLE
AppVeyor CI: install Meson from Ubuntu Eoan

### DIFF
--- a/ci/appveyor/install.sh
+++ b/ci/appveyor/install.sh
@@ -41,8 +41,8 @@ if [ "${BUILDTOOL}" = "cmake" ] ; then
 fi
 if [ "${BUILDTOOL}" = "meson" ] ; then
     # Ubuntu:bionic distribute Meson 0.45.1 but libosmscout requires >=0.46.0.
-    # lets borrow it from cosmic ;-)
-    echo "deb http://de.archive.ubuntu.com/ubuntu cosmic main universe" >> /etc/apt/sources.list
+    # lets borrow it from eoan ;-)
+    echo "deb http://de.archive.ubuntu.com/ubuntu eoan main universe" >> /etc/apt/sources.list
     apt-get update
     apt-get install -y \
           meson


### PR DESCRIPTION
Ubuntu Cosmic (19.04) is no longer supported, lets install Meson from Eoan (19.10). It should fix AppVeyor builds with Meson