### PR TITLE
comply of rule of five for data access classes

### DIFF
--- a/libosmscout/include/osmscout/AreaDataFile.h
+++ b/libosmscout/include/osmscout/AreaDataFile.h
@@ -38,6 +38,14 @@ namespace osmscout {
 
   public:
     explicit AreaDataFile(size_t cacheSize);
+
+    // disable copy and move
+    AreaDataFile(const AreaDataFile&) = delete;
+    AreaDataFile(AreaDataFile&&) = delete;
+    AreaDataFile& operator=(const AreaDataFile&) = delete;
+    AreaDataFile& operator=(AreaDataFile&&) = delete;
+
+    ~AreaDataFile() override = default;
   };
 
   using AreaDataFileRef = std::shared_ptr<AreaDataFile>;

--- a/libosmscout/include/osmscout/AreaIndex.h
+++ b/libosmscout/include/osmscout/AreaIndex.h
@@ -76,6 +76,14 @@ namespace osmscout {
                               TypeData &data) = 0;
 
   public:
+    AreaIndex() = default;
+
+    // disable copy and move
+    AreaIndex(const AreaIndex&) = delete;
+    AreaIndex(AreaIndex&&) = delete;
+    AreaIndex& operator=(const AreaIndex&) = delete;
+    AreaIndex& operator=(AreaIndex&&) = delete;
+
     virtual ~AreaIndex();
 
     void Close();

--- a/libosmscout/include/osmscout/AreaRouteIndex.h
+++ b/libosmscout/include/osmscout/AreaRouteIndex.h
@@ -53,7 +53,14 @@ namespace osmscout {
 
   public:
     AreaRouteIndex();
-    virtual ~AreaRouteIndex() = default;
+
+    // disable copy and move
+    AreaRouteIndex(const AreaRouteIndex&) = delete;
+    AreaRouteIndex(AreaRouteIndex&&) = delete;
+    AreaRouteIndex& operator=(const AreaRouteIndex&) = delete;
+    AreaRouteIndex& operator=(AreaRouteIndex&&) = delete;
+
+    ~AreaRouteIndex() override = default;
   };
 
   using AreaRouteIndexRef = std::shared_ptr<AreaRouteIndex>;

--- a/libosmscout/include/osmscout/AreaWayIndex.h
+++ b/libosmscout/include/osmscout/AreaWayIndex.h
@@ -53,7 +53,14 @@ namespace osmscout {
 
   public:
     AreaWayIndex();
-    virtual ~AreaWayIndex() = default;
+
+    // disable copy and move
+    AreaWayIndex(const AreaWayIndex&) = delete;
+    AreaWayIndex(AreaWayIndex&&) = delete;
+    AreaWayIndex& operator=(const AreaWayIndex&) = delete;
+    AreaWayIndex& operator=(AreaWayIndex&&) = delete;
+
+    ~AreaWayIndex() override = default;
   };
 
   using AreaWayIndexRef = std::shared_ptr<AreaWayIndex>;

--- a/libosmscout/include/osmscout/DataFile.h
+++ b/libosmscout/include/osmscout/DataFile.h
@@ -100,6 +100,12 @@ namespace osmscout {
   public:
     DataFile(const std::string& datafile, size_t cacheSize);
 
+    // disable copy and move
+    DataFile(const DataFile&) = delete;
+    DataFile(DataFile&&) = delete;
+    DataFile& operator=(const DataFile&) = delete;
+    DataFile& operator=(DataFile&&) = delete;
+
     virtual ~DataFile();
 
     bool Open(const TypeConfigRef& typeConfig,

--- a/libosmscout/include/osmscout/NodeDataFile.h
+++ b/libosmscout/include/osmscout/NodeDataFile.h
@@ -38,6 +38,14 @@ namespace osmscout {
 
   public:
     explicit NodeDataFile(size_t cacheSize);
+
+    // disable copy and move
+    NodeDataFile(const NodeDataFile&) = delete;
+    NodeDataFile(NodeDataFile&&) = delete;
+    NodeDataFile& operator=(const NodeDataFile&) = delete;
+    NodeDataFile& operator=(NodeDataFile&&) = delete;
+
+    ~NodeDataFile() override = default;
   };
 
   using NodeDataFileRef = std::shared_ptr<NodeDataFile>;

--- a/libosmscout/include/osmscout/PTRouteDataFile.h
+++ b/libosmscout/include/osmscout/PTRouteDataFile.h
@@ -37,6 +37,14 @@ namespace osmscout {
 
   public:
     explicit PTRouteDataFile(size_t cacheSize);
+
+    // disable copy and move
+    PTRouteDataFile(const PTRouteDataFile&) = delete;
+    PTRouteDataFile(PTRouteDataFile&&) = delete;
+    PTRouteDataFile& operator=(const PTRouteDataFile&) = delete;
+    PTRouteDataFile& operator=(PTRouteDataFile&&) = delete;
+
+    ~PTRouteDataFile() override = default;
   };
 
   using PTRouteDataFileRef = std::shared_ptr<PTRouteDataFile>;

--- a/libosmscout/include/osmscout/RouteDataFile.h
+++ b/libosmscout/include/osmscout/RouteDataFile.h
@@ -37,6 +37,14 @@ namespace osmscout {
   
   public:
     explicit RouteDataFile(size_t cacheSize);
+
+    // disable copy and move
+    RouteDataFile(const RouteDataFile&) = delete;
+    RouteDataFile(RouteDataFile&&) = delete;
+    RouteDataFile& operator=(const RouteDataFile&) = delete;
+    RouteDataFile& operator=(RouteDataFile&&) = delete;
+
+    ~RouteDataFile() override = default;
   };
   
   using RouteDataFileRef = std::shared_ptr<RouteDataFile>;

--- a/libosmscout/include/osmscout/WayDataFile.h
+++ b/libosmscout/include/osmscout/WayDataFile.h
@@ -38,6 +38,14 @@ namespace osmscout {
 
   public:
     explicit WayDataFile(size_t cacheSize);
+
+    // disable copy and move
+    WayDataFile(const WayDataFile&) = delete;
+    WayDataFile(WayDataFile&&) = delete;
+    WayDataFile& operator=(const WayDataFile&) = delete;
+    WayDataFile& operator=(WayDataFile&&) = delete;
+
+    ~WayDataFile() override = default;
   };
 
   using WayDataFileRef = std::shared_ptr<WayDataFile>;

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -537,8 +537,8 @@ namespace osmscout {
       StopClock timer;
 
       if (!areaRouteIndex->Open(typeConfig,
-                              path,
-                              parameter.GetIndexMMap())) {
+                                path,
+                                parameter.GetIndexMMap())) {
         log.Error() << "Cannot load area way index!";
         areaRouteIndex=nullptr;
 


### PR DESCRIPTION
and explicitly disable move and copy operations

rule of five:
> If you define or =delete any default operation,
> define or =delete them all. Because we have to define
> or =delete all six of them,
> this rule is called "the rule of five".