### PR TITLE
Import bugfix (#959)

### DIFF
--- a/libosmscout/src/osmscout/util/FileScanner.cpp
+++ b/libosmscout/src/osmscout/util/FileScanner.cpp
@@ -374,7 +374,7 @@ namespace osmscout {
 
 #if defined(HAVE_FSEEKO)
     hasError=fseeko(file,(off_t)pos,SEEK_SET)!=0;
-#elif defined(HAVE__FSEEKi64)
+#elif defined(HAVE__FSEEKI64)
     hasError=_fseeki64(file,(__int64)pos,SEEK_SET)!=0;
 #else
     hasError=fseek(file,(long)pos,SEEK_SET)!=0;


### PR DESCRIPTION
In HAVE__FSEEKI64 the 'i' must be written in capital letters. fseek uses under Windows a 4 byte long for the position, whose maximum value is 2147483647 - which could be below the calculated offset. With _fseeki64 an 8 byte integer is used, which should be sufficient for all files.

See issue #959