### PR TITLE
Route redering performance

### DIFF
--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1935,6 +1935,7 @@ namespace osmscout {
         }
       };
 
+      std::unique_ptr<Route::MemberCache> resolvedMembers;
       for (const auto &segment:route->segments){
         for (const auto &member:segment.members){
           auto memberWay=wayDataMap.find(member.way);
@@ -1942,9 +1943,12 @@ namespace osmscout {
             // when route member is not rendered, it is not present in wayPathData
             // but when we have it in resolved members, we may still process it
             // and render route on it
-            Route::MemberCache resolvedMembers=route->GetResolvedMembers();
-            if (auto it=resolvedMembers.find(member.way);
-                it!=resolvedMembers.end()){
+            if (resolvedMembers==nullptr) {
+              // load member cache lazy
+              resolvedMembers=std::make_unique<Route::MemberCache>(route->GetResolvedMembers());
+            }
+            if (auto it=resolvedMembers->find(member.way);
+                it!=resolvedMembers->end()){
 
               assert(member.way==it->second->GetFileOffset());
 
@@ -2190,7 +2194,7 @@ namespace osmscout {
       log.Info()
         << "Prep: "
         << prepareWaysTimer.ResultString() << " (sec) "
-        << prepareAreasTimer.ResultString() << " (sec)"
+        << prepareAreasTimer.ResultString() << " (sec) "
         << prepareRoutesTimer.ResultString() << " (sec)";
     }
   }

--- a/libosmscout/include/osmscout/Database.h
+++ b/libosmscout/include/osmscout/Database.h
@@ -83,7 +83,7 @@ namespace osmscout {
     unsigned long nodeDataCacheSize=5000;
     unsigned long wayDataCacheSize=40000;
     unsigned long areaDataCacheSize=5000;
-    unsigned long routeDataCacheSize=500;
+    unsigned long routeDataCacheSize=1500;
 
     bool routerDataMMap=true;
     bool nodesDataMMap=true;


### PR DESCRIPTION
Hi. Real-live usage shows that route preparison for rendering is slow. Perf shows that performance problem is in `map` copying... This change speedup rendering 10x ;-) It is still 25% slower than without routes... But usable. I want to use routes just in specialized stylesheets: public transport and hiking/cycling.