### PR TITLE
Route labels, simplify route rendering

### DIFF
--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -70,9 +70,10 @@ namespace osmscout {
     DrawAreaBorderLabels  = 13,
     DrawAreaBorderSymbols = 14,
     PrepareNodeLabels     = 15,
-    DrawLabels            = 16,
-    Postrender            = 17, //!< Implementation specific final step
-    LastStep              = 17
+    PrepareRouteLabels    = 16,
+    DrawLabels            = 17,
+    Postrender            = 18, //!< Implementation specific final step
+    LastStep              = 18
   };
 
   /**
@@ -207,6 +208,17 @@ namespace osmscout {
       std::list<PolyData>      clippings;       //!< Clipping polygons to be used during drawing of this area
     };
 
+    using WayPathDataIt=std::list<WayPathData>::iterator;
+
+    /**
+     * Data structure for holding temporary data route labels
+     */
+    struct OSMSCOUT_MAP_API RouteLabelData
+    {
+      WayPathDataIt wayData;
+      std::map<PathTextStyleRef,std::set<std::string>> labels;
+    };
+
   protected:
     CoordBuffer                  *coordBuffer;      //!< Reference to the coordinate buffer
     TextStyleRef                 debugLabel;
@@ -228,6 +240,7 @@ namespace osmscout {
     std::list<WayData>           wayData;
     std::list<WayPathData>       wayPathData;
     std::list<RouteData>         routeData;
+    std::list<RouteLabelData>    routeLabelData;
 
     std::vector<TextStyleRef>    textStyles;     //!< Temporary storage for StyleConfig return value
     std::vector<LineStyleRef>    lineStyles;     //!< Temporary storage for StyleConfig return value
@@ -366,6 +379,12 @@ namespace osmscout {
                              const MapParameter& parameter,
                              const WayPathData& data);
 
+    bool DrawWayContourLabel(const Projection& projection,
+                             const MapParameter& parameter,
+                             const WayPathData& data,
+                             const PathTextStyleRef &pathTextStyle,
+                             const std::string &textLabel);
+
     bool DrawAreaBorderLabel(const StyleConfig& styleConfig,
                              const Projection& projection,
                              const MapParameter& parameter,
@@ -454,6 +473,10 @@ namespace osmscout {
     void PrepareNodeLabels(const Projection& projection,
                            const MapParameter& parameter,
                            const MapData& data);
+
+    void PrepareRouteLabels(const Projection& projection,
+                            const MapParameter& parameter,
+                            const MapData& data);
 
     void Postrender(const Projection& projection,
                     const MapParameter& parameter,

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -63,17 +63,16 @@ namespace osmscout {
     DrawOSMTileGrids      =  6, //!< If special style exists, renders grid corresponding to OSM tiles
     DrawAreas             =  7,
     DrawWays              =  8,
-    DrawRoutes            =  9,
-    DrawWayDecorations    = 10,
-    DrawWayContourLabels  = 11,
-    PrepareAreaLabels     = 12,
-    DrawAreaBorderLabels  = 13,
-    DrawAreaBorderSymbols = 14,
-    PrepareNodeLabels     = 15,
-    PrepareRouteLabels    = 16,
-    DrawLabels            = 17,
-    Postrender            = 18, //!< Implementation specific final step
-    LastStep              = 18
+    DrawWayDecorations    =  9,
+    DrawWayContourLabels  = 10,
+    PrepareAreaLabels     = 11,
+    DrawAreaBorderLabels  = 12,
+    DrawAreaBorderSymbols = 13,
+    PrepareNodeLabels     = 14,
+    PrepareRouteLabels    = 15,
+    DrawLabels            = 16,
+    Postrender            = 17, //!< Implementation specific final step
+    LastStep              = 17
   };
 
   /**
@@ -115,6 +114,7 @@ namespace osmscout {
       const FeatureValueBuffer *buffer;         //!< Features of the line segment
       int8_t                   layer;           //!< Layer this way is in
       LineStyleRef             lineStyle;       //!< Line style
+      Color                    color;           //!< Line color
       size_t                   wayPriority;     //!< Priority of way (from style sheet)
       size_t                   transStart;      //!< Start of coordinates in transformation buffer
       size_t                   transEnd;        //!< End of coordinates in transformation buffer (inclusive)
@@ -152,24 +152,6 @@ namespace osmscout {
 
         return wayPriority>other.wayPriority;
       }
-    };
-
-    struct OSMSCOUT_MAP_API RouteSegmentData
-    {
-      size_t                   transStart;      //!< Start of coordinates in transformation buffer
-      size_t                   transEnd;        //!< End of coordinates in transformation buffer (inclusive)
-      Route::MemberDirection   direction;
-    };
-
-    /**
-     * Data structure for holding temporary data about route
-     */
-    struct OSMSCOUT_MAP_API RouteData
-    {
-      LineStyleRef                lineStyle;       //!< Line style
-      Color                       color;           //!< Color of route
-      double                      lineWidth;
-      std::list<RouteSegmentData> transSegments;   //!< Transformation buffer segments
     };
 
     /**
@@ -239,7 +221,7 @@ namespace osmscout {
     std::list<AreaData>          areaData;
     std::list<WayData>           wayData;
     std::list<WayPathData>       wayPathData;
-    std::list<RouteData>         routeData;
+    // std::list<RouteData>         routeData;
     std::list<RouteLabelData>    routeLabelData;
 
     std::vector<TextStyleRef>    textStyles;     //!< Temporary storage for StyleConfig return value
@@ -441,10 +423,6 @@ namespace osmscout {
     void DrawAreas(const Projection& projection,
                    const MapParameter& parameter,
                    const MapData& data);
-
-    void DrawRoutes(const Projection& projection,
-                    const MapParameter& parameter,
-                    const MapData& data);
 
     void DrawWays(const Projection& projection,
                   const MapParameter& parameter,
@@ -652,11 +630,6 @@ namespace osmscout {
                                          double averageCharWidth,
                                          double objectWidth,
                                          size_t stringLength);
-
-    virtual void DrawRoute(const StyleConfig& styleConfig,
-                           const Projection& projection,
-                           const MapParameter& parameter,
-                           const RouteData& data);
 
     virtual void DrawWay(const StyleConfig& styleConfig,
                          const Projection& projection,

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -100,6 +100,8 @@ namespace osmscout {
     double                              contourLabelSpace;         //!< Space in mm between repetitive labels on the same contour
     double                              contourLabelPadding;       //!< Space around contour labels in mm (default 1).
 
+    std::string                         routeLabelSeparator;       //!< Separator of contour labels
+
     bool                                renderBackground;          //!< Render any background features, else render like the background should be transparent
     bool                                renderSeaLand;             //!< Rendering of sea/land tiles
     bool                                renderUnknowns;            //!< Unknown areas are not rendered (transparent)
@@ -159,6 +161,8 @@ namespace osmscout {
     void SetPatternSize(double size);
 
     void SetContourLabelPadding(double padding);
+
+    void SetRouteLabelSeparator(const std::string &separator);
 
     void SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels);
 
@@ -325,6 +329,11 @@ namespace osmscout {
     inline double GetContourLabelPadding() const
     {
       return contourLabelPadding;
+    }
+
+    inline std::string GetRouteLabelSeparator() const
+    {
+      return routeLabelSeparator;
     }
 
     inline bool GetDropNotVisiblePointLabels() const

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -114,7 +114,7 @@ namespace osmscout {
 
     bool                                showAltLanguage;           //!< if true, display alternative language (needs support by style sheet and import)
 
-    Locale                              locale;                     //!< Locale used by the renderer, for example peak elevation
+    Locale                              locale;                    //!< Locale used by the renderer, for example peak elevation
 
     std::vector<FillStyleProcessorRef > fillProcessors;            //!< List of processors for FillStyles for types
 

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -617,6 +617,8 @@ namespace osmscout {
     // Route
     std::vector<LineStyleLookupTable>          routeLineStyleSelectors;
     std::list<LineConditionalStyle>            routeLineStyleConditionals;
+    std::list<PathTextConditionalStyle>        routePathTextStyleConditionals;
+    PathTextStyleLookupTable                   routePathTextStyleSelectors;
 
     FillStyleLookupTable                       areaFillStyleSelectors;
     std::vector<BorderStyleLookupTable>        areaBorderStyleSelectors;
@@ -714,6 +716,8 @@ namespace osmscout {
 
     void AddRouteLineStyle(const StyleFilter& filter,
                            LinePartialStyle& style);
+    void AddRoutePathTextStyle(const StyleFilter& filter,
+                               PathTextPartialStyle& style);
 
     void GetNodeTypesWithMaxMag(const Magnification& maxMag,
                                 TypeInfoSet& types) const;
@@ -758,6 +762,9 @@ namespace osmscout {
                                          const Projection& projection) const;
     PathShieldStyleRef GetWayPathShieldStyle(const FeatureValueBuffer& buffer,
                                              const Projection& projection) const;
+
+    PathTextStyleRef GetRoutePathTextStyle(const FeatureValueBuffer& buffer,
+                                           const Projection& projection) const;
 
     void GetRouteLineStyles(const FeatureValueBuffer& buffer,
                             const Projection& projection,

--- a/libosmscout-map/include/osmscout/oss/Parser.h
+++ b/libosmscout-map/include/osmscout/oss/Parser.h
@@ -282,6 +282,7 @@ void AddFeatureToFilter(StyleFilter& filter,
 	void WAYPATHSYMBOLSTYLE(StyleFilter filter, bool state);
 	void WAYSHIELDSTYLE(StyleFilter filter, bool state);
 	void LINESTYLEATTR(LinePartialStyle& style);
+	void ROUTEPATHTEXTSTYLE(StyleFilter filter, bool state);
 	void PATHTEXTSTYLEATTR(PathTextPartialStyle& style);
 	void PATHSYMBOLSTYLEATTR(PathSymbolPartialStyle& style);
 	void PATHSHIELDSTYLEATTR(PathShieldPartialStyle& style);

--- a/libosmscout-map/parser/OSS/OSS.atg
+++ b/libosmscout-map/parser/OSS/OSS.atg
@@ -1050,6 +1050,23 @@ PRODUCTIONS
                 .)
                 .
 
+  ROUTEPATHTEXTSTYLE<StyleFilter filter, bool state>
+              = SYNC "TEXT"
+                (.
+                  PathTextPartialStyle style;
+                .)
+                SYNC "{"
+                {
+                  PATHTEXTSTYLEATTR<style> WEAK ";"
+                }
+                SYNC "}"
+                (.
+                  if (state) {
+                    config.AddRoutePathTextStyle(filter,style);
+                  }
+                .)
+                .
+
   WAYPATHTEXTSTYLE<StyleFilter filter, bool state>
               = SYNC "TEXT"
                 (.
@@ -1237,10 +1254,10 @@ PRODUCTIONS
                 = SYNC "ROUTE"
                 (
                   ROUTESTYLE<filter,state>
-                  /*| "."
+                | "."
                   (
                     ROUTEPATHTEXTSTYLE<filter,state>
-                  )*/
+                  )
                 )
                 .
 

--- a/libosmscout-map/parser/OSS/Scanner.frame
+++ b/libosmscout-map/parser/OSS/Scanner.frame
@@ -7,7 +7,7 @@
 #include <map>
 #include <memory>
 
-#include <osmscout/system/OSMScoutTypes.h>
+#include <osmscout/system/SystemTypes.h>
 
 -->namespace_open
 

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -192,7 +192,6 @@ namespace osmscout {
     stepMethods[RenderSteps::DrawGroundTiles]=&MapPainter::DrawGroundTiles;
     stepMethods[RenderSteps::DrawOSMTileGrids]=&MapPainter::DrawOSMTileGrids;
     stepMethods[RenderSteps::DrawAreas]=&MapPainter::DrawAreas;
-    stepMethods[RenderSteps::DrawRoutes]=&MapPainter::DrawRoutes;
     stepMethods[RenderSteps::DrawWays]=&MapPainter::DrawWays;
     stepMethods[RenderSteps::DrawWayDecorations]=&MapPainter::DrawWayDecorations;
     stepMethods[RenderSteps::DrawWayContourLabels]=&MapPainter::DrawWayContourLabels;
@@ -999,51 +998,11 @@ namespace osmscout {
                       x,y);
   }
 
-  void MapPainter::DrawRoute(const StyleConfig& /*styleConfig*/,
-                             const Projection& projection,
-                             const MapParameter& parameter,
-                             const RouteData& data)
-  {
-    assert(data.lineStyle);
-
-    auto DrawSegments=[&](const Color &color,
-                          const std::vector<double> &dash){
-
-      size_t size=data.transSegments.size();
-      size_t i=0;
-      for (const auto &segment:data.transSegments) {
-        assert(segment.transStart < segment.transEnd);
-        DrawPath(projection,
-                 parameter,
-                 color,
-                 data.lineWidth,
-                 dash,
-                 (i==0 ? data.lineStyle->GetEndCap() : data.lineStyle->GetJoinCap()),
-                 (i==size-1 ? data.lineStyle->GetEndCap(): data.lineStyle->GetJoinCap()),
-                 segment.transStart, segment.transEnd);
-        i++;
-      }
-    };
-
-    if (data.lineStyle->HasDashes() &&
-        data.lineStyle->GetGapColor().IsVisible()) {
-
-      // Draw the background of a dashed line
-      DrawSegments(data.lineStyle->GetGapColor(),
-                   emptyDash);
-    }
-
-    DrawSegments(data.color,
-                 data.lineStyle->GetDash());
-  }
-
   void MapPainter::DrawWay(const StyleConfig& /*styleConfig*/,
                            const Projection& projection,
                            const MapParameter& parameter,
                            const WayData& data)
   {
-    Color color=data.lineStyle->GetLineColor();
-
     if (data.lineStyle->HasDashes() &&
         data.lineStyle->GetGapColor().IsVisible()) {
       // Draw the background of a dashed line
@@ -1059,7 +1018,7 @@ namespace osmscout {
 
     DrawPath(projection,
              parameter,
-             color,
+             data.color,
              data.lineWidth,
              data.lineStyle->GetDash(),
              data.startIsClosed ? data.lineStyle->GetEndCap() : data.lineStyle->GetJoinCap(),
@@ -1314,6 +1273,7 @@ namespace osmscout {
       data.buffer=&coastlineSegmentAttributes;
       data.layer=0;
       data.lineStyle=osmTileLine;
+      data.color=osmTileLine->GetLineColor();
       data.wayPriority=std::numeric_limits<size_t>::max();
       data.transStart=transStart;
       data.transEnd=transEnd;
@@ -1349,6 +1309,7 @@ namespace osmscout {
       data.buffer=&coastlineSegmentAttributes;
       data.layer=0;
       data.lineStyle=osmTileLine;
+      data.color=osmTileLine->GetLineColor();
       data.wayPriority=std::numeric_limits<size_t>::max();
       data.transStart=transStart;
       data.transEnd=transEnd;
@@ -1758,9 +1719,18 @@ namespace osmscout {
         wayPathData.push_back(pathData);
       }
 
+      Color color=lineStyle->GetLineColor();
+      if (lineStyle->GetPreferColorFeature()){
+        ColorFeatureValue *colorValue=colorReader.GetValue(buffer);
+        if (colorValue != nullptr){
+          color=colorValue->GetColor();
+        }
+      }
+
       data.layer=0;
       data.buffer=&buffer;
       data.lineStyle=lineStyle;
+      data.color=color;
       data.wayPriority=styleConfig.GetWayPrio(buffer.GetType());
       data.startIsClosed=way.nodes[0].GetSerial()==0;
       data.endIsClosed=way.nodes[way.nodes.size()-1].GetSerial()==0;
@@ -1891,7 +1861,24 @@ namespace osmscout {
       return;
     }
 
-    struct WayRoutes {
+    struct RouteSegmentData
+    {
+      size_t                   transStart;      //!< Start of coordinates in transformation buffer
+      size_t                   transEnd;        //!< End of coordinates in transformation buffer (inclusive)
+      Route::MemberDirection   direction;
+    };
+
+    // Data structure for holding temporary data about route
+    struct RouteData
+    {
+      LineStyleRef                lineStyle;       //!< Line style
+      Color                       color;           //!< Color of route
+      double                      lineWidth;
+      std::list<RouteSegmentData> transSegments;   //!< Transformation buffer segments
+    };
+
+    struct WayRoutes
+    {
       WayPathDataIt wayData;
       std::set<Color> colors; // collapse "sidecar" routes with same color
       double rightSideCarPos=0;
@@ -1953,7 +1940,26 @@ namespace osmscout {
           routeTmp.lineStyle=lineStyle;
           routeTmp.lineWidth=lineWidth;
           routeTmp.color=color;
-          routeData.push_back(std::move(routeTmp));
+
+          size_t size=routeTmp.transSegments.size();
+          size_t i=0;
+          for (const auto &segment : routeTmp.transSegments) {
+            assert(segment.transStart < segment.transEnd);
+            WayData segmentWay;
+            segmentWay.buffer=&(route->GetFeatureValueBuffer());
+            segmentWay.layer=0;
+            segmentWay.lineStyle=lineStyle;
+            segmentWay.color=color;
+            segmentWay.wayPriority=lineStyle->GetPriority();
+            segmentWay.transStart=segment.transStart;
+            segmentWay.transEnd=segment.transEnd;
+            segmentWay.lineWidth=lineWidth;
+            segmentWay.startIsClosed=(i==0);
+            segmentWay.endIsClosed=(i==size-1);
+            wayData.push_back(segmentWay);
+            i++;
+          }
+
           routeTmp = RouteData();
         }
       };
@@ -2197,7 +2203,6 @@ namespace osmscout {
     }
 
     StopClock prepareRoutesTimer;
-    routeData.clear();
     routeLabelData.clear();
 
     PrepareRoutes(*styleConfig,
@@ -2485,6 +2490,7 @@ namespace osmscout {
               wd.buffer=&coastlineSegmentAttributes;
               wd.layer=0;
               wd.lineStyle=coastlineLine;
+              wd.color=coastlineLine->GetLineColor();
               wd.wayPriority=std::numeric_limits<size_t>::max();
               wd.transStart=start+lineStart;
               wd.transEnd=start+lineEnd;
@@ -2598,27 +2604,6 @@ namespace osmscout {
     if (parameter.IsDebugPerformance() && timer.IsSignificant()) {
       log.Info()
         << "Draw areas: " << areaData.size() << " (pcs) " << timer.ResultString() << " (s)";
-    }
-  }
-
-  void MapPainter::DrawRoutes(const Projection& projection,
-                              const MapParameter& parameter,
-                              const MapData& /*data*/)
-  {
-    StopClock timer;
-
-    for (const auto& route : routeData) {
-      DrawRoute(*styleConfig,
-                projection,
-                parameter,
-                route);
-    }
-
-    timer.Stop();
-
-    if (parameter.IsDebugPerformance() && timer.IsSignificant()) {
-      log.Info()
-          << "Draw ways: " << wayData.size() << " (pcs) " << timer.ResultString() << " (s)";
     }
   }
 

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -2817,7 +2817,7 @@ namespace osmscout {
              it!=labelEntry.second.end();
              ++it){
           if (it!=labelEntry.second.begin()){
-            labels << ", "; // TODO: make separator configurable, possibly by MapParameter
+            labels << parameter.GetRouteLabelSeparator();
           }
           labels << *it;
         }

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -51,6 +51,7 @@ namespace osmscout {
     contourLabelOffset(50.0),
     contourLabelSpace(100.0),
     contourLabelPadding(1.0),
+    routeLabelSeparator(", "),
     renderBackground(true),
     renderSeaLand(false),
     renderUnknowns(false),
@@ -186,6 +187,11 @@ namespace osmscout {
   void MapParameter::SetContourLabelPadding(double padding)
   {
     this->contourLabelPadding=padding;
+  }
+
+  void MapParameter::SetRouteLabelSeparator(const std::string &separator)
+  {
+    this->routeLabelSeparator=separator;
   }
 
   void MapParameter::SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels)

--- a/libosmscout-map/src/osmscout/StyleConfig.cpp
+++ b/libosmscout-map/src/osmscout/StyleConfig.cpp
@@ -387,6 +387,7 @@ namespace osmscout {
 
     routeTypeSets.clear();
     routeLineStyleSelectors.clear();
+    routePathTextStyleConditionals.clear();
 
     constants.clear();
   }
@@ -814,6 +815,13 @@ namespace osmscout {
     size_t maxLevel=0;
     GetMaxLevelInConditionals(routeLineStyleConditionals,
                               maxLevel);
+    GetMaxLevelInConditionals(routePathTextStyleConditionals,
+                              maxLevel);
+
+    SortInConditionals(*typeConfig,
+                       routePathTextStyleConditionals,
+                       maxLevel,
+                       routePathTextStyleSelectors);
 
     routeTypeSets.reserve(maxLevel);
 
@@ -826,12 +834,18 @@ namespace osmscout {
                        maxLevel,
                        routeTypeSets);
 
+    CalculateUsedTypes(*typeConfig,
+                       routePathTextStyleConditionals,
+                       maxLevel,
+                       routeTypeSets);
+
     SortInConditionalsBySlot(*typeConfig,
                              routeLineStyleConditionals,
                              maxLevel,
                              routeLineStyleSelectors);
 
     routeLineStyleConditionals.clear();
+    routePathTextStyleConditionals.clear();
   }
 
   void StyleConfig::PostprocessIconId()
@@ -1046,6 +1060,14 @@ namespace osmscout {
     LineConditionalStyle conditional(filter,style);
 
     routeLineStyleConditionals.push_back(conditional);
+  }
+
+  void StyleConfig::AddRoutePathTextStyle(const StyleFilter& filter,
+                                          PathTextPartialStyle& style)
+  {
+    PathTextConditionalStyle conditional(filter,style);
+
+    routePathTextStyleConditionals.push_back(conditional);
   }
 
   void StyleConfig::GetNodeTypesWithMaxMag(const Magnification& maxMag,
@@ -1272,6 +1294,15 @@ namespace osmscout {
   {
     return GetFeatureStyle(styleResolveContext,
                            wayPathTextStyleSelectors[buffer.GetType()->GetIndex()],
+                           buffer,
+                           projection);
+  }
+
+  PathTextStyleRef StyleConfig::GetRoutePathTextStyle(const FeatureValueBuffer& buffer,
+                                                      const Projection& projection) const
+  {
+    return GetFeatureStyle(styleResolveContext,
+                           routePathTextStyleSelectors[buffer.GetType()->GetIndex()],
                            buffer,
                            projection);
   }

--- a/libosmscout-map/src/osmscout/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscout/oss/Parser.cpp
@@ -1308,11 +1308,16 @@ void Parser::AREASTYLEDEF(StyleFilter filter, bool state) {
 void Parser::ROUTESTYLEDEF(StyleFilter filter, bool state) {
 		while (!(la->kind == _EOF || la->kind == 57 /* "ROUTE" */)) {SynErr(99); Get();}
 		Expect(57 /* "ROUTE" */);
-		ROUTESTYLE(filter,state);
+		if (la->kind == 11 /* "{" */) {
+			ROUTESTYLE(filter,state);
+		} else if (la->kind == 24 /* "." */) {
+			Get();
+			ROUTEPATHTEXTSTYLE(filter,state);
+		} else SynErr(100);
 }
 
 void Parser::NODETEXTSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(100); Get();}
+		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(101); Get();}
 		Expect(50 /* "TEXT" */);
 		TextPartialStyle style;
 		std::string      slot;
@@ -1322,13 +1327,13 @@ void Parser::NODETEXTSTYLE(StyleFilter filter, bool state) {
 			IDENT(slot);
 			style.style->SetSlot(slot); 
 		}
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(101); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(102); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			TEXTSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(102); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(103); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddNodeTextStyle(filter,style);
@@ -1337,17 +1342,17 @@ void Parser::NODETEXTSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::NODEICONSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 52 /* "ICON" */)) {SynErr(103); Get();}
+		while (!(la->kind == _EOF || la->kind == 52 /* "ICON" */)) {SynErr(104); Get();}
 		Expect(52 /* "ICON" */);
 		IconPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(104); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(105); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			ICONSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(105); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(106); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddNodeIconStyle(filter,style);
@@ -1372,13 +1377,13 @@ void Parser::WAYSTYLE(StyleFilter filter, bool state) {
 			IDENT(slot);
 			style.style->SetSlot(slot); 
 		}
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(106); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(107); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			LINESTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(107); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(108); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddWayLineStyle(filter,style);
@@ -1387,17 +1392,17 @@ void Parser::WAYSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::WAYPATHTEXTSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(108); Get();}
+		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(109); Get();}
 		Expect(50 /* "TEXT" */);
 		PathTextPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(109); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(110); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			PATHTEXTSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(110); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(111); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddWayPathTextStyle(filter,style);
@@ -1406,7 +1411,7 @@ void Parser::WAYPATHTEXTSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::WAYPATHSYMBOLSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 21 /* "SYMBO" */)) {SynErr(111); Get();}
+		while (!(la->kind == _EOF || la->kind == 21 /* "SYMBO" */)) {SynErr(112); Get();}
 		Expect(21 /* "SYMBO" */);
 		PathSymbolPartialStyle style;
 		std::string      slot;
@@ -1416,13 +1421,13 @@ void Parser::WAYPATHSYMBOLSTYLE(StyleFilter filter, bool state) {
 			IDENT(slot);
 			style.style->SetSlot(slot); 
 		}
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(112); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(113); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			PATHSYMBOLSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(113); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(114); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddWayPathSymbolStyle(filter,style);
@@ -1431,17 +1436,17 @@ void Parser::WAYPATHSYMBOLSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::WAYSHIELDSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 54 /* "SHIELD" */)) {SynErr(114); Get();}
+		while (!(la->kind == _EOF || la->kind == 54 /* "SHIELD" */)) {SynErr(115); Get();}
 		Expect(54 /* "SHIELD" */);
 		PathShieldPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(115); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(116); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			PATHSHIELDSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(116); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(117); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddWayPathShieldStyle(filter,style);
@@ -1451,6 +1456,25 @@ void Parser::WAYSHIELDSTYLE(StyleFilter filter, bool state) {
 
 void Parser::LINESTYLEATTR(LinePartialStyle& style) {
 		ATTRIBUTE(style,*LineStyle::GetDescriptor());
+}
+
+void Parser::ROUTEPATHTEXTSTYLE(StyleFilter filter, bool state) {
+		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(118); Get();}
+		Expect(50 /* "TEXT" */);
+		PathTextPartialStyle style;
+		
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(119); Get();}
+		Expect(11 /* "{" */);
+		while (la->kind == _ident || la->kind == 58 /* "name" */) {
+			PATHTEXTSTYLEATTR(style);
+			ExpectWeak(16 /* ";" */, 1);
+		}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(120); Get();}
+		Expect(12 /* "}" */);
+		if (state) {
+		 config.AddRoutePathTextStyle(filter,style);
+		}
+		
 }
 
 void Parser::PATHTEXTSTYLEATTR(PathTextPartialStyle& style) {
@@ -1468,13 +1492,13 @@ void Parser::PATHSHIELDSTYLEATTR(PathShieldPartialStyle& style) {
 void Parser::AREASTYLE(StyleFilter filter, bool state) {
 		FillPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(117); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(121); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			FILLSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(118); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(122); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaFillStyle(filter,style);
@@ -1483,7 +1507,7 @@ void Parser::AREASTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::AREATEXTSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(119); Get();}
+		while (!(la->kind == _EOF || la->kind == 50 /* "TEXT" */)) {SynErr(123); Get();}
 		Expect(50 /* "TEXT" */);
 		TextPartialStyle style;
 		std::string      slot;
@@ -1493,13 +1517,13 @@ void Parser::AREATEXTSTYLE(StyleFilter filter, bool state) {
 			IDENT(slot);
 			style.style->SetSlot(slot); 
 		}
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(120); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(124); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			TEXTSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(121); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(125); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaTextStyle(filter,style);
@@ -1508,17 +1532,17 @@ void Parser::AREATEXTSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::AREAICONSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 52 /* "ICON" */)) {SynErr(122); Get();}
+		while (!(la->kind == _EOF || la->kind == 52 /* "ICON" */)) {SynErr(126); Get();}
 		Expect(52 /* "ICON" */);
 		IconPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(123); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(127); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			ICONSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(124); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(128); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaIconStyle(filter,style);
@@ -1527,7 +1551,7 @@ void Parser::AREAICONSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::AREABORDERSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 22 /* "BORDER" */)) {SynErr(125); Get();}
+		while (!(la->kind == _EOF || la->kind == 22 /* "BORDER" */)) {SynErr(129); Get();}
 		Expect(22 /* "BORDER" */);
 		BorderPartialStyle style;
 		std::string        slot;
@@ -1537,13 +1561,13 @@ void Parser::AREABORDERSTYLE(StyleFilter filter, bool state) {
 			IDENT(slot);
 			style.style->SetSlot(slot); 
 		}
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(126); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(130); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			BORDERSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(127); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(131); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaBorderStyle(filter,style);
@@ -1552,17 +1576,17 @@ void Parser::AREABORDERSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::AREABORDERTEXTSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 55 /* "BORDERTEXT" */)) {SynErr(128); Get();}
+		while (!(la->kind == _EOF || la->kind == 55 /* "BORDERTEXT" */)) {SynErr(132); Get();}
 		Expect(55 /* "BORDERTEXT" */);
 		PathTextPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(129); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(133); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			PATHTEXTSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(130); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(134); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaBorderTextStyle(filter,style);
@@ -1571,17 +1595,17 @@ void Parser::AREABORDERTEXTSTYLE(StyleFilter filter, bool state) {
 }
 
 void Parser::AREABORDERSYMBOLSTYLE(StyleFilter filter, bool state) {
-		while (!(la->kind == _EOF || la->kind == 56 /* "BORDERSYMBO" */)) {SynErr(131); Get();}
+		while (!(la->kind == _EOF || la->kind == 56 /* "BORDERSYMBO" */)) {SynErr(135); Get();}
 		Expect(56 /* "BORDERSYMBO" */);
 		PathSymbolPartialStyle style;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(132); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(136); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			PATHSYMBOLSTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(133); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(137); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddAreaBorderSymbolStyle(filter,style);
@@ -1593,13 +1617,13 @@ void Parser::ROUTESTYLE(StyleFilter filter, bool state) {
 		LinePartialStyle style;
 		std::string      slot;
 		
-		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(134); Get();}
+		while (!(la->kind == _EOF || la->kind == 11 /* "{" */)) {SynErr(138); Get();}
 		Expect(11 /* "{" */);
 		while (la->kind == _ident || la->kind == 58 /* "name" */) {
 			LINESTYLEATTR(style);
 			ExpectWeak(16 /* ";" */, 1);
 		}
-		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(135); Get();}
+		while (!(la->kind == _EOF || la->kind == 12 /* "}" */)) {SynErr(139); Get();}
 		Expect(12 /* "}" */);
 		if (state) {
 		 config.AddRouteLineStyle(filter,style);
@@ -1616,7 +1640,7 @@ void Parser::ATTRIBUTE(PartialStyleBase& style, const StyleDescriptor& descripto
 		} else if (la->kind == 58 /* "name" */) {
 			Get();
 			attributeName="name"; 
-		} else SynErr(136);
+		} else SynErr(140);
 		attributeDescriptor=descriptor.GetAttribute(attributeName);
 		
 		if (!attributeDescriptor) {
@@ -1669,7 +1693,7 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 						COLOR_VALUE(color);
 					} else if (la->kind == _variable) {
 						CONSTANT(constant);
-					} else SynErr(137);
+					} else SynErr(141);
 					Expect(20 /* "," */);
 					UDOUBLE(factor);
 					Expect(63 /* ")" */);
@@ -1680,7 +1704,7 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 					} else if (la->kind == 58 /* "name" */) {
 						Get();
 						subIdent="name"; 
-					} else SynErr(138);
+					} else SynErr(142);
 				}
 			}
 		} else if (la->kind == _string) {
@@ -1715,7 +1739,7 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 					} else if (la->kind == _double) {
 						Get();
 						numberList.push_back(t->val); 
-					} else SynErr(139);
+					} else SynErr(143);
 				}
 			} else if (la->kind == _double) {
 				Get();
@@ -1741,16 +1765,16 @@ void Parser::ATTRIBUTEVALUE(PartialStyleBase& style, const StyleAttributeDescrip
 					} else if (la->kind == _double) {
 						Get();
 						numberList.push_back(t->val); 
-					} else SynErr(140);
+					} else SynErr(144);
 				}
-			} else SynErr(141);
+			} else SynErr(145);
 		} else if (la->kind == _color) {
 			COLOR_VALUE(color);
 			valueType=ValueType::COLOR; 
 		} else if (la->kind == _variable) {
 			CONSTANT(constant);
 			valueType=ValueType::CONSTANT; 
-		} else SynErr(142);
+		} else SynErr(146);
 		if (descriptor.GetType()==StyleAttributeType::TYPE_BOOL) {
 		 if (valueType==ValueType::IDENT) {
 		   if (ident=="true" && subIdent.empty()) {
@@ -2548,49 +2572,53 @@ void Errors::SynErr(int line, int col, int n)
 			case 97: s = coco_string_create("invalid AREASTYLEDEF"); break;
 			case 98: s = coco_string_create("invalid AREASTYLEDEF"); break;
 			case 99: s = coco_string_create("this symbol not expected in ROUTESTYLEDEF"); break;
-			case 100: s = coco_string_create("this symbol not expected in NODETEXTSTYLE"); break;
+			case 100: s = coco_string_create("invalid ROUTESTYLEDEF"); break;
 			case 101: s = coco_string_create("this symbol not expected in NODETEXTSTYLE"); break;
 			case 102: s = coco_string_create("this symbol not expected in NODETEXTSTYLE"); break;
-			case 103: s = coco_string_create("this symbol not expected in NODEICONSTYLE"); break;
+			case 103: s = coco_string_create("this symbol not expected in NODETEXTSTYLE"); break;
 			case 104: s = coco_string_create("this symbol not expected in NODEICONSTYLE"); break;
 			case 105: s = coco_string_create("this symbol not expected in NODEICONSTYLE"); break;
-			case 106: s = coco_string_create("this symbol not expected in WAYSTYLE"); break;
+			case 106: s = coco_string_create("this symbol not expected in NODEICONSTYLE"); break;
 			case 107: s = coco_string_create("this symbol not expected in WAYSTYLE"); break;
-			case 108: s = coco_string_create("this symbol not expected in WAYPATHTEXTSTYLE"); break;
+			case 108: s = coco_string_create("this symbol not expected in WAYSTYLE"); break;
 			case 109: s = coco_string_create("this symbol not expected in WAYPATHTEXTSTYLE"); break;
 			case 110: s = coco_string_create("this symbol not expected in WAYPATHTEXTSTYLE"); break;
-			case 111: s = coco_string_create("this symbol not expected in WAYPATHSYMBOLSTYLE"); break;
+			case 111: s = coco_string_create("this symbol not expected in WAYPATHTEXTSTYLE"); break;
 			case 112: s = coco_string_create("this symbol not expected in WAYPATHSYMBOLSTYLE"); break;
 			case 113: s = coco_string_create("this symbol not expected in WAYPATHSYMBOLSTYLE"); break;
-			case 114: s = coco_string_create("this symbol not expected in WAYSHIELDSTYLE"); break;
+			case 114: s = coco_string_create("this symbol not expected in WAYPATHSYMBOLSTYLE"); break;
 			case 115: s = coco_string_create("this symbol not expected in WAYSHIELDSTYLE"); break;
 			case 116: s = coco_string_create("this symbol not expected in WAYSHIELDSTYLE"); break;
-			case 117: s = coco_string_create("this symbol not expected in AREASTYLE"); break;
-			case 118: s = coco_string_create("this symbol not expected in AREASTYLE"); break;
-			case 119: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
-			case 120: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
-			case 121: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
-			case 122: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
-			case 123: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
-			case 124: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
-			case 125: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
-			case 126: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
-			case 127: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
-			case 128: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
-			case 129: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
-			case 130: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
-			case 131: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
-			case 132: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
-			case 133: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
-			case 134: s = coco_string_create("this symbol not expected in ROUTESTYLE"); break;
-			case 135: s = coco_string_create("this symbol not expected in ROUTESTYLE"); break;
-			case 136: s = coco_string_create("invalid ATTRIBUTE"); break;
-			case 137: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
-			case 138: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
-			case 139: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
-			case 140: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
+			case 117: s = coco_string_create("this symbol not expected in WAYSHIELDSTYLE"); break;
+			case 118: s = coco_string_create("this symbol not expected in ROUTEPATHTEXTSTYLE"); break;
+			case 119: s = coco_string_create("this symbol not expected in ROUTEPATHTEXTSTYLE"); break;
+			case 120: s = coco_string_create("this symbol not expected in ROUTEPATHTEXTSTYLE"); break;
+			case 121: s = coco_string_create("this symbol not expected in AREASTYLE"); break;
+			case 122: s = coco_string_create("this symbol not expected in AREASTYLE"); break;
+			case 123: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
+			case 124: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
+			case 125: s = coco_string_create("this symbol not expected in AREATEXTSTYLE"); break;
+			case 126: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
+			case 127: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
+			case 128: s = coco_string_create("this symbol not expected in AREAICONSTYLE"); break;
+			case 129: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
+			case 130: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
+			case 131: s = coco_string_create("this symbol not expected in AREABORDERSTYLE"); break;
+			case 132: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
+			case 133: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
+			case 134: s = coco_string_create("this symbol not expected in AREABORDERTEXTSTYLE"); break;
+			case 135: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
+			case 136: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
+			case 137: s = coco_string_create("this symbol not expected in AREABORDERSYMBOLSTYLE"); break;
+			case 138: s = coco_string_create("this symbol not expected in ROUTESTYLE"); break;
+			case 139: s = coco_string_create("this symbol not expected in ROUTESTYLE"); break;
+			case 140: s = coco_string_create("invalid ATTRIBUTE"); break;
 			case 141: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
 			case 142: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
+			case 143: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
+			case 144: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
+			case 145: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
+			case 146: s = coco_string_create("invalid ATTRIBUTEVALUE"); break;
 
     default:
     {

--- a/stylesheets/public-transport.oss
+++ b/stylesheets/public-transport.oss
@@ -210,6 +210,19 @@ STYLE
 
   // -------------------------------------------------------
   //
+  // Bus & Tram routes
+  //
+  [TYPE route_bus]  {
+    [MAG detail-] ROUTE {color: #5e6cecd0; offsetRel: sidecar; displayWidth: 0.2mm; priority: -5; }
+    [MAG close-] ROUTE.TEXT {label: Ref.name; color: #5e6cec; size: 1.0; displayOffset: 3.0mm; priority: 19;}
+  }
+  [TYPE route_tram]  {
+    [MAG detail-] ROUTE {color: #b05bec; offsetRel: sidecar; displayWidth: 0.2mm; priority: -4; }
+    [MAG close-] ROUTE.TEXT {label: Ref.name; color: #b05bec; size: 1.0; displayOffset: 3.0mm; priority: 19;}
+  }
+
+  // -------------------------------------------------------
+  //
   // Places
   //
 
@@ -267,7 +280,7 @@ STYLE
     [MAG cityOver-] WAY { color: #ffffff; displayWidth: 0.5mm; width: 18m;}
     [MAG detail-] {
       WAY#outline { color: #808080; width: 18m; displayWidth: 0.55mm; priority: -1; joinCap: butt; }
-      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; }
+      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; priority: 20; }
     }
   }
   [TYPE highway_trunk, highway_trunk_link] {
@@ -275,7 +288,7 @@ STYLE
     [MAG detail-] WAY { color: #f8f8f8; }
     [MAG close-] {
       WAY#outline { color: #808080; width: 18m; displayWidth: 0.55mm; priority: -1; joinCap: butt; }
-      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; }
+      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; priority: 20; }
     }
   }
   [TYPE highway_primary, highway_motorway_primary] {
@@ -284,7 +297,7 @@ STYLE
     [MAG detail-] WAY { color: #f8f8f8; }
     [MAG close-] {
       WAY#outline { color: #808080; width: 14m; displayWidth: 0.45mm; priority: -1; joinCap: butt; }
-      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; }
+      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; priority: 20; }
     }
   }
   [TYPE highway_secondary, highway_secondary_link] {
@@ -292,7 +305,7 @@ STYLE
     [MAG detail-] WAY { color: #f8f8f8; }
     [MAG closer-] {
       WAY#outline { color: #808080; width: 10m; displayWidth: 0.45mm; priority: -1; joinCap: butt; }
-      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; }
+      WAY.TEXT{label: Name.name; color: #000000; size: 1.0; priority: 20; }
     }
   }
   [TYPE highway_tertiary,
@@ -306,7 +319,7 @@ STYLE
     [MAG veryClose-] WAY { color: #f8f8f8; }
     [MAG veryClose-] {
       WAY#outline { color: #808080; width: 8m; displayWidth: 0.35mm; priority: -1; joinCap: butt; }
-      WAY.TEXT{label: Name.name; color: #404040; size: 1.0; }
+      WAY.TEXT{label: Name.name; color: #404040; size: 1.0; priority: 20; }
     }
   }
 

--- a/stylesheets/public-transport.oss
+++ b/stylesheets/public-transport.oss
@@ -99,7 +99,7 @@ STYLE
     [MAG cityOver-] WAY {color: #8090c0; dash: 1.5,1.0; displayWidth: 0.6mm; joinCap: butt; endCap: butt; }    
   }
   [TYPE route_subway]  {
-    [MAG suburb-] ROUTE {color: #8090c0; preferColorFeature: true; offsetRel: sidecar; displayWidth: 0.8mm; priority: -10; }
+    [MAG suburb-] ROUTE {color: #8090c0; preferColorFeature: true; offsetRel: sidecar; displayWidth: 0.8mm; priority: 60; }
   }
 
   // -------------------------------------------------------
@@ -213,11 +213,11 @@ STYLE
   // Bus & Tram routes
   //
   [TYPE route_bus]  {
-    [MAG detail-] ROUTE {color: #5e6cecd0; offsetRel: sidecar; displayWidth: 0.2mm; priority: -5; }
+    [MAG detail-] ROUTE {color: #5e6cecd0; offsetRel: sidecar; displayWidth: 0.2mm; priority: 50; }
     [MAG close-] ROUTE.TEXT {label: Ref.name; color: #5e6cec; size: 1.0; displayOffset: 3.0mm; priority: 19;}
   }
   [TYPE route_tram]  {
-    [MAG detail-] ROUTE {color: #b05bec; offsetRel: sidecar; displayWidth: 0.2mm; priority: -4; }
+    [MAG detail-] ROUTE {color: #b05bec; offsetRel: sidecar; displayWidth: 0.2mm; priority: 50; }
     [MAG close-] ROUTE.TEXT {label: Ref.name; color: #b05bec; size: 1.0; displayOffset: 3.0mm; priority: 19;}
   }
 

--- a/webpage/content/documentation/stylesheet.md
+++ b/webpage/content/documentation/stylesheet.md
@@ -263,8 +263,14 @@ with values ("`<attributeName> : <value> ;`") and a closing
   * `leftOutline` - offset in relation to the left outline 
   * `rightOutline` - offset in relation to the right outline
   * `laneDivider` - offset on each lane divider - if lane information is
-  available for the given way and the numbe rof lanes is greater than 1.
-
+    available for the given way and the numbe rof lanes is greater than 1
+  * `laneForwardLeft`, `laneForwardThroughLeft`, `laneForwardThrough`, 
+    `laneForwardThroughRight`, `laneForwardRight`, `laneBackwardLeft`, 
+    `laneBackwardThroughLeft`, `laneBackwardThrough`, `laneBackwardThroughRight`, 
+    `laneBackwardRight` - when way has explicit turns, these offsets may be used 
+    to decorate them specially 
+  * `sidecar` - special offset available for routes, line are stacked next to way,
+    same colors are "collapsed"
   
 ## Slots
 
@@ -278,28 +284,28 @@ In this case the style name is postpended by an `#` and a slot name.
 Currently allowed instances:
 
 * `WAY#<slot>`
+* `ROUTE`
 
 The line style has the following attributes:
 
-Name         |Type         |Default |Description
--------------|-------------|--------|-----------
-color        |Color        |red     |Color of the line. if not set, color is transparent (a lines is not drawn)
-dash         |Dash         |        |Size of the dashes. If not set lines is solid
-gapColor     |Color        |red     |Color drawn in the "gap", if not set gapColor is transparent
-displayWidth |ScreenSize   |0       |width of the line in millimeter ("size on map")
-width        |GroundSize   |0       |width of the line in meters ("real word dimension"). Note that if the object itself has a "width" feature, this value will be replaced with the actual value!
-displayOffset|ScreenSize   |0       |Offset of drawn line in relation to the actual path.
-offset       |GroundSize   |0       |Offset of the drawn line in relation to the actual path.
-joinCap      |Cap          |round   |Cap in case where lines join.
-endCap       |Cap          |round   |Cap in the case where the lines ends without joining another line.
-priority     |Int          |0       |Drawing priority in relation to other slots/pathes of the same object. Smaller values are drawn first.
-offsetRel    |OffsetRel    |0       |Position the way offset is relative to
+Name               |Type         |Default |Description
+-------------------|-------------|--------|-----------
+color              |Color        |red     |Color of the line. if not set, color is transparent (a lines is not drawn)
+preferColorFeature |Bool         |false   |When way has Color feature and this property is set to true, feature color will be used
+dash               |Dash         |        |Size of the dashes. If not set lines is solid
+gapColor           |Color        |red     |Color drawn in the "gap", if not set gapColor is transparent
+displayWidth       |ScreenSize   |0       |width of the line in millimeter ("size on map")
+width              |GroundSize   |0       |width of the line in meters ("real word dimension"). Note that if the object itself has a "width" feature, this value will be replaced with the actual value!
+displayOffset      |ScreenSize   |0       |Offset of drawn line in relation to the actual path.
+offset             |GroundSize   |0       |Offset of the drawn line in relation to the actual path.
+joinCap            |Cap          |round   |Cap in case where lines join.
+endCap             |Cap          |round   |Cap in the case where the lines ends without joining another line.
+priority           |Int          |0       |Drawing priority in relation to other slots/pathes of the same object. Smaller values are drawn first.
+offsetRel          |OffsetRel    |0       |Position the way offset is relative to
 
 If `displayWidth` and `width` are both set, the resulting pixel values will be added.
 
 ### BorderStyle - Border of areas
-
-### LineStyle - Drawing lines
 
 Currently allowed instances:
 
@@ -354,12 +360,13 @@ scaleMag     |Magnification                |1000000 |Starting with the given mag
 priority     |Int                          |max(Int)|numeric value defining a relative priority between labels. Labels with a lower value will be drawn in favour of labels with a higher priority value. Note that labels with a certain alpha value will be ignored (so giant scaleMag labels will not "kill" all other labels beneeth).
 autoSize     |Bool                         |false   |The size of the label is automatically scaled to fit the height of the area itself. Thus bigger areas will get bigger labels, label with not be higher than the actual area.
 
-### PathTextStyle - Draw labels onto ways and area borders
+### PathTextStyle - Draw labels onto ways, routes and area borders
 
 Currently allowed instances:
 
 * `WAY.TEXT`
 * `AREA.BORDERTEXT`
+* `ROUTE.TEXT`
 
 The text style for contour labels has the following attributes:
 


### PR DESCRIPTION
Route labels on same way are concatenated (one way may contains multiple routes) and rendered similar way as usual contour labels. That way, it is possible render all tram numbers that are passing some way...

![Screenshot_20201020_212732](https://user-images.githubusercontent.com/309458/96634617-13abc100-131b-11eb-9cf5-5c8c591a8c54.png)
