### PR TITLE
fix use-after-free in Cache class

### DIFF
--- a/libosmscout/include/osmscout/util/Cache.h
+++ b/libosmscout/include/osmscout/util/Cache.h
@@ -216,6 +216,7 @@ namespace osmscout {
 
         order.push_front(entry);
 
+        previousEntry=order.begin();
         return order.begin();
       }
 
@@ -240,6 +241,7 @@ namespace osmscout {
         StripCache();
       }
 
+      previousEntry=order.begin();
       return order.begin();
     }
 
@@ -272,6 +274,7 @@ namespace osmscout {
       order.clear();
       map.clear();
       size=0;
+      previousEntry=order.end();
     }
 
     /**


### PR DESCRIPTION
Cached most recent entry "previousEntry"
(that is iterator to OrderList) is invalidated
when cache is cleared and may be invalidated
when new element is added to the cache.

previousEntry have to be udpated in such cases
to avoid undefined behaviour (use after free).