### PR TITLE
Router lanes

### DIFF
--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -535,6 +535,10 @@ struct RouteDescriptionGeneratorCallback : public osmscout::RouteDescriptionPost
 
       using namespace std::chrono;
       using hoursDouble = duration<double, std::ratio<3600>>;
+
+      std::cout << "// at " << node.GetLocation().GetDisplayText() << std::endl;
+
+      NextLine(lineCount);
       std::cout << "// " << duration_cast<hoursDouble>(node.GetTime()).count() << "h " << std::setw(0)
                 << std::setprecision(3) << node.GetDistance() << " ";
 

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -782,6 +782,7 @@ int main(int argc, char* argv[])
     std::make_shared<osmscout::RoutePostprocessor::CrossingWaysPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::DirectionPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::LanesPostprocessor>(),
+    std::make_shared<osmscout::RoutePostprocessor::SuggestedLanesPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::MotorwayJunctionPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::DestinationPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::MaxSpeedPostprocessor>(),

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -35,10 +35,6 @@
 #include <osmscout/util/Geometry.h>
 #include <osmscout/util/Time.h>
 
-//#define ROUTE_DEBUG
-//#define NODE_DEBUG
-//#define DATA_DEBUG
-
 /*
   Examples for the nordrhein-westfalen.osm:
 
@@ -70,6 +66,9 @@ struct Arguments
   std::string            databaseDirectory;
   osmscout::GeoCoord     start;
   osmscout::GeoCoord     target;
+  bool                   debug=false;
+  bool                   dataDebug=false;
+  bool                   routeDebug=false;
 };
 
 class ConsoleRoutingProgress : public osmscout::RoutingProgress
@@ -227,14 +226,16 @@ struct RouteDescriptionGeneratorCallback : public osmscout::RouteDescriptionPost
   double distance;
   osmscout::Duration time;
   bool  lineDrawn;
+  bool routeDebug;
 
-  RouteDescriptionGeneratorCallback()
+  RouteDescriptionGeneratorCallback(bool routeDebug)
   : lineCount(0),
     prevDistance(0.0),
     prevTime(osmscout::Duration::zero()),
     distance(0.0),
     time(osmscout::Duration::zero()),
-    lineDrawn(false)
+    lineDrawn(false),
+    routeDebug(routeDebug)
   {
   }
 
@@ -529,28 +530,31 @@ struct RouteDescriptionGeneratorCallback : public osmscout::RouteDescriptionPost
     distance=node.GetDistance().As<osmscout::Kilometer>();
     time=node.GetTime();
 
-#if defined(ROUTE_DEBUG) || defined(NODE_DEBUG)
-    NextLine(lineCount);
-
-    using namespace std::chrono;
-    using hoursDouble = duration<double, std::ratio<3600>>;
-    std::cout << "// " << duration_cast<hoursDouble>(node.GetTime()).count() << "h " << std::setw(0) << std::setprecision(3) << node.GetDistance() << " ";
-
-    if (node.GetPathObject().Valid()) {
-      std::cout << node.GetPathObject().GetTypeName() << " " << node.GetPathObject().GetFileOffset() << "[" << node.GetCurrentNodeIndex() << "] => " << node.GetPathObject().GetTypeName() << " " << node.GetPathObject().GetFileOffset() << "[" << node.GetTargetNodeIndex() << "]";
-    }
-
-    std::cout << std::endl;
-
-    for (std::list<osmscout::RouteDescription::DescriptionRef>::const_iterator d=node.GetDescriptions().begin();
-        d!=node.GetDescriptions().end();
-        ++d) {
-      osmscout::RouteDescription::DescriptionRef desc=*d;
-
+    if(routeDebug) {
       NextLine(lineCount);
-      std::cout << "// " << desc->GetDebugString() << std::endl;
+
+      using namespace std::chrono;
+      using hoursDouble = duration<double, std::ratio<3600>>;
+      std::cout << "// " << duration_cast<hoursDouble>(node.GetTime()).count() << "h " << std::setw(0)
+                << std::setprecision(3) << node.GetDistance() << " ";
+
+      if (node.GetPathObject().Valid()) {
+        std::cout << node.GetPathObject().GetTypeName() << " " << node.GetPathObject().GetFileOffset() << "["
+                  << node.GetCurrentNodeIndex() << "] => " << node.GetPathObject().GetTypeName() << " "
+                  << node.GetPathObject().GetFileOffset() << "[" << node.GetTargetNodeIndex() << "]";
+      }
+
+      std::cout << std::endl;
+
+      for (std::list<osmscout::RouteDescription::DescriptionRef>::const_iterator d = node.GetDescriptions().begin();
+           d != node.GetDescriptions().end();
+           ++d) {
+        osmscout::RouteDescription::DescriptionRef desc = *d;
+
+        NextLine(lineCount);
+        std::cout << "// " << desc->GetDebugString() << std::endl;
+      }
     }
-#endif
   }
 
   void AfterNode(const osmscout::RouteDescription::Node& node) override
@@ -583,7 +587,28 @@ int main(int argc, char* argv[])
                       }),
                       "gpx",
                       "Dump resulting route as GPX to std::cout",
-                      true);
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
+                      args.debug=value;
+                      }),
+                      "debug",
+                      "Enable debug output",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
+                        args.dataDebug=value;
+                      }),
+                      "dataDebug",
+                      "Dump data nodes to sdt::cout",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
+                        args.routeDebug=value;
+                      }),
+                      "routeDebug",
+                      "Dump route description data to std::cout",
+                      false);
 
   argParser.AddOption(osmscout::CmdLineAlternativeFlag([&args](const std::string& value) {
                         if (value=="foot") {
@@ -635,6 +660,11 @@ int main(int argc, char* argv[])
     std::cout << argParser.GetHelp() << std::endl;
     return 0;
   }
+
+  osmscout::log.Debug(args.debug);
+  osmscout::log.Info(true);
+  osmscout::log.Warn(true);
+  osmscout::log.Error(true);
 
   osmscout::DatabaseParameter databaseParameter;
   osmscout::DatabaseRef       database=std::make_shared<osmscout::Database>(databaseParameter);
@@ -724,12 +754,13 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-#ifdef DATA_DEBUG
-  std::cout << "Route raw data:" << std::endl;
-  for (const auto &entry : result.GetRoute().Entries()) {
-    std::cout << entry.GetPathObject().GetName() << "[" << entry.GetCurrentNodeIndex() << "]" << " = " << entry.GetCurrentNodeId() << " => " << entry.GetTargetNodeIndex() << std::endl;
+  if (args.dataDebug) {
+    std::cout << "Route raw data:" << std::endl;
+    for (const auto &entry : result.GetRoute().Entries()) {
+      std::cout << entry.GetPathObject().GetName() << "[" << entry.GetCurrentNodeIndex() << "]" << " = "
+                << entry.GetCurrentNodeId() << " => " << entry.GetTargetNodeIndex() << std::endl;
+    }
   }
-#endif
 
   auto routeDescriptionResult=router->TransformRouteDataToRouteDescription(result.GetRoute());
 
@@ -822,7 +853,7 @@ int main(int argc, char* argv[])
 
   osmscout::StopClock                     generateTimer;
   osmscout::RouteDescriptionPostprocessor generator;
-  RouteDescriptionGeneratorCallback       generatorCallback;
+  RouteDescriptionGeneratorCallback       generatorCallback(args.routeDebug);
 
   generator.GenerateDescription(*routeDescriptionResult.GetDescription(),
                                 generatorCallback);

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -532,10 +532,12 @@ struct RouteDescriptionGeneratorCallback : public osmscout::RouteDescriptionPost
 #if defined(ROUTE_DEBUG) || defined(NODE_DEBUG)
     NextLine(lineCount);
 
-    std::cout << "// " << node->GetTime() << "h " << std::setw(0) << std::setprecision(3) << node->GetDistance() << "km ";
+    using namespace std::chrono;
+    using hoursDouble = duration<double, std::ratio<3600>>;
+    std::cout << "// " << duration_cast<hoursDouble>(node.GetTime()).count() << "h " << std::setw(0) << std::setprecision(3) << node.GetDistance() << " ";
 
-    if (node->GetPathObject().Valid()) {
-      std::cout << node->GetPathObject().GetTypeName() << " " << node->GetPathObject().GetFileOffset() << "[" << node->GetCurrentNodeIndex() << "] => " << node->GetPathObject().GetTypeName() << " " << node->GetPathObject().GetFileOffset() << "[" << node->GetTargetNodeIndex() << "]";
+    if (node.GetPathObject().Valid()) {
+      std::cout << node.GetPathObject().GetTypeName() << " " << node.GetPathObject().GetFileOffset() << "[" << node.GetCurrentNodeIndex() << "] => " << node.GetPathObject().GetTypeName() << " " << node.GetPathObject().GetFileOffset() << "[" << node.GetTargetNodeIndex() << "]";
     }
 
     std::cout << std::endl;
@@ -744,6 +746,7 @@ int main(int argc, char* argv[])
     std::make_shared<osmscout::RoutePostprocessor::WayTypePostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::CrossingWaysPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::DirectionPostprocessor>(),
+    std::make_shared<osmscout::RoutePostprocessor::LanesPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::MotorwayJunctionPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::DestinationPostprocessor>(),
     std::make_shared<osmscout::RoutePostprocessor::MaxSpeedPostprocessor>(),

--- a/libosmscout/include/osmscout/routing/Route.h
+++ b/libosmscout/include/osmscout/routing/Route.h
@@ -587,13 +587,14 @@ namespace osmscout {
     {
     private:
       bool oneway{false};
-      uint8_t laneCount{1}; // in our direction
-      std::list<std::string> laneTurns;
+      uint8_t laneCount{1}; // in our direction, not sum on way
+      std::vector<std::string> laneTurns; // turns in lanes from left one (drivers view)
+                                          // vector size may be less than laneCount, even empty
 
     public:
       LaneDescription(bool oneway,
                       uint8_t laneCount,
-                      const std::list<std::string> &laneTurns);
+                      const std::vector<std::string> &laneTurns);
 
       std::string GetDebugString() const override;
     };

--- a/libosmscout/include/osmscout/routing/Route.h
+++ b/libosmscout/include/osmscout/routing/Route.h
@@ -87,6 +87,8 @@ namespace osmscout {
     static const char* const WAY_TYPE_NAME_DESC;
     /** Constant for a description of pois at the route (POIAtRouteDescription) */
     static const char* const POI_AT_ROUTE_DESC;
+    /** Constant for a description of route lanes (LaneDescription) */
+    static const char* const LANES_DESC;
 
   public:
     /**
@@ -576,6 +578,27 @@ namespace osmscout {
     };
 
     using POIAtRouteDescriptionRef = std::shared_ptr<POIAtRouteDescription>;
+
+    /**
+     * \ingroup Routing
+     * A route lane
+     */
+    class OSMSCOUT_API LaneDescription : public RouteDescription::Description
+    {
+    private:
+      bool oneway{false};
+      uint8_t laneCount{1}; // in our direction
+      std::list<std::string> laneTurns;
+
+    public:
+      LaneDescription(bool oneway,
+                      uint8_t laneCount,
+                      const std::list<std::string> &laneTurns);
+
+      std::string GetDebugString() const override;
+    };
+
+    typedef std::shared_ptr<LaneDescription> LaneDescriptionRef;
 
     /**
      * \ingroup Routing

--- a/libosmscout/include/osmscout/routing/Route.h
+++ b/libosmscout/include/osmscout/routing/Route.h
@@ -89,6 +89,8 @@ namespace osmscout {
     static const char* const POI_AT_ROUTE_DESC;
     /** Constant for a description of route lanes (LaneDescription) */
     static const char* const LANES_DESC;
+    /** Constant for a description of suggested route lanes (SuggestedLaneDescription) */
+    static const char* const SUGGESTED_LANES_DESC;
 
   public:
     /**
@@ -146,7 +148,7 @@ namespace osmscout {
     /**
      * \ingroup Routing
      * Something has a name. A name consists of a name and a optional alphanumeric
-     * reference (LIke B1 or A40).
+     * reference (Like B1 or A40).
      */
     class OSMSCOUT_API NameDescription : public Description
     {
@@ -587,9 +589,20 @@ namespace osmscout {
     {
     private:
       bool oneway{false};
-      uint8_t laneCount{1}; // in our direction, not sum on way
-      std::vector<std::string> laneTurns; // turns in lanes from left one (drivers view)
-                                          // vector size may be less than laneCount, even empty
+      uint8_t laneCount{1}; //!< in our direction, not sum on way
+
+      /**
+       * turns in lanes from left one (drivers view)
+       * vector size may be less than laneCount, even empty
+       *
+       * usual variants:
+       *    left, slight_left, merge_to_left,
+       *    through;left, through;slight_left, through;sharp_left,
+       *    through,
+       *    through;right, through;slight_right, through;sharp_right,
+       *    right, slight_right, merge_to_right
+       */
+      std::vector<std::string> laneTurns;
 
     public:
       LaneDescription(bool oneway,
@@ -597,9 +610,45 @@ namespace osmscout {
                       const std::vector<std::string> &laneTurns);
 
       std::string GetDebugString() const override;
+
+      bool IsOneway() const
+      {
+        return oneway;
+      }
+
+      uint8_t GetLaneCount() const
+      {
+        return laneCount;
+      }
+
+      const std::vector<std::string>& GetLaneTurns() const
+      {
+        return laneTurns;
+      }
+
+      bool operator==(const LaneDescription &o) const;
+      bool operator!=(const LaneDescription &o) const;
     };
 
     typedef std::shared_ptr<LaneDescription> LaneDescriptionRef;
+
+    /**
+     * \ingroup Routing
+     * A suggested route lane
+     */
+    class OSMSCOUT_API SuggestedLaneDescription : public RouteDescription::Description
+    {
+    private:
+      uint8_t from = -1;
+      uint8_t to = -1; // inclusive
+
+    public:
+      SuggestedLaneDescription(uint8_t from, uint8_t to);
+
+      std::string GetDebugString() const override;
+    };
+
+    typedef std::shared_ptr<SuggestedLaneDescription> SuggestedLaneDescriptionRef;
 
     /**
      * \ingroup Routing

--- a/libosmscout/include/osmscout/routing/Route.h
+++ b/libosmscout/include/osmscout/routing/Route.h
@@ -656,14 +656,14 @@ namespace osmscout {
     class OSMSCOUT_API Node
     {
     private:
-      DatabaseId                                     database;
-      size_t                                         currentNodeIndex;
-      std::vector<ObjectFileRef>                     objects;
-      ObjectFileRef                                  pathObject;
-      size_t                                         targetNodeIndex;
-      Distance                                       distance; // distance from route start
-      Timestamp::duration                            time; // time from route start
-      GeoCoord                                       location;
+      DatabaseId                                     database; //!< database id of objects and pathObject
+      size_t                                         currentNodeIndex; //!< current node index of pathObject
+      std::vector<ObjectFileRef>                     objects; //!< list of objects intersecting this node. Is empty when node belongs to pathObject only
+      ObjectFileRef                                  pathObject; //!< object used for traveling from this node. Is invalid for last node
+      size_t                                         targetNodeIndex; //!< target node index of pathObject
+      Distance                                       distance; //!< distance from route start
+      Duration                                       time; //!< time from route start
+      GeoCoord                                       location; //!< geographic coordinate of node
       std::unordered_map<std::string,DescriptionRef> descriptionMap;
       std::list<DescriptionRef>                      descriptions;
 

--- a/libosmscout/include/osmscout/routing/Route.h
+++ b/libosmscout/include/osmscout/routing/Route.h
@@ -634,18 +634,31 @@ namespace osmscout {
 
     /**
      * \ingroup Routing
-     * A suggested route lane
+     *
+     * A suggested route lanes. It specifies range of lanes <from, to> that drive
+     * should use. Lanes are counted from left (just route direction, not opposite direction),
+     * left-most lane has index 0, both indexes are inclusive.
      */
     class OSMSCOUT_API SuggestedLaneDescription : public RouteDescription::Description
     {
     private:
-      uint8_t from = -1;
-      uint8_t to = -1; // inclusive
+      uint8_t from = -1; //!< left-most suggested lane, inclusive
+      uint8_t to = -1; //!< right-most suggested lane, inclusive
 
     public:
       SuggestedLaneDescription(uint8_t from, uint8_t to);
 
       std::string GetDebugString() const override;
+
+      uint8_t getFrom() const
+      {
+        return from;
+      }
+
+      uint8_t getTo() const
+      {
+        return to;
+      }
     };
 
     typedef std::shared_ptr<SuggestedLaneDescription> SuggestedLaneDescriptionRef;

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -311,6 +311,21 @@ namespace osmscout {
 
     using POIsPostprocessorRef = std::shared_ptr<POIsPostprocessor>;
 
+    /**
+     * \ingroup Routing
+     * Evaluate route lanes
+     */
+    class OSMSCOUT_API LanesPostprocessor : public RoutePostprocessor::Postprocessor
+    {
+    public:
+      LanesPostprocessor() : Postprocessor() {};
+
+      bool Process(const RoutePostprocessor& postprocessor,
+                   RouteDescription& description) override;
+    };
+
+    typedef std::shared_ptr<LanesPostprocessor> LanesPostprocessorRef;
+
   private:
     std::vector<RoutingProfileRef>                                profiles;
     std::vector<DatabaseRef>                                      databases;
@@ -324,6 +339,8 @@ namespace osmscout {
     std::unordered_map<DatabaseId,RoundaboutFeatureReader*>       roundaboutReaders;
     std::unordered_map<DatabaseId,DestinationFeatureValueReader*> destinationReaders;
     std::unordered_map<DatabaseId,MaxSpeedFeatureValueReader*>    maxSpeedReaders;
+    std::unordered_map<DatabaseId,LanesFeatureValueReader*>       lanesReaders;
+    std::unordered_map<DatabaseId,AccessFeatureValueReader*>      accessReaders;
 
     std::unordered_map<DatabaseId,TypeInfoSet>                    motorwayTypes;
     std::unordered_map<DatabaseId,TypeInfoSet>                    motorwayLinkTypes;
@@ -366,6 +383,8 @@ namespace osmscout {
     RouteDescription::DestinationDescriptionRef GetDestination(const RouteDescription::Node& node) const;
 
     uint8_t GetMaxSpeed(const RouteDescription::Node& node) const;
+
+    RouteDescription::LaneDescriptionRef GetLanes(const RouteDescription::Node& node) const;
 
     Id GetNodeId(const RouteDescription::Node& node) const;
 

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -326,6 +326,25 @@ namespace osmscout {
 
     typedef std::shared_ptr<LanesPostprocessor> LanesPostprocessorRef;
 
+    /**
+     * \ingroup Routing
+     * Evaluate suggested route lanes that may be used.
+     * Route lanes have to be evaluated already (using LanesPostprocessor)
+     */
+    class OSMSCOUT_API SuggestedLanesPostprocessor : public RoutePostprocessor::Postprocessor
+    {
+    public:
+      SuggestedLanesPostprocessor(const Distance &distanceBefore=Meters(500)) :
+        Postprocessor(), distanceBefore(distanceBefore) {};
+
+      bool Process(const RoutePostprocessor& postprocessor,
+                   RouteDescription& description) override;
+    private:
+      Distance distanceBefore;
+    };
+
+    typedef std::shared_ptr<SuggestedLanesPostprocessor> SuggestedLanesPostprocessorRef;
+
   private:
     std::vector<RoutingProfileRef>                                profiles;
     std::vector<DatabaseRef>                                      databases;

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -307,9 +307,11 @@ namespace osmscout {
    * \note when stringList is empty, result is empty list
    * \note separator must not be empty
    * \note when string ends with separator, last (empty) element is omited
+   * \note when maxSize is negative, list will contains all elements
    */
   extern OSMSCOUT_API std::list<std::string> SplitString(const std::string& stringList,
-                                                         const std::string& separator);
+                                                         const std::string& separator,
+                                                         int maxSize=-1);
 
 
   /**

--- a/libosmscout/src/osmscout/routing/Route.cpp
+++ b/libosmscout/src/osmscout/routing/Route.cpp
@@ -486,7 +486,7 @@ namespace osmscout {
 
   RouteDescription::LaneDescription::LaneDescription(bool oneway,
                                                      uint8_t laneCount,
-                                                     const std::list<std::string> &laneTurns)
+                                                     const std::vector<std::string> &laneTurns)
                                                      : oneway(oneway), laneCount(laneCount), laneTurns(laneTurns)
   {}
 

--- a/libosmscout/src/osmscout/routing/Route.cpp
+++ b/libosmscout/src/osmscout/routing/Route.cpp
@@ -62,6 +62,8 @@ namespace osmscout {
   const char* const RouteDescription::POI_AT_ROUTE_DESC      = "POIAtRoute";
   /** Constant for a description of route lanes (LaneDescription) */
   const char* const RouteDescription::LANES_DESC             = "Lanes";
+  /** Constant for a description of suggested route lanes (SuggestedLaneDescription) */
+  const char* const RouteDescription::SUGGESTED_LANES_DESC   = "SuggestedLanes";
 
   RouteDescription::Description::~Description()
   {
@@ -492,11 +494,11 @@ namespace osmscout {
 
   std::string RouteDescription::LaneDescription::GetDebugString() const
   {
-    using namespace std::string_literals;
+    using namespace std::string_view_literals;
     std::stringstream ss;
     ss << "Lanes: ";
     ss << (int)laneCount;
-    ss << (oneway ? " [oneway]"s : ""s);
+    ss << (oneway ? " [oneway]"sv : ""sv);
     if (!laneTurns.empty()){
       ss << " :";
     }
@@ -509,6 +511,31 @@ namespace osmscout {
       }
     });
 
+    return ss.str();
+  }
+
+  bool RouteDescription::LaneDescription::operator==(const RouteDescription::LaneDescription &o) const
+  {
+    return oneway==o.oneway && laneCount==o.laneCount && laneTurns==o.laneTurns;
+  }
+
+  bool RouteDescription::LaneDescription::operator!=(const RouteDescription::LaneDescription &o) const
+  {
+    return !((*this)==o);
+  }
+
+  RouteDescription::SuggestedLaneDescription::SuggestedLaneDescription(uint8_t from, uint8_t to):
+      from(from), to(to)
+  {}
+
+  std::string RouteDescription::SuggestedLaneDescription::GetDebugString() const
+  {
+    std::stringstream ss;
+    ss << "Suggested lanes: <";
+    ss << (int)from;
+    ss << ", ";
+    ss << (int)to;
+    ss << ">";
     return ss.str();
   }
 

--- a/libosmscout/src/osmscout/routing/Route.cpp
+++ b/libosmscout/src/osmscout/routing/Route.cpp
@@ -19,10 +19,10 @@
 
 #include <osmscout/routing/Route.h>
 
-#include <sstream>
-
 #include <osmscout/system/Assert.h>
 #include <osmscout/system/Math.h>
+
+#include <sstream>
 
 namespace osmscout {
 
@@ -60,6 +60,8 @@ namespace osmscout {
   const char* const RouteDescription::WAY_TYPE_NAME_DESC     = "TypeName";
   /** Constant for a description of type name of the way (TypeNameDescription) */
   const char* const RouteDescription::POI_AT_ROUTE_DESC      = "POIAtRoute";
+  /** Constant for a description of route lanes (LaneDescription) */
+  const char* const RouteDescription::LANES_DESC             = "Lanes";
 
   RouteDescription::Description::~Description()
   {
@@ -444,7 +446,7 @@ namespace osmscout {
 
   std::string RouteDescription::TypeNameDescription::GetDebugString() const
   {
-    return "Name: '"+GetDescription()+"'";
+    return "Type name: '"+GetDescription()+"'";
   }
 
   bool RouteDescription::TypeNameDescription::HasName() const
@@ -480,6 +482,30 @@ namespace osmscout {
   std::string RouteDescription::POIAtRouteDescription::GetDebugString() const
   {
     return object.GetName() +" "+std::to_string(distance.AsMeter());
+  }
+
+  RouteDescription::LaneDescription::LaneDescription(bool oneway,
+                                                     uint8_t laneCount,
+                                                     const std::list<std::string> &laneTurns)
+                                                     : oneway(oneway), laneCount(laneCount), laneTurns(laneTurns)
+  {}
+
+  std::string RouteDescription::LaneDescription::GetDebugString() const
+  {
+    using namespace std::string_literals;
+    std::stringstream ss;
+    ss << "Lanes: ";
+    ss << (int)laneCount;
+    ss << (oneway ? " [oneway]"s : ""s);
+    if (!laneTurns.empty()){
+      ss << " :";
+    }
+    for_each(laneTurns.begin(), laneTurns.end(), [&ss] (const std::string& s) {
+      ss << " ";
+      ss << s;
+    });
+
+    return ss.str();
   }
 
   bool RouteDescription::Node::HasDescription(const char* name) const

--- a/libosmscout/src/osmscout/routing/Route.cpp
+++ b/libosmscout/src/osmscout/routing/Route.cpp
@@ -502,7 +502,11 @@ namespace osmscout {
     }
     for_each(laneTurns.begin(), laneTurns.end(), [&ss] (const std::string& s) {
       ss << " ";
-      ss << s;
+      if (s.empty()){
+        ss << "<unspecified>";
+      } else {
+        ss << s;
+      }
     });
 
     return ss.str();

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1509,8 +1509,6 @@ namespace osmscout {
         if (prevLanes->GetLaneCount() > lanes->GetLaneCount()) { // lane count was decreased
           RouteDescription::DirectionDescriptionRef direction = std::dynamic_pointer_cast<RouteDescription::DirectionDescription>(node.GetDescription(RouteDescription::DIRECTION_DESC));
 
-          //RouteDescription::MotorwayChangeDescriptionRef motorwayChange = std::dynamic_pointer_cast<RouteDescription::MotorwayChangeDescription>(node.GetDescription(RouteDescription::MOTORWAY_CHANGE_DESC));
-          //RouteDescription::MotorwayLeaveDescriptionRef motorwayLeave = std::dynamic_pointer_cast<RouteDescription::MotorwayLeaveDescription>(node.GetDescription(RouteDescription::MOTORWAY_LEAVE_DESC));
           using Move = RouteDescription::DirectionDescription::Move;
           Move directionMove = direction ? direction->GetTurn() : Move::straightOn;
 

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1455,6 +1455,7 @@ namespace osmscout {
     ObjectFileRef              curObject;
     DatabaseId                 curDb;
 
+    RouteDescription::LaneDescriptionRef lanes;
     // TODO:
     //  - evaluate allowed lanes
 
@@ -1466,10 +1467,10 @@ namespace osmscout {
         curDb=node.GetDatabaseId();
 
         if (curObject!=prevObject || curDb!=prevDb) {
-          auto lanes=postprocessor.GetLanes(node);
-          if (lanes) {
-            node.AddDescription(RouteDescription::LANES_DESC, lanes);
-          }
+          lanes=postprocessor.GetLanes(node);
+        }
+        if (lanes) {
+          node.AddDescription(RouteDescription::LANES_DESC, lanes);
         }
 
         prevObject=curObject;

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1911,12 +1911,14 @@ namespace osmscout {
       bool oneway = accessValue ? accessValue->IsOneway() : false;
 
       uint8_t laneCount;
-      std::list<std::string> laneTurns;
+      std::vector<std::string> laneTurns;
       LanesFeatureValue *lanesValue=lanesReader->second->GetValue(way->GetFeatureValueBuffer());
       if (lanesValue!=nullptr) {
         laneCount=std::max((uint8_t)1,forward ? lanesValue->GetForwardLanes() : lanesValue->GetBackwardLanes());
         std::string turns=forward ? lanesValue->GetTurnForward() : lanesValue->GetTurnBackward();;
-        laneTurns=SplitString(turns, "|");
+        std::list<std::string> turnList=SplitString(turns, "|", laneCount);
+        laneTurns.reserve(turnList.size());
+        laneTurns.insert(laneTurns.begin(), turnList.begin(), turnList.end());
       } else {
         // default lane count by object type
         if (oneway) {

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1534,6 +1534,17 @@ namespace osmscout {
             }
           };
 
+          static const std::set<std::string_view> leftPossibilities{
+            "left"sv, "slight_left"sv, "through;left"sv, "through;slight_left"sv, "through;sharp_left"sv};
+
+          static const std::set<std::string_view> straightPossibilities{
+            "through;left"sv, "through;slight_left"sv, "through;sharp_left"sv,
+            "through"sv,
+            "through;right"sv, "through;slight_right"sv, "through;sharp_right"sv};
+
+          static const std::set<std::string_view> rightPossibilities{
+              "right"sv, /*"slight_right"sv,*/ "through;right"sv, "through;slight_right"sv, "through;sharp_right"sv};
+
           // after some direction change, we will evaluate allowed lanes in backBuffer
           if (!prevLanes->GetLaneTurns().empty()){
             // we know explicit lane turns
@@ -1541,22 +1552,14 @@ namespace osmscout {
               case Move::sharpLeft:
               case Move::left:
               case Move::slightlyLeft:
-                static const std::set<std::string_view> leftPossibilities{
-                  "left"sv, "slight_left"sv, "through;left"sv, "through;slight_left"sv, "through;sharp_left"sv};
                 LookupLanesTurns(leftPossibilities);
                 break;
               case Move::straightOn:
-                static const std::set<std::string_view> straightPossibilities{
-                  "through;left"sv, "through;slight_left"sv, "through;sharp_left"sv,
-                  "through"sv,
-                  "through;right"sv, "through;slight_right"sv, "through;sharp_right"sv};
                 LookupLanesTurns(straightPossibilities);
                 break;
               case Move::slightlyRight:
               case Move::right:
               case Move::sharpRight:
-                static const std::set<std::string_view> rightPossibilities{
-                    "right"sv, /*"slight_right"sv,*/ "through;right"sv, "through;slight_right"sv, "through;sharp_right"sv};
                 LookupLanesTurns(rightPossibilities);
                 break;
             }

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1540,6 +1540,7 @@ namespace osmscout {
           static const std::set<std::string_view> straightPossibilities{
             "through;left"sv, "through;slight_left"sv, "through;sharp_left"sv,
             "through"sv,
+            ""sv, // no-sign implicitly as through
             "through;right"sv, "through;slight_right"sv, "through;sharp_right"sv};
 
           static const std::set<std::string_view> rightPossibilities{

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -260,13 +260,14 @@ namespace osmscout {
   }
 
   extern OSMSCOUT_API std::list<std::string> SplitString(const std::string& stringList,
-                                                         const std::string& separator)
+                                                         const std::string& separator,
+                                                         int maxSize)
   {
     assert(!separator.empty());
 
     std::string remaining=stringList;
     std::list<std::string> result;
-    while (!remaining.empty()) {
+    while (!remaining.empty() && (maxSize < 0 || result.size() < (size_t)maxSize)) {
       std::string::size_type pos = remaining.find(separator);
 
       if (pos == std::string::npos) {


### PR DESCRIPTION
Hi. 

These changes allows to add route lanes and suggested lanes to route description.
```
./Demos/Routing --debug --routeDebug \
  europe-czech-republic-20200229-004825 \
  50.0922 14.4928 \
  49.2153 16.62401

...
  7.5km  0.0km  0:08h  0:00h // at 50.05044 N 14.47787 E
                             // 0.1h 7.500853 km Way 98507071[0] => Way 98507071[1]
                             // Name: 'Jižní spojka (MO)'
                             // Type name: 'highway_motorway_trunk'
                             // Crossing: Crossing from 'Jižní spojka (MO)' to 'Jižní spojka (MO)'
                             // Direction: Turn: Straight on, 0.913341 degrees Curve: Straight on, 0.913341 degrees
                             // Lanes: 4 [oneway] : <unspecified> <unspecified> <unspecified> slight_right
                             // Suggested lanes: <3, 3>
                             // Max. speed 80km/h
```
Suggested lanes `<3, 3>` means that driver should used the most right lane from 4  (with "slight_right" sign).

Later I want to integrate these descriptions to navigation code and Qt UI...