### PR TITLE
use std::array instead of C-style array

### DIFF
--- a/Tests/src/CoordinateEncoding.cpp
+++ b/Tests/src/CoordinateEncoding.cpp
@@ -195,7 +195,7 @@ public:
 class TrivialEncoder : public Encoder
 {
 private:
-  char buffer[10]; // Enough for 64bit values
+  std::array<char,10> buffer; // Enough for 64bit values
 public:
   TrivialEncoder()
   : Encoder("TrivialEncoder")
@@ -225,7 +225,7 @@ public:
 class MinimumVLQDeltaEncoder : public Encoder
 {
 private:
-  char buffer[10]; // Enough for 64bit values
+  std::array<char,10> buffer; // Enough for 64bit values
 
 public:
   MinimumVLQDeltaEncoder()
@@ -265,7 +265,7 @@ public:
 class VLQDeltaEncoder : public Encoder
 {
 private:
-  char buffer[10]; // Enough for 64bit values
+  std::array<char,10> buffer; // Enough for 64bit values
 
 public:
   VLQDeltaEncoder()

--- a/Tests/src/EncodeNumber.cpp
+++ b/Tests/src/EncodeNumber.cpp
@@ -8,9 +8,8 @@
 bool CheckEncode(uint64_t value,
                  const char* expected, size_t expectedLength)
 {
-  const size_t bufferLength=10;
-  char         buffer[bufferLength];
-  size_t       bytes;
+  std::array<char,10> buffer;
+  size_t              bytes;
 
   bytes=osmscout::EncodeNumber(value,buffer);
 

--- a/libosmscout-import/include/osmscout/import/AreaIndexGenerator.h
+++ b/libosmscout-import/include/osmscout/import/AreaIndexGenerator.h
@@ -156,7 +156,7 @@ namespace osmscout {
       indexEntries+=cell.second.size();
 
       dataSize+=EncodeNumber(cell.second.size(),
-                             buffer.data());
+                             buffer);
 
       FileOffset previousOffset=0;
 
@@ -164,7 +164,7 @@ namespace osmscout {
         FileOffset data=offset-previousOffset;
 
         dataSize+=EncodeNumber(data,
-                               buffer.data());
+                               buffer);
 
         previousOffset=offset;
       }

--- a/libosmscout-import/include/osmscout/import/GenNumericIndex.h
+++ b/libosmscout-import/include/osmscout/import/GenNumericIndex.h
@@ -163,12 +163,12 @@ namespace osmscout {
         }
 
         if (currentPageSize>0) {
-          char         b1[10];
-          char         b2[10];
-          N            b1val=data.GetId()-lastId;
-          FileOffset   b2val=readPos-lastPos;
-          unsigned int b1size;
-          unsigned int b2size;
+          std::array<char,10> b1;
+          std::array<char,10> b2;
+          N                   b1val=data.GetId()-lastId;
+          FileOffset          b2val=readPos-lastPos;
+          unsigned int        b1size;
+          unsigned int        b2size;
 
 
           b1size=EncodeNumber(b1val,b1);
@@ -184,8 +184,8 @@ namespace osmscout {
             currentPageSize=0;
           }
           else {
-            writer.Write(b1,b1size);
-            writer.Write(b2,b2size);
+            writer.Write(b1.data(),b1size);
+            writer.Write(b2.data(),b2size);
 
             currentPageSize+=b1size+b2size;
           }
@@ -224,12 +224,12 @@ namespace osmscout {
 
         for (size_t i=0; i<si.size(); i++) {
           if (currentPageSize>0) {
-            char         b1[10];
-            char         b2[10];
-            N            b1val=si[i]-si[i-1];
-            FileOffset   b2val=po[i]-po[i-1];
-            unsigned int b1size;
-            unsigned int b2size;
+            std::array<char,10> b1;
+            std::array<char,10> b2;
+            N                   b1val=si[i]-si[i-1];
+            FileOffset          b2val=po[i]-po[i-1];
+            unsigned int        b1size;
+            unsigned int        b2size;
 
             b1size=EncodeNumber(b1val,b1);
             b2size=EncodeNumber(b2val,b2);
@@ -244,8 +244,8 @@ namespace osmscout {
               currentPageSize=0;
             }
             else {
-              writer.Write(b1,b1size);
-              writer.Write(b2,b2size);
+              writer.Write(b1.data(),b1size);
+              writer.Write(b2.data(),b2size);
 
               currentPageSize+=b1size+b2size;
             }

--- a/libosmscout-import/src/osmscout/import/GenAreaNodeIndex.cpp
+++ b/libosmscout-import/src/osmscout/import/GenAreaNodeIndex.cpp
@@ -437,7 +437,6 @@ namespace osmscout {
     std::map<TileId,std::list<FileOffset>> bitmapData;
     size_t                                 dataSize=0;
     std::array<char,10>                    buffer;
-    //char                                   buffer[10];
     MagnificationLevel                     magnification=GetBitmapZoomLevel(parameter,data);
 
     for (const auto& entry : data) {
@@ -452,7 +451,7 @@ namespace osmscout {
 
     // Calculate the size of the bitmap for each current node type
     for (const auto& cell : bitmapData) {
-      dataSize+=EncodeNumber(cell.second.size(),buffer.data());
+      dataSize+=EncodeNumber(cell.second.size(),buffer);
 
       FileOffset previousOffset=0;
       for (auto offset : cell.second) {

--- a/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeAreasLowZoom.cpp
@@ -413,14 +413,14 @@ namespace osmscout
       indexEntries+=cell.second.size();
 
       dataSize+=EncodeNumber(cell.second.size(),
-                             buffer.data());
+                             buffer);
 
       FileOffset previousOffset=0;
       for (const auto& offset : cell.second) {
         FileOffset dataOffset=offset-previousOffset;
 
         dataSize+=EncodeNumber(dataOffset,
-                               buffer.data());
+                               buffer);
 
         previousOffset=offset;
       }

--- a/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
+++ b/libosmscout-import/src/osmscout/import/GenOptimizeWaysLowZoom.cpp
@@ -537,14 +537,14 @@ namespace osmscout
       indexEntries+=cell.second.size();
 
       dataSize+=EncodeNumber(cell.second.size(),
-                             buffer.data());
+                             buffer);
 
       FileOffset previousOffset=0;
       for (const auto& offset : cell.second) {
         FileOffset data=offset-previousOffset;
 
         dataSize+=EncodeNumber(data,
-                               buffer.data());
+                               buffer);
 
         previousOffset=offset;
       }

--- a/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscout/import/WaterIndexProcessor.cpp
@@ -2547,8 +2547,8 @@ namespace osmscout {
       // Calculate size of data
       //
 
-      size_t dataSize=4;
-      char   buffer[10];
+      size_t              dataSize=4;
+      std::array<char,10> buffer;
 
       for (const auto& coord : cellGroundTileMap) {
         // Number of ground tiles

--- a/libosmscout/include/osmscout/AreaAreaIndex.h
+++ b/libosmscout/include/osmscout/AreaAreaIndex.h
@@ -20,6 +20,7 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <array>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -59,8 +60,8 @@ namespace osmscout {
       */
     struct IndexCell
     {
-      FileOffset children[4]; //!< File index of each of the four children, or 0 if there is no child
-      FileOffset data;        //!< The file index at which the data payload starts
+      std::array<FileOffset, 4> children; //!< File index of each of the four children, or 0 if there is no child
+      FileOffset data;                    //!< The file index at which the data payload starts
     };
 
     using IndexCache = Cache<FileOffset, IndexCell>;

--- a/libosmscout/src/osmscout/AreaAreaIndex.cpp
+++ b/libosmscout/src/osmscout/AreaAreaIndex.cpp
@@ -107,10 +107,7 @@ namespace osmscout {
     }
     else {
       indexCell.data=offset;
-
-      for (FileOffset& c : indexCell.children) {
-        c=0;
-      }
+      indexCell.children.fill(0);
     }
 
     dataOffset=indexCell.data;

--- a/libosmscout/src/osmscout/util/FileWriter.cpp
+++ b/libosmscout/src/osmscout/util/FileWriter.cpp
@@ -598,12 +598,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write int16_t number","File already in error state");
     }
 
-    char         buffer[3];
+    std::array<char,3> buffer;
     unsigned int bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write int16_t number");
@@ -623,12 +623,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write int32_t number","File already in error state");
     }
 
-    char         buffer[5];
-    unsigned int bytes;
+    std::array<char,5> buffer;
+    unsigned int       bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write int32_t number");
@@ -648,12 +648,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write int64_t number","File already in error state");
     }
 
-    char         buffer[10];
-    unsigned int bytes;
+    std::array<char,10> buffer;
+    unsigned int        bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write int64_t number");
@@ -673,12 +673,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write uint16_t number","File already in error state");
     }
 
-    char         buffer[10];
-    unsigned int bytes;
+    std::array<char,10> buffer;
+    unsigned int        bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write uint16_t number");
@@ -698,12 +698,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write uint32_t number","File already in error state");
     }
 
-    char         buffer[10];
-    unsigned int bytes;
+    std::array<char,10> buffer;
+    unsigned int        bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write uint32_t number");
@@ -723,12 +723,12 @@ namespace osmscout {
       throw IOException(filename,"Cannot write uint64_t number","File already in error state");
     }
 
-    char         buffer[10];
-    unsigned int bytes;
+    std::array<char,10> buffer;
+    unsigned int        bytes;
 
     bytes=EncodeNumber(number,buffer);
 
-    hasError=fwrite(buffer,sizeof(unsigned char),bytes,file)!=bytes;
+    hasError=fwrite(buffer.data(),sizeof(unsigned char),bytes,file)!=bytes;
 
     if (hasError) {
       throw IOException(filename,"Cannot write uint64_t number");


### PR DESCRIPTION
It is another clang-tidy recommendation. Other usages of C-arrays in library cannot be simply replaced without copying of buffers. 