### PR TITLE
Search transliterate

### DIFF
--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -43,6 +43,7 @@ struct Arguments
   size_t                 limit=30;
   size_t                 repeat=1;
   std::list<std::string> location;
+  bool                   transliterate=false;
 };
 
 bool GetAdminRegionHierachie(const osmscout::LocationServiceRef& locationService,
@@ -394,6 +395,13 @@ int main(int argc, char* argv[])
                       "repeat",
                       "Cout of repeat for performance test");
 
+  argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
+                        args.transliterate=value;
+                      }),
+                      "transliterate",
+                      "Transliterate non-ascii characters for matching",
+                      false);
+
   argParser.AddPositional(osmscout::CmdLineStringOption([&args](const std::string& value) {
                             args.databaseDirectory=value;
                           }),
@@ -450,8 +458,14 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  osmscout::StringMatcherFactoryRef matcherFactory=std::make_shared<osmscout::StringMatcherCIFactory>();
-  osmscout::LocationServiceRef     locationService=std::make_shared<osmscout::LocationService>(database);
+  osmscout::StringMatcherFactoryRef matcherFactory;
+  if(args.transliterate) {
+    matcherFactory=std::make_shared<osmscout::StringMatcherTransliterateFactory>();
+  } else {
+    matcherFactory=std::make_shared<osmscout::StringMatcherCIFactory>();
+  }
+
+  osmscout::LocationServiceRef locationService=std::make_shared<osmscout::LocationService>(database);
 
   osmscout::LocationStringSearchParameter searchParameter(osmscout::LocaleStringToUTF8String(searchPattern));
 
@@ -507,6 +521,7 @@ int main(int argc, char* argv[])
   std::cout << "Location only match:     " << (searchParameter.GetLocationOnlyMatch() ? "true" : "false") << std::endl;
   std::cout << "Address only match:      " << (searchParameter.GetAddressOnlyMatch() ? "true" : "false") << std::endl;
   std::cout << "Partial match:           " << (searchParameter.GetPartialMatch() ? "true" : "false") << std::endl;
+  std::cout << "Transliterate:           " << (args.transliterate ? "true" : "false") << std::endl;
 
   if (searchParameter.GetDefaultAdminRegion()) {
     std::cout << "Default admin region:    " << searchParameter.GetDefaultAdminRegion()->name << " (" << searchParameter.GetDefaultAdminRegion()->object.GetName() << ")" << std::endl;

--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -298,6 +298,10 @@ void DumpResult(const osmscout::DatabaseRef& database,
 
       std::cout << std::endl;
 
+      for (const auto& alias : entry.adminRegion->aliases) {
+        std::cout << "   - alias " << alias.name << std::endl;
+      }
+
       if (entry.adminRegion->aliasObject.Valid()) {
         std::cout << "   - " << GetObject(database,entry.adminRegion->aliasObject);
       }

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -199,6 +199,13 @@ int main(int argc, char* argv[])
     return 0;
   }
 
+  // setup c++ locale
+  try {
+    std::locale::global(std::locale(""));
+  } catch (const std::runtime_error& e) {
+    std::cerr << "Cannot set locale: \"" << e.what() << "\"" << std::endl;
+  }
+
   // install translator
   QTranslator translator;
   QLocale locale;

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -45,8 +45,8 @@ TEST_CASE("Split string by multi-character separator")
 TEST_CASE("Transliterate diacritics")
 {
   try {
-    std::locale::global(std::locale(""));
-    std::cout << "Current locale activated" << std::endl;
+    std::locale::global(std::locale("en_US.UTF-8"));
+    std::cout << "en_US.UTF-8 locale activated" << std::endl;
   } catch (const std::exception& e) {
     std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
   }

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -41,3 +41,17 @@ TEST_CASE("Split string by multi-character separator")
   REQUIRE(*(it++) == "ground");
   REQUIRE(*(it++) == "gravel");
 }
+
+TEST_CASE("Transliterate diacritics")
+{
+  try {
+    std::locale::global(std::locale(""));
+    std::cout << "Current locale activated" << std::endl;
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
+  }
+
+  auto transformed=osmscout::UTF8Transliterate("áéíýóúůďťňěščřžüöÁÉÍÝÓÚŮĎŤŇĚŠČŘŽÜÖ");
+
+  REQUIRE(transformed == "aeiyouudtnescrzuoAEIYOUUDTNESCRZUO");
+}

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Transliterate diacritics")
     std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
   }
 
-  auto transformed=osmscout::UTF8Transliterate("áéíýóúůďťňěščřžüöÁÉÍÝÓÚŮĎŤŇĚŠČŘŽÜÖ");
+  auto transformed=osmscout::UTF8Transliterate("áéíýóúůďťňěščřžüöÁÉÍÝÓÚŮĎŤŇĚŠČŘŽÜÖß");
 
-  REQUIRE(transformed == "aeiyouudtnescrzuoAEIYOUUDTNESCRZUO");
+  REQUIRE(transformed == "aeiyouudtnescrzuoAEIYOUUDTNESCRZUOss");
 }

--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -56,13 +56,7 @@ void SearchModule::SearchLocations(DBInstanceRef &db,
 
   osmscout::LocationStringSearchParameter searchParameter(stdSearchPattern);
 
-  // searchParameter.SetSearchForLocation(args.searchForLocation);
-  // searchParameter.SetSearchForPOI(args.searchForPOI);
-  // searchParameter.SetAdminRegionOnlyMatch(args.adminRegionOnlyMatch);
-  // searchParameter.SetPOIOnlyMatch(args.poiOnlyMatch);
-  // searchParameter.SetLocationOnlyMatch(args.locationOnlyMatch);
-  // searchParameter.SetAddressOnlyMatch(args.addressOnlyMatch);
-  // searchParameter.SetStringMatcherFactory(matcherFactory);
+  searchParameter.SetStringMatcherFactory(std::make_shared<osmscout::StringMatcherTransliterateFactory>());
   if (defaultRegion)
     searchParameter.SetDefaultAdminRegion(defaultRegion);
 

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -497,6 +497,20 @@ namespace osmscout {
   extern OSMSCOUT_API std::string UTF8NormForLookup(const std::string& text);
 
   /**
+   * Transliterate non-ascii characters to one or more characters that are similar to the original character.
+   * When there is no transformation available, question mark is used (iconv implementation)
+   * or original character is keep in place (translation table implementation).
+   *
+   * @param text
+   *    Text to get converted
+   * @return
+   *    Converted text
+   *
+   * @note that a global C++ locale must be set for more than simple ASCII conversions to work.
+   */
+  extern OSMSCOUT_API std::string UTF8Transliterate(const std::string& text);
+
+  /**
    * Parse time string in ISO 8601 format "2017-11-26T13:46:12.124Z" (UTC timezone)
    * to Timestamp (std::chrono::time_point with millisecond accuracy).
    *

--- a/libosmscout/include/osmscout/util/StringMatcher.h
+++ b/libosmscout/include/osmscout/util/StringMatcher.h
@@ -71,5 +71,24 @@ namespace osmscout {
   public:
     StringMatcherRef CreateMatcher(const std::string& pattern) const override;
   };
+
+  class StringMatcherTransliterate: public StringMatcher
+  {
+  private:
+    std::string pattern;
+    std::string transliteratedPattern;
+
+  public:
+    explicit StringMatcherTransliterate(const std::string &pattern);
+
+    StringMatcher::Result Match(const std::string &text) const override;
+  };
+
+  class OSMSCOUT_API StringMatcherTransliterateFactory : public StringMatcherFactory
+  {
+  public:
+    StringMatcherRef CreateMatcher(const std::string& pattern) const override;
+  };
+
 }
 #endif

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -864,90 +864,102 @@ namespace osmscout {
 
   std::string UTF8Transliterate(const std::string& text)
   {
+    using namespace std::string_view_literals;
+
+    auto transChar = [](wchar_t c) -> std::string_view {
+      switch(c){
+        case L'\u00A0': // no-break space (&nbsp;)
+        case L'\u2007': // figure space
+        case L'\u202F': // narrow no-break space
+          return " "sv;
+
+        case L'\u00E1': // á
+          return "a"sv;
+        case L'\u00E9': // é
+        case L'\u011B': // ě
+          return "e"sv;
+        case L'\u00ED': // í
+          return "i"sv;
+        case L'\u00FD': // ý
+          return "y"sv;
+        case L'\u00F6': // ö
+        case L'\u00F3': // ó
+          return "o"sv;
+        case L'\u00FA': // ú
+        case L'\u016F': // ů
+        case L'\u00FC': // ü
+          return "u"sv;
+        case L'\u010F': // ď
+          return "d"sv;
+        case L'\u0165': // ť
+          return "t"sv;
+        case L'\u0148': // ň
+          return "n"sv;
+        case L'\u0161': // š
+          return "s"sv;
+        case L'\u010D': // č
+          return "c"sv;
+        case L'\u0159': // ř
+          return "r"sv;
+        case L'\u017E': // ž
+          return "z"sv;
+
+        case L'\u00C1': // Á
+          return "A"sv;
+        case L'\u00C9': // É
+        case L'\u011A': // Ě
+          return "E"sv;
+        case L'\u00CD': // Í
+          return "I"sv;
+        case L'\u00DD': // Ý
+          return "Y"sv;
+        case L'\u00D3': // Ó
+        case L'\u00D6': // Ö
+          return "O"sv;
+        case L'\u00DA': // Ú
+        case L'\u016E': // Ů
+        case L'\u00DC': // Ü
+          return "U"sv;
+        case L'\u010E': // Ď
+          return "D"sv;
+        case L'\u0164': // Ť
+          return "T"sv;
+        case L'\u0147': // Ň
+          return "N"sv;
+        case L'\u0160': // Š
+          return "S"sv;
+        case L'\u010C': // Č
+          return "C"sv;
+        case L'\u0158': // Ř
+          return "R"sv;
+        case L'\u017D': // Ž
+          return "Z"sv;
+
+        case L'\u00DF': // ß
+          return "ss"sv;
+
+        default:
+          // std::wstring s(1, c);
+          // printf("case L'\\u%04X': // %ls\n  return \"%ls\"sv;\n", (int)c, s.c_str(), s.c_str());
+          return ""sv; // no-opt
+      }
+    };
+
     std::wstring wstr=UTF8StringToWString(text);
 
+    std::ostringstream buff;
+
     // replace SOME common (in European languages) non-ascii characters by table
-    std::transform(wstr.begin(), wstr.end(), wstr.begin(),
-                   [](wchar_t c) -> wchar_t {
-                     switch(c){
-                       case L'\u00A0': // no-break space (&nbsp;)
-                       case L'\u2007': // figure space
-                       case L'\u202F': // narrow no-break space
-                         return ' ';
+    std::for_each(wstr.begin(), wstr.end(), [&](wchar_t c) {
+      auto tch = transChar(c);
+      if (tch.empty()) {
+        buff << WStringToUTF8String(std::wstring(1, c));
+      } else {
+        buff << tch;
+      }
+    });
 
-                       case L'\u00E1': // á
-                         return 'a';
-                       case L'\u00E9': // é
-                       case L'\u011B': // ě
-                         return 'e';
-                       case L'\u00ED': // í
-                         return 'i';
-                       case L'\u00FD': // ý
-                         return 'y';
-                       case L'\u00F6': // ö
-                       case L'\u00F3': // ó
-                         return 'o';
-                       case L'\u00FA': // ú
-                       case L'\u016F': // ů
-                       case L'\u00FC': // ü
-                         return 'u';
-                       case L'\u010F': // ď
-                         return 'd';
-                       case L'\u0165': // ť
-                         return 't';
-                       case L'\u0148': // ň
-                         return 'n';
-                       case L'\u0161': // š
-                         return 's';
-                       case L'\u010D': // č
-                         return 'c';
-                       case L'\u0159': // ř
-                         return 'r';
-                       case L'\u017E': // ž
-                         return 'z';
-
-                       case L'\u00C1': // Á
-                         return 'A';
-                       case L'\u00C9': // É
-                       case L'\u011A': // Ě
-                         return 'E';
-                       case L'\u00CD': // Í
-                         return 'I';
-                       case L'\u00DD': // Ý
-                         return 'Y';
-                       case L'\u00D3': // Ó
-                       case L'\u00D6': // Ö
-                         return 'O';
-                       case L'\u00DA': // Ú
-                       case L'\u016E': // Ů
-                       case L'\u00DC': // Ü
-                         return 'U';
-                       case L'\u010E': // Ď
-                         return 'D';
-                       case L'\u0164': // Ť
-                         return 'T';
-                       case L'\u0147': // Ň
-                         return 'N';
-                       case L'\u0160': // Š
-                         return 'S';
-                       case L'\u010C': // Č
-                         return 'C';
-                       case L'\u0158': // Ř
-                         return 'R';
-                       case L'\u017D': // Ž
-                         return 'Z';
-
-                       default:
-                         // wchar_t *s;
-                         // s = (wchar_t *) malloc(sizeof(wchar_t) * 2);
-                         // s[0] = c;
-                         // s[1] = 0;
-                         // printf("case L'\\u%04X': // %ls\n  return '%ls';\n", c, s, s);
-                         // free(s);
-                         return c; // no-opt
-                     }});
-
-    return WStringToUTF8String(wstr);
+    return buff.str();
   }
 #endif
 

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -814,7 +814,10 @@ namespace osmscout {
     return WStringToUTF8String(wstr);
   }
 
-#if defined(HAVE_ICONV)
+// MacOS iconv implementation transiterate diacritics nasty way:
+// á => 'a , ü => "u ...
+// Lets use our transliterate implementation instead
+#if defined(HAVE_ICONV) && !defined(__APPLE__)
   std::string UTF8Transliterate(const std::string& text)
   {
     iconv_t handle;
@@ -847,15 +850,6 @@ namespace osmscout {
     delete [] out;
 
     iconv_close(handle);
-
-#if defined(__APPLE__)
-    // MacOS iconv implementation transiterate diacritics nasty way:
-    // á => 'a , ü => "u ...
-    // we want to avoid these extra characters
-    res.erase(std::remove_if(res.begin(), res.end(),
-                  [](char ch){ return ch == '\'' || ch == '"' || ch == '~'; }),
-              res.end());
-#endif
 
     return res;
   }

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -848,6 +848,15 @@ namespace osmscout {
 
     iconv_close(handle);
 
+#if defined(__APPLE__)
+    // MacOS iconv implementation transiterate diacritics nasty way:
+    // á => 'a , ü => "u ...
+    // we want to avoid these extra characters
+    res.erase(std::remove_if(res.begin(), res.end(),
+                  [](char ch){ return ch == '\'' || ch == '"' || ch == '~'; }),
+              res.end());
+#endif
+
     return res;
   }
 

--- a/libosmscout/src/osmscout/util/StringMatcher.cpp
+++ b/libosmscout/src/osmscout/util/StringMatcher.cpp
@@ -49,4 +49,43 @@ namespace osmscout {
   {
     return std::make_shared<StringMatcherCI>(pattern);
   }
+
+  StringMatcherTransliterate::StringMatcherTransliterate(const std::string& patternArg)
+        : pattern(UTF8StringToUpper(patternArg)),
+          transliteratedPattern(UTF8Transliterate(pattern))
+  {
+    // no code
+  }
+
+  StringMatcher::Result StringMatcherTransliterate::Match(const std::string& text) const
+  {
+    auto transformedText=UTF8StringToUpper(text);
+    auto pos            =transformedText.find(pattern);
+
+    if (pos==std::string::npos) {
+      auto transliterated=UTF8Transliterate(transformedText);
+      pos=transliterated.find(transliteratedPattern);
+
+      if (pos==std::string::npos) {
+        return noMatch;
+      }
+      if (pos==0 && transliteratedPattern.length()==transliterated.length()) {
+        return match;
+      }
+
+      return partialMatch;
+    }
+
+    if (pos==0 && pattern.length()==transformedText.length()) {
+      return match;
+    }
+
+    return partialMatch;
+  }
+
+  StringMatcherRef StringMatcherTransliterateFactory::CreateMatcher(const std::string& pattern) const
+  {
+    return std::make_shared<StringMatcherTransliterate>(pattern);
+  }
+
 }

--- a/libosmscout/src/osmscout/util/StringMatcher.cpp
+++ b/libosmscout/src/osmscout/util/StringMatcher.cpp
@@ -21,6 +21,8 @@
 
 #include <osmscout/util/String.h>
 
+#include <algorithm>
+
 namespace osmscout {
 
   StringMatcherCI::StringMatcherCI(const std::string& pattern)
@@ -54,7 +56,12 @@ namespace osmscout {
         : pattern(UTF8StringToUpper(patternArg)),
           transliteratedPattern(UTF8Transliterate(pattern))
   {
-    // no code
+    size_t unavailable=std::count(transliteratedPattern.begin(), transliteratedPattern.end(), '?');
+    if (unavailable > (transliteratedPattern.size()/2)) {
+      // if there is huge portion (more than 50%) of characters that cannot be transliterated
+      // we give up transliteration at all. It is usual for asian and arabic scripts.
+      transliteratedPattern.clear();
+    }
   }
 
   StringMatcher::Result StringMatcherTransliterate::Match(const std::string& text) const
@@ -63,6 +70,10 @@ namespace osmscout {
     auto pos            =transformedText.find(pattern);
 
     if (pos==std::string::npos) {
+      if (transliteratedPattern.empty()){
+        return noMatch;
+      }
+
       auto transliterated=UTF8Transliterate(transformedText);
       pos=transliterated.find(transliteratedPattern);
 


### PR DESCRIPTION
For long time, I have been frustrated that search isn't diacritic-agnostics. When you enter pattern "jindrichuv hradec" it was not able to find "Jindřichův Hradec" town. This merge request ads new string matcher that is able to do that. It is using `iconv` ascii transliteration (there is fallback implementation when iconv is not available). It is a bit slower, but it is still possible to use current string matcher...