### PR TITLE
make gcc happy, solve some maybe-uninitialized warnings

### DIFF
--- a/libosmscout-import/src/osmscout/import/GenRoute2Dat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRoute2Dat.cpp
@@ -129,7 +129,7 @@ namespace osmscout {
         // build route segments
         while (!wayPointMap.empty()){
           // find some point where is just one way
-          Id segmentFrontId;
+          Id segmentFrontId=0;
           for (auto it:wayPointMap){
             segmentFrontId=it.first;
             if (wayPointMap.count(segmentFrontId) == 1) {

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -111,7 +111,6 @@ namespace osmscout {
      */
     struct OSMSCOUT_MAP_API WayData
     {
-      FileOffset               ref;
       const FeatureValueBuffer *buffer;         //!< Features of the line segment
       int8_t                   layer;           //!< Layer this way is in
       LineStyleRef             lineStyle;       //!< Line style

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1727,7 +1727,6 @@ namespace osmscout {
 
       WayData data;
 
-      data.ref=ref;
       data.lineWidth=lineWidth;
 
       if (!IsVisibleWay(projection,


### PR DESCRIPTION
wayPointMap cannot be emtpy, so segmentFrontId is always initialised.
But gcc still prints warning... This change should make it happy.