### PR TITLE
Bugfixes

### DIFF
--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -77,7 +77,7 @@ endif
 
 EncodeNumber = executable('EncodeNumber',
              'src/EncodeNumber.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)
@@ -91,7 +91,7 @@ FeatureLabelTest = executable('FeatureLabelTest',
 
 FileScannerWriter = executable('FileScannerWriter',
              'src/FileScannerWriter.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)
@@ -105,7 +105,7 @@ GeoBox = executable('GeoBox',
 
 GeoCoordParse = executable('GeoCoordParse',
              'src/GeoCoordParse.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)
@@ -133,7 +133,7 @@ endif
 
 MapRotate = executable('MapRotate',
              'src/MapRotate.cpp',
-             include_directories: [osmscoutmapIncDir, osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutmapIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscoutmap, osmscout],
              install: false)
@@ -147,7 +147,7 @@ MultiDBRouting = executable('MultiDBRouting',
 
 NumberSet = executable('NumberSet',
              'src/NumberSet.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)
@@ -218,7 +218,7 @@ WorkQueue = executable('WorkQueue',
 
 WStringStringConversion = executable('WStringStringConversion',
              'src/WStringStringConversion.cpp',
-             include_directories: [osmscoutIncDir],
+             include_directories: [testIncDir, osmscoutIncDir],
              dependencies: [mathDep, openmpDep],
              link_with: [osmscout],
              install: false)

--- a/Tests/src/EncodeNumber.cpp
+++ b/Tests/src/EncodeNumber.cpp
@@ -2,7 +2,8 @@
 
 #include <osmscout/util/Number.h>
 
-int errors=0;
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
 bool CheckEncode(uint64_t value,
                  const char* expected, size_t expectedLength)
@@ -54,91 +55,30 @@ bool CheckDecode(const char* buffer, uint64_t expected, size_t bytesExpected)
   return true;
 }
 
-int main()
+TEST_CASE("Check encode")
 {
-  if (!CheckEncode(0,"\0",1)) {
-    errors++;
-  }
+    REQUIRE(CheckEncode(0, "\0", 1));
+    REQUIRE(CheckEncode(1, "\x01", 1));
+    REQUIRE(CheckEncode(127, "\x7f", 1));
+    REQUIRE(CheckEncode(128, "\x80\x01", 2));
+    REQUIRE(CheckEncode(213, "\xd5\x01", 2));
+    REQUIRE(CheckEncode(255, "\xff\x01", 2));
+    REQUIRE(CheckEncode(256, "\x80\x02", 2));
+    REQUIRE(CheckEncode(65535, "\xff\xff\x03", 3));
+    REQUIRE(CheckEncode(3622479373539965697, "\x81\xf6\x9d\xd0\xc2\xb9\xe8\xa2\x32", 9));
+    REQUIRE(CheckEncode(3627142814677078785, "\x81\xa6\xc0\xd3\xc2\xe5\x8c\xab\x32", 9));
+}
 
-  if (!CheckDecode("\0",0,1)) {
-    errors++;
-  }
-
-  if (!CheckEncode(1,"\x01",1)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x01",1,1)) {
-    errors++;
-  }
-
-  if (!CheckEncode(127,"\x7f",1)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x7f",127,1)) {
-    errors++;
-  }
-
-  if (!CheckEncode(128,"\x80\x01",2)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x80\x01",128,2)) {
-    errors++;
-  }
-
-  if (!CheckEncode(213,"\xd5\x01",2)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\xd5\x01",213,2)) {
-    errors++;
-  }
-
-  if (!CheckEncode(255,"\xff\x01",2)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\xff\x01",255,2)) {
-    errors++;
-  }
-
-  if (!CheckEncode(256,"\x80\x02",2)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x80\x02",256,2)) {
-    errors++;
-  }
-
-  if (!CheckEncode(65535,"\xff\xff\x03",3)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\xff\xff\x03",65535,3)) {
-    errors++;
-  }
-
-  if (!CheckEncode(3622479373539965697,"\x81\xf6\x9d\xd0\xc2\xb9\xe8\xa2\x32",9)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x81\xf6\x9d\xd0\xc2\xb9\xe8\xa2\x32", 3622479373539965697,9)) {
-    errors++;
-  }
-
-  if (!CheckEncode(3627142814677078785,"\x81\xa6\xc0\xd3\xc2\xe5\x8c\xab\x32",9)) {
-    errors++;
-  }
-
-  if (!CheckDecode("\x81\xa6\xc0\xd3\xc2\xe5\x8c\xab\x32",3627142814677078785,9)) {
-    errors++;
-  }
-
-  if (errors!=0) {
-    return 1;
-  }
-
-  return 0;
+TEST_CASE("Check decode")
+{
+    REQUIRE(CheckDecode("\0", 0, 1));
+    REQUIRE(CheckDecode("\x01", 1, 1));
+    REQUIRE(CheckDecode("\x7f", 127, 1));
+    REQUIRE(CheckDecode("\x80\x01", 128, 2));
+    REQUIRE(CheckDecode("\xd5\x01", 213, 2));
+    REQUIRE(CheckDecode("\xff\x01", 255, 2));
+    REQUIRE(CheckDecode("\x80\x02", 256, 2));
+    REQUIRE(CheckDecode("\xff\xff\x03", 65535, 3));
+    REQUIRE(CheckDecode("\x81\xf6\x9d\xd0\xc2\xb9\xe8\xa2\x32", 3622479373539965697, 9));
+    REQUIRE(CheckDecode("\x81\xa6\xc0\xd3\xc2\xe5\x8c\xab\x32", 3627142814677078785, 9));
 }

--- a/Tests/src/FileScannerWriter.cpp
+++ b/Tests/src/FileScannerWriter.cpp
@@ -7,49 +7,36 @@
 
 #include <osmscout/CoreFeatures.h>
 
-int errors=0;
-
-void DumpGeoCoords(const std::vector<osmscout::Point>& coords)
-{
-  std::cout << "[";
-  for (size_t i=0; i<coords.size(); i++) {
-    if (i>0) {
-      std::cout << ", ";
-    }
-
-    std::cout << coords[i].GetCoord().GetDisplayText();
-  }
-  std::cout << "]";
-}
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
 bool Equals(const std::vector<osmscout::Point>& coordsA, const std::vector<osmscout::Point>& coordsB)
 {
-  if (coordsA.size()!=coordsB.size()) {
-    return false;
-  }
-
-  for (size_t i=0; i<coordsA.size(); i++) {
-    if (coordsA[i].GetCoord().GetDisplayText()!=coordsB[i].GetCoord().GetDisplayText()) {
-      std::cerr << "Difference at offset " << i << " " << coordsA[i].GetCoord().GetDisplayText() << " <=> " << coordsB[i].GetCoord().GetDisplayText() << std::endl;
-      return false;
+    if (coordsA.size() != coordsB.size()) {
+        return false;
     }
-  }
 
-  return true;
+    for (size_t i = 0; i < coordsA.size(); i++) {
+        if (coordsA[i].GetCoord().GetDisplayText() != coordsB[i].GetCoord().GetDisplayText()) {
+            std::cerr << "Difference at offset " << i << " " << coordsA[i].GetCoord().GetDisplayText() << " <=> " << coordsB[i].GetCoord().GetDisplayText() << std::endl;
+            return false;
+        }
+    }
+
+    return true;
 }
 
-int main()
+TEST_CASE("FileScannerWriter")
 {
-  osmscout::FileWriter  writer;
-  osmscout::FileScanner scanner;
+    osmscout::FileWriter  writer;
+    osmscout::FileScanner scanner;
 
-  osmscout::FileOffset  finalWriteFileOffset;
+    osmscout::FileOffset  finalWriteFileOffset;
 
-  osmscout::FileOffset  info;
+    osmscout::FileOffset  info;
 
-  osmscout::FileOffset  finalReadFileOffset;
+    osmscout::FileOffset  finalReadFileOffset;
 
-  try {
     bool                  inBool;
     uint16_t              in16u;
     uint32_t              in32u;
@@ -69,38 +56,38 @@ int main()
     std::vector<osmscout::Point> inCoords6;
     std::vector<osmscout::Point> inCoords7;
 
-    bool                  outBool1=false;
-    bool                  outBool2=true;
+    bool                  outBool1 = false;
+    bool                  outBool2 = true;
 
-    uint16_t              out16u1=std::numeric_limits<uint16_t>::min();
-    uint16_t              out16u2=std::numeric_limits<uint16_t>::max()/2;
-    uint16_t              out16u3=std::numeric_limits<uint16_t>::max();
+    uint16_t              out16u1 = std::numeric_limits<uint16_t>::min();
+    uint16_t              out16u2 = std::numeric_limits<uint16_t>::max() / 2;
+    uint16_t              out16u3 = std::numeric_limits<uint16_t>::max();
 
-    uint32_t              out32u1=std::numeric_limits<uint32_t>::min();
-    uint32_t              out32u2=std::numeric_limits<uint32_t>::max()/2;
-    uint32_t              out32u3=std::numeric_limits<uint32_t>::max();
+    uint32_t              out32u1 = std::numeric_limits<uint32_t>::min();
+    uint32_t              out32u2 = std::numeric_limits<uint32_t>::max() / 2;
+    uint32_t              out32u3 = std::numeric_limits<uint32_t>::max();
 
-    uint64_t              out64u1=std::numeric_limits<uint64_t>::min();
-    uint64_t              out64u2=std::numeric_limits<uint64_t>::max()/2;
-    uint64_t              out64u3=std::numeric_limits<uint64_t>::max();
+    uint64_t              out64u1 = std::numeric_limits<uint64_t>::min();
+    uint64_t              out64u2 = std::numeric_limits<uint64_t>::max() / 2;
+    uint64_t              out64u3 = std::numeric_limits<uint64_t>::max();
 
-    int16_t               out16s1=std::numeric_limits<int16_t>::min();
-    int16_t               out16s2=std::numeric_limits<int16_t>::max()/2;
-    int16_t               out16s3=std::numeric_limits<int16_t>::max();
+    int16_t               out16s1 = std::numeric_limits<int16_t>::min();
+    int16_t               out16s2 = std::numeric_limits<int16_t>::max() / 2;
+    int16_t               out16s3 = std::numeric_limits<int16_t>::max();
 
-    int32_t               out32s1=std::numeric_limits<int32_t>::min();
-    int32_t               out32s2=std::numeric_limits<int32_t>::max()/2;
-    int32_t               out32s3=std::numeric_limits<int32_t>::max();
+    int32_t               out32s1 = std::numeric_limits<int32_t>::min();
+    int32_t               out32s2 = std::numeric_limits<int32_t>::max() / 2;
+    int32_t               out32s3 = std::numeric_limits<int32_t>::max();
 
-    int64_t               out64s1=std::numeric_limits<int64_t>::min();
-    int64_t               out64s2=std::numeric_limits<int64_t>::max()/2;
-    int64_t               out64s3=std::numeric_limits<int64_t>::max();
+    int64_t               out64s1 = std::numeric_limits<int64_t>::min();
+    int64_t               out64s2 = std::numeric_limits<int64_t>::max() / 2;
+    int64_t               out64s3 = std::numeric_limits<int64_t>::max();
 
-    osmscout::FileOffset  outfo1=std::numeric_limits<osmscout::FileOffset>::min();
-    osmscout::FileOffset  outfo2=std::numeric_limits<osmscout::FileOffset>::max()/2;
-    osmscout::FileOffset  outfo3=std::numeric_limits<osmscout::FileOffset>::max();
+    osmscout::FileOffset  outfo1 = std::numeric_limits<osmscout::FileOffset>::min();
+    osmscout::FileOffset  outfo2 = std::numeric_limits<osmscout::FileOffset>::max() / 2;
+    osmscout::FileOffset  outfo3 = std::numeric_limits<osmscout::FileOffset>::max();
 
-    osmscout::GeoCoord    outCoord1(51.57231,7.46418);
+    osmscout::GeoCoord    outCoord1(51.57231, 7.46418);
 
     std::vector<osmscout::Point> outCoords1;
     std::vector<osmscout::Point> outCoords2;
@@ -110,51 +97,51 @@ int main()
     std::vector<osmscout::Point> outCoords6;
     std::vector<osmscout::Point> outCoords7;
 
-    outCoords1.emplace_back(0,osmscout::GeoCoord(51.57231,7.46418));
-    outCoords1.emplace_back(0,osmscout::GeoCoord(51.57233,7.46430));
-    outCoords1.emplace_back(0,osmscout::GeoCoord(51.57261,7.46563));
-    outCoords1.emplace_back(0,osmscout::GeoCoord(51.57269,7.46594));
+    outCoords1.emplace_back(0, osmscout::GeoCoord(51.57231, 7.46418));
+    outCoords1.emplace_back(0, osmscout::GeoCoord(51.57233, 7.46430));
+    outCoords1.emplace_back(0, osmscout::GeoCoord(51.57261, 7.46563));
+    outCoords1.emplace_back(0, osmscout::GeoCoord(51.57269, 7.46594));
 
-    outCoords2=outCoords1;
-    std::reverse(outCoords2.begin(),outCoords2.end());
+    outCoords2 = outCoords1;
+    std::reverse(outCoords2.begin(), outCoords2.end());
 
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58549,7.55493));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58549,7.55494));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58550,7.55496));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58547,7.55504));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58544,7.55506));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58544,7.55507));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58543,7.55508));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58542,7.55508));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58540,7.55508));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58539,7.55508));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58538,7.55500));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58538,7.55498));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58539,7.55495));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58540,7.55494));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58540,7.55488));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58541,7.55484));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58542,7.55484));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58544,7.55483));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58546,7.55484));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58547,7.55485));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58548,7.55488));
-    outCoords3.emplace_back(0,osmscout::GeoCoord(51.58549,7.55492));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58549, 7.55493));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58549, 7.55494));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58550, 7.55496));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58547, 7.55504));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58544, 7.55506));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58544, 7.55507));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58543, 7.55508));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58542, 7.55508));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58540, 7.55508));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58539, 7.55508));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58538, 7.55500));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58538, 7.55498));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58539, 7.55495));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58540, 7.55494));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58540, 7.55488));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58541, 7.55484));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58542, 7.55484));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58544, 7.55483));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58546, 7.55484));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58547, 7.55485));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58548, 7.55488));
+    outCoords3.emplace_back(0, osmscout::GeoCoord(51.58549, 7.55492));
 
-    outCoords4=outCoords3;
-    std::reverse(outCoords4.begin(),outCoords4.end());
+    outCoords4 = outCoords3;
+    std::reverse(outCoords4.begin(), outCoords4.end());
 
-    outCoords5.emplace_back(0,osmscout::GeoCoord(5.0,-5.0));
-    outCoords5.emplace_back(0,osmscout::GeoCoord(5.0,5.0));
-    outCoords5.emplace_back(0,osmscout::GeoCoord(-5.0,5.0));
+    outCoords5.emplace_back(0, osmscout::GeoCoord(5.0, -5.0));
+    outCoords5.emplace_back(0, osmscout::GeoCoord(5.0, 5.0));
+    outCoords5.emplace_back(0, osmscout::GeoCoord(-5.0, 5.0));
 
-    outCoords6=outCoords5;
-    std::reverse(outCoords6.begin(),outCoords6.end());
+    outCoords6 = outCoords5;
+    std::reverse(outCoords6.begin(), outCoords6.end());
 
-    uint64_t maxCoords=1000000;
+    uint64_t maxCoords = 1000000;
 
-    for (uint64_t i=1; i<=maxCoords; i++) {
-      outCoords7.emplace_back(0,osmscout::GeoCoord(51.58549,7.55493));
+    for (uint64_t i = 1; i <= maxCoords; i++) {
+        outCoords7.emplace_back(0, osmscout::GeoCoord(51.58549, 7.55493));
     }
 
     writer.Open("test.dat");
@@ -203,352 +190,154 @@ int main()
 
     writer.WriteCoord(outCoord1);
 
-    writer.Write(outCoords1,false);
-    writer.Write(outCoords2,false);
-    writer.Write(outCoords3,false);
-    writer.Write(outCoords4,false);
-    writer.Write(outCoords5,false);
-    writer.Write(outCoords6,false);
-    writer.Write(outCoords7,false);
+    writer.Write(outCoords1, false);
+    writer.Write(outCoords2, false);
+    writer.Write(outCoords3, false);
+    writer.Write(outCoords4, false);
+    writer.Write(outCoords5, false);
+    writer.Write(outCoords6, false);
+    writer.Write(outCoords7, false);
 
-    finalWriteFileOffset=writer.GetPos();
+    finalWriteFileOffset = writer.GetPos();
 
     writer.Close();
 
-    for (int mmapMode = 0; mmapMode <= 1; mmapMode++){
-      scanner.Open("test.dat",osmscout::FileScanner::Normal,(bool)mmapMode);
-
-      // Read/Write
-
-      scanner.Read(inBool);
-      if (inBool!=outBool1) {
-        std::cerr << "Read/Write(bool): Expected " << outBool1 << ", got " << inBool << std::endl;
-        errors++;
-      }
-
-      scanner.Read(inBool);
-      if (inBool!=outBool2) {
-        std::cerr << "Read/Write(bool): Expected " << outBool2 << ", got " << inBool << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in16u);
-      if (in16u!=out16u1) {
-        std::cerr << "Read/Write(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in16u);
-      if (in16u!=out16u2) {
-        std::cerr << "Read/Write(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in16u);
-      if (in16u!=out16u3) {
-        std::cerr << "Read/Write(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in32u);
-      if (in32u!=out32u1) {
-        std::cerr << "Read/Write(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in32u);
-      if (in32u!=out32u2) {
-        std::cerr << "Read/Write(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in32u);
-      if (in32u!=out32u3) {
-        std::cerr << "Read/Write(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in64u);
-      if (in64u!=out64u1) {
-        std::cerr << "Read/Write(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in64u);
-      if (in64u!=out64u2) {
-        std::cerr << "Read/Write(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      scanner.Read(in64u);
-      if (in64u!=out64u3) {
-        std::cerr << "Read/Write(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      // Read/WriteNumber
-
-      scanner.ReadNumber(in16u);
-      if (in16u!=out16u1) {
-        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u1 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in16u);
-      if (in16u!=out16u2) {
-        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u2 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in16u);
-      if (in16u!=out16u3) {
-        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16u3 << ", got " << in16u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32u);
-      if (in32u!=out32u1) {
-        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u1 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32u);
-      if (in32u!=out32u2) {
-        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u2 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32u);
-      if (in32u!=out32u3) {
-        std::cerr << "Read/WriteNumber(uint32_t): Expected " << out32u3 << ", got " << in32u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64u);
-      if (in64u!=out64u1) {
-        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u1 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64u);
-      if (in64u!=out64u2) {
-        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u2 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64u);
-      if (in64u!=out64u3) {
-        std::cerr << "Read/WriteNumber(uint64_t): Expected " << out64u3 << ", got " << in64u << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in16s);
-      if (in16s!=out16s1) {
-        std::cerr << "Read/WriteNumber(int16_t): Expected " << out16s1 << ", got " << in16s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in16s);
-      if (in16s!=out16s2) {
-        std::cerr << "Read/WriteNumber(uint16_t): Expected " << out16s2 << ", got " << in16s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in16s);
-      if (in16s!=out16s3) {
-        std::cerr << "Read/WriteNumber(int16_t): Expected " << out16s3 << ", got " << in16s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32s);
-      if (in32s!=out32s1) {
-        std::cerr << "Read/WriteNumber(int32_t): Expected " << out32s1 << ", got " << in32s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32s);
-      if (in32s!=out32s2) {
-        std::cerr << "Read/WriteNumber(int32_t): Expected " << out32s2 << ", got " << in32s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in32s);
-      if (in32s!=out32s3) {
-        std::cerr << "Read/WriteNumber(int32_t): Expected " << out32s3 << ", got " << in32s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64s);
-      if (in64s!=out64s1) {
-        std::cerr << "Read/WriteNumber(int64_t): Expected " << out64s1 << ", got " << in64s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64s);
-      if (in64s!=out64s2) {
-        std::cerr << "Read/WriteNumber(int64_t): Expected " << out64s2 << ", got " << in64s << std::endl;
-        errors++;
-      }
-
-      scanner.ReadNumber(in64s);
-      if (in64s!=out64s3) {
-        std::cerr << "Read/WriteNumber(int64_t): Expected " << out64s3 << ", got " << in64s << std::endl;
-        errors++;
-      }
+    for (int mmapMode = 0; mmapMode <= 1; mmapMode++)
+    {
+        scanner.Open("test.dat", osmscout::FileScanner::Normal, (bool)mmapMode);
 
-      // Read/WriteFileOffset
+        // Read/Write
 
-      scanner.ReadFileOffset(info);
-      if (info!=outfo1) {
-        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo1 << ", got " << info << std::endl;
-        errors++;
-      }
+        scanner.Read(inBool);
+        REQUIRE(inBool == outBool1);
 
-      scanner.ReadFileOffset(info);
-      if (info!=outfo2) {
-        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo2 << ", got " << info << std::endl;
-        errors++;
-      }
+        scanner.Read(inBool);
+        REQUIRE(inBool == outBool2);
 
-      scanner.ReadFileOffset(info);
-      if (info!=outfo3) {
-        std::cerr << "Read/WriteFileOffset(FileOffset): Expected " << outfo3 << ", got " << info << std::endl;
-        errors++;
-      }
+        scanner.Read(in16u);
+        REQUIRE(in16u == out16u1);
 
-      scanner.ReadCoord(inCoord1);
+        scanner.Read(in16u);
+        REQUIRE(in16u == out16u2);
 
-      if (inCoord1.GetDisplayText()!=outCoord1.GetDisplayText()) {
-        std::cerr << "Read/WriteCoord(GeoCoord) 1: Expected " << outCoord1.GetDisplayText() << ", got " << inCoord1.GetDisplayText() << std::endl;
-        errors++;
-      }
+        scanner.Read(in16u);
+        REQUIRE(in16u == out16u3);
 
-      osmscout::GeoBox boundingBox;
-      std::vector<osmscout::SegmentGeoBox> segments;
+        scanner.Read(in32u);
+        REQUIRE(in32u == out32u1);
 
-      scanner.Read(inCoords1,segments,boundingBox,false);
-      if (!Equals(inCoords1,outCoords1)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 1: Expected ";
+        scanner.Read(in32u);
+        REQUIRE(in32u == out32u2);
 
-        DumpGeoCoords(outCoords1);
+        scanner.Read(in32u);
+        REQUIRE(in32u == out32u3);
 
-        std::cout << ", got ";
+        scanner.Read(in64u);
+        REQUIRE(in64u == out64u1);
 
-        DumpGeoCoords(inCoords1);
+        scanner.Read(in64u);
+        REQUIRE(in64u == out64u2);
 
-        std::cout << std::endl;
-        errors++;
-      }
+        scanner.Read(in64u);
+        REQUIRE(in64u == out64u3);
 
-      scanner.Read(inCoords2,segments,boundingBox,false);
-      if (!Equals(inCoords2,outCoords2)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 2: Expected ";
+        // Read/WriteNumber
 
-        DumpGeoCoords(outCoords2);
+        scanner.ReadNumber(in16u);
+        REQUIRE(in16u == out16u1);
 
-        std::cout << ", got ";
+        scanner.ReadNumber(in16u);
+        REQUIRE(in16u == out16u2);
 
-        DumpGeoCoords(inCoords2);
+        scanner.ReadNumber(in16u);
+        REQUIRE(in16u == out16u3);
 
-        std::cout << std::endl;
-        errors++;
-      }
+        scanner.ReadNumber(in32u);
+        REQUIRE(in32u == out32u1);
 
-      scanner.Read(inCoords3,segments,boundingBox,false);
-      if (!Equals(inCoords3,outCoords3)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 3: Expected ";
+        scanner.ReadNumber(in32u);
+        REQUIRE(in32u == out32u2);
 
-        DumpGeoCoords(outCoords3);
+        scanner.ReadNumber(in32u);
+        REQUIRE(in32u == out32u3);
 
-        std::cout << ", got ";
+        scanner.ReadNumber(in64u);
+        REQUIRE(in64u == out64u1);
 
-        DumpGeoCoords(inCoords3);
+        scanner.ReadNumber(in64u);
+        REQUIRE(in64u == out64u2);
 
-        std::cout << std::endl;
-        errors++;
-      }
+        scanner.ReadNumber(in64u);
+        REQUIRE(in64u == out64u3);
 
-      scanner.Read(inCoords4,segments,boundingBox,false);
-      if (!Equals(inCoords4,outCoords4)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 4: Expected ";
+        scanner.ReadNumber(in16s);
+        REQUIRE(in16s == out16s1);
 
-        DumpGeoCoords(outCoords4);
+        scanner.ReadNumber(in16s);
+        REQUIRE(in16s == out16s2);
 
-        std::cout << ", got ";
+        scanner.ReadNumber(in16s);
+        REQUIRE(in16s == out16s3);
 
-        DumpGeoCoords(inCoords4);
+        scanner.ReadNumber(in32s);
+        REQUIRE(in32s == out32s1);
 
-        std::cout << std::endl;
-        errors++;
-      }
+        scanner.ReadNumber(in32s);
+        REQUIRE(in32s == out32s2);
 
-      scanner.Read(inCoords5,segments,boundingBox,false);
-      if (!Equals(inCoords5,outCoords5)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 5: Expected ";
+        scanner.ReadNumber(in32s);
+        REQUIRE(in32s == out32s3);
 
-        DumpGeoCoords(outCoords5);
+        scanner.ReadNumber(in64s);
+        REQUIRE(in64s == out64s1);
 
-        std::cout << ", got ";
+        scanner.ReadNumber(in64s);
+        REQUIRE(in64s == out64s2);
 
-        DumpGeoCoords(inCoords5);
+        scanner.ReadNumber(in64s);
+        REQUIRE(in64s == out64s3);
 
-        std::cout << std::endl;
-        errors++;
-      }
+        // Read/WriteFileOffset
 
-      scanner.Read(inCoords6,segments,boundingBox,false);
-      if (!Equals(inCoords6,outCoords6)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 6: Expected ";
+        scanner.ReadFileOffset(info);
+        REQUIRE(info == outfo1);
 
-        DumpGeoCoords(outCoords6);
+        scanner.ReadFileOffset(info);
+        REQUIRE(info == outfo2);
 
-        std::cout << ", got ";
+        scanner.ReadFileOffset(info);
+        REQUIRE(info == outfo3);
 
-        DumpGeoCoords(inCoords6);
+        scanner.ReadCoord(inCoord1);
+        REQUIRE(inCoord1.GetDisplayText() == outCoord1.GetDisplayText());
 
-        std::cout << std::endl;
-        errors++;
-      }
+        osmscout::GeoBox boundingBox;
+        std::vector<osmscout::SegmentGeoBox> segments;
 
-      scanner.Read(inCoords7,segments,boundingBox,false);
-      if (!Equals(inCoords7,outCoords7)) {
-        std::cerr << "Read/Write(std::vector<GeoCoord>) 7: Expected ";
+        scanner.Read(inCoords1, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords1, outCoords1));
 
-        std::cout << outCoords7.size();
+        scanner.Read(inCoords2, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords2, outCoords2));
 
-        std::cout << ", got ";
+        scanner.Read(inCoords3, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords3, outCoords3));
 
-        std::cout << inCoords7.size();
+        scanner.Read(inCoords4, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords4, outCoords4));
 
-        std::cout << std::endl;
-        errors++;
-      }
+        scanner.Read(inCoords5, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords5, outCoords5));
 
-      finalReadFileOffset=scanner.GetPos();
+        scanner.Read(inCoords6, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords6, outCoords6));
 
-      if (finalWriteFileOffset!=finalReadFileOffset) {
-        std::cerr << "Final file offset check: Expected ";
+        scanner.Read(inCoords7, segments, boundingBox, false);
+        REQUIRE(Equals(inCoords7, outCoords7));
 
-        std::cout << finalWriteFileOffset;
+        finalReadFileOffset = scanner.GetPos();
+        REQUIRE(finalWriteFileOffset == finalReadFileOffset);
 
-        std::cout << ", got ";
-
-        std::cout << finalReadFileOffset;
-
-        std::cout << std::endl;
-        errors++;
-      }
-      scanner.Close();
+        scanner.Close();
     }
-  }
-  catch (osmscout::IOException& e) {
-    std::cerr << e.GetDescription() << std::endl;
-    errors++;
-  }
-
-  if (errors!=0) {
-    return 1;
-  }
-
-  return 0;
 }

--- a/Tests/src/GeoCoordParse.cpp
+++ b/Tests/src/GeoCoordParse.cpp
@@ -2,6 +2,9 @@
 
 #include <osmscout/GeoCoord.h>
 
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
 bool CheckParseFail(const std::string& text)
 {
   osmscout::GeoCoord coord;
@@ -43,141 +46,59 @@ bool CheckParseSuccess(const std::string& text,
   return false;
 }
 
-int main()
+TEST_CASE()
 {
-  int errors=0;
+    // Empty string
+    REQUIRE(CheckParseFail(""));
 
-  // Empty string
-  if (!CheckParseFail("")) {
-    errors++;
-  }
+    // Only whitespace
+    REQUIRE(CheckParseFail(" "));
 
-  // Only whitespace
-  if (!CheckParseFail(" ")) {
-    errors++;
-  }
+    // Illegal character
+    REQUIRE(CheckParseFail("X"));
 
-  // Illegal character
-  if (!CheckParseFail("X")) {
-    errors++;
-  }
+    // Incomplete
+    REQUIRE(CheckParseFail("N"));
 
-  // Incomplete
-  if (!CheckParseFail("N")) {
-    errors++;
-  }
+    // Incomplete
+    REQUIRE(CheckParseFail("N "));
 
-  // Incomplete
-  if (!CheckParseFail("N ")) {
-    errors++;
-  }
+    // Incomplete
+    REQUIRE(CheckParseFail("N 40"));
 
-  // Incomplete
-  if (!CheckParseFail("N 40")) {
-    errors++;
-  }
+    // Incomplete
+    REQUIRE(CheckParseFail("N 40 W"));
 
-  // Incomplete
-  if (!CheckParseFail("N 40 W")) {
-    errors++;
-  }
+    // Incomplete
+    REQUIRE(CheckParseFail("N 40 X"));
 
-  // Incomplete
-  if (!CheckParseFail("N 40 X")) {
-    errors++;
-  }
+    // Simplest complete case
+    REQUIRE(CheckParseSuccess("40 7", osmscout::GeoCoord(40.0, 7.0)));
 
-  // Simplest complete case
-  if (!CheckParseSuccess("40 7",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
+    //
+    // various variants for positive/negative values
+    //
+    REQUIRE(CheckParseSuccess("40 -7", osmscout::GeoCoord(40.0, -7.0)));
+    REQUIRE(CheckParseSuccess("+40 -7", osmscout::GeoCoord(40.0, -7.0)));
+    REQUIRE(CheckParseSuccess("N40 E7", osmscout::GeoCoord(40.0, 7.0)));
+    REQUIRE(CheckParseSuccess("N 40 E 7", osmscout::GeoCoord(40.0, 7.0)));
+    REQUIRE(CheckParseSuccess("40 N E 7", osmscout::GeoCoord(40.0, 7.0)));
+    REQUIRE(CheckParseSuccess("40 N 7 E", osmscout::GeoCoord(40.0, 7.0)));
+    REQUIRE(CheckParseSuccess("40 N 7 E  ", osmscout::GeoCoord(40.0, 7.0)));
 
-  //
-  // various variants for positive/negative values
-  //
-  if (!CheckParseSuccess("40 -7",
-                         osmscout::GeoCoord(40.0,-7.0))) {
-    errors++;
-  }
+    // Trailing garbage
+    REQUIRE(CheckParseFail("40 7X"));
 
-  if (!CheckParseSuccess("+40 -7",
-                         osmscout::GeoCoord(40.0,-7.0))) {
-    errors++;
-  }
+    // Trailing garbage
+    REQUIRE(CheckParseFail("40 7 X"));
 
-  if (!CheckParseSuccess("N40 E7",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("N 40 E 7",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40 N E 7",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40 N 7 E",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40 N 7 E  ",
-                         osmscout::GeoCoord(40.0,7.0))) {
-    errors++;
-  }
-
-  // Trailing garbage
-  if (!CheckParseFail("40 7X")) {
-    errors++;
-  }
-
-  // Trailing garbage
-  if (!CheckParseFail("40 7 X")) {
-    errors++;
-  }
-
-  //
-  // Now with fraction values
-  //
-
-  if (!CheckParseSuccess("40.1 7.1",
-                         osmscout::GeoCoord(40.1,7.1))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40.12 7.12",
-                         osmscout::GeoCoord(40.12,7.12))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40,123 7,123",
-                         osmscout::GeoCoord(40.123,7.123))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("40,123 -7,123",
-                         osmscout::GeoCoord(40.123,-7.123))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess( "50°5'8.860\"N 14°24'37.592\"E",
-                         osmscout::GeoCoord(50.0857944, 14.4104422))) {
-    errors++;
-  }
-
-  if (!CheckParseSuccess("N 50°5.14767' E 14°24.62653'",
-                         osmscout::GeoCoord(50.0857944, 14.4104422))) {
-    errors++;
-  }
-
-  if (errors!=0) {
-    return 1;
-  }
-
-  return 0;
+    //
+    // Now with fraction values
+    //
+    REQUIRE(CheckParseSuccess("40.1 7.1", osmscout::GeoCoord(40.1, 7.1)));
+    REQUIRE(CheckParseSuccess("40.12 7.12", osmscout::GeoCoord(40.12, 7.12)));
+    REQUIRE(CheckParseSuccess("40,123 7,123", osmscout::GeoCoord(40.123, 7.123)));
+    REQUIRE(CheckParseSuccess("40,123 -7,123", osmscout::GeoCoord(40.123, -7.123)));
+    REQUIRE(CheckParseSuccess("50°5'8.860\"N 14°24'37.592\"E", osmscout::GeoCoord(50.0857944, 14.4104422)));
+    REQUIRE(CheckParseSuccess("N 50°5.14767' E 14°24.62653'", osmscout::GeoCoord(50.0857944, 14.4104422)));
 }

--- a/Tests/src/MapRotate.cpp
+++ b/Tests/src/MapRotate.cpp
@@ -21,6 +21,9 @@
 
 #include <osmscout/MapPainterNoOp.h>
 
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
 static const double ringCoords[] = {
   50.08336917, 14.41309835,
   50.08305669, 14.41285159,
@@ -815,7 +818,7 @@ bool TestPainter::IsVisibleAreaPublic(const osmscout::Projection& projection,
                        pixelOffset);
 }
 
-int main(int /*argc*/, char** /*argv*/)
+TEST_CASE()
 {
   osmscout::TypeConfigRef typeConfig = std::make_shared<osmscout::TypeConfig>();
   osmscout::StyleConfigRef styleConfig=std::make_shared<osmscout::StyleConfig>(typeConfig);
@@ -847,20 +850,7 @@ int main(int /*argc*/, char** /*argv*/)
                    dpi, width, height
                    );
     double angleDeg = (360*(angle/(2*M_PI)));
-
-    bool visible = painter.IsVisibleAreaPublic(projection, ring, 0.0);
-
-    if (!visible) {
-      problems+=1;
-      std::cerr << "angle " << angle << " (" << angleDeg << "°) => " << visible << " ERROR" << std::endl;
-    }
-    else {
-      std::cout << "angle " << angle << " (" << angleDeg << "°) => " << visible << " OK" << std::endl;
-    }
+    REQUIRE(painter.IsVisibleAreaPublic(projection, ring, 0.0));
   }
-
-  std::cout << problems << " problems found" << std::endl;
-
-  return problems;
 }
 

--- a/Tests/src/NumberSet.cpp
+++ b/Tests/src/NumberSet.cpp
@@ -2,55 +2,32 @@
 
 #include <osmscout/util/NumberSet.h>
 
-int errors=0;
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
-int main()
+TEST_CASE()
 {
   osmscout::NumberSet set;
 
-  if (set.IsSet(0)) {
-    std::cerr << "0 found in set!" << std::endl;
-    errors++;
-  }
+  REQUIRE_FALSE(set.IsSet(0));
 
-  if (set.IsSet(1)) {
-    std::cerr << "1 found in set!" << std::endl;
-    errors++;
-  }
+  REQUIRE_FALSE(set.IsSet(1));
 
   set.Set(1);
 
-  if (!set.IsSet(1)) {
-    std::cerr << "1 not found in set!" << std::endl;
-    errors++;
-  }
+  REQUIRE(set.IsSet(1));
 
   set.Set(255);
 
-  if (!set.IsSet(255)) {
-    std::cerr << "255 not found in set!" << std::endl;
-    errors++;
-  }
+  REQUIRE(set.IsSet(255));
 
   set.Set(256);
 
-  if (!set.IsSet(256)) {
-    std::cerr << "256 not found in set!" << std::endl;
-    errors++;
-  }
+  REQUIRE(set.IsSet(256));
 
   for (size_t i=256; i<256*256; i++) {
     set.Set(i);
 
-    if (!set.IsSet(i)) {
-      std::cerr << i << " not found in set!" << std::endl;
-      errors++;
-    }
+    REQUIRE(set.IsSet(i));
   }
-
-  if (errors!=0) {
-    return 1;
-  }
-
-  return 0;
 }

--- a/Tests/src/TransPolygon.cpp
+++ b/Tests/src/TransPolygon.cpp
@@ -25,6 +25,9 @@
 #include <osmscout/util/Geometry.h>
 #include <osmscout/util/Transformation.h>
 
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
 using namespace std;
 
 bool WayIsSimple(const std::vector<osmscout::Point> &points)
@@ -62,14 +65,11 @@ bool WayIsSimple(const std::vector<osmscout::Point> &points)
   return true;
 }
 
-int main(int /*argc*/, char** /*argv*/)
+TEST_CASE()
 {
   std::vector<osmscout::Point> testWay=GetTestWay();
 
-  if (!WayIsSimple(testWay)){
-    std::cout << "Test way is not simple" << std::endl;
-    return 1;
-  }
+  REQUIRE(WayIsSimple(testWay));
 
   osmscout::MercatorProjection projection;
   osmscout::Magnification mag;
@@ -95,10 +95,7 @@ int main(int /*argc*/, char** /*argv*/)
     }
   }
 
-  if (!WayIsSimple(optimised)){
-    std::cout << "Optimised way is not simple" << std::endl;
-    return 2;
-  }
+  REQUIRE(WayIsSimple(optimised));
 
   // try again as area
   polygon.TransformArea(projection,
@@ -114,13 +111,6 @@ int main(int /*argc*/, char** /*argv*/)
     }
   }
 
-  if (!AreaIsSimple(optimised)){
-    std::cout << "Optimised area is not simple" << std::endl;
-    return 3;
-  }
-
-  std::cout << "OK" << std::endl;
-
-  return 0;
+  REQUIRE(AreaIsSimple(optimised));
 }
 

--- a/Tests/src/WStringStringConversion.cpp
+++ b/Tests/src/WStringStringConversion.cpp
@@ -3,95 +3,66 @@
 
 #include <osmscout/util/String.h>
 
-int errors=0;
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
-bool CheckCharsetConversion(const std::string& oText)
+TEST_CASE("Check ANSI charset conversion")
 {
-  std::cout << "Original: \"" << oText << "\"" << std::endl;
-  // Convert to std::wstring
-  std::wstring wText=osmscout::UTF8StringToWString(oText);
-  std::wcout << "WString: \"" << wText << "\"" << std::endl;
-  // ...and convert it back to UTF8
-  std::string  uText=osmscout::WStringToUTF8String(wText);
-  std::cout << "UTF8String: \"" << uText << "\"" << std::endl;
-
-  return oText==uText;
+	const std::string oText = "abcABC";
+	std::wstring wText = osmscout::UTF8StringToWString(oText);
+	std::string  uText = osmscout::WStringToUTF8String(wText);
+	REQUIRE(oText == uText);
 }
 
-bool CheckToUpper(const std::string& oText,
-                  const std::string& eText)
+TEST_CASE("Check german umlauts upper and lower case and euro-sign charset conversion")
 {
-  std::cout << "Original: \"" << oText << "\"" << std::endl;
-  // Convert to upper
-  std::string uText=osmscout::UTF8StringToUpper(oText);
-  std::cout << "Upper: \"" << uText << "\" vs \"" << eText << "\"" << std::endl;
-
-  return uText==eText;
+	try
+	{
+		std::locale::global(std::locale(""));
+	}
+	catch (const std::exception& e) {
+		std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
+	}
+	const std::string oText = "\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac";
+	std::wstring wText = osmscout::UTF8StringToWString(oText);
+	std::string  uText = osmscout::WStringToUTF8String(wText);
+	REQUIRE(oText == uText);
 }
 
-bool CheckToLower(const std::string& oText,
-                  const std::string& eText)
+TEST_CASE("Check ANSI to lower")
 {
-  std::cout << "Original: \"" << oText << "\"" << std::endl;
-  // Convert to lower
-  std::string lText=osmscout::UTF8StringToLower(oText);
-  std::cout << "Lower: \"" << lText << "\" vs \"" << eText << "\"" << std::endl;
-
-  return lText==eText;
+	std::string lText = osmscout::UTF8StringToLower("abcABC");
+	REQUIRE(lText == "abcabc");
 }
 
-int main()
+TEST_CASE("Check ANSI to upper")
 {
-  try {
-    std::locale::global(std::locale(""));
+	std::string uText = osmscout::UTF8StringToUpper("abcABC");
+	REQUIRE(uText == "ABCABC");
+}
 
-    std::cout << "Current locale activated" << std::endl;
-  }
-  catch (const std::exception& e) {
-    std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
-  }
+TEST_CASE("Check German umlauts upper and lower case and euro-sign to lower")
+{
+	try
+	{
+		std::locale::global(std::locale(""));
+	}
+	catch (const std::exception& e) {
+		std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
+	}
+	std::string lText = osmscout::UTF8StringToLower("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac");
+	REQUIRE(lText == "\xc3\xa4\xc3\xb6\xc3\xbc\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac");
+}
 
-  // ANSI
-  if (!CheckCharsetConversion("abcABC")) {
-    errors++;
-  }
-
-  // German umlauts upper and lower case and euro-sign
-  if (!CheckCharsetConversion("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac")) {
-    errors++;
-  }
-
-  // ANSI
-  if (!CheckToLower("abcABC","abcabc")) {
-    errors++;
-  }
-
-  // ANSI
-  if (!CheckToUpper("abcABC","ABCABC")) {
-    errors++;
-  }
-
-  // German umlauts upper
-  if (!CheckToUpper("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc",
-                    "\xc3\x84\xc3\x96\xc3\x9c\xc3\x84\xc3\x96\xc3\x9c")) {
-    errors++;
-  }
-
-  // German umlauts upper and lower case and euro-sign
-  if (!CheckToUpper("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac",
-                    "\xc3\x84\xc3\x96\xc3\x9c\xc3\x84\xc3\x96\xc3\x9c\xe2\x82\xac")) {
-    errors++;
-  }
-
-  if (!CheckToLower("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac",
-                    "\xc3\xa4\xc3\xb6\xc3\xbc\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac")) {
-    errors++;
-  }
-
-  if (errors!=0) {
-    return 1;
-  }
-  else {
-    return 0;
-  }
+TEST_CASE("Check German umlauts upper and lower case and euro-sign to upper")
+{
+	try
+	{
+		std::locale::global(std::locale(""));
+	}
+	catch (const std::exception& e) {
+		std::cerr << "ERROR: Cannot set locale: " << e.what() << std::endl;
+	}
+	std::string uText = osmscout::UTF8StringToUpper("\xc3\x84\xc3\x96\xc3\x9c\xc3\xa4\xc3\xb6\xc3\xbc\xe2\x82\xac");
+	REQUIRE(uText == "\xc3\x84\xc3\x96\xc3\x9c\xc3\x84\xc3\x96\xc3\x9c\xe2\x82\xac");
 }

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -25,6 +25,7 @@
 #include <osmscout/InputHandler.h>
 #include <osmscout/OSMScoutQt.h>
 #include <QtSvg/QSvgRenderer>
+#include <QtGlobal>
 
 namespace osmscout {
 
@@ -210,11 +211,17 @@ void MapWidget::wheelEvent(QWheelEvent* event)
     int numDegrees =  cumulNumDegrees / 8;
     int numSteps = numDegrees / 15;
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QPoint pos = event->pos();
+#else
+    QPoint pos = QPoint((int)event->position().x(), (int)event->position().y());
+#endif
+
     if (numSteps>=0) {
-        zoomIn(numSteps*1.35, event->pos());
+        zoomIn(numSteps*1.35, pos);
     }
     else {
-        zoomOut(-numSteps*1.35, event->pos());
+        zoomOut(-numSteps*1.35, pos);
     }
     cumulNumDegrees %= 120;
 

--- a/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscout/OsmTileDownloader.cpp
@@ -19,6 +19,9 @@
 
 #include <QDebug>
 #include <QThread>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) /* For compatibility with QT 5.6 */
+#include <QRandomGenerator>
+#endif
 
 #include <osmscout/OsmTileDownloader.h>
 #include <osmscout/OnlineTileProvider.h>
@@ -29,7 +32,11 @@ namespace osmscout {
 
 OsmTileDownloader::OsmTileDownloader(QString diskCacheDir,
                                      const OnlineTileProvider &provider):
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0) /* For compatibility with QT 5.6 */
   serverNumber(qrand()),
+#else
+  serverNumber(QRandomGenerator::global()->generate()),
+#endif
   tileProvider(provider)
 {
   /** http://wiki.openstreetmap.org/wiki/Tile_usage_policy
@@ -92,7 +99,11 @@ void OsmTileDownloader::fileDownloaded(const TileCacheKey &key, QNetworkReply *r
     
   if (reply->error() != QNetworkReply::NoError){
     qWarning() << "Downloading" << url << "failed with" << reply->errorString();
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0) /* For compatibility with QT 5.6 */
     serverNumber = qrand(); // try another server for future requests
+#else
+    serverNumber = QRandomGenerator::global()->generate(); // try another server for future requests
+#endif
     emit failed(key.zoomLevel, key.xtile, key.ytile, false);
   }else{
     QByteArray downloadedData = reply->readAll();

--- a/libosmscout/include/osmscout/Database.h
+++ b/libosmscout/include/osmscout/Database.h
@@ -26,6 +26,7 @@
 #include <set>
 #include <unordered_map>
 #include <vector>
+#include <string_view>
 
 // Type and style sheet configuration
 #include <osmscout/OSMScoutTypes.h>

--- a/libosmscout/src/osmscout/util/Logger.cpp
+++ b/libosmscout/src/osmscout/util/Logger.cpp
@@ -20,6 +20,7 @@
 #include <osmscout/util/Logger.h>
 
 #include <iostream>
+#include <string_view>
 
 #include <osmscout/system/Assert.h>
 


### PR DESCRIPTION
**Fix missing headers for std::string_view (issue #923)**
The GCC and CLANG forgive much easier if you forget headers from the standard library. MSVC is very strict about this. Header `<string_view>` is required to compile with VS2017 (https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv).

**Resolve 2/3 Qt deprecation warnings (issue #879)**
Somewhere we already had the discussion about the QT version. As far as I'm concerned, you can assume 5.14, but on some old systems there is only QT 5.6 for licensing reasons, so the old code is still included. I could not (yet) find the problem `bool QVariant::operator>(const QVariant&) const`.

**Update Tests (issue #310)**
I have switched some tests to the catch framework.