### PR TITLE
reduce dynamic_cast invocations

### DIFF
--- a/Demos/src/NavigationSimulator.cpp
+++ b/Demos/src/NavigationSimulator.cpp
@@ -338,8 +338,8 @@ bool DataLoader::loadRoutableObjects(const osmscout::GeoBox &box,
 void Simulator::ProcessMessages(const std::list<osmscout::NavigationMessageRef>& messages)
 {
   for (const auto& message : messages) {
-    if (dynamic_cast<osmscout::BearingChangedMessage*>(message.get())!=nullptr) {
-      auto bearingChangedMessage=dynamic_cast<osmscout::BearingChangedMessage*>(message.get());
+    if (auto bearingChangedMessage = dynamic_cast<osmscout::BearingChangedMessage*>(message.get());
+        bearingChangedMessage != nullptr) {
 
       auto bearingString=bearingChangedMessage->bearing.DisplayString();
       if (lastBearingString!=bearingString) {
@@ -357,8 +357,8 @@ void Simulator::ProcessMessages(const std::list<osmscout::NavigationMessageRef>&
       << " Street name: " << streetChangedMessage->name << std::endl;
     }
     */
-    else if (dynamic_cast<osmscout::RerouteRequestMessage*>(message.get())!=nullptr) {
-      auto rerouteRequest=dynamic_cast<osmscout::RerouteRequestMessage*>(message.get());
+    else if (auto rerouteRequest = dynamic_cast<osmscout::RerouteRequestMessage*>(message.get());
+             rerouteRequest != nullptr) {
 
       std::cout << osmscout::TimestampToISO8601TimeString(rerouteRequest->timestamp)
                 << " Reroute request: " << rerouteRequest->from.GetDisplayText()
@@ -367,8 +367,8 @@ void Simulator::ProcessMessages(const std::list<osmscout::NavigationMessageRef>&
                 << std::endl;
 
     }
-    else if (dynamic_cast<osmscout::TargetReachedMessage*>(message.get())!=nullptr) {
-      auto targetReachedMessage = dynamic_cast<osmscout::TargetReachedMessage *>(message.get());
+    else if (auto targetReachedMessage = dynamic_cast<osmscout::TargetReachedMessage *>(message.get());
+             targetReachedMessage != nullptr) {
 
       if (targetReachedMessage->targetDistance < osmscout::Meters(1)){
         std::cout << osmscout::TimestampToISO8601TimeString(targetReachedMessage->timestamp)
@@ -381,8 +381,8 @@ void Simulator::ProcessMessages(const std::list<osmscout::NavigationMessageRef>&
                   << std::endl;
       }
     }
-    else if (dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get())!=nullptr) {
-      auto positionMessage=dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get());
+    else if (auto positionMessage = dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get());
+             positionMessage != nullptr) {
 
       if (positionMessage->position.state!=routeState) {
 
@@ -393,18 +393,21 @@ void Simulator::ProcessMessages(const std::list<osmscout::NavigationMessageRef>&
                   << std::endl;
       }
     }
-    else if (dynamic_cast<osmscout::ArrivalEstimateMessage*>(message.get())!=nullptr) {
-      auto arrivalMessage = dynamic_cast<osmscout::ArrivalEstimateMessage *>(message.get());
+    else if (auto arrivalMessage = dynamic_cast<osmscout::ArrivalEstimateMessage *>(message.get());
+             arrivalMessage != nullptr) {
+
       std::cout << "Estimated arrival: " << osmscout::TimestampToISO8601TimeString(arrivalMessage->arrivalEstimate)
                 << " remaining distance: " << arrivalMessage->remainingDistance.AsString()
                 << std::endl;
     }
-    else if (dynamic_cast<osmscout::CurrentSpeedMessage*>(message.get())!=nullptr) {
-      auto currentSpeedMessage = dynamic_cast<osmscout::CurrentSpeedMessage *>(message.get());
+    else if (auto currentSpeedMessage = dynamic_cast<osmscout::CurrentSpeedMessage *>(message.get());
+             currentSpeedMessage != nullptr) {
+
       std::cout << "Current speed: " << currentSpeedMessage->speed << " km/h" << std::endl;
     }
-    else if (dynamic_cast<osmscout::MaxAllowedSpeedMessage*>(message.get())!=nullptr) {
-      auto maxSpeedMessage = dynamic_cast<osmscout::MaxAllowedSpeedMessage *>(message.get());
+    else if (auto maxSpeedMessage = dynamic_cast<osmscout::MaxAllowedSpeedMessage *>(message.get());
+             maxSpeedMessage != nullptr) {
+
       std::cout << "Max. allowed speed: " << maxSpeedMessage->maxAllowedSpeed << " km/h" << std::endl;
     }
   }

--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -561,75 +561,75 @@ static void DumpFeatureValueBuffer(const osmscout::FeatureValueBuffer& buffer,
       if (meta.GetFeature()->HasValue()) {
         osmscout::FeatureValue *value=buffer.GetValue(idx);
 
-        if (dynamic_cast<osmscout::NameFeatureValue*>(value)!=nullptr) {
-          auto*nameValue=dynamic_cast<osmscout::NameFeatureValue*>(value);
+        if (auto* nameValue = dynamic_cast<osmscout::NameFeatureValue*>(value);
+            nameValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Name: " << nameValue->GetName() << std::endl;
         }
-        else if (dynamic_cast<osmscout::NameAltFeatureValue*>(value)!=nullptr) {
-          auto*nameAltValue=dynamic_cast<osmscout::NameAltFeatureValue*>(value);
+        else if (auto* nameAltValue = dynamic_cast<osmscout::NameAltFeatureValue*>(value);
+                 nameAltValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "NameAlt: " << nameAltValue->GetNameAlt() << std::endl;
         }
-        else if (dynamic_cast<osmscout::RefFeatureValue*>(value)!=nullptr) {
-          auto*refValue=dynamic_cast<osmscout::RefFeatureValue*>(value);
+        else if (auto* refValue = dynamic_cast<osmscout::RefFeatureValue*>(value);
+                 refValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Ref: " << refValue->GetRef() << std::endl;
         }
-        else if (dynamic_cast<osmscout::LocationFeatureValue*>(value)!=nullptr) {
-          auto*locationValue=dynamic_cast<osmscout::LocationFeatureValue*>(value);
+        else if (auto* locationValue = dynamic_cast<osmscout::LocationFeatureValue*>(value);
+                 locationValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Location: "<< locationValue->GetLocation() << std::endl;
         }
-        else if (dynamic_cast<osmscout::AddressFeatureValue*>(value)!=nullptr) {
-          auto*addressValue=dynamic_cast<osmscout::AddressFeatureValue*>(value);
+        else if (auto* addressValue = dynamic_cast<osmscout::AddressFeatureValue*>(value);
+                 addressValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Address: " << addressValue->GetAddress() << std::endl;
         }
-        else if (dynamic_cast<osmscout::AccessFeatureValue*>(value)!=nullptr) {
-          auto*accessValue=dynamic_cast<osmscout::AccessFeatureValue*>(value);
+        else if (auto* accessValue = dynamic_cast<osmscout::AccessFeatureValue*>(value);
+                 accessValue != nullptr) {
 
           DumpAccessFeatureValue(*accessValue,
                                  indent,
                                  false);
         }
-        else if (dynamic_cast<osmscout::AccessRestrictedFeatureValue*>(value)!=nullptr) {
-          auto*accessValue=dynamic_cast<osmscout::AccessRestrictedFeatureValue*>(value);
+        else if (auto* accessValue=dynamic_cast<osmscout::AccessRestrictedFeatureValue*>(value);
+                 accessValue != nullptr) {
 
           DumpAccessRestrictedFeatureValue(*accessValue,
                                            indent);
         }
-        else if (dynamic_cast<osmscout::LayerFeatureValue*>(value)!=nullptr) {
-          auto*layerValue=dynamic_cast<osmscout::LayerFeatureValue*>(value);
+        else if (auto* layerValue = dynamic_cast<osmscout::LayerFeatureValue*>(value);
+                 layerValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Layer: " << (int)layerValue->GetLayer() << std::endl;
         }
-        else if (dynamic_cast<osmscout::WidthFeatureValue*>(value)!=nullptr) {
-          auto*widthValue=dynamic_cast<osmscout::WidthFeatureValue*>(value);
+        else if (auto* widthValue = dynamic_cast<osmscout::WidthFeatureValue*>(value);
+                 widthValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Width: " << (int)widthValue->GetWidth() << std::endl;
         }
-        else if (dynamic_cast<osmscout::MaxSpeedFeatureValue*>(value)!=nullptr) {
-          auto*maxSpeedValue=dynamic_cast<osmscout::MaxSpeedFeatureValue*>(value);
+        else if (auto* maxSpeedValue = dynamic_cast<osmscout::MaxSpeedFeatureValue*>(value);
+                 maxSpeedValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "MaxSpeed: " << (int)maxSpeedValue->GetMaxSpeed() << std::endl;
         }
-        else if (dynamic_cast<osmscout::GradeFeatureValue*>(value)!=nullptr) {
-          auto*gradeValue=dynamic_cast<osmscout::GradeFeatureValue*>(value);
+        else if (auto* gradeValue = dynamic_cast<osmscout::GradeFeatureValue*>(value);
+                 gradeValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "Grade: " << (int)gradeValue->GetGrade() << std::endl;
         }
-        else if (dynamic_cast<osmscout::AdminLevelFeatureValue*>(value)!=nullptr) {
-          auto*adminLevelValue=dynamic_cast<osmscout::AdminLevelFeatureValue*>(value);
+        else if (auto* adminLevelValue = dynamic_cast<osmscout::AdminLevelFeatureValue*>(value);
+                 adminLevelValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "AdminLevel: " << (unsigned int)adminLevelValue->GetAdminLevel();
@@ -640,19 +640,19 @@ static void DumpFeatureValueBuffer(const osmscout::FeatureValueBuffer& buffer,
 
           std::cout << std::endl;
         }
-        else if (dynamic_cast<osmscout::IsInFeatureValue*>(value)!=nullptr) {
-          auto*isInValue=dynamic_cast<osmscout::IsInFeatureValue*>(value);
+        else if (auto* isInValue = dynamic_cast<osmscout::IsInFeatureValue*>(value);
+                 isInValue != nullptr) {
 
           DumpIndent(indent);
           std::cout << "IsIn: " << isInValue->GetIsIn() << std::endl;
         }
-        else if (dynamic_cast<osmscout::SidewayFeatureValue*>(value)!=nullptr) {
-          auto*sidewayValue=dynamic_cast<osmscout::SidewayFeatureValue*>(value);
+        else if (auto* sidewayValue = dynamic_cast<osmscout::SidewayFeatureValue*>(value);
+                 sidewayValue != nullptr) {
 
           DumpSidewayFeatureValue(*sidewayValue,indent);
         }
-        else if (dynamic_cast<osmscout::LanesFeatureValue*>(value)!=nullptr) {
-          auto*lanesValue=dynamic_cast<osmscout::LanesFeatureValue*>(value);
+        else if (auto* lanesValue = dynamic_cast<osmscout::LanesFeatureValue*>(value);
+                 lanesValue != nullptr) {
 
           DumpLanesFeatureValue(*lanesValue,
                                 indent);

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -67,61 +67,72 @@ void NavigationModule::InitPlayer()
 void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessageRef>& messages)
 {
   for (const auto &message : messages) {
-    if (dynamic_cast<PositionAgent::PositionMessage *>(message.get()) != nullptr) {
-      auto positionMessage=static_cast<PositionAgent::PositionMessage*>(message.get());
+    if (auto positionMessage=dynamic_cast<PositionAgent::PositionMessage*>(message.get());
+        positionMessage != nullptr) {
+
       auto &position=positionMessage->position;
       assert(position.state!=PositionAgent::Uninitialised); // unitialised position newer should be used in UI
       emit positionEstimate(position.state, position.coord, lastBearing);
     }
-    else if (dynamic_cast<osmscout::BearingChangedMessage*>(message.get())!=nullptr) {
-      auto bearingMessage = static_cast<osmscout::BearingChangedMessage *>(message.get());
+    else if (auto bearingMessage = dynamic_cast<osmscout::BearingChangedMessage *>(message.get());
+             bearingMessage != nullptr) {
+
       lastBearing=bearingMessage->bearing;
     }
-    else if (dynamic_cast<osmscout::TargetReachedMessage*>(message.get())!=nullptr) {
-      auto targetReachedMessage = static_cast<osmscout::TargetReachedMessage *>(message.get());
+    else if (auto targetReachedMessage = dynamic_cast<osmscout::TargetReachedMessage *>(message.get());
+             targetReachedMessage != nullptr) {
+
       emit targetReached(targetReachedMessage->targetBearing,targetReachedMessage->targetDistance);
     }
-    else if (dynamic_cast<RerouteRequestMessage*>(message.get())!=nullptr) {
-      auto req = static_cast<RerouteRequestMessage *>(message.get());
+    else if (auto req = dynamic_cast<RerouteRequestMessage *>(message.get());
+             req != nullptr) {
+
       emit rerouteRequest(req->from,
                           req->initialBearing,
                           req->to);
     }
-    else if (dynamic_cast<RouteInstructionsMessage<RouteStep> *>(message.get())!=nullptr) {
-      auto instructions = static_cast<RouteInstructionsMessage<RouteStep> *>(message.get());
+    else if (auto instructions = dynamic_cast<RouteInstructionsMessage<RouteStep> *>(message.get());
+             instructions != nullptr) {
+
       emit update(instructions->instructions);
     }
-    else if (dynamic_cast<NextRouteInstructionsMessage<RouteStep> *>(message.get())!=nullptr) {
-      auto nextInstruction = static_cast<NextRouteInstructionsMessage<RouteStep> *>(message.get());
+    else if (auto nextInstruction = dynamic_cast<NextRouteInstructionsMessage<RouteStep> *>(message.get());
+             nextInstruction != nullptr) {
+
       if (!nextInstruction->nextRouteInstruction.shortDescription.isEmpty()) {
         log.Debug() << "In " << nextInstruction->nextRouteInstruction.distanceTo.AsMeter() << " m: "
                     << nextInstruction->nextRouteInstruction.shortDescription.toStdString();
       }
       emit updateNext(nextInstruction->nextRouteInstruction);
     }
-    else if (dynamic_cast<osmscout::ArrivalEstimateMessage*>(message.get())!=nullptr) {
-      auto arrivalMessage = static_cast<osmscout::ArrivalEstimateMessage *>(message.get());
+    else if (auto arrivalMessage = dynamic_cast<osmscout::ArrivalEstimateMessage *>(message.get());
+             arrivalMessage != nullptr) {
+
       using namespace std::chrono;
       emit arrivalEstimate(QDateTime::fromMSecsSinceEpoch(duration_cast<milliseconds>(arrivalMessage->arrivalEstimate.time_since_epoch()).count()),
                            arrivalMessage->remainingDistance);
     }
-    else if (dynamic_cast<osmscout::CurrentSpeedMessage*>(message.get())!=nullptr) {
-      auto currentSpeedMessage = static_cast<osmscout::CurrentSpeedMessage *>(message.get());
+    else if (auto currentSpeedMessage = dynamic_cast<osmscout::CurrentSpeedMessage *>(message.get());
+             currentSpeedMessage != nullptr) {
+
       emit currentSpeed(currentSpeedMessage->speed);
     }
-    else if (dynamic_cast<osmscout::MaxAllowedSpeedMessage*>(message.get())!=nullptr) {
-      auto maxSpeedMessage = static_cast<osmscout::MaxAllowedSpeedMessage *>(message.get());
+    else if (auto maxSpeedMessage = dynamic_cast<osmscout::MaxAllowedSpeedMessage *>(message.get());
+             maxSpeedMessage != nullptr) {
+
       emit maxAllowedSpeed(maxSpeedMessage->maxAllowedSpeed);
-    } else if (dynamic_cast<osmscout::VoiceInstructionMessage*>(message.get())!=nullptr) {
-      auto voiceInstructionMessage = static_cast<osmscout::VoiceInstructionMessage*>(message.get());
+    } else if (auto voiceInstructionMessage = dynamic_cast<osmscout::VoiceInstructionMessage*>(message.get());
+               voiceInstructionMessage != nullptr) {
+
       if (!voiceDir.isEmpty()) {
         nextMessage = voiceInstructionMessage->message;
         InitPlayer();
         assert(mediaPlayer);
         playerStateChanged(mediaPlayer->state());
       }
-    } else if (dynamic_cast<osmscout::LaneAgent::LaneMessage*>(message.get())!=nullptr) {
-      auto laneMessage = static_cast<osmscout::LaneAgent::LaneMessage*>(message.get());
+    } else if (auto laneMessage = dynamic_cast<osmscout::LaneAgent::LaneMessage*>(message.get());
+               laneMessage != nullptr) {
+
       emit laneUpdate(laneMessage->lane);
     }
   }

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -274,8 +274,9 @@ namespace osmscout {
                                 const LabelData& label,
                                 const NativeLabel& layout)
   {
-    if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
-      const TextStyle *style = dynamic_cast<const TextStyle *>(label.style.get());
+    if (const TextStyle *style = dynamic_cast<const TextStyle *>(label.style.get());
+        style != nullptr) {
+
       double r = style->GetTextColor().GetR();
       double g = style->GetTextColor().GetG();
       double b = style->GetTextColor().GetB();
@@ -478,8 +479,9 @@ namespace osmscout {
     for (const auto& primitive : symbol.GetPrimitives()) {
       const DrawPrimitive *primitivePtr=primitive.get();
 
-      if (dynamic_cast<const PolygonPrimitive*>(primitivePtr)!=nullptr) {
-        const auto        *polygon=dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+      if (const auto *polygon = dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+          polygon != nullptr) {
+
         FillStyleRef      fillStyle=polygon->GetFillStyle();
         BorderStyleRef    borderStyle=polygon->GetBorderStyle();
         agg::path_storage path;
@@ -507,8 +509,9 @@ namespace osmscout {
                  borderStyle,
                  path);
       }
-      else if (dynamic_cast<const RectanglePrimitive*>(primitivePtr)!=nullptr) {
-        const auto        *rectangle=dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+      else if (const auto *rectangle = dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+               rectangle != nullptr) {
+
         FillStyleRef      fillStyle=rectangle->GetFillStyle();
         BorderStyleRef    borderStyle=rectangle->GetBorderStyle();
         agg::path_storage path;
@@ -532,8 +535,9 @@ namespace osmscout {
                  borderStyle,
                  path);
       }
-      else if (dynamic_cast<const CirclePrimitive*>(primitivePtr)!=nullptr) {
-        const auto        *circle=dynamic_cast<const CirclePrimitive*>(primitivePtr);
+      else if (const auto *circle = dynamic_cast<const CirclePrimitive*>(primitivePtr);
+               circle != nullptr) {
+
         FillStyleRef      fillStyle=circle->GetFillStyle();
         BorderStyleRef    borderStyle=circle->GetBorderStyle();
         agg::path_storage path;

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -975,8 +975,9 @@ namespace osmscout {
                                   const LabelData &label,
                                   const CairoNativeLabel &layout)
   {
-    if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
-      const auto *style = dynamic_cast<const TextStyle *>(label.style.get());
+    if (const auto *style = dynamic_cast<const TextStyle *>(label.style.get());
+        style != nullptr) {
+
       double r = style->GetTextColor().GetR();
       double g = style->GetTextColor().GetG();
       double b = style->GetTextColor().GetB();
@@ -1033,8 +1034,8 @@ namespace osmscout {
 #endif
 
     }
-    else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {
-      const auto* style=dynamic_cast<const ShieldStyle*>(label.style.get());
+    else if (const auto* style = dynamic_cast<const ShieldStyle*>(label.style.get());
+             style != nullptr) {
 
       cairo_set_dash(draw,nullptr,0,0);
       cairo_set_line_width(draw,1);
@@ -1144,8 +1145,8 @@ namespace osmscout {
     double         centerX=(minX+maxX)/2;
     double         centerY=(minY+maxY)/2;
 
-    if (dynamic_cast<PolygonPrimitive*>(primitive)!=nullptr) {
-      const auto* polygon=dynamic_cast<const PolygonPrimitive*>(primitive);
+    if (const auto* polygon = dynamic_cast<const PolygonPrimitive*>(primitive);
+        polygon != nullptr) {
 
       for (auto pixel=polygon->GetCoords().begin();
            pixel!=polygon->GetCoords().end();
@@ -1164,8 +1165,8 @@ namespace osmscout {
 
       cairo_close_path(draw);
     }
-    else if (dynamic_cast<RectanglePrimitive*>(primitive)!=nullptr) {
-      const auto* rectangle=dynamic_cast<const RectanglePrimitive*>(primitive);
+    else if (const auto* rectangle = dynamic_cast<const RectanglePrimitive*>(primitive);
+             rectangle != nullptr) {
 
       cairo_rectangle(draw,
                       x+projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX())-centerX,
@@ -1173,8 +1174,8 @@ namespace osmscout {
                       projection.ConvertWidthToPixel(rectangle->GetWidth()),
                       projection.ConvertWidthToPixel(rectangle->GetHeight()));
     }
-    else if (dynamic_cast<CirclePrimitive*>(primitive)!=nullptr) {
-      const auto* circle=dynamic_cast<const CirclePrimitive*>(primitive);
+    else if (const auto* circle = dynamic_cast<const CirclePrimitive*>(primitive);
+             circle != nullptr) {
 
       cairo_arc(draw,
                 x+projection.ConvertWidthToPixel(circle->GetCenter().GetX())-centerX,

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -571,8 +571,9 @@ namespace osmscout
                                     const DirectXTextLayout& textLayout)
 
   {
-    if (dynamic_cast<const TextStyle*>(label.style.get()) !=nullptr) {
-      const TextStyle* style = dynamic_cast<const TextStyle*>(label.style.get());
+    if (const TextStyle* style = dynamic_cast<const TextStyle*>(label.style.get());
+        style != nullptr) {
+
       double r = style->GetTextColor().GetR();
       double g = style->GetTextColor().GetG();
       double b = style->GetTextColor().GetB();
@@ -584,8 +585,9 @@ namespace osmscout
                 Color(r,g,b,label.alpha),
                 textLayout);
     }
-    else if (dynamic_cast<const ShieldStyle*>(label.style.get()) != nullptr) {
-      const ShieldStyle *style = dynamic_cast<const ShieldStyle*>(label.style.get());
+    else if (const ShieldStyle *style = dynamic_cast<const ShieldStyle*>(label.style.get());
+             style != nullptr) {
+
       double r = style->GetTextColor().GetR();
       double g = style->GetTextColor().GetG();
       double b = style->GetTextColor().GetB();
@@ -719,9 +721,10 @@ namespace osmscout
       BorderStyleRef borderStyle = primitive->GetBorderStyle();
       bool hasBorder = borderStyle && borderStyle->GetWidth() > 0.0 && borderStyle->GetColor().IsVisible();
       float borderWidth = hasBorder ? float(projection.ConvertWidthToPixel(borderStyle->GetWidth())) : 0.0f;
-      if (dynamic_cast<PolygonPrimitive*>(primitive) != nullptr)
+
+      if (PolygonPrimitive* polygon = dynamic_cast<PolygonPrimitive*>(primitive);
+          polygon != nullptr)
       {
-        PolygonPrimitive* polygon = dynamic_cast<PolygonPrimitive*>(primitive);
         const std::list<osmscout::Vertex2D> data = polygon->GetCoords();
         if (data.size() > 2)
         {
@@ -764,9 +767,9 @@ namespace osmscout
           delete coords;
         }
       }
-      else if (dynamic_cast<RectanglePrimitive*>(primitive) != nullptr)
+      else if (RectanglePrimitive* rectangle = dynamic_cast<RectanglePrimitive*>(primitive);
+               rectangle != nullptr)
       {
-        RectanglePrimitive* rectangle = dynamic_cast<RectanglePrimitive*>(primitive);
         D2D1_RECT_F rect = RECTF(x + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()) - centerX,
                                  y + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetY()) - centerY,
                                  x + projection.ConvertWidthToPixel(rectangle->GetTopLeft().GetX()) - centerX + projection.ConvertWidthToPixel(rectangle->GetWidth()),
@@ -774,9 +777,9 @@ namespace osmscout
         m_pRenderTarget->FillRectangle(rect, GetColorBrush(fillStyle->GetFillColor()));
         if (hasBorder) m_pRenderTarget->DrawRectangle(rect, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));
       }
-      else if (dynamic_cast<CirclePrimitive*>(primitive) != nullptr)
+      else if (CirclePrimitive* circle = dynamic_cast<CirclePrimitive*>(primitive);
+               circle != nullptr)
       {
-        CirclePrimitive* circle = dynamic_cast<CirclePrimitive*>(primitive);
         D2D1_ELLIPSE ellipse = D2D1::Ellipse(POINTF(centerX, centerY), float(projection.ConvertWidthToPixel(circle->GetRadius())), float(projection.ConvertWidthToPixel(circle->GetRadius())));
         m_pRenderTarget->FillEllipse(ellipse, GetColorBrush(fillStyle->GetFillColor()));
         if (hasBorder) m_pRenderTarget->DrawEllipse(ellipse, GetColorBrush(borderStyle->GetColor()), borderWidth, GetStrokeStyle(borderStyle->GetDash()));

--- a/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iOSX/src/osmscout/MapPainterIOS.mm
@@ -469,8 +469,8 @@ namespace osmscout {
                                   const LabelData& label,
                                   const IOSLabel& layout) {
         
-        if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
-            const auto *style=dynamic_cast<const TextStyle*>(label.style.get());
+        if (const auto *style = dynamic_cast<const TextStyle*>(label.style.get());
+            style != nullptr) {
             
             if (style->GetStyle()==TextStyle::normal) {
                 LayoutDrawLabel(layout, CGPointMake(labelRect.x, labelRect.y), style->GetTextColor(), false);
@@ -479,9 +479,8 @@ namespace osmscout {
                 LayoutDrawLabel(layout, CGPointMake(labelRect.x, labelRect.y), style->GetTextColor(), true);
             }
             
-        } else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {
-            
-            const ShieldStyle* style=dynamic_cast<const ShieldStyle*>(label.style.get());
+        } else if (const ShieldStyle* style = dynamic_cast<const ShieldStyle*>(label.style.get());
+                   style != nullptr) {
             
             CGContextSaveGState(cg);
             CGContextSetRGBFillColor(cg,
@@ -694,8 +693,9 @@ namespace osmscout {
         for (const auto& primitive : symbol.GetPrimitives()) {
             const DrawPrimitive *primitivePtr=primitive.get();
             
-            if (dynamic_cast<const PolygonPrimitive*>(primitivePtr)!=nullptr) {
-                const auto *polygon=dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+            if (const auto *polygon = dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+                polygon != nullptr) {
+
                 FillStyleRef fillStyle=polygon->GetFillStyle();
                 BorderStyleRef borderStyle=polygon->GetBorderStyle();
 
@@ -727,8 +727,9 @@ namespace osmscout {
 
                 CGContextDrawPath(cg, kCGPathFillStroke);
             }
-            else if (dynamic_cast<const RectanglePrimitive*>(primitivePtr)!=nullptr) {
-                const auto *rectangle=dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+            else if (const auto *rectangle = dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+                     rectangle != nullptr) {
+
                 FillStyleRef fillStyle=rectangle->GetFillStyle();
                 BorderStyleRef borderStyle=rectangle->GetBorderStyle();
                 if (fillStyle) {
@@ -749,8 +750,9 @@ namespace osmscout {
                 CGContextAddRect(cg,rect);
                 CGContextDrawPath(cg, kCGPathFillStroke);
             }
-            else if (dynamic_cast<const CirclePrimitive*>(primitivePtr)!=nullptr) {
-                const auto *circle=dynamic_cast<const CirclePrimitive*>(primitivePtr);
+            else if (const auto *circle = dynamic_cast<const CirclePrimitive*>(primitivePtr);
+                     circle != nullptr) {
+
                 FillStyleRef fillStyle=circle->GetFillStyle();
                 BorderStyleRef borderStyle=circle->GetBorderStyle();
                 if (fillStyle) {

--- a/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscout/MapPainterOpenGL.cpp
@@ -1026,8 +1026,9 @@ namespace osmscout {
             DrawPrimitive *primitive = p.get();
             FillStyleRef fillStyle = primitive->GetFillStyle();
 
-            if (dynamic_cast<PolygonPrimitive *>(primitive) !=nullptr) {
-              PolygonPrimitive *polygon = dynamic_cast<PolygonPrimitive *>(primitive);
+            if (PolygonPrimitive *polygon = dynamic_cast<PolygonPrimitive *>(primitive);
+                polygon !=nullptr) {
+
               double meterPerPixelLat = (40075.016686 * 1000) * std::cos(node->GetCoords().GetLat()) /
                                         (float) (std::pow(2, (Magnification.GetLevel() + 9)));
               double meterPerPixel = (40075.016686 * 1000) / (float) (std::pow(2, (Magnification.GetLevel() + 9)));

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -310,8 +310,9 @@ namespace osmscout {
       return;
     }
 
-    if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
-      const auto *style=dynamic_cast<const TextStyle*>(label.style.get());
+    if (const auto *style = dynamic_cast<const TextStyle*>(label.style.get());
+        style != nullptr) {
+
       double      r=style->GetTextColor().GetR();
       double      g=style->GetTextColor().GetG();
       double      b=style->GetTextColor().GetB();
@@ -348,12 +349,12 @@ namespace osmscout {
         textLayout.draw(painter, rect.topLeft());
       }
     }
-    else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {
+    else if (const auto *style = dynamic_cast<const ShieldStyle*>(label.style.get());
+             style != nullptr) {
 
       QPointF marginMove(-5,-5);
       QSizeF marginResize(10,10);
 
-      const auto *style=dynamic_cast<const ShieldStyle*>(label.style.get());
       QColor     textColor=QColor::fromRgbF(style->GetTextColor().GetR(),
                                             style->GetTextColor().GetG(),
                                             style->GetTextColor().GetB(),
@@ -654,8 +655,9 @@ namespace osmscout {
     for (const auto& primitive : symbol.GetPrimitives()) {
       const DrawPrimitive *primitivePtr=primitive.get();
 
-      if (dynamic_cast<const PolygonPrimitive*>(primitivePtr)!=nullptr) {
-        const auto     *polygon=dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+      if (const auto *polygon = dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+          polygon != nullptr) {
+
         FillStyleRef   fillStyle=polygon->GetFillStyle();
         BorderStyleRef borderStyle=polygon->GetBorderStyle();
 
@@ -711,8 +713,9 @@ namespace osmscout {
 
         painter->drawPath(path);
       }
-      else if (dynamic_cast<const RectanglePrimitive*>(primitivePtr)!=nullptr) {
-        const auto     *rectangle=dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+      else if (const auto *rectangle = dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+               rectangle != nullptr) {
+
         FillStyleRef   fillStyle=rectangle->GetFillStyle();
         BorderStyleRef borderStyle=rectangle->GetBorderStyle();
 
@@ -751,8 +754,9 @@ namespace osmscout {
 
         painter->drawPath(path);
       }
-      else if (dynamic_cast<const CirclePrimitive*>(primitivePtr)!=nullptr) {
-        const auto     *circle=dynamic_cast<const CirclePrimitive*>(primitivePtr);
+      else if (const auto *circle = dynamic_cast<const CirclePrimitive*>(primitivePtr);
+               circle != nullptr) {
+
         FillStyleRef   fillStyle=circle->GetFillStyle();
         BorderStyleRef borderStyle=circle->GetBorderStyle();
         QPointF        center;

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -280,8 +280,8 @@ namespace osmscout {
                                 const LabelData &label,
                                 const NativeLabel &/*layout*/)
   {
-    if (dynamic_cast<const TextStyle*>(label.style.get())!=nullptr) {
-      const TextStyle* style=dynamic_cast<const TextStyle*>(label.style.get());
+    if (const TextStyle* style = dynamic_cast<const TextStyle*>(label.style.get());
+        style != nullptr) {
 
       // TODO: text x, y coordinate is text baseline, our placement is not precise
 
@@ -300,8 +300,8 @@ namespace osmscout {
       stream << StrEscape(label.text);
       stream << "</text>" << std::endl;
     }
-    else if (dynamic_cast<const ShieldStyle*>(label.style.get())!=nullptr) {
-      const ShieldStyle* style=dynamic_cast<const ShieldStyle*>(label.style.get());
+    else if (const ShieldStyle* style = dynamic_cast<const ShieldStyle*>(label.style.get());
+             style != nullptr) {
 
       // Shield background
       stream << "    <rect";

--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -1468,14 +1468,13 @@ PRODUCTIONS
                    else if (descriptor.GetType()==StyleAttributeType::TYPE_COLOR) {
                      if (valueType==ValueType::COLOR) {
                        if (constant) {
-                         if (dynamic_cast<StyleConstantColor*>(constant.get())==nullptr) {
+                         if (StyleConstantColor* colorConstant = dynamic_cast<StyleConstantColor*>(constant.get());
+                             colorConstant == nullptr) {
                            std::string e="Constant is not of type 'COLOR'";
 
                            SemErr(e.c_str());
                          }
                          else {
-                           StyleConstantColor* colorConstant=dynamic_cast<StyleConstantColor*>(constant.get());
-
                            color=colorConstant->GetColor();
                          }
                        }

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1765,14 +1765,13 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 		else if (descriptor.GetType()==StyleAttributeType::TYPE_COLOR) {
 		 if (valueType==ValueType::COLOR) {
 		   if (constant) {
-		     if (dynamic_cast<StyleConstantColor*>(constant.get())==nullptr) {
+		     if (StyleConstantColor* colorConstant = dynamic_cast<StyleConstantColor*>(constant.get());
+		         colorConstant == nullptr) {
 		       std::string e="Constant is not of type 'COLOR'";
 		
 		       SemErr(e.c_str());
 		     }
 		     else {
-		       StyleConstantColor* colorConstant=dynamic_cast<StyleConstantColor*>(constant.get());
-		
 		       color=colorConstant->GetColor();
 		     }
 		   }

--- a/libosmscout/include/osmscout/navigation/DataAgent.h
+++ b/libosmscout/include/osmscout/navigation/DataAgent.h
@@ -86,19 +86,22 @@ namespace osmscout {
     {
       auto result=std::list<NavigationMessageRef>();
 
-      if (dynamic_cast<RouteUpdateMessage*>(message.get())!=nullptr) {
-        auto* routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+      if (auto* routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+          routeUpdateMessage != nullptr) {
+
         databaseMapping.clear();
         // build reverse mapping
         for (auto &e:routeUpdateMessage->routeDescription->GetDatabaseMapping()){
           databaseMapping[e.second]=e.first;
         }
         vehicle=routeUpdateMessage->vehicle;
-      } else if (dynamic_cast<RoutableObjectsRequestMessage*>(message.get())!=nullptr) {
+      } else if (auto* requestMessage = dynamic_cast<RoutableObjectsRequestMessage*>(message.get());
+                 requestMessage != nullptr) {
+
         if (databaseMapping.empty()){
           return result; // no route yet
         }
-        auto* requestMessage=dynamic_cast<RoutableObjectsRequestMessage*>(message.get());
+
         if (GetSphericalDistance(requestMessage->bbox.GetMinCoord(),
                                  requestMessage->bbox.GetMaxCoord()) > Kilometers(2)){
           log.Warn() << "Requested routable data from huge region: " << requestMessage->bbox.GetDisplayText();

--- a/libosmscout/src/osmscout/navigation/BearingAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/BearingAgent.cpp
@@ -41,8 +41,9 @@ namespace osmscout {
 
     auto now=message->timestamp;
 
-    if (dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get())!=nullptr) {
-      auto msg=dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get());
+    if (auto* msg = dynamic_cast<osmscout::PositionAgent::PositionMessage*>(message.get());
+        msg != nullptr) {
+
       auto coord=msg->position.coord;
 
       if (!previousPointValid){

--- a/libosmscout/src/osmscout/navigation/PositionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/PositionAgent.cpp
@@ -193,8 +193,9 @@ namespace osmscout {
     std::list<NavigationMessageRef> result;
     auto now=message->timestamp;
 
-    if (dynamic_cast<GPSUpdateMessage*>(message.get())!=nullptr) {
-      auto gpsUpdateMessage=dynamic_cast<GPSUpdateMessage*>(message.get());
+    if (auto gpsUpdateMessage = dynamic_cast<GPSUpdateMessage*>(message.get());
+        gpsUpdateMessage != nullptr) {
+
       // ignore gps update when we accuracy is too low and we have good data already
       if (gps.GetState(now)!=Good ||
           gpsUpdateMessage->horizontalAccuracy < Meters(100)){
@@ -202,13 +203,15 @@ namespace osmscout {
                    gpsUpdateMessage->currentPosition,
                    gpsUpdateMessage->horizontalAccuracy);
       }
-    } else if (dynamic_cast<RoutableObjectsMessage*>(message.get())!=nullptr){
-      auto msg=dynamic_cast<RoutableObjectsMessage*>(message.get());
+    } else if (auto msg = dynamic_cast<RoutableObjectsMessage*>(message.get());
+               msg != nullptr){
+
       if (Includes(msg->data,gps.GetGeoBox())){
         this->routableObjects = msg->data;
       }
-    } else if (dynamic_cast<RouteUpdateMessage*>(message.get())!=nullptr) {
-      auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+    } else if (auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+               routeUpdateMessage != nullptr) {
+
       route=routeUpdateMessage->routeDescription;
       vehicle=routeUpdateMessage->vehicle;
       position.routeNode=route->Nodes().begin();

--- a/libosmscout/src/osmscout/navigation/RouteStateAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/RouteStateAgent.cpp
@@ -62,20 +62,21 @@ namespace osmscout {
 
     auto now = message->timestamp;
 
-    if (dynamic_cast<RouteUpdateMessage*>(message.get())!=nullptr) {
-      auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+    if (auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage *>(message.get());
+        routeUpdateMessage != nullptr) {
 
       if (!routeUpdateMessage->routeDescription->Nodes().empty()) {
         target = routeUpdateMessage->routeDescription->Nodes().rbegin()->GetLocation();
         targetSetup = true;
       }
-    } else if (dynamic_cast<osmscout::BearingChangedMessage*>(message.get())!=nullptr) {
-      auto bearingChangedMessage=dynamic_cast<osmscout::BearingChangedMessage*>(message.get());
+    } else if (auto bearingChangedMessage = dynamic_cast<osmscout::BearingChangedMessage*>(message.get());
+               bearingChangedMessage != nullptr) {
 
       bearing = bearingChangedMessage->bearing;
 
-    } else if (dynamic_cast<PositionAgent::PositionMessage*>(message.get())!=nullptr) {
-      auto positionMessage=dynamic_cast<PositionAgent::PositionMessage*>(message.get());
+    } else if (auto positionMessage = dynamic_cast<PositionAgent::PositionMessage*>(message.get());
+               positionMessage != nullptr) {
+
       auto &position = positionMessage->position;
 
       if (position.state==state){


### PR DESCRIPTION
library code is often using conditions with dynamic cast:
```
  if (dynamic_cast<Type*>(ptr) != nullptr){
    auto casted = dynamic_cast<Type*>(ptr);
```
in c++17 we may use if with init statement to reduce one dynamic_cast
and keep scope of casted variable inside if (and else) statement:
```
  if (auto casted = dynamic_cast<Type*>(ptr);
      casted != nullptr){
```
this way, code is more readable and less error prone