### PR TITLE
skip preparison of way labels/shields when there is no style for it

### DIFF
--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -760,8 +760,21 @@ namespace osmscout {
                                std::vector<PathSymbolStyleRef> &symbolStyles) const;
     PathTextStyleRef GetWayPathTextStyle(const FeatureValueBuffer& buffer,
                                          const Projection& projection) const;
+
+    /**
+     * @param projection
+     * @return true when some way text style is defined on provided projection
+     */
+    bool HasWayPathTextStyle(const Projection& projection) const;
+
     PathShieldStyleRef GetWayPathShieldStyle(const FeatureValueBuffer& buffer,
                                              const Projection& projection) const;
+
+    /**
+     * @param projection
+     * @return true when some way shield style is defined on provided projection
+     */
+    bool HasWayPathShieldStyle(const Projection& projection) const;
 
     PathTextStyleRef GetRoutePathTextStyle(const FeatureValueBuffer& buffer,
                                            const Projection& projection) const;

--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -603,7 +603,9 @@ namespace osmscout {
     std::vector<PathSymbolStyleLookupTable>    wayPathSymbolStyleSelectors;
     PathShieldStyleLookupTable                 wayPathShieldStyleSelectors;
 
-    std::vector<TypeInfoSet>                   wayTypeSets;
+    std::vector<TypeInfoSet>                   wayTypeSets;     //!< way types with defined style by magnification level
+    std::vector<bool>                          wayTextFlags;    //!< flags by magnification level if there is style with way label
+    std::vector<bool>                          wayShieldFlags;  //!< flags by magnification level if there is style with way shield
 
     // Area
 

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1827,16 +1827,20 @@ namespace osmscout {
                                const MapParameter& parameter,
                                const MapData& data)
   {
+    bool hasShieldLabels = styleConfig.HasWayPathShieldStyle(projection);
+
     for (const auto& way : data.ways) {
       CalculatePaths(styleConfig,
                      projection,
                      parameter,
                      *way);
 
-      CalculateWayShieldLabels(styleConfig,
-                               projection,
-                               parameter,
-                               *way);
+      if (hasShieldLabels) {
+        CalculateWayShieldLabels(styleConfig,
+                                 projection,
+                                 parameter,
+                                 *way);
+      }
     }
 
     for (const auto& way : data.poiWays) {
@@ -1845,10 +1849,12 @@ namespace osmscout {
                      parameter,
                      *way);
 
-      CalculateWayShieldLabels(styleConfig,
-                               projection,
-                               parameter,
-                               *way);
+      if (hasShieldLabels) {
+        CalculateWayShieldLabels(styleConfig,
+                                 projection,
+                                 parameter,
+                                 *way);
+      }
     }
   }
 
@@ -2660,8 +2666,11 @@ namespace osmscout {
                                        const MapParameter& parameter,
                                        const MapData& /*data*/)
   {
-    // TODO: Draw labels only if there is a style for the current zoom level
+    // Draw labels only if there is a style for the current zoom level
     // that requires labels
+    if (!styleConfig->HasWayPathTextStyle(projection)){
+      return;
+    }
 
     StopClock timer;
     size_t    drawnCount=0;

--- a/libosmscout-map/src/osmscout/StyleConfig.cpp
+++ b/libosmscout-map/src/osmscout/StyleConfig.cpp
@@ -1102,6 +1102,23 @@ namespace osmscout {
     }
   }
 
+  template <class S, class A>
+  bool HasStyle(const std::vector<std::vector<std::list<StyleSelector<S,A>>>>& styleSelectors,
+                const Projection& projection)
+  {
+    for (const auto &selectorsForType: styleSelectors){
+      assert(!selectorsForType.empty());
+      size_t level=projection.GetMagnification().GetLevel();
+      if (level >= selectorsForType.size()) {
+        level = selectorsForType.size() - 1;
+      }
+      if (!selectorsForType[level].empty()){
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Get the style data based on the given features of an object,
    * a given style (S) and its style attributes (A).
@@ -1112,6 +1129,8 @@ namespace osmscout {
                                      const FeatureValueBuffer& buffer,
                                      const Projection& projection)
   {
+    assert(!styleSelectors.empty());
+
     bool               fastpath=false;
     bool               composed=false;
     size_t             level=projection.GetMagnification().GetLevel();
@@ -1298,6 +1317,11 @@ namespace osmscout {
                            projection);
   }
 
+  bool StyleConfig::HasWayPathTextStyle(const Projection& projection) const
+  {
+    return HasStyle(wayPathTextStyleSelectors, projection);
+  }
+
   PathTextStyleRef StyleConfig::GetRoutePathTextStyle(const FeatureValueBuffer& buffer,
                                                       const Projection& projection) const
   {
@@ -1314,6 +1338,11 @@ namespace osmscout {
                            wayPathShieldStyleSelectors[buffer.GetType()->GetIndex()],
                            buffer,
                            projection);
+  }
+
+  bool StyleConfig::HasWayPathShieldStyle(const Projection& projection) const
+  {
+    return HasStyle(wayPathShieldStyleSelectors, projection);
   }
 
   FillStyleRef StyleConfig::GetAreaFillStyle(const TypeInfoRef& type,

--- a/libosmscout-map/src/osmscout/StyleConfig.cpp
+++ b/libosmscout-map/src/osmscout/StyleConfig.cpp
@@ -428,9 +428,9 @@ namespace osmscout {
   }
 
   /**
-   * Returns thevalue of the given flag identified by the name of the flag.
+   * Returns the value of the given flag identified by the name of the flag.
    *
-   * Asserts, if the flag name is unnown.
+   * Asserts, if the flag name is unknown.
    */
   bool StyleConfig::GetFlagByName(const std::string& name) const
   {
@@ -446,7 +446,7 @@ namespace osmscout {
    * gets overwritten.
    */
   void StyleConfig::AddFlag(const std::string& name,
-                           bool value)
+                            bool value)
   {
     flags[name]=value;
   }


### PR DESCRIPTION
Rendering should be faster when there is no way labels or way shields.

With standard stylesheets, there are no way labels until zoom level 12. But during my performance testing (used Prague area), zoom level 11 contained 14145 ways and there was no measurable improvement...

What do you think? Is code change simple enough to accept it even when there is no measurable improvement?