### PR TITLE
DumpData: report all ways for OSM id

### DIFF
--- a/libosmscout-import/src/osmscout/import/ImportErrorReporter.cpp
+++ b/libosmscout-import/src/osmscout/import/ImportErrorReporter.cpp
@@ -261,10 +261,10 @@ namespace osmscout {
     DebugDatabase          database(debugDatabaseParameter);
 
     if (database.Open(destinationDirectory)) {
-      std::set<ObjectOSMRef>               ids;
-      std::set<ObjectFileRef>              fileOffsets;
-      std::map<ObjectOSMRef,ObjectFileRef> idFileOffsetMap;
-      std::map<ObjectFileRef,ObjectOSMRef> fileOffsetIdMap;
+      std::set<ObjectOSMRef>                    ids;
+      std::set<ObjectFileRef>                   fileOffsets;
+      std::multimap<ObjectOSMRef,ObjectFileRef> idFileOffsetMap;
+      std::map<ObjectFileRef,ObjectOSMRef>      fileOffsetIdMap;
 
       for (const auto& error : errors) {
         fileOffsets.insert(error.ref);

--- a/libosmscout/include/osmscout/DebugDatabase.h
+++ b/libosmscout/include/osmscout/DebugDatabase.h
@@ -66,7 +66,7 @@ namespace osmscout {
                            RefType fileType,
                            const std::set<ObjectOSMRef>& ids,
                            const std::set<ObjectFileRef>& fileOffsets,
-                           std::map<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
+                           std::multimap<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
                            std::map<ObjectFileRef,ObjectOSMRef>& fileOffsetIdMap);
 
   public:
@@ -84,7 +84,7 @@ namespace osmscout {
 
     bool ResolveReferences(const std::set<ObjectOSMRef>& ids,
                            const std::set<ObjectFileRef>& fileOffsets,
-                           std::map<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
+                           std::multimap<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
                            std::map<ObjectFileRef,ObjectOSMRef>& fileOffsetIdMap);
   };
 }

--- a/libosmscout/src/osmscout/DebugDatabase.cpp
+++ b/libosmscout/src/osmscout/DebugDatabase.cpp
@@ -100,7 +100,7 @@ namespace osmscout {
                                         RefType fileType,
                                         const std::set<ObjectOSMRef>& ids,
                                         const std::set<ObjectFileRef>& fileOffsets,
-                                        std::map<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
+                                        std::multimap<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
                                         std::map<ObjectFileRef,ObjectOSMRef>& fileOffsetIdMap)
   {
     FileScanner scanner;
@@ -146,7 +146,7 @@ namespace osmscout {
 
   bool DebugDatabase::ResolveReferences(const std::set<ObjectOSMRef>& ids,
                                         const std::set<ObjectFileRef>& fileOffsets,
-                                        std::map<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
+                                        std::multimap<ObjectOSMRef,ObjectFileRef>& idFileOffsetMap,
                                         std::map<ObjectFileRef,ObjectOSMRef>& fileOffsetIdMap)
   {
     bool haveToScanNodes=false;


### PR DESCRIPTION
Long ways may be splitted during import. In such case, we may have
multiple ways in database that corresponds to one original OSM way.
DumpData tool should print them all.

Opposite situation, when multiple OSM ways are merged to single database way, is more complicated. We would need to extend RawWay to hold set of OSMId's and extend format of temporary files during import... So I postpone it right now.