### PR TITLE
fix crash SIGSEGV caused by referencing deleted iterator in iteration

### DIFF
--- a/libosmscout-client-qt/include/osmscout/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscout/NearPOIModel.h
@@ -107,7 +107,7 @@ public slots:
 private:
   bool searching{false};
   int currentRequest{0};
-  QList<LocationEntry*> locations;
+  QList<LocationEntryRef> locations;
   osmscout::GeoCoord searchCenter{INVALID_COORD,INVALID_COORD};
   int resultLimit{100};
   osmscout::BreakerRef breaker;

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -144,7 +144,7 @@ public slots:
 private:
   QString pattern;
   QString lastRequestPattern;
-  QList<LocationEntry*> locations;
+  QList<LocationEntryRef> locations;
   bool searching;
   SearchModule* searchModule;
   LookupModule* lookupModule;


### PR DESCRIPTION
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8 in tid 28485 (qtMainLoopThrea), pid 28463
(QScopedPointer<QObjectData, QScopedPointerDeleter<QObjectData>>::operator->() const+12)
(QObject::parent() const+28)
(osmscout::LocationEntry::LocationEntry(osmscout::LocationEntry const&)+80)
(osmscout::LocationListModel::onSearchResult(QString, QList<osmscout::LocationEntry>)+1552)

Platform: Qt5.12.9, arm64

The fix erase merged locations outside of the loop