### PR TITLE
filter candidates for reverse lookup

### DIFF
--- a/libosmscout/include/osmscout/LocationDescriptionService.h
+++ b/libosmscout/include/osmscout/LocationDescriptionService.h
@@ -383,13 +383,17 @@ namespace osmscout {
 
     void AddToCandidates(std::vector<LocationDescriptionCandicate>& candidates,
                          const GeoCoord& location,
-                         const NodeRegionSearchResult& results);
+                         const NodeRegionSearchResult& results,
+                         bool requireAddress,
+                         bool requireName);
     void AddToCandidates(std::vector<LocationDescriptionCandicate>& candidates,
                          const GeoCoord& location,
                          const WayRegionSearchResult& results);
     void AddToCandidates(std::vector<LocationDescriptionCandicate>& candidates,
                          const GeoCoord& location,
-                         const AreaRegionSearchResult& results);
+                         const AreaRegionSearchResult& results,
+                         bool requireAddress,
+                         bool requireName);
 
   public:
     explicit LocationDescriptionService(const DatabaseRef& database);


### PR DESCRIPTION
Improves https://github.com/Framstag/libosmscout/issues/968 by skipping candidates that cannot be location index. If I understand it correctly, location index is composed from nodes processed in `NodeLocationProcessorFilter` and areas in `AreaLocationProcessorFilter`.

There may be just:

 - objects with address feature
 - POIs with name feature
