### PR TITLE
add util class that cleanup LocationIndex cache when destructed

### DIFF
--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -126,6 +126,7 @@ bool SearchLocationsRunnable::SearchLocations(DBInstanceRef &db,
   searchParameter.SetBreaker(breaker);
 
   osmscout::LocationSearchResult result;
+  LocationIndex::ScopeCacheCleaner cacheCleaner(db->GetDatabase()->GetLocationIndex());
 
   if (!db->GetLocationService()->SearchForLocationByString(searchParameter, result)){
     if (breaker){

--- a/libosmscout/include/osmscout/LocationDescriptionService.h
+++ b/libosmscout/include/osmscout/LocationDescriptionService.h
@@ -395,8 +395,6 @@ namespace osmscout {
                          bool requireAddress,
                          bool requireName);
 
-    void FlushLocationIndexCache() const;
-
   public:
     explicit LocationDescriptionService(const DatabaseRef& database);
 

--- a/libosmscout/include/osmscout/LocationIndex.h
+++ b/libosmscout/include/osmscout/LocationIndex.h
@@ -49,6 +49,28 @@ namespace osmscout {
   public:
     static const char* const FILENAME_LOCATION_IDX;
 
+    /**
+     * Util class that cleanup location index cache when instance is destructed.
+     */
+    class OSMSCOUT_API ScopeCacheCleaner CLASS_FINAL {
+      std::shared_ptr<LocationIndex> index;
+    public:
+      explicit ScopeCacheCleaner(std::shared_ptr<LocationIndex> index):
+        index(index)
+      {}
+
+      ScopeCacheCleaner(const ScopeCacheCleaner&) = delete;
+      ScopeCacheCleaner(ScopeCacheCleaner&&) = delete;
+      ScopeCacheCleaner& operator=(const ScopeCacheCleaner &) = delete;
+      ScopeCacheCleaner& operator=(ScopeCacheCleaner &&) = delete;
+
+      ~ScopeCacheCleaner() {
+        if (index) {
+          index->FlushCache();
+        }
+      }
+    };
+
   private:
 
     /**

--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -932,6 +932,13 @@ namespace osmscout {
       }
     }
 
+    {
+      std::lock_guard<std::mutex> guard(locationIndexMutex);
+      if (locationIndex){
+        locationIndex->FlushCache();
+      }
+    }
+
   }
 
   NodeRegionSearchResult Database::LoadNodesInRadius(const GeoCoord& location,

--- a/libosmscout/src/osmscout/LocationDescriptionService.cpp
+++ b/libosmscout/src/osmscout/LocationDescriptionService.cpp
@@ -669,6 +669,7 @@ namespace osmscout {
     result.clear();
 
     LocationIndexRef locationIndex=database->GetLocationIndex();
+    LocationIndex::ScopeCacheCleaner cacheCleaner(database->GetLocationIndex());
 
     if (!locationIndex) {
       return false;
@@ -695,7 +696,6 @@ namespace osmscout {
       result.push_back(regionResult);
     }
 
-    FlushLocationIndexCache();
     return true;
   }
 
@@ -844,6 +844,7 @@ namespace osmscout {
       return false;
     }
 
+    LocationIndex::ScopeCacheCleaner          cacheCleaner(database->GetLocationIndex());
     std::vector<LocationDescriptionCandicate> candidates;
 
     TypeInfoSet nameTypes;
@@ -953,12 +954,10 @@ namespace osmscout {
                                                                                         candidate.GetBearing()));
         }
 
-        FlushLocationIndexCache();
         return true;
       }
     }
 
-    FlushLocationIndexCache();
     return true;
   }
 
@@ -973,6 +972,8 @@ namespace osmscout {
     if (!typeConfig) {
       return false;
     }
+
+    LocationIndex::ScopeCacheCleaner cacheCleaner(database->GetLocationIndex());
 
     std::vector<LocationDescriptionCandicate> candidates;
 
@@ -1049,21 +1050,11 @@ namespace osmscout {
           description.SetAtAddressDescription(std::make_shared<LocationAtPlaceDescription>(place,
                             candidate.GetDistance(), candidate.GetBearing()));
         }
-        FlushLocationIndexCache();
         return true;
       }
     }
 
-    FlushLocationIndexCache();
     return true;
-  }
-
-  void LocationDescriptionService::FlushLocationIndexCache() const
-  {
-    if (LocationIndexRef locationIndex=database->GetLocationIndex();
-        locationIndex) {
-      locationIndex->FlushCache();
-    }
   }
 
   bool LocationDescriptionService::DescribeLocationByPOI(const GeoCoord& location,
@@ -1078,6 +1069,7 @@ namespace osmscout {
       return false;
     }
 
+    LocationIndex::ScopeCacheCleaner          cacheCleaner(database->GetLocationIndex());
     std::vector<LocationDescriptionCandicate> candidates;
 
     TypeInfoSet poiTypes;
@@ -1149,12 +1141,10 @@ namespace osmscout {
                                                                                        candidate.GetDistance(),
                                                                                        candidate.GetBearing()));
         }
-        FlushLocationIndexCache();
         return true;
       }
     }
 
-    FlushLocationIndexCache();
     return true;
   }
 
@@ -1175,12 +1165,12 @@ namespace osmscout {
   {
     TypeConfigRef          typeConfig=database->GetTypeConfig();
     NameFeatureLabelReader nameFeatureLabelReader(*typeConfig);
-
     if (!typeConfig) {
       return false;
     }
 
-    std::vector<WayRef> candidates;
+    LocationIndex::ScopeCacheCleaner cacheCleaner(database->GetLocationIndex());
+    std::vector<WayRef>              candidates;
 
     TypeInfoSet wayTypes;
 
@@ -1291,7 +1281,6 @@ namespace osmscout {
 
     description.SetCrossingDescription(crossingDescription);
 
-    FlushLocationIndexCache();
     return true;
   }
 
@@ -1318,7 +1307,8 @@ namespace osmscout {
       return false;
     }
 
-    std::vector<WayRef> candidates;
+    std::vector<WayRef>              candidates;
+    LocationIndex::ScopeCacheCleaner cacheCleaner(database->GetLocationIndex());
 
     TypeInfoSet wayTypes;
 
@@ -1376,7 +1366,6 @@ namespace osmscout {
     }
 
     if(result.empty()) {
-      FlushLocationIndexCache();
       return true;
     }
 
@@ -1385,7 +1374,6 @@ namespace osmscout {
 
     description.SetWayDescription(wayDescription);
 
-    FlushLocationIndexCache();
     return true;
   }
 

--- a/libosmscout/src/osmscout/LocationService.cpp
+++ b/libosmscout/src/osmscout/LocationService.cpp
@@ -1844,11 +1844,11 @@ namespace osmscout {
   bool LocationService::SearchForLocationByString(const LocationStringSearchParameter& searchParameter,
                                                   LocationSearchResult& result) const
   {
-    LocationIndexRef                locationIndex=database->GetLocationIndex();
-    std::unordered_set<std::string> regionIgnoreTokenSet;
-    AdminRegionRef                  defaultAdminRegion=searchParameter.GetDefaultAdminRegion();
-    std::string                     searchPattern=searchParameter.GetSearchString();
-    SearchParameter                 parameter;
+    LocationIndexRef                 locationIndex=database->GetLocationIndex();
+    std::unordered_set<std::string>  regionIgnoreTokenSet;
+    AdminRegionRef                   defaultAdminRegion=searchParameter.GetDefaultAdminRegion();
+    std::string                      searchPattern=searchParameter.GetSearchString();
+    SearchParameter                  parameter;
 
     BreakerRef breaker=searchParameter.GetBreaker();
 
@@ -2072,9 +2072,9 @@ namespace osmscout {
   bool LocationService::SearchForLocationByForm(const LocationFormSearchParameter& searchParameter,
                                                 LocationSearchResult& result) const
   {
-    LocationIndexRef                locationIndex=database->GetLocationIndex();
-    std::unordered_set<std::string> regionIgnoreTokenSet;
-    SearchParameter                 parameter;
+    LocationIndexRef                 locationIndex=database->GetLocationIndex();
+    std::unordered_set<std::string>  regionIgnoreTokenSet;
+    SearchParameter                  parameter;
 
     BreakerRef breaker=searchParameter.GetBreaker();
 
@@ -2202,9 +2202,9 @@ namespace osmscout {
   bool LocationService::SearchForPOIByForm(const POIFormSearchParameter& searchParameter,
                                            LocationSearchResult& result) const
   {
-    LocationIndexRef                locationIndex=database->GetLocationIndex();
-    std::unordered_set<std::string> regionIgnoreTokenSet;
-    SearchParameter                 parameter;
+    LocationIndexRef                 locationIndex=database->GetLocationIndex();
+    std::unordered_set<std::string>  regionIgnoreTokenSet;
+    SearchParameter                  parameter;
 
     BreakerRef breaker=searchParameter.GetBreaker();
 


### PR DESCRIPTION
...and use it in LocationService and LocationDescriptionService.
That way, it is not necessary to explicitly cleanup cache
before every function exit point and it keep memory footprint
small when location index is not used.

___

I am still not sure if it makes sense to try cleanup location index cache (file scanner pool) after every usage, or keep it to application to decide when to cleanup cache and free resources...