### PR TITLE
Label layouter overlap

### DIFF
--- a/Demos/src/Tiler.cpp
+++ b/Demos/src/Tiler.cpp
@@ -251,9 +251,6 @@ int main(int argc, char* argv[])
   drawParameter.SetFontSize(2.0);
   // Fadings make problems with tile approach, we disable it
   drawParameter.SetDrawFadings(false);
-  // To get accurate label drawing at tile borders, we take into account labels
-  // of other than the current tile, too.
-  drawParameter.SetDropNotVisiblePointLabels(false);
 
   searchParameter.SetUseLowZoomOptimization(true);
   searchParameter.SetMaximumAreaLevel(3);

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -173,7 +173,7 @@ bool TiledMapRenderer::RenderMap(QPainter& painter,
   QMutexLocker locker(&tileCacheMutex);
   int elapsed = start.elapsed();
   if (elapsed > 1){
-    osmscout::log.Warn() << "Mutex acquiere took " << elapsed << " ms";
+    osmscout::log.Warn() << "Mutex acquire took " << elapsed << " ms";
   }
 
   QList<TileCache*> layerCaches;

--- a/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/TiledMapRenderer.cpp
@@ -448,12 +448,6 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     drawParameter.SetLabelLineFitToArea(true);
     drawParameter.SetLabelLineFitToWidth(std::min(screenWidth, screenHeight));
 
-    // see Tiler.cpp example...
-
-    // To get accurate label drawing at tile borders, we take into account labels
-    // of other than the current tile, too.
-    drawParameter.SetDropNotVisiblePointLabels(loadZ.Get() >= 14);
-
     drawParameter.GetLocaleRef().SetDistanceUnits(units == "imperial" ? osmscout::Units::Imperial : osmscout::Units::Metrics);
 
     // setup projection for these tiles

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -440,7 +440,7 @@ namespace osmscout {
                                       const MapData& /*data*/)
   {
     labelLayouter.SetViewport(DoubleRectangle(0, 0, projection.GetWidth(), projection.GetHeight()));
-    labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+    labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
   void MapPainterAgg::DrawContourSymbol(const Projection& /*projection*/,

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -678,7 +678,7 @@ namespace osmscout {
   }
 
   void MapPainterCairo::BeforeDrawing(const StyleConfig& /*styleConfig*/,
-                                      const Projection& /*projection*/,
+                                      const Projection& projection,
                                       const MapParameter& parameter,
                                       const MapData& /*data*/)
   {
@@ -689,7 +689,7 @@ namespace osmscout {
     viewport.height = y2 - viewport.y;
 
     labelLayouter.SetViewport(viewport);
-    labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+    labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
 #if defined(OSMSCOUT_MAP_CAIRO_HAVE_LIB_PANGO)

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -414,7 +414,7 @@ namespace osmscout
     viewport.height=projection.GetHeight();
 
     m_LabelLayouter.SetViewport(viewport);
-    m_LabelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+    m_LabelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
   void MapPainterDirectX::AfterDrawing(const StyleConfig& /*styleConfig*/,

--- a/libosmscout-map-gdi/src/osmscout/MapPainterGDI.cpp
+++ b/libosmscout-map-gdi/src/osmscout/MapPainterGDI.cpp
@@ -495,7 +495,7 @@ namespace osmscout {
 	{
 		DoubleRectangle viewport(0.0, 0.0, (double)projection.GetWidth(), (double)projection.GetHeight());
 		m_labelLayouter.SetViewport(viewport);
-		m_labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+		m_labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
 	}
 
 	void MapPainterGDI::AfterDrawing(const StyleConfig& /*styleConfig*/,

--- a/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
@@ -518,7 +518,7 @@ namespace osmscout {
                                const MapParameter& parameter,
                        const MapData& data){
         labelLayouter.SetViewport(DoubleRectangle(0, 0, CGBitmapContextGetWidth(cg), CGBitmapContextGetHeight(cg)));
-        labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+        labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
     }
     
     void MapPainterIOS::RegisterRegularLabel(const Projection &projection,

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -967,12 +967,12 @@ namespace osmscout {
   }
 
   void MapPainterQt::BeforeDrawing(const StyleConfig& /*styleConfig*/,
-                                   const Projection& /*projection*/,
+                                   const Projection& projection,
                                    const MapParameter& parameter,
                                    const MapData& /*data*/)
   {
     labelLayouter.SetViewport(DoubleRectangle(0, 0, painter->window().width(), painter->window().height()));
-    labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+    labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
   MapPainterQt::QtLabelLayouter& MapPainterQt::GetLayouter()

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -609,7 +609,7 @@ namespace osmscout {
                              (double)projection.GetWidth(), (double)projection.GetHeight());
 
     labelLayouter.SetViewport(viewport);
-    labelLayouter.SetLayoutOverlap(parameter.GetDropNotVisiblePointLabels() ? 0 : 1);
+    labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
   void MapPainterSVG::AfterDrawing(const StyleConfig& /*styleConfig*/,

--- a/libosmscout-map/include/osmscout/LabelLayouter.h
+++ b/libosmscout-map/include/osmscout/LabelLayouter.h
@@ -295,16 +295,13 @@ namespace osmscout {
       SetLayoutOverlap(layoutOverlap);
     }
 
-    void SetLayoutOverlap(double overlap)
+    void SetLayoutOverlap(uint32_t overlap)
     {
-      if (overlap < 0){
-        overlap = 0;
-      }
       layoutOverlap = overlap;
-      layoutViewport.width = visibleViewport.width * (overlap + 1);
-      layoutViewport.height = visibleViewport.height * (overlap + 1);
-      layoutViewport.x = visibleViewport.x - (visibleViewport.width * overlap) / 2;
-      layoutViewport.y = visibleViewport.y - (visibleViewport.height * overlap) / 2;
+      layoutViewport.width = visibleViewport.width + (overlap * 2);
+      layoutViewport.height = visibleViewport.height + (overlap * 2);
+      layoutViewport.x = visibleViewport.x - overlap;
+      layoutViewport.y = visibleViewport.y - overlap;
     }
 
     void Reset()
@@ -801,7 +798,7 @@ namespace osmscout {
     std::vector<LabelInstanceType> labelInstances;
     DoubleRectangle visibleViewport;
     DoubleRectangle layoutViewport;
-    double layoutOverlap; // overlap ratio used for label layouting
+    uint32_t layoutOverlap; // overlap [pixels] used for label layouting
   };
 
 }

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -92,7 +92,7 @@ namespace osmscout {
     PatternMode                         patternMode;               //!< Mode of pattern, it controls what type of files would be loaded and how pattern geometry will be canculated
     double                              patternSize;               //!< Size of pattern image in mm (default 3.7)
 
-    bool                                dropNotVisiblePointLabels; //!< Point labels that are not visible, are clipped during label positioning phase
+    double                              labelLayouterOverlap;      //!< Overlap of visible area used by label layouter in mm (default 30)
 
   private:
 // Contour labels
@@ -164,7 +164,7 @@ namespace osmscout {
 
     void SetRouteLabelSeparator(const std::string &separator);
 
-    void SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels);
+    void SetLabelLayouterOverlap(double labelLayouterOverlap);
 
     void SetContourLabelOffset(double contourLabelOffset);
     void SetContourLabelSpace(double contourLabelSpace);
@@ -336,9 +336,9 @@ namespace osmscout {
       return routeLabelSeparator;
     }
 
-    inline bool GetDropNotVisiblePointLabels() const
+    inline double GetLabelLayouterOverlap() const
     {
-      return dropNotVisiblePointLabels;
+      return labelLayouterOverlap;
     }
 
     inline double GetContourLabelOffset() const

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -47,7 +47,7 @@ namespace osmscout {
     iconPadding(1.0),
     patternMode(PatternMode::OriginalPixmap),
     patternSize(3.7),
-    dropNotVisiblePointLabels(true),
+    labelLayouterOverlap(30),
     contourLabelOffset(50.0),
     contourLabelSpace(100.0),
     contourLabelPadding(1.0),
@@ -194,9 +194,9 @@ namespace osmscout {
     this->routeLabelSeparator=separator;
   }
 
-  void MapParameter::SetDropNotVisiblePointLabels(bool dropNotVisiblePointLabels)
+  void MapParameter::SetLabelLayouterOverlap(double labelLayouterOverlap)
   {
-    this->dropNotVisiblePointLabels=dropNotVisiblePointLabels;
+    this->labelLayouterOverlap=labelLayouterOverlap;
   }
 
   void MapParameter::SetContourLabelOffset(double contourLabelOffset)


### PR DESCRIPTION
 - specify label layouter overlap in exact dimension, not multiplies of viewport
 - use it on all zoom levels (by default), it has no measurable impact with current label layouter