### PR TITLE
reuse FileScanner in LocationIndex using object pool

### DIFF
--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -32,6 +32,7 @@ set(HEADER_FILES_UTIL
     include/osmscout/util/NodeUseMap.h
     include/osmscout/util/Number.h
     include/osmscout/util/NumberSet.h
+    include/osmscout/util/ObjectPool.h
     include/osmscout/util/Parsing.h
     include/osmscout/util/Progress.h
     include/osmscout/util/Projection.h

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -31,6 +31,7 @@ osmscoutHeader = [
             'osmscout/util/NodeUseMap.h',
             'osmscout/util/Number.h',
             'osmscout/util/NumberSet.h',
+            'osmscout/util/ObjectPool.h',
             'osmscout/util/Parsing.h',
             'osmscout/util/Progress.h',
             'osmscout/util/Projection.h',

--- a/libosmscout/include/osmscout/LocationDescriptionService.h
+++ b/libosmscout/include/osmscout/LocationDescriptionService.h
@@ -391,6 +391,8 @@ namespace osmscout {
                          const GeoCoord& location,
                          const AreaRegionSearchResult& results);
 
+    void FlushLocationIndexCache() const;
+
   public:
     explicit LocationDescriptionService(const DatabaseRef& database);
 

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -1,0 +1,114 @@
+#ifndef OSMSCOUT_OBJECTPOOL_H
+#define OSMSCOUT_OBJECTPOOL_H
+
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2020  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/CoreImportExport.h>
+
+#include <list>
+#include <memory>
+#include <mutex>
+
+namespace osmscout {
+
+  template<typename T>
+  class ObjectPool {
+  private:
+    std::list<T*> pool;
+    size_t maxSize;
+    std::mutex mutex;
+
+  private:
+    void Return(T* o){
+      std::lock_guard<std::mutex> guard(mutex);
+      if (!IsValid(o) || pool.size()==maxSize){
+        Close(o);
+        delete o;
+      } else {
+        pool.push_back(o);
+      }
+    }
+
+  public:
+    using Ptr = std::unique_ptr<T, std::function<void(T*)>>;
+
+  public:
+    explicit ObjectPool(size_t maxSize):
+        maxSize(maxSize)
+    {}
+
+    virtual ~ObjectPool(){
+      Clear();
+    }
+
+    /**
+     * Make a new object. It may return nullptr in case of failure.
+     */
+    virtual T* MakeNew() noexcept
+    {
+      return new T();
+    }
+
+    virtual void Close(T*) noexcept
+    {
+      // no-op
+    }
+
+    virtual bool IsValid(T*) noexcept
+    {
+      return true;
+    }
+
+    virtual Ptr Borrow()
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      T* o;
+      if (!pool.empty()){
+        o=pool.back();
+        pool.pop_back();
+      } else {
+        o=MakeNew();
+        if (o == nullptr){
+          return std::unique_ptr<T>(nullptr);
+        }
+      }
+      return Ptr(o, [this](T* o){ Return(o); });
+    }
+
+    size_t Size()
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      return pool.size();
+    }
+
+    void Clear()
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      for (T* o:pool){
+        Close(o);
+        delete o;
+      }
+      pool.clear();
+    }
+  };
+
+}
+
+#endif //OSMSCOUT_OBJECTPOOL_H

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -31,7 +31,7 @@ namespace osmscout {
   template<typename T>
   class ObjectPool {
   private:
-    std::list<T*> pool;
+    std::vector<T*> pool;
     size_t maxSize;
     std::mutex mutex;
 
@@ -52,7 +52,9 @@ namespace osmscout {
   public:
     explicit ObjectPool(size_t maxSize):
         maxSize(maxSize)
-    {}
+    {
+      pool.reserve(std::min((size_t)100, maxSize));
+    }
 
     virtual ~ObjectPool(){
       Clear();

--- a/libosmscout/src/osmscout/LocationDescriptionService.cpp
+++ b/libosmscout/src/osmscout/LocationDescriptionService.cpp
@@ -619,6 +619,7 @@ namespace osmscout {
       result.push_back(regionResult);
     }
 
+    FlushLocationIndexCache();
     return true;
   }
 
@@ -923,10 +924,12 @@ namespace osmscout {
                                                                                         candidate.GetBearing()));
         }
 
+        FlushLocationIndexCache();
         return true;
       }
     }
 
+    FlushLocationIndexCache();
     return true;
   }
 
@@ -1013,11 +1016,21 @@ namespace osmscout {
           description.SetAtAddressDescription(std::make_shared<LocationAtPlaceDescription>(place,
                             candidate.GetDistance(), candidate.GetBearing()));
         }
+        FlushLocationIndexCache();
         return true;
       }
     }
 
+    FlushLocationIndexCache();
     return true;
+  }
+
+  void LocationDescriptionService::FlushLocationIndexCache() const
+  {
+    if (LocationIndexRef locationIndex=database->GetLocationIndex();
+        locationIndex) {
+      locationIndex->FlushCache();
+    }
   }
 
   bool LocationDescriptionService::DescribeLocationByPOI(const GeoCoord& location,
@@ -1099,10 +1112,12 @@ namespace osmscout {
                                                                                        candidate.GetDistance(),
                                                                                        candidate.GetBearing()));
         }
+        FlushLocationIndexCache();
         return true;
       }
     }
 
+    FlushLocationIndexCache();
     return true;
   }
 
@@ -1239,6 +1254,7 @@ namespace osmscout {
 
     description.SetCrossingDescription(crossingDescription);
 
+    FlushLocationIndexCache();
     return true;
   }
 
@@ -1323,7 +1339,8 @@ namespace osmscout {
     }
 
     if(result.empty()) {
-      return false;
+      FlushLocationIndexCache();
+      return true;
     }
 
     Place place = GetPlace(result);
@@ -1331,6 +1348,7 @@ namespace osmscout {
 
     description.SetWayDescription(wayDescription);
 
+    FlushLocationIndexCache();
     return true;
   }
 

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1193,14 +1193,16 @@ namespace osmscout {
                                                     ways,
                                                     areas);
 
-    database.GetLocationIndex()->VisitAdminRegions(regionCollector);
+    LocationIndexRef locationIndex=database.GetLocationIndex();
+    assert(locationIndex);
+    locationIndex->VisitAdminRegions(regionCollector);
 
     for (const auto& adminRegion : regionCollector.regions) {
       LocationNameByPathCollectorVisitor locationCollector(paths);
 
-      database.GetLocationIndex()->VisitLocations(*adminRegion,
-                                                  locationCollector,
-                                                  false);
+      locationIndex->VisitLocations(*adminRegion,
+                                    locationCollector,
+                                    false);
 
       if (locationCollector.namePathsMap.empty()) {
         continue;
@@ -1208,9 +1210,9 @@ namespace osmscout {
 
       LocationByNameCollectorVisitor location2Collector(locationCollector.namePathsMap);
 
-      database.GetLocationIndex()->VisitLocations(*adminRegion,
-                                                   location2Collector,
-                                                   false);
+      locationIndex->VisitLocations(*adminRegion,
+                                   location2Collector,
+                                   false);
 
       AddressCollectorVisitor addressCollector(location2Collector.locationPathsMap,
                                                poiCandidates);
@@ -1219,10 +1221,10 @@ namespace osmscout {
         AdminRegion fakeRegion;
         PostalArea  fakePostalArea;
 
-        database.GetLocationIndex()->VisitAddresses(*adminRegion,
-                                                    fakePostalArea,
-                                                    *location,
-                                                    addressCollector);
+        locationIndex->VisitAddresses(*adminRegion,
+                                      fakePostalArea,
+                                      *location,
+                                      addressCollector);
       }
     }
 
@@ -1230,6 +1232,7 @@ namespace osmscout {
 
     std::cout << "Scanning locations: " << scanLocationTime.ResultString() << std::endl;
 
+    locationIndex->FlushCache();
     return poiCandidates;
   }
 


### PR DESCRIPTION
FileScanner opening may be expensive operation,
but LocationIndex may be recursive, because some Visit* method
may be called even from visitor. So it is not possible
use "global" scanner, because its position would be different
when returning from visitor. So, scanners are managed in
the ObjectPool that allows reusing the objects, and guarantee
exclusive access.

To keep small LocationIndex memory footprint, user may call
FlushCache method when index is not needed anymore.

it improves https://github.com/Framstag/libosmscout/issues/968 
and should improve even searching...