### PR TITLE
Use full class name (with namespace) with Qt function tr

### DIFF
--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -18,313 +18,248 @@
 <context>
     <name>osmscout::RouteDescriptionBuilder</name>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="77"/>
-        <source>Turn</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="81"/>
         <source>Turn sharp left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="83"/>
         <source>Turn left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="85"/>
         <source>Turn slightly left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte mírně vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="87"/>
         <source>Straight on</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokračuje rovně</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="89"/>
         <source>Turn slightly right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte mírně vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="91"/>
         <source>Turn right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="93"/>
         <source>Turn sharp right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="104"/>
+        <source>Turn</source>
+        <translation>Zahněte</translation>
+    </message>
+    <message>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="108"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="110"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="112"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="114"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračuje rovně&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="116"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="118"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="120"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="131"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="135"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="137"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="139"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="141"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračujte rovně&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="143"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="145"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="147"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="161"/>
         <source>unnamed road</source>
-        <translation type="unfinished"></translation>
+        <translation>nepojmenovaná cesta</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="164"/>
         <source>(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>(%1)</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="167"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="230"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="268"/>
         <source>&quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="169"/>
         <source>&quot;%1&quot; (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; (%2)</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="239"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte&lt;/strong&gt; na %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="240"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="252"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="257"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyjeďte</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="245"/>
         <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Pokračujte&lt;/strong&gt; po %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="246"/>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokračujte</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="251"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt; po %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="256"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="272"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt; na %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="274"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="276"/>
         <source>Target reached</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosaženo cíle</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="329"/>
         <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="332"/>
         <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="334"/>
         <source>Enter roundabout</source>
-        <translation type="unfinished"></translation>
+        <translation>Vjeďte na kruhový objezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="346"/>
-        <source>Take the first exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="349"/>
-        <source>Take the second exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="352"/>
-        <source>Take the third exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="355"/>
-        <source>Take the %1th exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="362"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu na ulici %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="366"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="378"/>
         <source>Enter motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Vjeďte na dálnici</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="390"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="394"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="399"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="402"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="415"/>
         <source>Change motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Změna dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="422"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="426"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="439"/>
         <source>Leave motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="448"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="452"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="456"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="484"/>
         <source>Way changes name</source>
-        <translation type="unfinished"></translation>
+        <translation>Změna silnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="487"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="491"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1</translation>
+    </message>
+    <message>
+        <source>Take the first exit</source>
+        <translation>Použijte první výjezd</translation>
+    </message>
+    <message>
+        <source>Take the second exit</source>
+        <translation>Použijte druhý výjezd</translation>
+    </message>
+    <message>
+        <source>Take the third exit</source>
+        <translation>Použijte třetí výjezd</translation>
+    </message>
+    <message>
+        <source>Take the %1th exit</source>
+        <translation>Použijte %1. výjezd</translation>
     </message>
 </context>
 </TS>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -18,311 +18,311 @@
 <context>
     <name>osmscout::RouteDescriptionBuilder</name>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="77"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="74"/>
         <source>Turn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="81"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="78"/>
         <source>Turn sharp left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="83"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="80"/>
         <source>Turn left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="85"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="82"/>
         <source>Turn slightly left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="87"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="84"/>
         <source>Straight on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="89"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="86"/>
         <source>Turn slightly right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="91"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="88"/>
         <source>Turn right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="93"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="90"/>
         <source>Turn sharp right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="104"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="100"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="108"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="104"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="110"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="106"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="112"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="108"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="114"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="110"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="116"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="112"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="118"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="114"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="120"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="116"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="131"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="126"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="135"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="130"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="137"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="132"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="139"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="134"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="141"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="136"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="143"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="138"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="145"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="140"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="147"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="142"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="161"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="155"/>
         <source>unnamed road</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="164"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="158"/>
         <source>(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="167"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="230"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="268"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="161"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="219"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="257"/>
         <source>&quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="169"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="163"/>
         <source>&quot;%1&quot; (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="239"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="228"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="240"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="252"/>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="257"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="229"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="241"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="246"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="245"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="234"/>
         <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="246"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="235"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="251"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="240"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="256"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="245"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="272"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="261"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="274"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="263"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="276"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="265"/>
         <source>Target reached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="329"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="320"/>
         <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="332"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="323"/>
         <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="334"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="325"/>
         <source>Enter roundabout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="346"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="338"/>
         <source>Take the first exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="349"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="341"/>
         <source>Take the second exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="352"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="344"/>
         <source>Take the third exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="355"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="347"/>
         <source>Take the %1th exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="362"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="354"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="366"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="358"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="378"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="370"/>
         <source>Enter motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="390"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="382"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="394"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="386"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="399"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="391"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="402"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="394"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="415"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="407"/>
         <source>Change motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="422"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="414"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="426"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="418"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="439"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="431"/>
         <source>Leave motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="448"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="440"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="452"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="444"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="456"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="448"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="484"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="476"/>
         <source>Way changes name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="487"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="479"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="491"/>
+        <location filename="../../libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp" line="483"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp
+++ b/libosmscout-client-qt/src/osmscout/RouteDescriptionBuilder.cpp
@@ -71,23 +71,23 @@ static QString TurnCommandType(const RouteDescription::DirectionDescriptionRef& 
 static QString ShortTurnCommand(const RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("Turn");
+    return osmscout::RouteDescriptionBuilder::tr("Turn");
   }
   switch (directionDescription->GetCurve()) {
     case RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("Turn sharp left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn sharp left");
     case RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("Turn left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn left");
     case RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("Turn slightly left");
+      return osmscout::RouteDescriptionBuilder::tr("Turn slightly left");
     case RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("Straight on");
+      return osmscout::RouteDescriptionBuilder::tr("Straight on");
     case RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("Turn slightly right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn slightly right");
     case RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("Turn right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn right");
     case RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("Turn sharp right");
+      return osmscout::RouteDescriptionBuilder::tr("Turn sharp right");
   }
 
   assert(false);
@@ -97,23 +97,23 @@ static QString ShortTurnCommand(const RouteDescription::DirectionDescriptionRef&
 static QString FullTurnCommand(const RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong> into %2");
+    return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong> into %2");
   }
   switch (directionDescription->GetCurve()) {
     case RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong> into %2");
     case RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong> into %2");
     case RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong> into %2");
     case RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong> into %2");
     case RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong> into %2");
     case RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong> into %2");
     case RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong> into %2");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong> into %2");
   }
 
   assert(false);
@@ -123,23 +123,23 @@ static QString FullTurnCommand(const RouteDescription::DirectionDescriptionRef& 
 static QString TurnCommandWithList(const RouteDescription::DirectionDescriptionRef& directionDescription)
 {
   if (!directionDescription){
-    return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong>");
+    return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn</strong>");
   }
   switch (directionDescription->GetCurve()) {
     case RouteDescription::DirectionDescription::sharpLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp left</strong>");
     case RouteDescription::DirectionDescription::left:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn left</strong>");
     case RouteDescription::DirectionDescription::slightlyLeft:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly left</strong>");
     case RouteDescription::DirectionDescription::straightOn:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Straight on</strong>");
     case RouteDescription::DirectionDescription::slightlyRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn slightly right</strong>");
     case RouteDescription::DirectionDescription::right:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn right</strong>");
     case RouteDescription::DirectionDescription::sharpRight:
-      return RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong>");
+      return osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Turn sharp right</strong>");
   }
 
   assert(false);
@@ -152,15 +152,15 @@ static QString FormatName(const RouteDescription::NameDescription &nameDescripti
   std::string ref=nameDescription.GetRef();
   if (name.empty() &&
       ref.empty()) {
-    return RouteDescriptionBuilder::tr("unnamed road");
+    return osmscout::RouteDescriptionBuilder::tr("unnamed road");
   }
   if (name.empty()){
-    return RouteDescriptionBuilder::tr("(%1)").arg(QString::fromStdString(ref));
+    return osmscout::RouteDescriptionBuilder::tr("(%1)").arg(QString::fromStdString(ref));
   }
   if (ref.empty()){
-    return RouteDescriptionBuilder::tr("\"%1\"").arg(QString::fromStdString(name));
+    return osmscout::RouteDescriptionBuilder::tr("\"%1\"").arg(QString::fromStdString(name));
   }
-  return RouteDescriptionBuilder::tr("\"%1\" (%2)").arg(QString::fromStdString(name)).arg(QString::fromStdString(ref));
+  return osmscout::RouteDescriptionBuilder::tr("\"%1\" (%2)").arg(QString::fromStdString(name)).arg(QString::fromStdString(ref));
 }
 
 static QString CrossingWaysDescriptionToString(const RouteDescription::CrossingWaysDescription& crossingWaysDescription)
@@ -216,7 +216,7 @@ void RouteDescriptionBuilder::Callback::OnStart(const RouteDescription::StartDes
   QString startDesc;
   QString driveAlongDesc;
   if (startDescription && !startDescription->GetDescription().empty()) {
-    startDesc = RouteDescriptionBuilder::tr("\"%1\"")
+    startDesc = osmscout::RouteDescriptionBuilder::tr("\"%1\"")
         .arg(QString::fromStdString(startDescription->GetDescription()));
   }
   if (nameDescription && nameDescription->HasName()) {
@@ -225,25 +225,25 @@ void RouteDescriptionBuilder::Callback::OnStart(const RouteDescription::StartDes
 
   if (!startDesc.isEmpty()){
     RouteStep startAt = MkStep("start");
-    startAt.description=RouteDescriptionBuilder::tr("<strong>Start</strong> at %1").arg(startDesc);
-    startAt.shortDescription=RouteDescriptionBuilder::tr("Start");
+    startAt.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong> at %1").arg(startDesc);
+    startAt.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(startAt);
 
     if (!driveAlongDesc.isEmpty()) {
       RouteStep driveAlong = MkStep("drive-along");
-      driveAlong.description=RouteDescriptionBuilder::tr("<strong>Continue</strong> along %1").arg(driveAlongDesc);
-      driveAlong.shortDescription=RouteDescriptionBuilder::tr("Continue");
+      driveAlong.description=osmscout::RouteDescriptionBuilder::tr("<strong>Continue</strong> along %1").arg(driveAlongDesc);
+      driveAlong.shortDescription=osmscout::RouteDescriptionBuilder::tr("Continue");
       routeSteps.push_back(driveAlong);
     }
   } else if (!driveAlongDesc.isEmpty()) {
     RouteStep startAt = MkStep("start");
-    startAt.description=RouteDescriptionBuilder::tr("<strong>Start</strong> along %1").arg(driveAlongDesc);
-    startAt.shortDescription=RouteDescriptionBuilder::tr("Start");
+    startAt.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong> along %1").arg(driveAlongDesc);
+    startAt.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(startAt);
   } else {
     RouteStep start = MkStep("start");
-    start.description=RouteDescriptionBuilder::tr("<strong>Start</strong>");
-    start.shortDescription=RouteDescriptionBuilder::tr("Start");
+    start.description=osmscout::RouteDescriptionBuilder::tr("<strong>Start</strong>");
+    start.shortDescription=osmscout::RouteDescriptionBuilder::tr("Start");
     routeSteps.push_back(start);
   }
 }
@@ -254,15 +254,15 @@ void RouteDescriptionBuilder::Callback::OnTargetReached(const RouteDescription::
 
   QString targetDesc;
   if (targetDescription && !targetDescription->GetDescription().empty()){
-    targetDesc = RouteDescriptionBuilder::tr("\"%1\"")
+    targetDesc = osmscout::RouteDescriptionBuilder::tr("\"%1\"")
         .arg(QString::fromStdString(targetDescription->GetDescription()));
   }
   if (!targetDesc.isEmpty()){
-    targetReached.description=RouteDescriptionBuilder::tr("<strong>Target reached</strong> at %1").arg(targetDesc);
+    targetReached.description=osmscout::RouteDescriptionBuilder::tr("<strong>Target reached</strong> at %1").arg(targetDesc);
   }else{
-    targetReached.description=RouteDescriptionBuilder::tr("<strong>Target reached</strong>");
+    targetReached.description=osmscout::RouteDescriptionBuilder::tr("<strong>Target reached</strong>");
   }
-  targetReached.shortDescription=RouteDescriptionBuilder::tr("Target reached");
+  targetReached.shortDescription=osmscout::RouteDescriptionBuilder::tr("Target reached");
   routeSteps.push_back(targetReached);
 }
 
@@ -317,12 +317,12 @@ void RouteDescriptionBuilder::Callback::OnRoundaboutEnter(const RouteDescription
   }
 
   if (!crossingWaysString.isEmpty()) {
-    enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter roundabout</strong>")
+    enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter roundabout</strong>")
         .arg(crossingWaysString);
   }else {
-    enter.description=RouteDescriptionBuilder::tr("<strong>Enter roundabout</strong>");
+    enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter roundabout</strong>");
   }
-  enter.shortDescription=RouteDescriptionBuilder::tr("Enter roundabout");
+  enter.shortDescription=osmscout::RouteDescriptionBuilder::tr("Enter roundabout");
   routeSteps.push_back(enter);
 }
 
@@ -335,27 +335,27 @@ void RouteDescriptionBuilder::Callback::OnRoundaboutLeave(const RouteDescription
 
   switch (roundaboutLeaveDescription->GetExitCount()){
     case 1:
-      leave.shortDescription=RouteDescriptionBuilder::tr("Take the first exit");
+      leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Take the first exit");
       break;
     case 2:
-      leave.shortDescription=RouteDescriptionBuilder::tr("Take the second exit");
+      leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Take the second exit");
       break;
     case 3:
-      leave.shortDescription=RouteDescriptionBuilder::tr("Take the third exit");
+      leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Take the third exit");
       break;
     default:
-      leave.shortDescription=RouteDescriptionBuilder::tr("Take the %1th exit")
+      leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Take the %1th exit")
           .arg(roundaboutLeaveDescription->GetExitCount());
   }
 
   if (nameDescription &&
       nameDescription->HasName()) {
 
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit into street %2")
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit into street %2")
         .arg(roundaboutLeaveDescription->GetExitCount())
         .arg(FormatName(*nameDescription));
   }else{
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit")
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave roundabout</strong> on %1. exit")
         .arg(roundaboutLeaveDescription->GetExitCount());
   }
 
@@ -367,7 +367,7 @@ void RouteDescriptionBuilder::Callback::OnMotorwayEnter(const RouteDescription::
 {
   RouteStep enter = MkStep("enter-motorway");
 
-  enter.shortDescription=RouteDescriptionBuilder::tr("Enter motorway");
+  enter.shortDescription=osmscout::RouteDescriptionBuilder::tr("Enter motorway");
 
   QString crossingWaysString;
 
@@ -379,19 +379,19 @@ void RouteDescriptionBuilder::Callback::OnMotorwayEnter(const RouteDescription::
       motorwayEnterDescription->GetToDescription()->HasName()) {
 
     if (!crossingWaysString.isEmpty()){
-      enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong> %2")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong> %2")
           .arg(crossingWaysString)
           .arg(FormatName(*(motorwayEnterDescription->GetToDescription())));
     }else {
-      enter.description=RouteDescriptionBuilder::tr("<strong>Enter motorway</strong> %1")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter motorway</strong> %1")
           .arg(FormatName(*(motorwayEnterDescription->GetToDescription())));
     }
   }else{
     if (!crossingWaysString.isEmpty()){
-      enter.description=RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong>")
+      enter.description=osmscout::RouteDescriptionBuilder::tr("At crossing %1<strong>Enter motorway</strong>")
           .arg(crossingWaysString);
     }else {
-      enter.description=RouteDescriptionBuilder::tr("<strong>Enter motorway</strong>");
+      enter.description=osmscout::RouteDescriptionBuilder::tr("<strong>Enter motorway</strong>");
     }
   }
 
@@ -404,18 +404,18 @@ void RouteDescriptionBuilder::Callback::OnMotorwayChange(const RouteDescription:
 {
   RouteStep change = MkStep("change-motorway");
 
-  change.shortDescription=RouteDescriptionBuilder::tr("Change motorway");
+  change.shortDescription=osmscout::RouteDescriptionBuilder::tr("Change motorway");
 
   if (motorwayChangeDescription->GetFromDescription() &&
       motorwayChangeDescription->GetFromDescription()->HasName() &&
       motorwayChangeDescription->GetToDescription() &&
       motorwayChangeDescription->GetToDescription()->HasName()) {
 
-    change.description=RouteDescriptionBuilder::tr("<strong>Change motorway</strong> from %1 to %2")
+    change.description=osmscout::RouteDescriptionBuilder::tr("<strong>Change motorway</strong> from %1 to %2")
         .arg(FormatName(*(motorwayChangeDescription->GetFromDescription())))
         .arg(FormatName(*(motorwayChangeDescription->GetToDescription())));
   }else{
-    change.description=RouteDescriptionBuilder::tr("<strong>Change motorway</strong>");
+    change.description=osmscout::RouteDescriptionBuilder::tr("<strong>Change motorway</strong>");
   }
 
   routeSteps.push_back(change);
@@ -428,7 +428,7 @@ void RouteDescriptionBuilder::Callback::OnMotorwayLeave(const RouteDescription::
 {
   RouteStep leave = MkStep("leave-motorway");
 
-  leave.shortDescription=RouteDescriptionBuilder::tr("Leave motorway");
+  leave.shortDescription=osmscout::RouteDescriptionBuilder::tr("Leave motorway");
 
   // TODO: should we add leave direction to phrase? directionDescription->GetCurve()
   if (motorwayLeaveDescription->GetFromDescription() &&
@@ -437,15 +437,15 @@ void RouteDescriptionBuilder::Callback::OnMotorwayLeave(const RouteDescription::
     if (nameDescription &&
         nameDescription->HasName()) {
 
-      leave.description = RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1 into %2")
+      leave.description = osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1 into %2")
           .arg(FormatName(*(motorwayLeaveDescription->GetFromDescription())))
           .arg(FormatName(*nameDescription));
     }else{
-      leave.description = RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1")
+      leave.description = osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong> %1")
           .arg(FormatName(*(motorwayLeaveDescription->GetFromDescription())));
     }
   }else{
-    leave.description=RouteDescriptionBuilder::tr("<strong>Leave motorway</strong>");
+    leave.description=osmscout::RouteDescriptionBuilder::tr("<strong>Leave motorway</strong>");
   }
 
   routeSteps.push_back(leave);
@@ -473,14 +473,14 @@ void RouteDescriptionBuilder::Callback::OnPathNameChange(const RouteDescription:
 
   RouteStep changed = MkStep("name-change");
 
-  changed.shortDescription=RouteDescriptionBuilder::tr("Way changes name");
+  changed.shortDescription=osmscout::RouteDescriptionBuilder::tr("Way changes name");
 
   if (nameChangedDescription->GetOriginDescription()) {
-    changed.description=RouteDescriptionBuilder::tr("<strong>Way changes name</strong> from %1 to %2")
+    changed.description=osmscout::RouteDescriptionBuilder::tr("<strong>Way changes name</strong> from %1 to %2")
         .arg(FormatName(*(nameChangedDescription->GetOriginDescription())))
         .arg(FormatName(*(nameChangedDescription->GetTargetDescription())));
   } else {
-    changed.description=RouteDescriptionBuilder::tr("<strong>Way changes name</strong> to %1")
+    changed.description=osmscout::RouteDescriptionBuilder::tr("<strong>Way changes name</strong> to %1")
       .arg(FormatName(*(nameChangedDescription->GetTargetDescription())));
   }
 


### PR DESCRIPTION
Qt's lupdate tool that collects localisable strings from sources
don't work with C++ namespaces properly. Using full name workaround
this issue.