### PR TITLE
use object pool to reuse iconv_t handler

### DIFF
--- a/libosmscout/include/osmscout/LocationIndex.h
+++ b/libosmscout/include/osmscout/LocationIndex.h
@@ -81,7 +81,7 @@ namespace osmscout {
 
       FileScanner* MakeNew() noexcept override;
 
-      void Close(FileScanner*) noexcept override;
+      void Destroy(FileScanner*) noexcept override;
 
       bool IsValid(FileScanner* o) noexcept override;
     };

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -39,8 +39,7 @@ namespace osmscout {
     void Return(T* o){
       std::lock_guard<std::mutex> guard(mutex);
       if (!IsValid(o) || pool.size()==maxSize){
-        Close(o);
-        delete o;
+        Destroy(o);
       } else {
         pool.push_back(o);
       }
@@ -68,9 +67,9 @@ namespace osmscout {
       return new T();
     }
 
-    virtual void Close(T*) noexcept
+    virtual void Destroy(T* o) noexcept
     {
-      // no-op
+      delete o;
     }
 
     virtual bool IsValid(T*) noexcept
@@ -104,8 +103,8 @@ namespace osmscout {
     {
       std::lock_guard<std::mutex> guard(mutex);
       for (T* o:pool){
-        Close(o);
-        delete o;
+        Destroy(o);
+        Delete(o);
       }
       pool.clear();
     }

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -62,10 +62,7 @@ namespace osmscout {
     /**
      * Make a new object. It may return nullptr in case of failure.
      */
-    virtual T* MakeNew() noexcept
-    {
-      return new T();
-    }
+    virtual T* MakeNew() noexcept = 0;
 
     virtual void Destroy(T* o) noexcept
     {
@@ -104,7 +101,6 @@ namespace osmscout {
       std::lock_guard<std::mutex> guard(mutex);
       for (T* o:pool){
         Destroy(o);
-        Delete(o);
       }
       pool.clear();
     }

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -22,7 +22,7 @@
 
 #include <osmscout/CoreImportExport.h>
 
-#include <list>
+#include <vector>
 #include <memory>
 #include <mutex>
 

--- a/libosmscout/include/osmscout/util/ObjectPool.h
+++ b/libosmscout/include/osmscout/util/ObjectPool.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <memory>
 #include <mutex>
+#include <functional>
 
 namespace osmscout {
 

--- a/libosmscout/src/osmscout/LocationIndex.cpp
+++ b/libosmscout/src/osmscout/LocationIndex.cpp
@@ -131,7 +131,7 @@ namespace osmscout {
     }
   }
 
-  void LocationIndex::FileScannerPool::Close(FileScanner* o) noexcept
+  void LocationIndex::FileScannerPool::Destroy(FileScanner* o) noexcept
   {
     try{
       o->Close();
@@ -139,6 +139,7 @@ namespace osmscout {
       log.Error() << e.GetDescription();
       o->CloseFailsafe();
     }
+    delete o;
   }
 
   bool LocationIndex::FileScannerPool::IsValid(FileScanner* o) noexcept


### PR DESCRIPTION
`iconv_open` is relatively expensive. When some string conversion
is called extensively (for example during object search by name),
it makes sense to reuse iconv handler. To keep String api simple,
for each kind of iconv conversion is created static object pool
(with maximal size of hardware concurecy).

___

When search is using "transliterate" feature, with this path is searching much faster - `3.716` seconds vs. `1.431` seconds for these arguments (on x86):
```
./Demos/LocationLookup \
 --transliterate \
  /home/karry/Maps/europe-czech-republic-20201013-230909 \
  "Pod Lipami 2517, Czechia"
```