### PR TITLE
tune junction penalty

### DIFF
--- a/libosmscout/include/osmscout/routing/RoutingProfile.h
+++ b/libosmscout/include/osmscout/routing/RoutingProfile.h
@@ -241,6 +241,8 @@ namespace osmscout {
   {
   protected:
     bool applyJunctionPenalty=true;
+    Distance penaltySameType=Meters(160);
+    Distance penaltyDifferentType=Meters(250);
 
   public:
     explicit FastestPathRoutingProfile(const TypeConfigRef& typeConfig);
@@ -305,10 +307,14 @@ namespace osmscout {
       // it is estimate without considering real junction geometry
       double junctionPenalty{0};
       if (applyJunctionPenalty && inObjIndex!=outObjIndex){
+        auto penaltyDistance = inPathVariant.type != outPathVariant.type ?
+                               penaltyDifferentType :
+                               penaltySameType;
+
         double minSpeed=std::min(GetMaxSpeed(inPathVariant),GetMaxSpeed(outPathVariant));
         junctionPenalty = minSpeed <= 0 ?
-            std::numeric_limits<double>::infinity() :
-            0.160 / minSpeed;
+                          std::numeric_limits<double>::infinity() :
+                          penaltyDistance.As<Kilometer>() / minSpeed;
       }
 
       return outPrice + junctionPenalty;


### PR DESCRIPTION
Current junction penalty don't consider real junction geometry,
it would require bigger refactoring of route profiles.
But it may lead to wrong assumption that ride thru service road
around fuel station is faster than continue on main road
with two junctions. To workaround that problem,
we penalise junction more when route type is changed.

![Screenshot_20200527_081513](https://user-images.githubusercontent.com/309458/82985876-1a950880-9ff5-11ea-9380-05bf752967b2.png)