### PR TITLE
use alignment specific for feature value type

### DIFF
--- a/libosmscout/include/osmscout/TypeFeature.h
+++ b/libosmscout/include/osmscout/TypeFeature.h
@@ -129,6 +129,15 @@ namespace osmscout {
     virtual std::string GetName() const = 0;
 
     /**
+     * If feature have value object, this method returns
+     * alignment requirements of the value type (alignof( type-id )).
+     */
+    inline virtual size_t GetValueAlignment() const
+    {
+      return 0;
+    }
+
+    /**
      * A feature, if set for an object, can hold a value. If there is no value object,
      * this method returns 0, else it returns the C++ size of the value object.
      */

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -86,6 +86,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -152,6 +153,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -220,6 +222,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -287,6 +290,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -357,6 +361,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -434,6 +439,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -679,6 +685,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -806,6 +813,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -862,6 +870,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -918,6 +927,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -984,6 +994,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1041,6 +1052,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1111,6 +1123,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1181,6 +1194,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1346,6 +1360,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1416,6 +1431,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1507,6 +1523,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1578,6 +1595,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1634,6 +1652,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1719,6 +1738,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1824,6 +1844,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -1957,6 +1978,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -2026,6 +2048,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -2095,6 +2118,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -2190,6 +2214,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 
@@ -2260,6 +2285,7 @@ namespace osmscout {
 
     std::string GetName() const override;
 
+    size_t GetValueAlignment() const override;
     size_t GetValueSize() const override;
     FeatureValue* AllocateValue(void* buffer) override;
 

--- a/libosmscout/src/osmscout/TypeConfig.cpp
+++ b/libosmscout/src/osmscout/TypeConfig.cpp
@@ -129,13 +129,13 @@ namespace osmscout {
     size_t featureBit=0;
     size_t index=0;
     size_t offset=0;
-    size_t alignment=std::max(sizeof(size_t),sizeof(void*));
 
     if (!features.empty()) {
       featureBit=features.back().GetFeatureBit()+1+feature->GetFeatureBitCount();
       index=features.back().GetIndex()+1;
       offset=features.back().GetOffset()+features.back().GetFeature()->GetValueSize();
-      if (offset%alignment!=0) {
+      size_t alignment=feature->GetValueAlignment();
+      if (alignment!=0 && (offset%alignment!=0)) {
         offset=(offset/alignment+1)*alignment;
       }
     }

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -80,6 +80,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t NameFeature::GetValueAlignment() const
+  {
+    return alignof(NameFeatureValue);
+  }
+
   size_t NameFeature::GetValueSize() const
   {
     return sizeof(NameFeatureValue);
@@ -164,6 +169,11 @@ namespace osmscout {
   std::string NameAltFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t NameAltFeature::GetValueAlignment() const
+  {
+    return alignof(NameAltFeatureValue);
   }
 
   size_t NameAltFeature::GetValueSize() const
@@ -253,6 +263,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t NameShortFeature::GetValueAlignment() const
+  {
+    return alignof(NameShortFeatureValue);
+  }
+
   size_t NameShortFeature::GetValueSize() const
   {
     return sizeof(NameShortFeatureValue);
@@ -329,6 +344,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t RefFeature::GetValueAlignment() const
+  {
+    return alignof(RefFeatureValue);
+  }
+
   size_t RefFeature::GetValueSize() const
   {
     return sizeof(RefFeatureValue);
@@ -396,6 +416,11 @@ namespace osmscout {
   std::string LocationFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t LocationFeature::GetValueAlignment() const
+  {
+    return alignof(LocationFeatureValue);
   }
 
   size_t LocationFeature::GetValueSize() const
@@ -492,6 +517,11 @@ namespace osmscout {
   std::string AddressFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t AddressFeature::GetValueAlignment() const
+  {
+    return alignof(AddressFeatureValue);
   }
 
   size_t AddressFeature::GetValueSize() const
@@ -595,6 +625,11 @@ namespace osmscout {
   std::string AccessFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t AccessFeature::GetValueAlignment() const
+  {
+    return alignof(AccessFeatureValue);
   }
 
   size_t AccessFeature::GetValueSize() const
@@ -859,6 +894,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t AccessRestrictedFeature::GetValueAlignment() const
+  {
+    return alignof(AccessRestrictedFeatureValue);
+  }
+
   size_t AccessRestrictedFeature::GetValueSize() const
   {
     return sizeof(AccessRestrictedFeatureValue);
@@ -976,6 +1016,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t LayerFeature::GetValueAlignment() const
+  {
+    return alignof(LayerFeatureValue);
+  }
+
   size_t LayerFeature::GetValueSize() const
   {
     return sizeof(LayerFeatureValue);
@@ -1049,6 +1094,11 @@ namespace osmscout {
   std::string WidthFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t WidthFeature::GetValueAlignment() const
+  {
+    return alignof(WidthFeatureValue);
   }
 
   size_t WidthFeature::GetValueSize() const
@@ -1161,6 +1211,11 @@ namespace osmscout {
   std::string MaxSpeedFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t MaxSpeedFeature::GetValueAlignment() const
+  {
+    return alignof(MaxSpeedFeatureValue);
   }
 
   size_t MaxSpeedFeature::GetValueSize() const
@@ -1383,6 +1438,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t GradeFeature::GetValueAlignment() const
+  {
+    return alignof(GradeFeatureValue);
+  }
+
   size_t GradeFeature::GetValueSize() const
   {
     return sizeof(GradeFeatureValue);
@@ -1504,6 +1564,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t AdminLevelFeature::GetValueAlignment() const
+  {
+    return alignof(AdminLevelFeatureValue);
+  }
+
   size_t AdminLevelFeature::GetValueSize() const
   {
     return sizeof(AdminLevelFeatureValue);
@@ -1590,6 +1655,11 @@ namespace osmscout {
   std::string PostalCodeFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t PostalCodeFeature::GetValueAlignment() const
+  {
+    return alignof(PostalCodeFeatureValue);
   }
 
   size_t PostalCodeFeature::GetValueSize() const
@@ -1682,6 +1752,11 @@ namespace osmscout {
   std::string WebsiteFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t WebsiteFeature::GetValueAlignment() const
+  {
+    return alignof(WebsiteFeatureValue);
   }
 
   size_t WebsiteFeature::GetValueSize() const
@@ -1777,6 +1852,11 @@ namespace osmscout {
   std::string PhoneFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t PhoneFeature::GetValueAlignment() const
+  {
+    return alignof(PhoneFeatureValue);
   }
 
   size_t PhoneFeature::GetValueSize() const
@@ -2055,6 +2135,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t EleFeature::GetValueAlignment() const
+  {
+    return alignof(EleFeatureValue);
+  }
+
   size_t EleFeature::GetValueSize() const
   {
     return sizeof(EleFeatureValue);
@@ -2178,6 +2263,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t DestinationFeature::GetValueAlignment() const
+  {
+    return alignof(DestinationFeatureValue);
+  }
+
   size_t DestinationFeature::GetValueSize() const
   {
     return sizeof(DestinationFeatureValue);
@@ -2285,6 +2375,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t IsInFeature::GetValueAlignment() const
+  {
+    return alignof(IsInFeatureValue);
+  }
+
   size_t IsInFeature::GetValueSize() const
   {
     return sizeof(IsInFeatureValue);
@@ -2360,6 +2455,11 @@ namespace osmscout {
   std::string ConstructionYearFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t ConstructionYearFeature::GetValueAlignment() const
+  {
+    return alignof(ConstructionYearFeatureValue);
   }
 
   size_t ConstructionYearFeature::GetValueSize() const
@@ -2546,6 +2646,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t SidewayFeature::GetValueAlignment() const
+  {
+    return alignof(SidewayFeatureValue);
+  }
+
   size_t SidewayFeature::GetValueSize() const
   {
     return sizeof(SidewayFeatureValue);
@@ -2726,6 +2831,11 @@ namespace osmscout {
   std::string LanesFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t LanesFeature::GetValueAlignment() const
+  {
+    return alignof(LanesFeatureValue);
   }
 
   size_t LanesFeature::GetValueSize() const
@@ -2941,6 +3051,11 @@ namespace osmscout {
     return NAME;
   }
 
+  size_t OperatorFeature::GetValueAlignment() const
+  {
+    return alignof(OperatorFeatureValue);
+  }
+
   size_t OperatorFeature::GetValueSize() const
   {
     return sizeof(OperatorFeatureValue);
@@ -3012,6 +3127,11 @@ namespace osmscout {
   std::string NetworkFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t NetworkFeature::GetValueAlignment() const
+  {
+    return alignof(NetworkFeatureValue);
   }
 
   size_t NetworkFeature::GetValueSize() const
@@ -3090,6 +3210,11 @@ namespace osmscout {
   std::string FromToFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t FromToFeature::GetValueAlignment() const
+  {
+    return alignof(FromToFeatureValue);
   }
 
   size_t FromToFeature::GetValueSize() const
@@ -3172,6 +3297,11 @@ namespace osmscout {
   std::string ColorFeature::GetName() const
   {
     return NAME;
+  }
+
+  size_t ColorFeature::GetValueAlignment() const
+  {
+    return alignof(ColorFeatureValue);
   }
 
   size_t ColorFeature::GetValueSize() const


### PR DESCRIPTION
Hi Tim. 

Recent version was crashing on my phone (armv7) with unalignment access when ColorFeatureValue was allocated... Current alignment to size of pointer (`std::max(sizeof(size_t),sizeof(void*))`) is wrong.

details in commit message:

Some architectures don't support unalignment access,
application receives SIGBUS when it happens.
On other architectures, kernel tries to fix it,
but it is slow or even impossible for some types.
For example for double (64bit) on some Armv7 (32bit) platforms.

Safe alignment should be alignof(std::max_align_t),
but it would waste feature buffer space.
Majority of feature values require less.
For that reason it makes sense to make alignment
value type specific.