### PR TITLE
Qt: Improve search

### DIFF
--- a/Demos/src/LookupText.cpp
+++ b/Demos/src/LookupText.cpp
@@ -118,12 +118,15 @@ int main (int argc, char *argv[])
                "* Input at least 3 characters or 'q' to quit\n" << std::endl;
 
 
-  while(true) {
+  while(!std::cin.eof()) {
     std::string searchInput;
 
     std::cout << std::endl;
     std::cout << "Enter a search term:"<< std::endl;
     std::getline(std::cin,searchInput);
+    if (searchInput.empty() && std::cin.eof()){
+      break;
+    }
 
     if(searchInput.size() < 3) {
       if(searchInput.size()==1) {

--- a/OSMScout2/qml/custom/LocationSearch.qml
+++ b/OSMScout2/qml/custom/LocationSearch.qml
@@ -340,6 +340,10 @@ LineEdit {
 
                 model: suggestionModel
 
+                onContentHeightChanged: {
+                    updatePopup();
+                }
+
                 delegate: Item{
                     width: suggestionView.width
                     height: labelLabel.height + entryRegion.height

--- a/OSMScout2/qml/custom/LocationSearch.qml
+++ b/OSMScout2/qml/custom/LocationSearch.qml
@@ -229,6 +229,7 @@ LineEdit {
 
     LocationListModel {
         id: suggestionModel
+        resultLimit: 150 // default is 50, higher numbers for test UI performance
 
         // compute rank for location, it should be in range 0~1
         function locationRank(loc){

--- a/libosmscout-client-qt/include/osmscout/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscout/LookupModule.h
@@ -48,7 +48,7 @@ typedef std::shared_ptr<AdminRegionInfo> AdminRegionInfoRef;
 class OSMSCOUT_CLIENT_QT_API LookupModule:public QObject{
   Q_OBJECT
 
-  friend class SearchModule;
+  friend class SearchRunnable;
 
 public:
 

--- a/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
@@ -109,6 +109,9 @@ void LocationEntry::mergeWith(const LocationEntry &location)
   for (auto &ref:location.getReferences()) {
     addReference(ref);
   }
+  if (adminRegionList.empty() && !location.adminRegionList.empty()){
+    adminRegionList=location.adminRegionList;
+  }
   coord=bbox.GetCenter();
 }
 

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -19,7 +19,6 @@
 
 #include <osmscout/POILookupModule.h>
 #include <osmscout/POIService.h>
-#include <osmscout/SearchModule.h>
 
 namespace osmscout {
 

--- a/libosmscout/src/osmscout/util/FileScanner.cpp
+++ b/libosmscout/src/osmscout/util/FileScanner.cpp
@@ -2154,7 +2154,7 @@ namespace osmscout {
       if (offset+coordByteSize-1>=size) {
         hasError=true;
 
-        throw IOException(filename,"Cannot read coordinate","Cannot read beyonf end of file");
+        throw IOException(filename,"Cannot read coordinate","Cannot read beyond end of file");
       }
 
       char *dataPtr=&mmap[offset];


### PR DESCRIPTION
main changes: 

 - run partial search in parallel (each database, search type) in global Qt thread pool, it makes searching faster on multicore systems
 - rewrite sorting of search results to minimise C++ => JavaScript calls, it improves UI latency
