### PR TITLE
fix locale specific statm parsing

### DIFF
--- a/libosmscout/src/osmscout/util/MemoryMonitor.cpp
+++ b/libosmscout/src/osmscout/util/MemoryMonitor.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <osmscout/util/MemoryMonitor.h>
+#include <osmscout/util/Logger.h>
 
 // For MemoryMonitor
 #ifdef __linux__
@@ -67,12 +68,17 @@ namespace osmscout {
     double currentResidentSet=0.0;
 
 #ifdef __linux__
-    double vsize;
-    double rss;
+    double vsize=0;
+    double rss=0;
     {
       std::ifstream ifs("/proc/self/statm", std::ios_base::in);
+      ifs.imbue(std::locale("C"));
 
       ifs >> vsize >> rss;
+
+      if (ifs.fail()){
+        log.Warn() << "Failed to measure memory usage";
+      }
     }
 
     long pageSizeInByte=sysconf(_SC_PAGE_SIZE);


### PR DESCRIPTION
I just run Importer under valgrind and find "Conditional jump or move depends on uninitialised value"... Then I found out that istream number extracting is locale dependent and eats spaces with Czech locale! So, memory monitor was broken on my system :-) 