### PR TITLE
use default constructors and destructors where possible

### DIFF
--- a/Demos/src/DumpOSS.cpp
+++ b/Demos/src/DumpOSS.cpp
@@ -27,15 +27,9 @@
 
 struct Arguments
 {
-  bool        help;
+  bool        help=false;
   std::string ostFile;
   std::string ossFile;
-
-  Arguments()
-    : help(false)
-  {
-    // no code
-  }
 };
 
 void DumpFillStyleAttributes(const std::set<osmscout::FillStyle::Attribute>& attributes,

--- a/Demos/src/GpxPipe.cpp
+++ b/Demos/src/GpxPipe.cpp
@@ -28,15 +28,9 @@
 
 struct Arguments
 {
-  bool               help;
+  bool               help=false;
   std::string        gpxInput;
   std::string        gpxOutput;
-
-  Arguments()
-      : help(false)
-  {
-    // no code
-  }
 };
 
 int main(int argc, char* argv[])

--- a/Demos/src/LookupPOI.cpp
+++ b/Demos/src/LookupPOI.cpp
@@ -31,17 +31,11 @@
 
 struct Arguments
 {
-  bool                   help;
+  bool                   help=false;
   std::string            databaseDirectory;
   osmscout::GeoCoord     topLeft;
   osmscout::GeoCoord     bottomRight;
   std::list<std::string> typeNames;
-
-  Arguments()
-    : help(false)
-  {
-    // no code
-  }
 };
 
 

--- a/Demos/src/LookupText.cpp
+++ b/Demos/src/LookupText.cpp
@@ -27,14 +27,8 @@
 
 struct Arguments
 {
-  bool        help;
+  bool        help=false;
   std::string databaseDirectory;
-
-  Arguments()
-    : help(false)
-  {
-    // no code
-  }
 };
 
 void printDetails(const osmscout::FeatureValueBuffer& features)

--- a/Demos/src/NavigationSimulator.cpp
+++ b/Demos/src/NavigationSimulator.cpp
@@ -65,16 +65,11 @@ struct Arguments
 class ConsoleRoutingProgress : public osmscout::RoutingProgress
 {
 private:
-  std::chrono::system_clock::time_point lastDump;
-  double                                maxPercent;
+  std::chrono::system_clock::time_point lastDump=std::chrono::system_clock::now();
+  double                                maxPercent=0.0;
 
 public:
-  ConsoleRoutingProgress()
-    : lastDump(std::chrono::system_clock::now()),
-      maxPercent(0.0)
-  {
-    // no code
-  }
+  ConsoleRoutingProgress() = default;
 
   void Reset() override
   {

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -73,16 +73,11 @@ struct Arguments
 class ConsoleRoutingProgress : public osmscout::RoutingProgress
 {
 private:
-  std::chrono::system_clock::time_point lastDump;
-  double                                maxPercent;
+  std::chrono::system_clock::time_point lastDump=std::chrono::system_clock::now();
+  double                                maxPercent=0.0;
 
 public:
-  ConsoleRoutingProgress()
-  : lastDump(std::chrono::system_clock::now()),
-    maxPercent(0.0)
-  {
-    // no code
-  }
+  ConsoleRoutingProgress() = default;
 
   void Reset() override
   {

--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -76,16 +76,11 @@
 class ConsoleRoutingProgress : public osmscout::RoutingProgress
 {
 private:
-  std::chrono::system_clock::time_point lastDump;
-  double                                maxPercent;
+  std::chrono::system_clock::time_point lastDump=std::chrono::system_clock::now();
+  double                                maxPercent=0.0;
 
 public:
-  ConsoleRoutingProgress()
-  : lastDump(std::chrono::system_clock::now()),
-    maxPercent(0.0)
-  {
-    // no code
-  }
+  ConsoleRoutingProgress() = default;
 
   void Reset()
   {

--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -44,10 +44,7 @@ struct Job
   osmscout::ObjectOSMRef  osmRef;
   osmscout::ObjectFileRef fileRef;
 
-  Job()
-  {
-    // no code
-  }
+  Job() = default;
 
   Job(osmscout::OSMRefType type, osmscout::Id id)
   : osmRef(id,type)

--- a/OSMScout2/src/Theme.cpp
+++ b/OSMScout2/src/Theme.cpp
@@ -33,11 +33,6 @@ Theme::Theme()
   // no code
 }
 
-Theme::~Theme()
-{
-  // no code
-}
-
 qreal Theme::mmToPixel(qreal mm) const
 {
     return mm*GetDPI()/25.4;

--- a/OSMScout2/src/Theme.h
+++ b/OSMScout2/src/Theme.h
@@ -53,7 +53,7 @@ private:
 
 public:
     Theme();
-    ~Theme() override;
+    ~Theme() override = default;
 
     qreal GetDPI() const;
 

--- a/Tests/src/CoordinateEncoding.cpp
+++ b/Tests/src/CoordinateEncoding.cpp
@@ -184,10 +184,7 @@ public:
     // no code
   }
 
-  virtual ~Encoder()
-  {
-    // no code
-  }
+  virtual ~Encoder() = default;
 
   virtual void Encode(osmscout::FileOffset offset, const std::vector<osmscout::Point>& coords) = 0;
 };

--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -81,7 +81,7 @@ public:
 
   LocationEntry(QObject* parent = nullptr);
   LocationEntry(const LocationEntry& other);
-  virtual ~LocationEntry();
+  ~LocationEntry() override = default;
 
   void operator=(const LocationEntry&);
 

--- a/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
@@ -77,11 +77,6 @@ LocationEntry::LocationEntry(const LocationEntry& other)
     // no code
 }
 
-LocationEntry::~LocationEntry()
-{
-    // no code
-}
-
 void LocationEntry::operator=(const LocationEntry& other)
 {
     type=other.type;

--- a/libosmscout-import/include/osmscout/import/GenRouteDat.h
+++ b/libosmscout-import/include/osmscout/import/GenRouteDat.h
@@ -274,7 +274,7 @@ namespace osmscout {
                          const std::string& variantFilename);
 
   public:
-    RouteDataGenerator();
+    RouteDataGenerator() = default;
 
     void GetDescription(const ImportParameter& parameter,
                         ImportModuleDescription& description) const override;

--- a/libosmscout-import/include/osmscout/import/Import.h
+++ b/libosmscout-import/include/osmscout/import/Import.h
@@ -67,7 +67,7 @@ namespace osmscout {
                         ImportProgress& progress);
   public:
     explicit Importer(const ImportParameter& parameter);
-    virtual ~Importer();
+    virtual ~Importer() = default;
 
     bool Import(ImportProgress& progress);
 

--- a/libosmscout-import/include/osmscout/import/Preprocessor.h
+++ b/libosmscout-import/include/osmscout/import/Preprocessor.h
@@ -77,7 +77,7 @@ namespace osmscout {
     using RawBlockDataRef = std::shared_ptr<RawBlockData>;
 
   public:
-    virtual ~PreprocessorCallback();
+    virtual ~PreprocessorCallback() = default;
 
     virtual void ProcessBlock(RawBlockDataRef data) = 0;
   };
@@ -85,7 +85,7 @@ namespace osmscout {
   class OSMSCOUT_IMPORT_API Preprocessor
   {
   public:
-    virtual ~Preprocessor();
+    virtual ~Preprocessor() = default;
 
     virtual bool Import(const TypeConfigRef& typeConfig,
                         const ImportParameter& parameter,

--- a/libosmscout-import/src/osmscout/import/GenRouteDat.cpp
+++ b/libosmscout-import/src/osmscout/import/GenRouteDat.cpp
@@ -46,11 +46,6 @@
 
 namespace osmscout {
 
-  RouteDataGenerator::RouteDataGenerator()
-  {
-    // no code
-  }
-
   void RouteDataGenerator::GetDescription(const ImportParameter& parameter,
                                           ImportModuleDescription& description) const
   {

--- a/libosmscout-import/src/osmscout/import/Import.cpp
+++ b/libosmscout-import/src/osmscout/import/Import.cpp
@@ -94,11 +94,6 @@ namespace osmscout {
     }
   }
 
-  Importer::~Importer()
-  {
-    // no code
-  }
-
   bool Importer::ValidateDescription(Progress& progress)
   {
     std::unordered_set<std::string> temporaryFiles;

--- a/libosmscout-import/src/osmscout/import/Preprocessor.cpp
+++ b/libosmscout-import/src/osmscout/import/Preprocessor.cpp
@@ -21,14 +21,5 @@
 
 namespace osmscout {
 
-  PreprocessorCallback::~PreprocessorCallback()
-  {
-    // no code
-  }
-
-  Preprocessor::~Preprocessor()
-  {
-    // no code
-  }
 }
 

--- a/libosmscout-map/include/osmscout/DataTileCache.h
+++ b/libosmscout-map/include/osmscout/DataTileCache.h
@@ -286,7 +286,7 @@ namespace osmscout {
   public:
     friend class DataTileCache;
 
-    ~Tile();
+    ~Tile() = default;
 
     /**
      * Return the id of the tile

--- a/libosmscout-map/include/osmscout/LabelProvider.h
+++ b/libosmscout-map/include/osmscout/LabelProvider.h
@@ -39,7 +39,7 @@ namespace osmscout {
   class OSMSCOUT_MAP_API LabelProvider
   {
   public:
-    virtual ~LabelProvider();
+    virtual ~LabelProvider() = default;
 
     /**
      * Returns the label based on the given feature value buffer
@@ -67,7 +67,7 @@ namespace osmscout {
   class OSMSCOUT_MAP_API LabelProviderFactory
   {
   public:
-    virtual ~LabelProviderFactory();
+    virtual ~LabelProviderFactory() = default;
 
     virtual LabelProviderRef Create(const TypeConfig& typeConfig) const = 0;
   };

--- a/libosmscout-map/include/osmscout/MapTileCache.h
+++ b/libosmscout-map/include/osmscout/MapTileCache.h
@@ -215,7 +215,7 @@ namespace osmscout {
   public:
     explicit MapTile(const TileKey& key);
 
-    ~MapTile();
+    ~MapTile() = default;
 
     /**
      * Return the id of the tile

--- a/libosmscout-map/include/osmscout/StyleDescription.h
+++ b/libosmscout-map/include/osmscout/StyleDescription.h
@@ -51,7 +51,7 @@ namespace osmscout {
   class OSMSCOUT_MAP_API Style
   {
   public:
-    virtual ~Style();
+    virtual ~Style() = default;
 
     virtual void SetBoolValue(int attribute, bool value);
     virtual void SetStringValue(int attribute, const std::string& value);
@@ -112,7 +112,7 @@ namespace osmscout {
                              int attribute);
 
   public:
-    virtual ~StyleAttributeDescriptor();
+    virtual ~StyleAttributeDescriptor() = default;
 
     inline std::string GetName() const
     {

--- a/libosmscout-map/include/osmscout/StyleProcessor.h
+++ b/libosmscout-map/include/osmscout/StyleProcessor.h
@@ -30,7 +30,7 @@ namespace osmscout {
   class OSMSCOUT_MAP_API FillStyleProcessor
   {
   public:
-    virtual ~FillStyleProcessor();
+    virtual ~FillStyleProcessor() = default;
 
     virtual FillStyleRef Process(const FeatureValueBuffer& features,
                                  const FillStyleRef& fillStyle) const = 0;

--- a/libosmscout-map/include/osmscout/Styles.h
+++ b/libosmscout-map/include/osmscout/Styles.h
@@ -473,7 +473,7 @@ namespace osmscout {
     LabelStyle();
     LabelStyle(const LabelStyle& style);
 
-    ~LabelStyle() override;
+    ~LabelStyle() override = default;
 
     virtual bool IsVisible() const = 0;
     virtual double GetAlpha() const = 0;
@@ -995,7 +995,7 @@ namespace osmscout {
     DrawPrimitive(ProjectionMode projectionMode,
                   const FillStyleRef& fillStyle,
                   const BorderStyleRef& borderStyle);
-    virtual ~DrawPrimitive();
+    virtual ~DrawPrimitive() = default;
 
     inline ProjectionMode GetProjectionMode() const
     {

--- a/libosmscout-map/include/osmscout/oss/Scanner.h
+++ b/libosmscout-map/include/osmscout/oss/Scanner.h
@@ -86,15 +86,9 @@ private:
   std::map<int,int> map;
 
 public:
-  StartStates()
-  {
-    // no code
-  }
+  StartStates() = default;
 
-  virtual ~StartStates()
-  {
-    // no code
-  }
+  virtual ~StartStates() = default;
 
   void set(int key, int val)
   {
@@ -122,15 +116,9 @@ private:
   std::map<std::string,int> map;
 
 public:
-  KeywordMap()
-  {
-    // no code
-  }
+  KeywordMap() = default;
 
-  virtual ~KeywordMap()
-  {
-    // no code
-  }
+  virtual ~KeywordMap() = default;
 
   void set(const char* key, int val)
   {

--- a/libosmscout-map/src/osmscout/DataTileCache.cpp
+++ b/libosmscout-map/src/osmscout/DataTileCache.cpp
@@ -35,11 +35,6 @@ namespace osmscout {
     // no code
   }
 
-  Tile::~Tile()
-  {
-    // no code
-  }
-
   /**
    * Create a new tile cache with the given cache size
    */

--- a/libosmscout-map/src/osmscout/LabelProvider.cpp
+++ b/libosmscout-map/src/osmscout/LabelProvider.cpp
@@ -23,16 +23,6 @@
 
 namespace osmscout {
 
-  LabelProvider::~LabelProvider()
-  {
-    // No code
-  }
-
-  LabelProviderFactory::~LabelProviderFactory()
-  {
-    // no code
-  }
-
   INameLabelProviderFactory::INameLabelProvider::INameLabelProvider(const TypeConfig& typeConfig)
   {
     nameLookupTable.resize(typeConfig.GetTypeCount(),

--- a/libosmscout-map/src/osmscout/MapTileCache.cpp
+++ b/libosmscout-map/src/osmscout/MapTileCache.cpp
@@ -31,8 +31,4 @@ namespace osmscout {
     // no code
   }
 
-  MapTile::~MapTile()
-  {
-    // no code
-  }
 }

--- a/libosmscout-map/src/osmscout/StyleDescription.cpp
+++ b/libosmscout-map/src/osmscout/StyleDescription.cpp
@@ -23,11 +23,6 @@
 
 namespace osmscout {
 
-  Style::~Style()
-  {
-    // no code
-  }
-
   void Style::SetBoolValue(int /*attribute*/,
                            bool /*value*/)
   {
@@ -94,11 +89,6 @@ namespace osmscout {
   : type(type),
     name(name),
     attribute(attribute)
-  {
-    // no code
-  }
-
-  StyleAttributeDescriptor::~StyleAttributeDescriptor()
   {
     // no code
   }

--- a/libosmscout-map/src/osmscout/StyleProcessor.cpp
+++ b/libosmscout-map/src/osmscout/StyleProcessor.cpp
@@ -21,8 +21,4 @@
 
 namespace osmscout {
 
-  FillStyleProcessor::~FillStyleProcessor()
-  {
-    // no code
-  }
 }

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -830,11 +830,6 @@ namespace osmscout {
     this->size=style.size;
   }
 
-  LabelStyle::~LabelStyle()
-  {
-    // no code
-  }
-
   LabelStyle& LabelStyle::SetPriority(size_t priority)
   {
     this->priority=priority;
@@ -1554,11 +1549,6 @@ namespace osmscout {
         break;
       }
     }
-  }
-
-  DrawPrimitive::~DrawPrimitive()
-  {
-    // no code
   }
 
   DrawPrimitive::DrawPrimitive(ProjectionMode projectionMode,

--- a/libosmscout/include/osmscout/routing/RouteDescriptionPostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RouteDescriptionPostprocessor.h
@@ -52,7 +52,7 @@ namespace osmscout {
      */
     struct OSMSCOUT_API Callback
     {
-      virtual ~Callback();
+      virtual ~Callback() = default;
 
       /**
        * Call once before evaluation the the RouteDescription starts

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -63,7 +63,7 @@ namespace osmscout {
     class OSMSCOUT_API Postprocessor
     {
     public:
-      virtual ~Postprocessor();
+      virtual ~Postprocessor() = default;
 
       virtual bool Process(const RoutePostprocessor& postprocessor,
                            RouteDescription& description) = 0;

--- a/libosmscout/include/osmscout/routing/RoutingService.h
+++ b/libosmscout/include/osmscout/routing/RoutingService.h
@@ -153,7 +153,7 @@ namespace osmscout {
   class OSMSCOUT_API RoutingProgress
   {
   public:
-    virtual ~RoutingProgress();
+    virtual ~RoutingProgress() = default;
 
     /**
      * Call, if you want to reset the progress

--- a/libosmscout/include/osmscout/util/Progress.h
+++ b/libosmscout/include/osmscout/util/Progress.h
@@ -61,7 +61,7 @@ namespace osmscout {
   {
     public:
     SilentProgress() = default;
-    ~SilentProgress() override;
+    ~SilentProgress() override = default;
   };
 
   class OSMSCOUT_API ConsoleProgress : public Progress

--- a/libosmscout/src/osmscout/routing/RouteDescriptionPostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RouteDescriptionPostprocessor.cpp
@@ -27,10 +27,6 @@
 
 
 namespace osmscout {
-  RouteDescriptionPostprocessor::Callback::~Callback()
-  {
-    // no code
-  }
 
   void RouteDescriptionPostprocessor::Callback::BeforeRoute()
   {

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -31,11 +31,6 @@
 
 namespace osmscout {
 
-  RoutePostprocessor::Postprocessor::~Postprocessor()
-  {
-    // no code
-  }
-
   RoutePostprocessor::StartPostprocessor::StartPostprocessor(const std::string& startDescription)
   : startDescription(startDescription)
   {

--- a/libosmscout/src/osmscout/routing/RoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/RoutingService.cpp
@@ -66,11 +66,6 @@ namespace osmscout {
     return debugPerformance;
   }
 
-  RoutingProgress::~RoutingProgress()
-  {
-    // no code
-  }
-
   void RoutingParameter::SetBreaker(const BreakerRef& breaker)
   {
     this->breaker=breaker;

--- a/libosmscout/src/osmscout/util/Progress.cpp
+++ b/libosmscout/src/osmscout/util/Progress.cpp
@@ -98,11 +98,6 @@ namespace osmscout {
     // no code
   }
 
-  SilentProgress::~SilentProgress() // NOLINT
-  {
-    // no code
-  }
-
   void ConsoleProgress::SetStep(const std::string& step)
   {
     std::cout << "+ " << step << "..." << std::endl;


### PR DESCRIPTION
...as suggested by clang-tidy: 

> Use '= default' to define a trivial destructor. 
