### PR TITLE
fix return type of extectedSize method

### DIFF
--- a/libosmscout-client-qt/include/osmscout/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscout/FileDownloader.h
@@ -175,7 +175,7 @@ public:
 
   void cancel();
 
-  virtual size_t expectedSize() const = 0;
+  virtual uint64_t expectedSize() const = 0;
 
   inline bool isDone() const
   {

--- a/libosmscout-client-qt/include/osmscout/MapManager.h
+++ b/libosmscout-client-qt/include/osmscout/MapManager.h
@@ -67,7 +67,7 @@ public:
     return map.getPath();
   }
 
-  inline size_t expectedSize() const override
+  inline uint64_t expectedSize() const override
   {
     return map.getSize();
   }

--- a/libosmscout-client-qt/include/osmscout/VoiceManager.h
+++ b/libosmscout-client-qt/include/osmscout/VoiceManager.h
@@ -49,7 +49,7 @@ public:
 
   void start();
 
-  inline size_t expectedSize() const override
+  inline uint64_t expectedSize() const override
   {
     return 0;
   }


### PR DESCRIPTION
size_t is 32 bit unsigned number on 32 bit architectures,
this is not enough for when download job has more than 4 GiB