### PR TITLE
Elevation profile chart

### DIFF
--- a/Demos/CMakeLists.txt
+++ b/Demos/CMakeLists.txt
@@ -155,6 +155,40 @@ else()
 	message("Skip ResourceConsumptionQt and DrawMapQt demos, libosmscout-map-qt is missing.")
 endif()
 
+#---- ElevationProfileChart
+if(${OSMSCOUT_BUILD_CLIENT_QT})
+
+	qt5_add_resources(RESOURCE_FILES ../OSMScout2/res.qrc demo.qrc)
+
+	set_property(SOURCE qrc_res.cpp PROPERTY SKIP_AUTOMOC ON)
+	set_property(SOURCE qrc_demo.cpp PROPERTY SKIP_AUTOMOC ON)
+
+	#---- ElevationProfileChart
+	osmscout_demo_project(NAME ElevationProfileChart
+			SOURCES
+				src/ElevationProfileChart.cpp
+				src/QtDemoApp.cpp
+				${RESOURCE_FILES}
+
+				# qml files in CMake sources make it visible in QtCreator
+				qml/ElevationProfileChart.qml
+
+			TARGET OSMScout::OSMScout OSMScout::Map OSMScout::MapQt OSMScout::ClientQt Qt5::Widgets)
+	target_compile_definitions(ElevationProfileChart PRIVATE ${Qt5Widgets_DEFINITIONS})
+	if(MSVC)
+		visual_studio_qt_helper("ElevationProfileChart")
+	endif()
+	if(OSMSCOUT_INSTALL_QT_DLL AND TARGET Qt5::windeployqt)
+		add_custom_command(TARGET ElevationProfileChart
+				POST_BUILD
+				COMMAND set PATH=%PATH%$<SEMICOLON>${qt5_install_prefix}/bin
+				COMMAND Qt5::windeployqt --dir "${CMAKE_BINARY_DIR}/windeployqt" "$<TARGET_FILE_DIR:ElevationProfileChart>/$<TARGET_FILE_NAME:ElevationProfileChart>"
+				)
+	endif()
+else()
+	message("Skip ElevationProfileChart demo, libosmscout-client-qt is missing.")
+endif()
+
 #---- DrawMapSVG
 if(${OSMSCOUT_BUILD_MAP_SVG})
     osmscout_demo_project(NAME DrawMapSVG SOURCES src/DrawMapSVG.cpp TARGET OSMScout::OSMScout OSMScout::Map OSMScout::MapSVG)

--- a/Demos/CMakeLists.txt
+++ b/Demos/CMakeLists.txt
@@ -175,6 +175,8 @@ if(${OSMSCOUT_BUILD_CLIENT_QT})
 
 			TARGET OSMScout::OSMScout OSMScout::Map OSMScout::MapQt OSMScout::ClientQt Qt5::Widgets)
 	target_compile_definitions(ElevationProfileChart PRIVATE ${Qt5Widgets_DEFINITIONS})
+	set_target_properties(ElevationProfileChart PROPERTIES
+		UNITY_BUILD OFF) # generated code for qt resources use static variables with the same name
 	if(MSVC)
 		visual_studio_qt_helper("ElevationProfileChart")
 	endif()

--- a/Demos/demo.qrc
+++ b/Demos/demo.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qml/ElevationProfileChart.qml</file>
+    </qresource>
+</RCC>

--- a/Demos/include/QtDemoApp.h
+++ b/Demos/include/QtDemoApp.h
@@ -1,0 +1,78 @@
+#ifndef DEMO_LIBOSMSCOUT_QTDEMOAPP_H
+#define DEMO_LIBOSMSCOUT_QTDEMOAPP_H
+
+/*
+  QtDemoApp - a part of demo programs for libosmscout
+  Copyright (C) 2021  Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <osmscout/util/CmdLineParsing.h>
+
+#include <QStringList>
+#include <QGuiApplication>
+#include <QUrl>
+#include <QQmlContext>
+
+class QtDemoApp {
+public:
+
+  class Arguments {
+  public:
+    virtual ~Arguments() = default;
+
+    virtual void AddOptions(osmscout::CmdLineParser &argParser);
+
+    bool Parse(int argc, char* argv[], int &exitCode);
+
+  public:
+    bool help=false;
+
+#ifdef NDEBUG
+    bool debug=false;
+#else
+    bool debug=true;
+#endif
+
+    QStringList mapLookupDirectories;
+    QString style="stylesheets/standard.oss";
+    QString iconDirectory="icons";
+    QString translationDir;
+    QString basemapDir;
+  };
+
+public:
+  QtDemoApp(QString appName, int &argc, char* argv[]);
+
+  QtDemoApp(const QtDemoApp &) = delete;
+  QtDemoApp(const QtDemoApp &&) = delete;
+  QtDemoApp &operator=(const QtDemoApp &) = delete;
+  QtDemoApp &operator=(const QtDemoApp &&) = delete;
+
+  virtual ~QtDemoApp() = default;
+
+  int Run(const Arguments &args, const QUrl &qmlFileUrl);
+
+  virtual void SetupQmlContext(QQmlContext *, const Arguments &)
+  {
+    // no-op
+  };
+
+private:
+  QGuiApplication app;
+};
+
+#endif //DEMO_LIBOSMSCOUT_QTDEMOAPP_H

--- a/Demos/meson.build
+++ b/Demos/meson.build
@@ -146,6 +146,24 @@ if buildMapQt
                                 install: true)
 endif
 
+if buildClientQt
+
+  eleDemoMocs = qt5.preprocess(moc_headers : [
+                                'include/QtDemoApp.h'
+                               ],
+                               qresources: ['demo.qrc', '../OSMScout2/res.qrc'])
+
+  ElevationProfileChart = executable('ElevationProfileChart',
+                                ['src/ElevationProfileChart.cpp',
+                                 'src/QtDemoApp.cpp'],
+                                eleDemoMocs,
+                                cpp_args: ['-fPIC'],
+                                include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir],
+                                dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
+                                link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
+                                install: true)
+endif
+
 Routing = executable('Routing',
                      'src/Routing.cpp',
                      include_directories: [osmscoutIncDir],

--- a/Demos/meson.build
+++ b/Demos/meson.build
@@ -161,6 +161,7 @@ if buildClientQt
                                 include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir],
                                 dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
                                 link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
+                                override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
                                 install: true)
 endif
 

--- a/Demos/qml/ElevationProfileChart.qml
+++ b/Demos/qml/ElevationProfileChart.qml
@@ -1,0 +1,174 @@
+import QtQuick 2.2
+
+import QtQuick.Controls 1.1
+import QtQuick.Layouts 1.1
+import QtQuick.Controls.Styles 1.1
+import QtQuick.Window 2.0
+
+import QtPositioning 5.2
+
+import net.sf.libosmscout.map 1.0
+
+Window {
+    id: mainWindow
+    objectName: "main"
+    title: "ElevationProfileChart"
+    visible: true
+    width: 800
+    height: 600
+
+    // provided as global context:
+    //  - string routeFrom
+    //  - string routeTo
+    //  - string routeVehicle
+
+    property LocationEntry routeFromLocation
+    property LocationEntry routeToLocation
+
+    function locationStr(location){
+        if (location==null){
+            return "null";
+        }
+        return (location.label=="" ) ?
+                    location.lat.toFixed(5) + " " + location.lon.toFixed(5) :
+                    "\"" + location.label + "\"";
+    }
+
+
+    Item {
+        id: stateMachine
+        state: "resolvingFromLocation"
+        states: [
+            State {
+                name: "resolvingFromLocation"
+                PropertyChanges {
+                   target: locationSearchModel
+                   pattern: routeFrom
+                }
+                PropertyChanges {
+                   target: statusText
+                   text: "Looking location " + routeFrom + "..."
+                }
+            },
+            State {
+                name: "resolvingToLocation"
+                PropertyChanges {
+                   target: locationSearchModel
+                   pattern: routeTo
+                }
+                PropertyChanges {
+                   target: statusText
+                   text: "Looking location " + routeTo + "..."
+                }
+            },
+            State {
+                name: "routing"
+                PropertyChanges {
+                   target: statusText
+                   text: "Routing from " + locationStr(routeFromLocation) + " to " + locationStr(routeToLocation) + "..."
+                }
+            },
+            State {
+                name: "computingElevation"
+                PropertyChanges {
+                   target: statusText
+                   text: "Computing route elevation profile..."
+                }
+            },
+            State {
+                name: "done"
+                PropertyChanges {
+                   target: statusText
+                   visible: false
+                }
+            },
+            State { name: "error"}
+        ]
+
+        onStateChanged: {
+            console.log("State changed: " + state);
+            if (state=="routing" && routeFromLocation != null && routeToLocation != null){
+                console.log("Routing from " + locationStr(routeFromLocation) + " to " + locationStr(routeToLocation) + " with " + routeVehicle + "...");
+                routingModel.setStartAndTarget(routeFromLocation, routeToLocation, routeVehicle);
+            }
+        }
+    }
+
+    LocationListModel {
+        id: locationSearchModel
+
+        onCountChanged:{
+            console.log("Current state: " + stateMachine.state + ", entry count: " + count);
+            if (stateMachine.state=="resolvingFromLocation" || stateMachine.state=="resolvingToLocation"){
+                if (count==0){
+                    if (pattern!="" && !searching){
+                        statusText.text = "No location found for " + pattern;
+                        stateMachine.state = "error";
+                    }
+
+                    console.log("empty!");
+                    return;
+                }
+                console.log("NOT empty!");
+
+                console.log("First location: " + locationStr(locationSearchModel.get(0)));
+                if (stateMachine.state=="resolvingFromLocation"){
+                    routeFromLocation = locationSearchModel.get(0);
+                    stateMachine.state = "resolvingToLocation";
+                } else if (stateMachine.state=="resolvingToLocation"){
+                    routeToLocation = locationSearchModel.get(0);
+                    stateMachine.state = "routing";
+                }
+            }
+        }
+    }
+
+    RoutingListModel {
+        id: routingModel
+        onReadyChanged: {
+            if (ready){
+                var routeWay = routingModel.routeWay;
+                if (routeWay==null){
+                    statusText.text = "No route way!";
+                    stateMachine.state = "error";
+                    return;
+                }
+
+                stateMachine.state = "computingElevation";
+                //elevationChart.way = routingModel.routeWay;
+            }
+        }
+        onRouteFailed: {
+            statusText.text = "Failed to compute reoute: " + reason;
+            stateMachine.state = "error";
+        }
+    }
+
+    ElevationChart {
+        id: elevationChart
+        anchors{
+            fill: parent
+        }
+
+        way: routingModel.routeWay
+
+        onLoadingChanged: {
+            if (!loading && stateMachine.state == "computingElevation"){
+                stateMachine.state = "done";
+            }
+        }
+    }
+
+    Text {
+        id: statusText
+        anchors{
+            fill: parent
+        }
+
+        Layout.fillWidth: true
+
+        text: "Loading..."
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+}

--- a/Demos/src/ElevationProfileChart.cpp
+++ b/Demos/src/ElevationProfileChart.cpp
@@ -1,0 +1,91 @@
+/*
+  ElevationProfileChart - a demo program for libosmscout
+  Copyright (C) 2021 Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <QtDemoApp.h>
+
+#include <QDebug>
+
+class EleChartArgs: public QtDemoApp::Arguments {
+public:
+  EleChartArgs() = default;
+  ~EleChartArgs() override = default;
+
+  void AddOptions(osmscout::CmdLineParser &argParser) override
+  {
+    QtDemoApp::Arguments::AddOptions(argParser);
+
+    using namespace std::string_literals;
+
+    argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                          vehicle=QString::fromStdString(value);
+                        }),
+                        "vehicle",
+                        "Used vehicle (car, foot, bicycle). Default is "s + vehicle.toStdString(),
+                        false);
+
+    argParser.AddPositional(osmscout::CmdLineStringOption([this](const std::string& value) {
+                              routeFrom=QString::fromStdString(value);
+                            }),
+                            "routeFrom",
+                            "Route from");
+
+    argParser.AddPositional(osmscout::CmdLineStringOption([this](const std::string& value) {
+                              routeTo=QString::fromStdString(value);
+                            }),
+                            "routeTo",
+                            "Route to");
+  }
+
+public:
+  QString routeFrom;
+  QString routeTo;
+  QString vehicle="car";
+};
+
+class ElevationProfileChart: public QtDemoApp {
+public:
+  ElevationProfileChart(int &argc, char* argv[]):
+      QtDemoApp("ElevationProfileChart", argc, argv)
+  {}
+
+  ~ElevationProfileChart() override = default;
+
+  void SetupQmlContext(QQmlContext *context, const Arguments &args) override
+  {
+    QtDemoApp::SetupQmlContext(context, args);
+    assert(context);
+    const EleChartArgs &eleArgs = static_cast<const EleChartArgs&>(args);
+    context->setContextProperty("routeFrom", eleArgs.routeFrom);
+    context->setContextProperty("routeTo", eleArgs.routeTo);
+    context->setContextProperty("routeVehicle", eleArgs.vehicle);
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  ElevationProfileChart app( argc, argv);
+
+  EleChartArgs args;
+  int result=0;
+  if (!args.Parse(argc, argv, result)){
+    return result;
+  }
+
+  return app.Run(args, QUrl("qrc:/qml/ElevationProfileChart.qml"));
+}

--- a/Demos/src/QtDemoApp.cpp
+++ b/Demos/src/QtDemoApp.cpp
@@ -1,0 +1,184 @@
+/*
+  QtDemoApp - a part of demo programs for libosmscout
+  Copyright (C) 2021  Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <QtDemoApp.h>
+
+#include <osmscout/OSMScoutQt.h>
+
+#include <QGuiApplication>
+#include <QApplication>
+
+#include <iostream>
+#include <QQmlApplicationEngine>
+
+void QtDemoApp::Arguments::AddOptions(osmscout::CmdLineParser &argParser)
+{
+  std::vector<std::string>  helpArgs{"h","help"};
+
+  argParser.AddOption(osmscout::CmdLineFlag([this](const bool& value) {
+                        help=value;
+                      }),
+                      helpArgs,
+                      "Return argument help",
+                      true);
+
+  argParser.AddOption(osmscout::CmdLineFlag([this](const bool& value) {
+                        debug=value;
+                      }),
+                      "debug",
+                      "Enable debug output",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                        iconDirectory=QString::fromStdString(value);
+                      }),
+                      "icons",
+                      "Icon directory",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                        mapLookupDirectories.append(QString::fromStdString(value));
+                      }),
+                      "database",
+                      "Map database directory",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                        basemapDir=QString::fromStdString(value);
+                      }),
+                      "basemap",
+                      "World base map directory",
+                      false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                        translationDir=QString::fromStdString(value);
+                      }),
+                      "translations",
+                      "Directory with translation files (*.qm)",
+                      false);
+}
+
+bool QtDemoApp::Arguments::Parse(int argc, char* argv[], int &exitCode)
+{
+  osmscout::CmdLineParser   argParser(QApplication::applicationDisplayName().toStdString(),
+                                      argc,argv);
+
+  AddOptions(argParser);
+  osmscout::CmdLineParseResult argResult=argParser.Parse();
+
+  QString documentsLocation = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+  if (mapLookupDirectories.empty()){
+    mapLookupDirectories << documentsLocation + QDir::separator() + "Maps";
+  }
+  if (basemapDir.isEmpty()){
+    basemapDir = documentsLocation + QDir::separator() + "Maps" + QDir::separator() + "world";
+  }
+
+  if (argResult.HasError()) {
+    std::cerr << "ERROR: " << argResult.GetErrorDescription() << std::endl;
+    std::cout << argParser.GetHelp() << std::endl;
+    exitCode = 1;
+    return false;
+  } else if (help) {
+    std::cout << argParser.GetHelp() << std::endl;
+    exitCode = 0;
+    return false;
+  }
+
+  return true;
+}
+
+QtDemoApp::QtDemoApp(QString appName, int &argc, char* argv[]):
+    app(argc, argv)
+{
+  app.setOrganizationName("libosmscout");
+  app.setOrganizationDomain("libosmscout.sf.net");
+  app.setApplicationName(appName);
+
+  // setup c++ locale
+  try {
+    std::locale::global(std::locale(""));
+  } catch (const std::runtime_error& e) {
+    std::cerr << "Cannot set locale: \"" << e.what() << "\"" << std::endl;
+  }
+
+  // register OSMScout library QML types
+  osmscout::OSMScoutQt::RegisterQmlTypes();
+}
+
+int QtDemoApp::Run(const Arguments &args, const QUrl &qmlFileUrl)
+{
+  osmscout::log.Debug(args.debug);
+  osmscout::log.Info(true);
+  osmscout::log.Warn(true);
+  osmscout::log.Error(true);
+
+  // install translator
+  QTranslator translator;
+  QLocale locale;
+  QString translationDir;
+  if (args.translationDir.isEmpty()) {
+    // translations are installed to <PREFIX>/share/libosmscout/OSMScout2/translations
+    // Qt lookup app data (on Linux) in directories "~/.local/share/<APPNAME>", "/usr/local/share/<APPNAME>", "/usr/share/<APPNAME>"
+    // when APPNAME is combination of <organisation>/<app name>
+    translationDir = QStandardPaths::locate(QStandardPaths::DataLocation, "translations",
+                                            QStandardPaths::LocateDirectory);
+  }else{
+    translationDir = args.translationDir;
+  }
+  if (translator.load(locale.name(), translationDir)) {
+    qDebug() << "Install translator for locale " << locale << "/" << locale.name();
+    app.installTranslator(&translator);
+  }else{
+    qWarning() << "Can't load translator for locale" << locale << "/" << locale.name() <<
+               "(" << translationDir << ")";
+  }
+
+  QFileInfo stylesheetFile(args.style);
+
+  osmscout::OSMScoutQtBuilder builder=osmscout::OSMScoutQt::NewInstance();
+
+  builder
+      .WithStyleSheetDirectory(stylesheetFile.dir().path())
+      .WithStyleSheetFile(stylesheetFile.fileName())
+      .WithIconDirectory(args.iconDirectory)
+      .WithMapLookupDirectories(args.mapLookupDirectories)
+      .WithBasemapLookupDirectory(args.basemapDir)
+      .WithOnlineTileProviders(":/resources/online-tile-providers.json")
+      .WithMapProviders(":/resources/map-providers.json")
+      .WithVoiceProviders(":/resources/voice-providers.json")
+      .WithUserAgent(QApplication::applicationName(), QApplication::applicationVersion());
+
+  if (!builder.Init()){
+    std::cerr << "Cannot initialize OSMScout library" << std::endl;
+    return 1;
+  }
+
+  int result;
+  {
+    QQmlApplicationEngine window;
+    SetupQmlContext(window.rootContext(), args);
+    window.load(qmlFileUrl);
+    result = app.exec();
+  }
+
+  osmscout::OSMScoutQt::FreeInstance();
+
+  return result;
+}

--- a/OSMScout2/res.qrc
+++ b/OSMScout2/res.qrc
@@ -66,5 +66,6 @@
 
         <file>resources/online-tile-providers.json</file>
         <file>resources/map-providers.json</file>
+        <file>resources/voice-providers.json</file>
     </qresource>
 </RCC>

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -55,3 +55,11 @@ TEST_CASE("Transliterate diacritics")
 
   REQUIRE(transformed == "aeiyouudtnescrzuoAEIYOUUDTNESCRZUOss");
 }
+
+TEST_CASE("Local aware number to string")
+{
+  osmscout::Locale locale;
+  locale.SetThousandsSeparator(" ");
+  REQUIRE(osmscout::NumberToString(1002030, locale) == "1 002 030");
+  REQUIRE(osmscout::NumberToString(-1002030, locale) == "-1 002 030");
+}

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -5,6 +5,8 @@ set(HEADER_FILES
     include/osmscout/ClientQtImportExport.h
     include/osmscout/DBThread.h
     include/osmscout/DBInstance.h
+    include/osmscout/ElevationChartWidget.h
+    include/osmscout/ElevationModule.h
     include/osmscout/FileDownloader.h
     include/osmscout/InputHandler.h
     include/osmscout/LocationEntry.h
@@ -58,6 +60,8 @@ set(HEADER_FILES
 set(SOURCE_FILES
     src/osmscout/DBThread.cpp
     src/osmscout/DBInstance.cpp
+    src/osmscout/ElevationChartWidget.cpp
+    src/osmscout/ElevationModule.cpp
     src/osmscout/FileDownloader.cpp
     src/osmscout/InputHandler.cpp
     src/osmscout/LocationEntry.cpp

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -4,6 +4,8 @@ osmscoutclientqtHeader = [
             'osmscout/ClientQtImportExport.h',
             'osmscout/DBThread.h',
             'osmscout/DBInstance.h',
+            'osmscout/ElevationChartWidget.h',
+            'osmscout/ElevationModule.h',
             'osmscout/RoutingModel.h',
             'osmscout/Router.h',
             'osmscout/RouteDescriptionBuilder.h',

--- a/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
@@ -35,7 +35,8 @@ class OSMSCOUT_CLIENT_QT_API ElevationChartWidget : public QQuickPaintedItem {
   Q_PROPERTY(bool loading READ isLoading NOTIFY loadingChanged)
   Q_PROPERTY(QColor lineColor READ getLineColor WRITE setLineColor NOTIFY lineColorChanged)
   Q_PROPERTY(qreal lineWidth READ getLineWidth WRITE setLineWidth NOTIFY lineWidthChanged)
-
+  Q_PROPERTY(QColor gradientTopColor READ getGradientTopColor WRITE setGradientTopColor NOTIFY gradientTopColorChanged)
+  Q_PROPERTY(QColor gradientBottomColor READ getGradientBottomColor WRITE setGradientBottomColor NOTIFY gradientBottomColorChanged)
 signals:
   void wayChanged();
   void loadingChanged();
@@ -44,6 +45,8 @@ signals:
                                osmscout::BreakerRef breaker);
   void lineColorChanged();
   void lineWidthChanged();
+  void gradientTopColorChanged();
+  void gradientBottomColorChanged();
 
 public slots:
   void onError(int requestId);
@@ -78,6 +81,20 @@ public:
 
   void setLineWidth(qreal w);
 
+  QColor getGradientTopColor() const
+  {
+    return gradientTopColor;
+  }
+
+  void setGradientTopColor(const QColor &c);
+
+  QColor getGradientBottomColor() const
+  {
+    return gradientBottomColor;
+  }
+
+  void setGradientBottomColor(const QColor &c);
+
 private:
   void reset();
 
@@ -93,6 +110,8 @@ private:
   std::optional<ElevationPoint> highest;
 
   QColor lineColor=QColorConstants::DarkBlue;
+  QColor gradientTopColor=QColor(QColorConstants::DarkBlue.red(), QColorConstants::DarkBlue.green(), QColorConstants::DarkBlue.blue(), 0xA0);
+  QColor gradientBottomColor=QColorConstants::Transparent;
   qreal lineWidth=5;
 };
 

--- a/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
@@ -1,0 +1,101 @@
+#ifndef OSMSCOUT_CLIENT_QT_ELEVATIONCHARTWIDGET_H
+#define OSMSCOUT_CLIENT_QT_ELEVATIONCHARTWIDGET_H
+
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2021  Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/ClientQtImportExport.h>
+#include <osmscout/OverlayObject.h>
+#include <osmscout/ElevationModule.h>
+
+#include <QQuickPaintedItem>
+#include <QColor>
+
+namespace osmscout {
+
+class OSMSCOUT_CLIENT_QT_API ElevationChartWidget : public QQuickPaintedItem {
+  Q_OBJECT
+  Q_PROPERTY(QObject *way READ getWay WRITE setWay NOTIFY wayChanged)
+  Q_PROPERTY(bool loading READ isLoading NOTIFY loadingChanged)
+  Q_PROPERTY(QColor lineColor READ getLineColor WRITE setLineColor NOTIFY lineColorChanged)
+  Q_PROPERTY(qreal lineWidth READ getLineWidth WRITE setLineWidth NOTIFY lineWidthChanged)
+
+signals:
+  void wayChanged();
+  void loadingChanged();
+  void elevationProfileRequest(std::shared_ptr<OverlayWay> way,
+                               int requestId,
+                               osmscout::BreakerRef breaker);
+  void lineColorChanged();
+  void lineWidthChanged();
+
+public slots:
+  void onError(int requestId);
+  void onElevationProfileAppend(ElevationModule::ElevationPoints points, int requestId);
+  void onLoadingFinished(int requestId);
+
+public:
+  ElevationChartWidget(QQuickItem* parent = nullptr);
+  ~ElevationChartWidget() override;
+
+  void paint(QPainter *painter) override;
+
+  QObject* getWay() const;
+  void setWay(QObject* o);
+
+  bool isLoading() const
+  {
+    return loading;
+  }
+
+  QColor getLineColor() const
+  {
+    return lineColor;
+  }
+
+  void setLineColor(const QColor &color);
+
+  qreal getLineWidth() const
+  {
+    return lineWidth;
+  }
+
+  void setLineWidth(qreal w);
+
+private:
+  void reset();
+
+private:
+  ElevationModule* elevationModule=nullptr;
+  std::shared_ptr<OverlayWay> way;
+  osmscout::BreakerRef breaker;
+  bool loading=false;
+  int requestId=0;
+
+  ElevationModule::ElevationPoints points;
+  std::optional<ElevationPoint> lowest;
+  std::optional<ElevationPoint> highest;
+
+  QColor lineColor=QColorConstants::DarkBlue;
+  qreal lineWidth=5;
+};
+
+}
+
+#endif // OSMSCOUT_CLIENT_QT_ELEVATIONCHARTWIDGET_H

--- a/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
@@ -38,6 +38,10 @@ class OSMSCOUT_CLIENT_QT_API ElevationChartWidget : public QQuickPaintedItem {
   Q_PROPERTY(qreal lineWidth READ getLineWidth WRITE setLineWidth NOTIFY lineWidthChanged)
   Q_PROPERTY(QColor gradientTopColor READ getGradientTopColor WRITE setGradientTopColor NOTIFY gradientTopColorChanged)
   Q_PROPERTY(QColor gradientBottomColor READ getGradientBottomColor WRITE setGradientBottomColor NOTIFY gradientBottomColorChanged)
+  Q_PROPERTY(QColor textColor READ getTextColor WRITE setTextColor NOTIFY textColorChanged)
+  Q_PROPERTY(int textPixelSize READ getTextPixelSize WRITE setTextPixelSize NOTIFY textPixelSizeChanged)
+  Q_PROPERTY(int textPadding READ getTextPadding WRITE setTextPadding NOTIFY textPaddingChanged)
+
 signals:
   void wayChanged();
   void loadingChanged();
@@ -48,6 +52,9 @@ signals:
   void lineWidthChanged();
   void gradientTopColorChanged();
   void gradientBottomColorChanged();
+  void textColorChanged();
+  void textPixelSizeChanged();
+  void textPaddingChanged();
 
 public slots:
   void onError(int requestId);
@@ -96,6 +103,27 @@ public:
 
   void setGradientBottomColor(const QColor &c);
 
+  QColor getTextColor() const
+  {
+    return textColor;
+  }
+
+  void setTextColor(const QColor &c);
+
+  int getTextPixelSize() const
+  {
+    return textPixelSize;
+  }
+
+  void setTextPixelSize(int size);
+
+  int getTextPadding() const
+  {
+    return textPadding;
+  }
+
+  void setTextPadding(int size);
+
 private:
   void reset();
 
@@ -115,7 +143,8 @@ private:
   QColor gradientTopColor=QColor(QColorConstants::DarkBlue.red(), QColorConstants::DarkBlue.green(), QColorConstants::DarkBlue.blue(), 0xA0);
   QColor gradientBottomColor=QColorConstants::Transparent;
   qreal lineWidth=5;
-  int textSize=14;
+  int textPixelSize=14;
+  int textPadding=4;
 
   Locale locale=Locale::ByEnvironment();
 };

--- a/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
@@ -23,6 +23,7 @@
 #include <osmscout/ClientQtImportExport.h>
 #include <osmscout/OverlayObject.h>
 #include <osmscout/ElevationModule.h>
+#include <osmscout/util/Locale.h>
 
 #include <QQuickPaintedItem>
 #include <QColor>
@@ -110,9 +111,13 @@ private:
   std::optional<ElevationPoint> highest;
 
   QColor lineColor=QColorConstants::DarkBlue;
+  QColor textColor=QColorConstants::DarkBlue;
   QColor gradientTopColor=QColor(QColorConstants::DarkBlue.red(), QColorConstants::DarkBlue.green(), QColorConstants::DarkBlue.blue(), 0xA0);
   QColor gradientBottomColor=QColorConstants::Transparent;
   qreal lineWidth=5;
+  int textSize=14;
+
+  Locale locale=Locale::ByEnvironment();
 };
 
 }

--- a/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationChartWidget.h
@@ -138,10 +138,10 @@ private:
   std::optional<ElevationPoint> lowest;
   std::optional<ElevationPoint> highest;
 
-  QColor lineColor=QColorConstants::DarkBlue;
-  QColor textColor=QColorConstants::DarkBlue;
-  QColor gradientTopColor=QColor(QColorConstants::DarkBlue.red(), QColorConstants::DarkBlue.green(), QColorConstants::DarkBlue.blue(), 0xA0);
-  QColor gradientBottomColor=QColorConstants::Transparent;
+  QColor lineColor=Qt::darkBlue;
+  QColor textColor=Qt::darkBlue;
+  QColor gradientTopColor=QColor(lineColor.red(), lineColor.green(), lineColor.blue(), 0xA0);
+  QColor gradientBottomColor=Qt::transparent;
   qreal lineWidth=5;
   int textPixelSize=14;
   int textPadding=4;

--- a/libosmscout-client-qt/include/osmscout/ElevationModule.h
+++ b/libosmscout-client-qt/include/osmscout/ElevationModule.h
@@ -1,0 +1,77 @@
+#ifndef OSMSCOUT_CLIENT_QT_ELEVATIONMODULE_H
+#define OSMSCOUT_CLIENT_QT_ELEVATIONMODULE_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2021 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/OverlayObject.h>
+#include <osmscout/DBThread.h>
+#include <osmscout/ElevationService.h>
+
+#include <osmscout/ClientQtImportExport.h>
+
+#include <QThread>
+#include <memory>
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API ElevationModule : public QObject
+{
+  Q_OBJECT
+public:
+  using ElevationPoints = std::vector<osmscout::ElevationPoint>;
+
+  class DataLoader
+  {
+  private:
+    std::vector<osmscout::DatabaseRef> database;
+    std::vector<osmscout::TypeInfoSet> contourTypes;
+    std::vector<osmscout::EleFeatureValueReader> reader;
+  public:
+    explicit DataLoader(const std::list<DBInstanceRef> &databases);
+
+    std::vector<osmscout::ContoursData> LoadContours(const osmscout::GeoBox &box);
+  };
+
+public slots:
+  void onElevationProfileRequest(std::shared_ptr<OverlayWay> way,
+                                 int requestId,
+                                 osmscout::BreakerRef breaker);
+
+signals:
+  void error(int requestId);
+
+  void elevationProfileAppend(ElevationModule::ElevationPoints points, int requestId);
+  void loadingFinished(int requestId);
+
+public:
+  ElevationModule(QThread *thread,DBThreadRef dbThread);
+
+  ~ElevationModule() override;
+
+private:
+  QThread          *thread;
+  DBThreadRef      dbThread;
+};
+}
+
+#endif // OSMSCOUT_CLIENT_QT_ELEVATIONMODULE_H

--- a/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscout/OSMScoutQt.h
@@ -32,6 +32,7 @@
 #include <osmscout/NavigationModule.h>
 #include <osmscout/POILookupModule.h>
 #include <osmscout/VoiceManager.h>
+#include <osmscout/ElevationModule.h>
 
 #include <osmscout/ClientQtImportExport.h>
 
@@ -304,6 +305,7 @@ public:
   SearchModule *MakeSearchModule();
   StyleModule *MakeStyleModule();
   POILookupModule *MakePOILookupModule();
+  ElevationModule *MakeElevationModule();
 
   QString GetUserAgent() const;
   QString GetCacheLocation() const;

--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -130,6 +130,8 @@ public:
   }
 
   osmscout::GeoBox boundingBox() const;
+  std::vector<osmscout::GeoCoord> getCoords() const;
+  std::vector<osmscout::Point> getPoints() const;
 
 protected:
   void setupFeatures(const osmscout::TypeInfoRef &type,

--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -64,12 +64,11 @@ public slots:
 public:
   OverlayObject(QObject *parent=Q_NULLPTR);
 
-  OverlayObject(const std::vector<osmscout::Point> &nodes,
-                QString typeName="_route",
-                QObject *parent=Q_NULLPTR);
+  explicit OverlayObject(const std::vector<osmscout::Point> &nodes,
+                         QString typeName="_route",
+                         QObject *parent=Q_NULLPTR);
 
   OverlayObject(const OverlayObject &o);
-
 
   ~OverlayObject() override;
 
@@ -151,9 +150,9 @@ Q_OBJECT
 public:
   OverlayArea(QObject *parent=Q_NULLPTR);
 
-  OverlayArea(const std::vector<osmscout::Point> &nodes,
-              QString typeName="_route",
-              QObject *parent=Q_NULLPTR);
+  explicit OverlayArea(const std::vector<osmscout::Point> &nodes,
+                       QString typeName="_route",
+                       QObject *parent=Q_NULLPTR);
 
   ~OverlayArea() override;
 
@@ -172,9 +171,9 @@ Q_OBJECT
 public:
   OverlayWay(QObject *parent=Q_NULLPTR);
 
-  OverlayWay(const std::vector<osmscout::Point> &nodes,
-             QString typeName="_route",
-             QObject *parent=Q_NULLPTR);
+  explicit OverlayWay(const std::vector<osmscout::Point> &nodes,
+                      QString typeName="_route",
+                      QObject *parent=Q_NULLPTR);
 
   ~OverlayWay() override;
 
@@ -193,9 +192,9 @@ Q_OBJECT
 public:
   OverlayNode(QObject *parent=Q_NULLPTR);
 
-  OverlayNode(const std::vector<osmscout::Point> &nodes,
-              QString typeName="_route",
-              QObject *parent=Q_NULLPTR);
+  explicit OverlayNode(const std::vector<osmscout::Point> &nodes,
+                       QString typeName="_route",
+                       QObject *parent=Q_NULLPTR);
 
   ~OverlayNode() override;
 

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -1,6 +1,8 @@
 osmscoutclientqtSrc = [
             'src/osmscout/DBThread.cpp',
             'src/osmscout/DBInstance.cpp',
+            'src/osmscout/ElevationChartWidget.cpp',
+            'src/osmscout/ElevationModule.cpp',
             'src/osmscout/RoutingModel.cpp',
             'src/osmscout/Router.cpp',
             'src/osmscout/RouteDescriptionBuilder.cpp',

--- a/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
@@ -1,0 +1,193 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2021  Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/ElevationChartWidget.h>
+#include <osmscout/OSMScoutQt.h>
+
+namespace osmscout {
+
+ElevationChartWidget::ElevationChartWidget(QQuickItem* parent):
+  QQuickPaintedItem(parent)
+{
+  elevationModule=OSMScoutQt::GetInstance().MakeElevationModule();
+
+  connect(this, &ElevationChartWidget::elevationProfileRequest,
+          elevationModule, &ElevationModule::onElevationProfileRequest,
+          Qt::QueuedConnection);
+
+  connect(elevationModule, &ElevationModule::loadingFinished,
+          this, &ElevationChartWidget::onLoadingFinished,
+          Qt::QueuedConnection);
+
+  connect(elevationModule, &ElevationModule::error,
+          this, &ElevationChartWidget::onError,
+          Qt::QueuedConnection);
+
+  connect(elevationModule, &ElevationModule::elevationProfileAppend,
+          this, &ElevationChartWidget::onElevationProfileAppend,
+          Qt::QueuedConnection);
+}
+
+ElevationChartWidget::~ElevationChartWidget()
+{
+  if (elevationModule!=nullptr){
+    elevationModule->deleteLater();
+    elevationModule=nullptr;
+  }
+}
+
+void ElevationChartWidget::paint(QPainter *painter)
+{
+  if (points.empty()){
+    return;
+  }
+  assert(painter);
+  assert(lowest.has_value());
+  assert(highest.has_value());
+
+  QRectF painterViewport=painter->viewport();
+  QRectF chartRect(painterViewport.width() * 0.1,
+                  painterViewport.height()*0.05,
+                  painterViewport.width()*0.9,
+                  painterViewport.height()*0.9);
+
+  Distance wayLength=points.back().distance;
+  qreal distancePixelM = wayLength==Distance::Zero() ? 0 : chartRect.width() / wayLength.AsMeter();
+
+  Distance eleDiff = highest->elevation - lowest->elevation;
+  qreal elePixelM = eleDiff==Distance::Zero() ? 0 : chartRect.height() / eleDiff.AsMeter();
+
+  QPainterPath path;
+  path.moveTo(chartRect.left(),
+              chartRect.bottom() - (points.front().elevation - lowest->elevation).AsMeter() * elePixelM);
+  for (const auto &point:points) {
+    path.lineTo(chartRect.left() + point.distance.AsMeter() * distancePixelM,
+                chartRect.bottom() - (point.elevation - lowest->elevation).AsMeter() * elePixelM);
+  }
+
+  QPen pen;
+  pen.setColor(lineColor);
+  pen.setWidthF(lineWidth);
+  pen.setStyle(Qt::SolidLine);
+  pen.setCapStyle(Qt::RoundCap);
+
+  painter->setPen(pen);
+  painter->drawPath(path);
+}
+
+void ElevationChartWidget::onError(int requestId)
+{
+  if (this->requestId!=requestId){
+    return;
+  }
+  loading=false;
+  emit loadingChanged();
+}
+
+void ElevationChartWidget::onElevationProfileAppend(ElevationModule::ElevationPoints batch, int requestId)
+{
+  if (this->requestId!=requestId){
+    return;
+  }
+  points.insert(points.end(), batch.begin(), batch.end());
+  for (const auto point:batch){
+    std::cout << point.distance << " \t" << point.elevation.AsMeter() << " m \t" << point.coord.GetDisplayText() << " (" << point.contour->GetType()->GetName() << " " << point.contour->GetFileOffset() << ")" << std::endl;
+    if (!lowest.has_value() || lowest->elevation > point.elevation){
+      lowest=point;
+    }
+    if (!highest.has_value() || highest->elevation < point.elevation){
+      highest=point;
+    }
+  }
+  update();
+}
+
+void ElevationChartWidget::onLoadingFinished(int requestId)
+{
+  if (this->requestId!=requestId){
+    return;
+  }
+  loading=false;
+  emit loadingChanged();
+}
+
+
+QObject* ElevationChartWidget::getWay() const
+{
+  if (!way) {
+    return nullptr;
+  }
+  return new OverlayWay(*way); // copy, QML takes ownership
+}
+
+void ElevationChartWidget::reset()
+{
+  way.reset();
+  points.clear();
+  lowest=std::nullopt;
+  highest=std::nullopt;
+}
+
+void ElevationChartWidget::setWay(QObject* o)
+{
+  if (o == nullptr){
+    reset();
+    emit wayChanged();
+    return;
+  }
+
+  OverlayWay *newWay = dynamic_cast<OverlayWay*>(o);
+  if (newWay == nullptr){
+    qWarning() << "Cannot cast " << o << " to OverlayWay";
+    return;
+  }
+  reset();
+  way=std::make_shared<OverlayWay>(*newWay);
+  emit wayChanged();
+
+  if (breaker){
+    breaker->Break();
+  }
+  requestId++;
+  loading=true;
+  breaker=std::make_shared<ThreadedBreaker>();
+  emit elevationProfileRequest(way, requestId, breaker);
+  emit loadingChanged();
+}
+
+void ElevationChartWidget::setLineColor(const QColor &color)
+{
+  if (lineColor==color){
+    return;
+  }
+  lineColor=color;
+  emit lineColorChanged();
+  update();
+}
+
+void ElevationChartWidget::setLineWidth(qreal w)
+{
+  if (lineWidth==w){
+    return;
+  }
+  lineWidth=w;
+  emit lineWidthChanged();
+  update();
+}
+}

--- a/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
@@ -26,7 +26,12 @@ namespace osmscout {
 ElevationChartWidget::ElevationChartWidget(QQuickItem* parent):
   QQuickPaintedItem(parent)
 {
-  elevationModule=OSMScoutQt::GetInstance().MakeElevationModule();
+  OSMScoutQt& osmScoutInst = OSMScoutQt::GetInstance();
+  elevationModule=osmScoutInst.MakeElevationModule();
+
+  locale.SetDistanceUnits(osmScoutInst.GetSettings()->GetUnits() == "imperial" ?
+                          osmscout::Units::Imperial :
+                          osmscout::Units::Metrics);
 
   connect(this, &ElevationChartWidget::elevationProfileRequest,
           elevationModule, &ElevationModule::onElevationProfileRequest,

--- a/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
@@ -167,10 +167,14 @@ void ElevationChartWidget::paint(QPainter *painter)
   painter->setRenderHint(QPainter::TextAntialiasing, true);
 
   QRectF painterViewport=painter->viewport();
-  QRectF chartRect(painterViewport.width() * 0.1,
-                  painterViewport.height() * 0.05,
-                  painterViewport.width() * 0.85,
-                  painterViewport.height() * 0.9);
+  double topMargin = 0;
+  double rightMargin = 0;
+  double bottomMargin = textPixelSize * 1.5;
+  double leftMargin = textPixelSize * 4;
+  QRectF chartRect(leftMargin,
+                   topMargin,
+                  painterViewport.width() - (leftMargin+rightMargin),
+                  painterViewport.height() - (topMargin+bottomMargin));
 
   Distance wayLength=points.back().distance;
   qreal distancePixelM = wayLength==Distance::Zero() ? 0 : chartRect.width() / wayLength.AsMeter();
@@ -239,7 +243,7 @@ void ElevationChartWidget::paint(QPainter *painter)
 
   for (int i = 1; true; i++) {
     double position = distanceLabelUnit->ToMeter(distanceLabelInterval * i) * distancePixelM;
-    if (position > chartRect.width()) {
+    if (position > chartRect.width() - 2*textPixelSize) {
       break;
     }
     std::stringstream ss;
@@ -285,7 +289,7 @@ void ElevationChartWidget::paint(QPainter *painter)
   double lastPosition = firstPosition;
   for (int i=0; true; i++) {
     double position = firstPosition + eleLabelUnit->ToMeter(eleLabelInterval * i) * elePixelM;
-    if (position > chartRect.height()) {
+    if (position > chartRect.height() - 1.5*textPixelSize) {
       break;
     }
     lastPosition = position;
@@ -306,7 +310,7 @@ void ElevationChartWidget::paint(QPainter *painter)
     ss << NumberToString(eleLabelUnit->FromMeter(highest->elevation.AsMeter()), locale);
     ss << locale.GetUnitsSeparator();
     ss << eleLabelUnit->UnitStr();
-    painter->drawText(0, chartRect.top() - textPixelSize, chartRect.left()-textPadding, 2*textPixelSize,
+    painter->drawText(0, chartRect.top() - textPixelSize*0.5, chartRect.left()-textPadding, 2*textPixelSize,
                       Qt::AlignVCenter | Qt::AlignRight, QString::fromStdString(ss.str()));
   }
 }

--- a/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
@@ -61,11 +61,14 @@ void ElevationChartWidget::paint(QPainter *painter)
   assert(lowest.has_value());
   assert(highest.has_value());
 
+  painter->setRenderHint(QPainter::Antialiasing, true);
+  painter->setRenderHint(QPainter::TextAntialiasing, true);
+
   QRectF painterViewport=painter->viewport();
   QRectF chartRect(painterViewport.width() * 0.1,
-                  painterViewport.height()*0.05,
-                  painterViewport.width()*0.9,
-                  painterViewport.height()*0.9);
+                  painterViewport.height() * 0.05,
+                  painterViewport.width() * 0.85,
+                  painterViewport.height() * 0.9);
 
   Distance wayLength=points.back().distance;
   qreal distancePixelM = wayLength==Distance::Zero() ? 0 : chartRect.width() / wayLength.AsMeter();
@@ -80,6 +83,15 @@ void ElevationChartWidget::paint(QPainter *painter)
     path.lineTo(chartRect.left() + point.distance.AsMeter() * distancePixelM,
                 chartRect.bottom() - (point.elevation - lowest->elevation).AsMeter() * elePixelM);
   }
+
+  QPainterPath gradientArea=path;
+  gradientArea.lineTo(chartRect.bottomRight());
+  gradientArea.lineTo(chartRect.bottomLeft());
+
+  QLinearGradient gradient(0,0,0, chartRect.height());
+  gradient.setColorAt(0.0, gradientTopColor);
+  gradient.setColorAt(1.0, gradientBottomColor);
+  painter->fillPath(gradientArea, gradient);
 
   QPen pen;
   pen.setColor(lineColor);
@@ -178,6 +190,26 @@ void ElevationChartWidget::setLineColor(const QColor &color)
   }
   lineColor=color;
   emit lineColorChanged();
+  update();
+}
+
+void ElevationChartWidget::setGradientTopColor(const QColor &color)
+{
+  if (gradientTopColor==color){
+    return;
+  }
+  gradientTopColor=color;
+  emit gradientTopColorChanged();
+  update();
+}
+
+void ElevationChartWidget::setGradientBottomColor(const QColor &color)
+{
+  if (gradientBottomColor==color){
+    return;
+  }
+  gradientBottomColor=color;
+  emit gradientBottomColorChanged();
   update();
 }
 

--- a/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationChartWidget.cpp
@@ -47,6 +47,10 @@ ElevationChartWidget::ElevationChartWidget(QQuickItem* parent):
 
 ElevationChartWidget::~ElevationChartWidget()
 {
+  if (breaker){
+    breaker->Break();
+  }
+
   if (elevationModule!=nullptr){
     elevationModule->deleteLater();
     elevationModule=nullptr;

--- a/libosmscout-client-qt/src/osmscout/ElevationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/ElevationModule.cpp
@@ -1,0 +1,103 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2021 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/ElevationModule.h>
+#include <osmscout/ElevationService.h>
+
+namespace osmscout {
+
+ElevationModule::ElevationModule(QThread *thread,DBThreadRef dbThread):
+    thread(thread), dbThread(dbThread)
+{
+
+}
+
+ElevationModule::~ElevationModule()
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "Destroy" << this << "from non incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+  if (thread!=nullptr){
+    thread->quit();
+  }
+}
+
+ElevationModule::DataLoader::DataLoader(const std::list<DBInstanceRef> &databases)
+{
+  database.reserve(databases.size());
+  contourTypes.reserve(databases.size());
+  reader.reserve(databases.size());
+
+  for (const DBInstanceRef &dbInst: databases){
+    DatabaseRef db=dbInst->GetDatabase();
+    database.push_back(db);
+    reader.push_back(osmscout::EleFeatureValueReader(*db->GetTypeConfig()));
+    osmscout::TypeInfoSet types;
+    for (const auto &type:db->GetTypeConfig()->GetWayTypes()){
+      if (type->HasFeature(osmscout::EleFeature::NAME)){
+        osmscout::log.Debug() << "Using type " << type->GetName();
+        types.Set(type);
+      }
+    }
+    contourTypes.push_back(types);
+  }
+}
+
+std::vector<osmscout::ContoursData> ElevationModule::DataLoader::LoadContours(const osmscout::GeoBox &box)
+{
+  assert(database.size() == contourTypes.size());
+  assert(database.size() == reader.size());
+
+  std::vector<osmscout::ContoursData> result;
+  result.reserve(database.size());
+  for (size_t i=0; i<database.size(); i++) {
+    osmscout::StopClock stopClock;
+    std::vector<osmscout::FileOffset> offsets;
+    osmscout::TypeInfoSet loadedTypes;
+    if (!database[i]->GetAreaWayIndex()->GetOffsets(box, contourTypes[i], offsets, loadedTypes)) {
+      assert(false);
+    }
+    std::vector<osmscout::WayRef> contours;
+    if (!database[i]->GetWaysByOffset(offsets, contours)) {
+      assert(false);
+    }
+    result.push_back({reader[i],contours});
+  }
+  return result;
+}
+
+void ElevationModule::onElevationProfileRequest(std::shared_ptr<OverlayWay> overlayWay,
+                                                int requestId,
+                                                osmscout::BreakerRef breaker)
+{
+  assert(overlayWay);
+  dbThread->RunSynchronousJob([&](const std::list<DBInstanceRef> &databases){
+    DataLoader dataLoader(databases);
+    osmscout::ElevationService<DataLoader> eleService(dataLoader, osmscout::Magnification::magSuburb);
+
+    eleService.ElevationProfile(overlayWay->getCoords(), [&](const osmscout::Distance&, const std::vector<osmscout::ElevationPoint> &points){
+      emit elevationProfileAppend( points, requestId);
+    }, breaker);
+
+    emit loadingFinished(requestId);
+  });
+}
+
+
+}

--- a/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscout/OSMScoutQt.cpp
@@ -27,6 +27,7 @@
 #include <osmscout/DBThread.h>
 #include <osmscout/DataTileCache.h>
 #include <osmscout/MapWidget.h>
+#include <osmscout/ElevationChartWidget.h>
 #include <osmscout/PlaneMapRenderer.h>
 #include <osmscout/TiledMapRenderer.h>
 #include <osmscout/OverlayObject.h>
@@ -159,9 +160,11 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<RouteStep>("RouteStep");
   qRegisterMetaType<std::list<RouteStep>>("std::list<RouteStep>");
   qRegisterMetaType<OverlayWay*>("OverlayWay*");
+  qRegisterMetaType<std::shared_ptr<OverlayWay>>("std::shared_ptr<OverlayWay>");
   qRegisterMetaType<OverlayArea*>("OverlayArea*");
   qRegisterMetaType<OverlayNode*>("OverlayNode*");
   qRegisterMetaType<QList<LookupModule::ObjectInfo>>("QList<LookupModule::ObjectInfo>");
+  qRegisterMetaType<ElevationModule::ElevationPoints>("ElevationModule::ElevationPoints");
 
   // register osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");
@@ -172,6 +175,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qmlRegisterType<MapObjectInfoModel>(uri, versionMajor, versionMinor, "MapObjectInfoModel");
   qmlRegisterType<MapStyleModel>(uri, versionMajor, versionMinor, "MapStyleModel");
   qmlRegisterType<MapWidget>(uri, versionMajor, versionMinor, "Map");
+  qmlRegisterType<ElevationChartWidget>(uri, versionMajor, versionMinor, "ElevationChart");
   qmlRegisterType<NavigationModel>(uri, versionMajor, versionMinor, "NavigationModel");
   qmlRegisterType<OnlineTileProviderModel>(uri, versionMajor, versionMinor, "OnlineTileProviderModel");
   qmlRegisterType<OverlayWay>(uri, versionMajor, versionMinor, "OverlayWay");
@@ -343,6 +347,15 @@ POILookupModule *OSMScoutQt::MakePOILookupModule()
 {
   QThread *thread=makeThread("POILookupModule");
   POILookupModule *module=new POILookupModule(thread,dbThread);
+  module->moveToThread(thread);
+  thread->start();
+  return module;
+}
+
+ElevationModule *OSMScoutQt::MakeElevationModule()
+{
+  QThread *thread=makeThread("ElevationModule");
+  ElevationModule *module=new ElevationModule(thread,dbThread);
   module->moveToThread(thread);
   thread->start();
   return module;

--- a/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
+++ b/libosmscout-client-qt/src/osmscout/OverlayObject.cpp
@@ -79,6 +79,24 @@ osmscout::GeoBox OverlayObject::boundingBox() const
   return boundingBoxInternal();
 }
 
+std::vector<osmscout::GeoCoord> OverlayObject::getCoords() const
+{
+  QMutexLocker locker(&lock);
+  std::vector<osmscout::GeoCoord> coords;
+  coords.reserve(nodes.size());
+  for (const auto &point: nodes){
+    coords.push_back(point.GetCoord());
+  }
+  return coords;
+}
+
+std::vector<osmscout::Point> OverlayObject::getPoints() const
+{
+  QMutexLocker locker(&lock);
+  return nodes;
+}
+
+
 osmscout::GeoBox OverlayObject::boundingBoxInternal() const
 {
   if (!box.IsValid() && !nodes.empty()){

--- a/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/RoutingModel.cpp
@@ -63,6 +63,18 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   }
   cancel(); // cancel current computation
   clear(); // clear model
+
+  if (start==nullptr || target==nullptr) {
+    if (start == nullptr) {
+      qWarning() << "Start is null";
+    } else {
+      qWarning() << "Target is null";
+    }
+    computing=false;
+    emit computingChanged();
+    return;
+  }
+
   computing=true;
   breaker=std::make_shared<osmscout::ThreadedBreaker>();
   emit computingChanged();

--- a/libosmscout/include/osmscout/ElevationService.h
+++ b/libosmscout/include/osmscout/ElevationService.h
@@ -61,13 +61,24 @@ public:
   std::vector<ElevationPoint> ElevationProfile(const std::vector<GeoCoord> &way)
   {
     std::vector<ElevationPoint> result;
+    ElevationProfile(way, [&result](const Distance &, const std::vector<ElevationPoint> &points){
+      result.insert(result.end(), points.begin(), points.end());
+    });
+    return result;
+  }
+
+  size_t ElevationProfile(const std::vector<GeoCoord> &way,
+                          std::function<void(const Distance &distance, const std::vector<ElevationPoint> &points)> callback)
+  {
     Distance distance;
+    size_t pointCnt = 0;
     GeoCoord intersection;
 
     std::vector<ContoursData> contours;
     GeoBox loadBox;
 
     for (size_t i=0; i < way.size()-1; i+=1){
+      std::vector<ElevationPoint> result;
       GeoCoord a1=way[i];
       GeoCoord a2=way[i+1];
       GeoBox lineBox(a1,a2);
@@ -119,19 +130,24 @@ public:
 
         }
       }
+
       //log.Debug() << "At distance " << distance << " adding " << GetEllipsoidalDistance(a1,a2) << " (" << a1.GetDisplayText() << " -> " << a2.GetDisplayText() << ")";
       distance+=GetEllipsoidalDistance(a1,a2);
+      if (!result.empty()) {
+        std::sort(result.begin(), result.end(), [](const ElevationPoint &a, const ElevationPoint &b) {
+          if (a.distance != b.distance) {
+            return a.distance < b.distance;
+          }
+          if (a.elevation != b.elevation) {
+            return a.elevation < b.elevation;
+          }
+          return a.coord < b.coord;
+        });
+        pointCnt += result.size();
+        callback(distance, result);
+      }
     }
-    std::sort(result.begin(), result.end(), [](const ElevationPoint &a, const ElevationPoint &b) {
-      if (a.distance != b.distance) {
-        return a.distance < b.distance;
-      }
-      if (a.elevation != b.elevation) {
-        return a.elevation < b.elevation;
-      }
-      return a.coord < b.coord;
-    });
-    return result;
+    return pointCnt;
   }
 };
 

--- a/libosmscout/include/osmscout/ElevationService.h
+++ b/libosmscout/include/osmscout/ElevationService.h
@@ -71,6 +71,10 @@ public:
                           std::function<void(const Distance &distance, const std::vector<ElevationPoint> &points)> callback,
                           BreakerRef breaker=nullptr)
   {
+    if (way.empty()){
+      return 0;
+    }
+
     Distance distance;
     size_t pointCnt = 0;
     GeoCoord intersection;

--- a/libosmscout/include/osmscout/ElevationService.h
+++ b/libosmscout/include/osmscout/ElevationService.h
@@ -68,7 +68,8 @@ public:
   }
 
   size_t ElevationProfile(const std::vector<GeoCoord> &way,
-                          std::function<void(const Distance &distance, const std::vector<ElevationPoint> &points)> callback)
+                          std::function<void(const Distance &distance, const std::vector<ElevationPoint> &points)> callback,
+                          BreakerRef breaker=nullptr)
   {
     Distance distance;
     size_t pointCnt = 0;
@@ -82,6 +83,10 @@ public:
       GeoCoord a1=way[i];
       GeoCoord a2=way[i+1];
       GeoBox lineBox(a1,a2);
+
+      if (i%100==0 && breaker && breaker->IsAborted()){
+        break;
+      }
 
       if (!loadBox.Includes(a1) || !loadBox.Includes(a2)) {
         TileId tile1=TileId::GetTile(loadTileMag, lineBox.GetMinCoord());

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -30,6 +30,7 @@
 
 #include <osmscout/system/Assert.h>
 #include <osmscout/util/Time.h>
+#include <osmscout/util/Locale.h>
 
 #include <osmscout/CoreImportExport.h>
 #include <osmscout/OSMScoutTypes.h>
@@ -56,7 +57,7 @@ namespace osmscout {
   extern OSMSCOUT_API bool StringToBool(const char* string, bool& value);
 
   /**
-   * Rteurns a string representation of the given boolean value (either 'true' or 'false')
+   * Returns a string representation of the given boolean value (either 'true' or 'false')
    *
    * @param value
    *    value to return
@@ -64,6 +65,15 @@ namespace osmscout {
    *    result of the conversion
    */
   extern OSMSCOUT_API const char* BoolToString(bool value);
+
+  /**
+   * Returns locale-aware string representation of number
+   *
+   * @param value
+   * @param locale
+   * @return
+   */
+  extern OSMSCOUT_API std::string NumberToString(long value, const Locale &locale);
 
   /**
    * \ingroup Util

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -2087,15 +2087,7 @@ namespace osmscout {
     }
 
     std::stringstream ss;
-    if (value < 1000 || locale.GetThousandsSeparator().empty()){
-      ss << value;
-    }else{
-      // not expecting that value will be bigger than million
-      ss << (value/1000);
-      ss << locale.GetThousandsSeparator();
-      ss << std::setw(3) << std::setfill('0') << (value%1000);
-    }
-
+    ss << NumberToString(value, locale);
     ss << locale.GetUnitsSeparator();
     ss << unitsStr;
     return ss.str();

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -33,6 +33,7 @@
 #include <osmscout/system/Math.h>
 
 #include <osmscout/util/Logger.h>
+#include <osmscout/util/Locale.h>
 #include <osmscout/util/ObjectPool.h>
 
 #include <osmscout/private/Config.h>
@@ -189,6 +190,27 @@ namespace osmscout {
     }
 
     return "false";
+  }
+
+  std::string NumberToString(long value, const Locale &locale)
+  {
+    std::stringstream ss;
+    if (std::abs(value) < 1000 || locale.GetThousandsSeparator().empty()){
+      ss << value;
+    }else{
+      long mag=1000;
+      while (mag*1000 < std::abs(value)) {
+        mag*=1000;
+      }
+      ss << (value/mag);
+      while (mag>1) {
+        ss << locale.GetThousandsSeparator();
+        value = std::abs(value % mag);
+        mag/=1000;
+        ss << std::setw(3) << std::setfill('0') << (value/mag);
+      }
+    }
+    return ss.str();
   }
 
   bool GetDigitValue(char digit, size_t& result)


### PR DESCRIPTION
Hi Tim, 

This merge request is a bit bigger. Sorry for that. But I tried to split it to multiple isolated commits for simpler review...

Goal was to create QML component that shows elevation profile estimate for route from router. To be able test that component, I also created new UI demo. For following arguments:

```
./Demos/ElevationProfileChart --vehicle foot "Pec pod Sněžkou 197" "Poštovna, Pec pod Sněžkou"
```

It shows following chart (with czech database):
![Screenshot_20210104_233145](https://user-images.githubusercontent.com/309458/103586262-07301100-4ee5-11eb-9844-4cc2f8fa296c.png)

First I tried to use Qt Chart module to achieve that, but it depends on desktop Qt Widget module. It would be hard to make it work on Sailfish OS and even chart customization would not be trivial. So I decided to to draw that chart by basic painter primitives... On phone, it may look like this:

![Snimek_20210104_001](https://user-images.githubusercontent.com/309458/103587142-e2d53400-4ee6-11eb-97d9-464fcefe3d85.png)

___

I hope that you're well in this tough time period. I wish you all the best for the new year :-)