### PR TITLE
Location search tunning

### DIFF
--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -38,7 +38,7 @@ struct Arguments
   bool                   adminRegionOnlyMatch=false;
   bool                   poiOnlyMatch=false;
   bool                   locationOnlyMatch=false;
-  bool                   addressOnlyMatch=true;
+  bool                   addressOnlyMatch=false;
   bool                   partialMatch=false;
   size_t                 limit=30;
   size_t                 repeat=1;

--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -30,6 +30,7 @@
 struct Arguments
 {
   bool                   help=false;
+  bool                   debug=false;
   std::string            databaseDirectory;
   std::string            defaultAdminRegion;
   bool                   searchForLocation=true;
@@ -326,6 +327,13 @@ int main(int argc, char* argv[])
                       "Return argument help",
                       true);
 
+  argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
+                        args.debug=value;
+                      }),
+                      "debug",
+                      "Enable debug output",
+                      false);
+
   argParser.AddOption(osmscout::CmdLineBoolOption([&args](bool value) {
                         args.searchForLocation=value;
                       }),
@@ -411,11 +419,10 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  /*
-  osmscout::log.Debug(true);
+  osmscout::log.Debug(args.debug);
   osmscout::log.Info(true);
   osmscout::log.Warn(true);
-  osmscout::log.Error(true);*/
+  osmscout::log.Error(true);
 
   try {
     std::locale::global(std::locale(""));

--- a/libosmscout/include/osmscout/LocationService.h
+++ b/libosmscout/include/osmscout/LocationService.h
@@ -156,24 +156,24 @@ namespace osmscout {
   class OSMSCOUT_API LocationStringSearchParameter CLASS_FINAL
   {
   private:
-    AdminRegionRef          defaultAdminRegion;   //!< A default admin region to use, if no admin region was found based on the search string
+    AdminRegionRef          defaultAdminRegion;          //!< A default admin region to use, if no admin region was found based on the search string
 
-    bool                    searchForLocation;    //!< Search for a location
-    bool                    searchForPOI;         //!< Search for a POI
+    bool                    searchForLocation=true;      //!< Search for a location
+    bool                    searchForPOI=true;           //!< Search for a POI
 
-    bool                    adminRegionOnlyMatch; //!< Evaluate on direct admin region matches
-    bool                    poiOnlyMatch;         //!< Evaluate on direct poi matches
-    bool                    locationOnlyMatch;    //!< Evaluate on direct location matches
-    bool                    addressOnlyMatch;     //!< Evaluate on direct address matches
+    bool                    adminRegionOnlyMatch=false;  //!< Evaluate on direct admin region matches
+    bool                    poiOnlyMatch=false;          //!< Evaluate on direct poi matches
+    bool                    locationOnlyMatch=false;     //!< Evaluate on direct location matches
+    bool                    addressOnlyMatch=false;      //!< Evaluate on direct address matches
 
-    bool                    partialMatch;         //!< Add matches to the result, event if they do not match the complete search string
+    bool                    partialMatch=false;          //!< Add matches to the result, event if they do not match the complete search string
 
-    std::string             searchString;         //!< The search string itself, must bot be empty
-    StringMatcherFactoryRef stringMatcherFactory; //!< String matcher factory to use
+    std::string             searchString;                //!< The search string itself, must bot be empty
+    StringMatcherFactoryRef stringMatcherFactory;        //!< String matcher factory to use
 
-    size_t                  limit;                //!< The maximum number of results over all sub searches requested
+    size_t                  limit=100;                   //!< The maximum number of results over all sub searches requested
 
-    BreakerRef              breaker;              //!< Breaker for search
+    BreakerRef              breaker;                     //!< Breaker for search
 
   public:
     explicit LocationStringSearchParameter(const std::string& searchString);

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -284,16 +284,8 @@ namespace osmscout {
   }
 
   LocationStringSearchParameter::LocationStringSearchParameter(const std::string& searchString)
-    : searchForLocation(true),
-      searchForPOI(true),
-      adminRegionOnlyMatch(false),
-      poiOnlyMatch(false),
-      locationOnlyMatch(false),
-      addressOnlyMatch(true),
-      partialMatch(false),
-      searchString(searchString),
-      stringMatcherFactory(std::make_shared<osmscout::StringMatcherCIFactory>()),
-      limit(100)
+    : searchString(searchString),
+      stringMatcherFactory(std::make_shared<osmscout::StringMatcherCIFactory>())
   {
     // no code
   }

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -21,11 +21,11 @@
 
 #include <algorithm>
 
-#include <osmscout/util/Geometry.h>
 #include <osmscout/util/Logger.h>
 #include <osmscout/util/String.h>
 #include <osmscout/TypeFeatures.h>
 #include <iostream>
+
 namespace osmscout {
 
   /**
@@ -744,14 +744,14 @@ namespace osmscout {
         StringMatcher::Result matchResult=pattern.matcher->Match(region.name);
 
         if (matchResult==StringMatcher::match) {
-          //std::cout << "Match of pattern " << pattern.tokenString->text << " against region name '" << region.name << "'" << std::endl;
+          osmscout::log.Debug() << "Match of pattern " << pattern.tokenString->text << " against region name '" << region.name << "'";
           matches.emplace_back(pattern.tokenString,
                                std::make_shared<AdminRegion>(region),
                                region.name);
 
         }
         else if (matchResult==StringMatcher::partialMatch) {
-          //std::cout << "Partial match of pattern " << pattern.tokenString->text << " against region name '" << region.name << "'" << std::endl;
+          osmscout::log.Debug() << "Partial match of pattern " << pattern.tokenString->text << " against region name '" << region.name << "'";
           partialMatches.emplace_back(pattern.tokenString,
                                       std::make_shared<AdminRegion>(region),
                                       region.name);
@@ -762,14 +762,14 @@ namespace osmscout {
             matchResult=pattern.matcher->Match(alias.name);
 
             if (matchResult==StringMatcher::match) {
-              //std::cout << "Match of pattern " << pattern.tokenString->text << " against region alias '" << region.name << "' '" << alias.name << "'" << std::endl;
+              osmscout::log.Debug() << "Match of pattern " << pattern.tokenString->text << " against region alias '" << region.name << "' '" << alias.name << "'";
               matches.emplace_back(pattern.tokenString,
                                           std::make_shared<AdminRegion>(region),
                                           alias.name);
               break;
             }
             else if (matchResult==StringMatcher::partialMatch) {
-              //std::cout << "Partial match of pattern " << pattern.tokenString->text << " against region alias '" << region.name << "' '" << alias.name << "'" << std::endl;
+              osmscout::log.Debug() << "Partial match of pattern " << pattern.tokenString->text << " against region alias '" << region.name << "' '" << alias.name << "'";
               partialMatches.emplace_back(pattern.tokenString,
                                           std::make_shared<AdminRegion>(region),
                                           alias.name);
@@ -825,11 +825,11 @@ namespace osmscout {
 
     Action Visit(const AdminRegion& region) override
     {
-      //std::cout << "Visiting admin region: " << region.name << std::endl;
+      osmscout::log.Debug() << "Visiting admin region: " << region.name;
 
       for (const auto& area : region.postalAreas) {
         if (patterns.empty()) {
-          //std::cout << "Match postal area name '" << area.name << "'" << std::endl;
+          osmscout::log.Debug() << "Match postal area name '" << area.name << "'";
           matches.emplace_back(std::make_shared<TokenString>(0,0,""),
                                       std::make_shared<AdminRegion>(region),
                                       std::make_shared<PostalArea>(area),
@@ -848,7 +848,7 @@ namespace osmscout {
             }
 
             if (matchResult==StringMatcher::match) {
-              //std::cout << "Match postal area name '" << area.name << "'" << std::endl;
+              osmscout::log.Debug() << "Match postal area name '" << area.name << "'";
               matches.emplace_back(pattern.tokenString,
                                    std::make_shared<AdminRegion>(region),
                                    std::make_shared<PostalArea>(area),
@@ -856,7 +856,7 @@ namespace osmscout {
 
             }
             else if (matchResult==StringMatcher::partialMatch) {
-              //std::cout << "Partial match postal area name '" << area.name << "'" << std::endl;
+              osmscout::log.Debug() << "Partial match postal area name '" << area.name << "'";
               partialMatches.emplace_back(pattern.tokenString,
                                           std::make_shared<AdminRegion>(region),
                                           std::make_shared<PostalArea>(area),
@@ -916,17 +916,17 @@ namespace osmscout {
                const POI& poi) override
     {
       for (const auto& pattern : patterns) {
-        //std::cout << pattern.tokenString->text << " vs. " << poi.name << std::endl;
+        osmscout::log.Debug() << pattern.tokenString->text << " vs. " << poi.name;
         StringMatcher::Result matchResult=pattern.matcher->Match(poi.name);
 
         if (matchResult==StringMatcher::match) {
-          //std::cout << " => match" << std::endl;
+          osmscout::log.Debug() << " => match";
           matches.emplace_back(pattern.tokenString,
                                std::make_shared<AdminRegion>(adminRegion),
                                std::make_shared<POI>(poi));
         }
         else if (matchResult==StringMatcher::partialMatch) {
-          //std::cout << " => partial match" << std::endl;
+          osmscout::log.Debug() << " => partial match";
           partialMatches.emplace_back(pattern.tokenString,
                                       std::make_shared<AdminRegion>(adminRegion),
                                       std::make_shared<POI>(poi));
@@ -982,20 +982,20 @@ namespace osmscout {
                const PostalArea& postalArea,
                const Location& location) override
     {
-      //std::cout << "Visiting " << adminRegion.name << " " << postalArea.name << "..." << std::endl;
+      // osmscout::log.Debug() << "Visiting " << adminRegion.name << " " << postalArea.name << "...";
 
       for (const auto& pattern : patterns) {
         StringMatcher::Result matchResult=pattern.matcher->Match(location.name);
 
         if (matchResult==StringMatcher::match) {
-          //std::cout << "Match location name '" << location.name << "'" << std::endl;
+          osmscout::log.Debug() << "Match location name '" << location.name << "'";
           matches.emplace_back(pattern.tokenString,
                                std::make_shared<AdminRegion>(adminRegion),
                                std::make_shared<PostalArea>(postalArea),
                                std::make_shared<Location>(location));
         }
         else if (matchResult==StringMatcher::partialMatch) {
-          //std::cout << "Partial match location name '" << location.name << "'" << std::endl;
+          osmscout::log.Debug() << "Partial match location name '" << location.name << "'";
           partialMatches.emplace_back(pattern.tokenString,
                                       std::make_shared<AdminRegion>(adminRegion),
                                       std::make_shared<PostalArea>(postalArea),
@@ -1057,7 +1057,7 @@ namespace osmscout {
         StringMatcher::Result matchResult=pattern.matcher->Match(address.name);
 
         if (matchResult==StringMatcher::match) {
-          //std::cout << "Match region name '" << region.name << "'" << std::endl;
+          osmscout::log.Debug() << "Match address '" << address.name << "'";
           matches.emplace_back(pattern.tokenString,
                                std::make_shared<AdminRegion>(adminRegion),
                                std::make_shared<PostalArea>(postalArea),
@@ -1065,7 +1065,7 @@ namespace osmscout {
                                std::make_shared<Address>(address));
         }
         else if (matchResult==StringMatcher::partialMatch) {
-          //std::cout << "Partial match region name '" << region.name << "'" << std::endl;
+          osmscout::log.Debug() << "Partial match address '" << address.name << "'";
           partialMatches.emplace_back(pattern.tokenString,
                                       std::make_shared<AdminRegion>(adminRegion),
                                       std::make_shared<PostalArea>(postalArea),
@@ -1212,7 +1212,7 @@ namespace osmscout {
     else {
       LocationSearchResult::Entry entry;
 
-      //std::cout << "Add location: " << locationMatch.location->name << " " << locationMatch.postalArea->name << " " << locationMatch.adminRegion->name << std::endl;
+      osmscout::log.Debug() << "Add location: " << postalAreaMatch.name << " " << postalAreaMatch.postalArea->name << " " << postalAreaMatch.adminRegion->name;
 
       entry.adminRegion=postalAreaMatch.adminRegion;
       entry.adminRegionMatchQuality=regionMatchQuality;
@@ -1241,7 +1241,7 @@ namespace osmscout {
     else {
       LocationSearchResult::Entry entry;
 
-      //std::cout << "Add location: " << locationMatch.location->name << " " << locationMatch.postalArea->name << " " << locationMatch.adminRegion->name << std::endl;
+      osmscout::log.Debug() << "Add location: " << locationMatch.location->name << " " << locationMatch.postalArea->name << " " << locationMatch.adminRegion->name;
 
       entry.adminRegion=locationMatch.adminRegion;
       entry.adminRegionMatchQuality=regionMatchQuality;
@@ -1321,10 +1321,10 @@ namespace osmscout {
 
     addressVisitTime.Stop();
 
-    //std::cout << "Address visit time: " << addressVisitTime.ResultString() << std::endl;
+    osmscout::log.Debug() << "Address visit time: " << addressVisitTime.ResultString();
 
     for (const auto& addressMatch : addressVisitor.matches) {
-      //std::cout << "Found address match '" << addressMatch.address->name << "' for pattern '" << addressMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found address match '" << addressMatch.address->name << "' for pattern '" << addressMatch.tokenString->text << "'";
       std::list<std::string> restTokens=BuildStringListFromSubToken(addressMatch.tokenString,
                                                                     addressTokens);
 
@@ -1341,7 +1341,7 @@ namespace osmscout {
 
     if (!parameter.addressOnlyMatch) {
       for (const auto& addressMatch : addressVisitor.partialMatches) {
-        //std::cout << "Found address candidate '" << addressMatch.address->name << "' for pattern '" << addressMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found address candidate '" << addressMatch.address->name << "' for pattern '" << addressMatch.tokenString->text << "'";
         std::list<std::string> restTokens=BuildStringListFromSubToken(addressMatch.tokenString,
                                                                       addressTokens);
 
@@ -1397,13 +1397,13 @@ namespace osmscout {
 
     locationVisitTime.Stop();
 
-    //std::cout << "Location (" << regionMatch.adminRegion->name << ") visit time: " << locationVisitTime.ResultString() << std::endl;
+    osmscout::log.Debug() << "Location (" << regionMatch.adminRegion->name << ") visit time: " << locationVisitTime.ResultString();
 
     for (const auto& locationMatch : locationVisitor.matches) {
       if (breaker && breaker->IsAborted()){
         return true;
       }
-      //std::cout << "Found location match '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found location match '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'";
       std::list<std::string> addressTokens=BuildStringListFromSubToken(locationMatch.tokenString,
                                                                        locationTokens);
 
@@ -1442,7 +1442,7 @@ namespace osmscout {
 
     if (!parameter.locationOnlyMatch) {
       for (const auto& locationMatch : locationVisitor.partialMatches) {
-        //std::cout << "Found location candidate '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found location candidate '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'";
         std::list<std::string> addressTokens=BuildStringListFromSubToken(locationMatch.tokenString,
                                                                          locationTokens);
 
@@ -1511,7 +1511,7 @@ namespace osmscout {
                                           locationSearchPatterns,
                                           breaker);
 
-    //std::cout << "Search for location for " << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "..." << std::endl;
+    osmscout::log.Debug() << "Search for location for " << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "...";
 
     if (!locationIndex->VisitLocations(*postalAreaMatch.adminRegion,
                                        *postalAreaMatch.postalArea,
@@ -1521,7 +1521,7 @@ namespace osmscout {
     }
 
     for (const auto& locationMatch : locationVisitor.matches) {
-      //std::cout << "Found location match '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found location match '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'";
       if (addressPattern.empty()) {
         AddLocationResult(parameter,
                           regionMatchQuality,
@@ -1561,7 +1561,7 @@ namespace osmscout {
 
     if (!parameter.locationOnlyMatch) {
       for (const auto& locationMatch : locationVisitor.partialMatches) {
-        //std::cout << "Found location candidate '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found location candidate '" << locationMatch.location->name << "' for pattern '" << locationMatch.tokenString->text << "'";
         if (addressPattern.empty()) {
           AddLocationResult(parameter,
                             regionMatchQuality,
@@ -1622,7 +1622,7 @@ namespace osmscout {
 
     // Build Location search patterns
 
-    //std::cout << "Search for postal area '" << postalAreaPattern << "'" << std::endl;
+    osmscout::log.Debug() << "Search for postal area '" << postalAreaPattern << "'";
 
     std::list<TokenStringRef> postalAreaSearchPatterns;
 
@@ -1642,7 +1642,7 @@ namespace osmscout {
     }
 
     for (const auto& postalAreaMatch : postalAreaVisitor.matches) {
-      //std::cout << "Found postal area match '" << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "' for pattern '" << postalAreaMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found postal area match '" << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "' for pattern '" << postalAreaMatch.tokenString->text << "'";
 
       if (locationPattern.empty() &&
           addressPattern.empty()) {
@@ -1683,7 +1683,7 @@ namespace osmscout {
 
     if (!parameter.postalAreaOnlyMatch) {
       for (const auto& postalAreaMatch : postalAreaVisitor.partialMatches) {
-        //std::cout << "Found postal area candidate '" << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "' for pattern '" << postalAreaMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found postal area candidate '" << postalAreaMatch.adminRegion->name << " " << postalAreaMatch.postalArea->name << "' for pattern '" << postalAreaMatch.tokenString->text << "'";
         if (locationPattern.empty() &&
             addressPattern.empty()) {
           AddPostalAreaResult(parameter,
@@ -1759,7 +1759,7 @@ namespace osmscout {
     }
 
     for (const auto& poiMatch : poiVisitor.matches) {
-      //std::cout << "Found poi match '" << poiMatch.poi->name << "' for pattern '" << poiMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found poi match '" << poiMatch.poi->name << "' for pattern '" << poiMatch.tokenString->text << "'";
       std::list<std::string> restTokens=BuildStringListFromSubToken(poiMatch.tokenString,
                                                                     poiTokens);
 
@@ -1774,7 +1774,7 @@ namespace osmscout {
 
     if (!parameter.locationOnlyMatch) {
       for (const auto& poiMatch : poiVisitor.partialMatches) {
-        //std::cout << "Found poi candidate '" << poiMatch.poi->name << "' for pattern '" << poiMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found poi candidate '" << poiMatch.poi->name << "' for pattern '" << poiMatch.tokenString->text << "'";
         std::list<std::string> restTokens=BuildStringListFromSubToken(poiMatch.tokenString,
                                                                       poiTokens);
 
@@ -1957,14 +1957,14 @@ namespace osmscout {
 
     adminRegionVisitTime.Stop();
 
-    //std::cout << "Admin Region visit: " << adminRegionVisitTime.ResultString() << std::endl;
+    osmscout::log.Debug() << "Admin Region visit: " << adminRegionVisitTime.ResultString();
     if (searchParameter.IsAborted()){
       osmscout::log.Debug() << "Search aborted";
       return true;
     }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
-      //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' (" << regionMatch.adminRegion->object.GetName() << ") for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found region match '" << regionMatch.adminRegion->name << "' (" << regionMatch.adminRegion->object.GetName() << ") for pattern '" << regionMatch.tokenString->text << "'";
       std::list<std::string> locationTokens=BuildStringListFromSubToken(regionMatch.tokenString,
                                                                         tokens);
 
@@ -2018,7 +2018,7 @@ namespace osmscout {
 
     if (!parameter.adminRegionOnlyMatch) {
       for (const auto& regionMatch : adminRegionVisitor.partialMatches) {
-        //std::cout << "Found region candidate '" << regionMatch.adminRegion->name << "' (" << regionMatch.adminRegion->object.GetName() << ") for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+        osmscout::log.Debug() << "Found region candidate '" << regionMatch.adminRegion->name << "' (" << regionMatch.adminRegion->object.GetName() << ") for pattern '" << regionMatch.tokenString->text << "'";
         std::list<std::string> locationTokens=BuildStringListFromSubToken(regionMatch.tokenString,
                                                                           tokens);
 
@@ -2127,7 +2127,7 @@ namespace osmscout {
     }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
-      //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'";
 
       if (searchParameter.GetPostalAreaSearchString().empty() &&
           searchParameter.GetLocationSearchString().empty() &&
@@ -2163,7 +2163,7 @@ namespace osmscout {
     }
 
     for (const auto& regionMatch : adminRegionVisitor.partialMatches) {
-      //std::cout << "Found region candidate '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found region candidate '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'";
 
       if (searchParameter.GetPostalAreaSearchString().empty() &&
           searchParameter.GetLocationSearchString().empty() &&
@@ -2256,7 +2256,7 @@ namespace osmscout {
     }
 
     for (const auto& regionMatch : adminRegionVisitor.matches) {
-      //std::cout << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found region match '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'";
 
       if (searchParameter.GetPOISearchString().empty()) {
         AddRegionResult(parameter,
@@ -2288,7 +2288,7 @@ namespace osmscout {
     }
 
     for (const auto& regionMatch : adminRegionVisitor.partialMatches) {
-      //std::cout << "Found region candidate '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'" << std::endl;
+      osmscout::log.Debug() << "Found region candidate '" << regionMatch.adminRegion->name << "' for pattern '" << regionMatch.tokenString->text << "'";
 
       if (searchParameter.GetPOISearchString().empty()) {
         AddRegionResult(parameter,

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -916,7 +916,7 @@ namespace osmscout {
                const POI& poi) override
     {
       for (const auto& pattern : patterns) {
-        osmscout::log.Debug() << pattern.tokenString->text << " vs. " << poi.name;
+        // osmscout::log.Debug() << pattern.tokenString->text << " vs. " << poi.name;
         StringMatcher::Result matchResult=pattern.matcher->Match(poi.name);
 
         if (matchResult==StringMatcher::match) {


### PR DESCRIPTION
Hi. 

I was investigating why string search don't return me address "2517/76" when I have "2517" or "76" in search pattern. The cause was that `addressOnlyMatch` search parameter that was true by default... I changed that parameter to false by default. Similar address pattern "address number / street house number" is common in Czechia and people are using just one number for search...

Beside change of this default, I convert commented `std::cout` prints to debug logger and removed few very verbose log messages (from visit methods)...