### PR TITLE
fix OSM tile downloader, use unsigned value for serverNumber

### DIFF
--- a/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/OsmTileDownloader.h
@@ -58,7 +58,7 @@ private slots:
   void fileDownloaded(const TileCacheKey &key, QNetworkReply *reply);
 
 private:
-  int                       serverNumber;
+  quint32                   serverNumber;
   QNetworkAccessManager     webCtrl;
   QNetworkDiskCache         diskCache;
   OnlineTileProvider        tileProvider;


### PR DESCRIPTION
QRandomGenerator may generate random number (quint32)
with higher value than max value of signed int.
serverNumber holds negative value then and server
evaluation fails on line:

```
  QString server = servers.at(serverNumber % servers.size());
```