### PR TITLE
add initial stylesheet analysis to OSTAndOSSCheck

### DIFF
--- a/libosmscout-map/include/osmscout/StyleConfig.h
+++ b/libosmscout-map/include/osmscout/StyleConfig.h
@@ -561,7 +561,7 @@ namespace osmscout {
    */
   class OSMSCOUT_MAP_API StyleConfig
   {
-  private:
+  protected:
     TypeConfigRef                              typeConfig;             //!< Reference to the type configuration
     mutable StyleResolveContext                styleResolveContext;    //!< Instance of helper class that can get passed around to templated helper methods
 


### PR DESCRIPTION
When I am playing with map stylesheet, sometimes found a issue that may be detected automatically by tool. For example when important label visible on low zoom disappear on higher zoom because of another label... Tool should check that labels that are visible on lower zoom levels should have higher priority. But we don't have such tool unfortunately. Yet :-) There is ticket with similar idea - even include real database data to analysis https://github.com/Framstag/libosmscout/issues/63 . 

This commit extends existing `OSTAndOSSCheck` tool by `--analyze` option. I just show database types and zoom levels when these types are visible... Later, we may extend this test or move code to separate code. Or Stylesheet editor possibly. Not sure.

![Screenshot_20201119_090432](https://user-images.githubusercontent.com/309458/99638264-40e8ad80-2a46-11eb-8590-b05da66db2bd.png)