### PR TITLE
fix size of painted items using HiDPI device

### DIFF
--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -140,6 +140,8 @@ private:
   };
   Vehicle vehicle;
 
+  float vehicleScaleFactor{1.0};
+
 signals:
   void viewChanged();
   void lockToPossitionChanged();
@@ -230,6 +232,14 @@ public slots:
 
   bool toggleDebug();
   bool toggleInfo();
+
+  /**
+   * Method for configuring the aspect ratio of painted items. Default value is 1.0.
+   * Using HiDPI it is required to set the value according with the scale factor.
+   *
+   * @param ratio
+   */
+  void setVehicleScaleFactor(float factor);
 
 private slots:
 

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -277,9 +277,8 @@ void MapWidget::paint(QPainter *painter)
       }
 
       painter->save();
-      QTransform t=QTransform::fromTranslate(x, y); // move to rotation center
-      t.rotateRadians(iconAngle.AsRadians());
-      painter->setTransform(t);
+      painter->translate(x,y);
+      painter->rotate(iconAngle.AsDegrees());
       // draw vehicleIcon center on coordinate 0x0
       painter->drawImage(QPointF(vehicleIcon.width()/-2, vehicleIcon.height()/-2), vehicleIcon);
       painter->restore();
@@ -782,7 +781,7 @@ QImage MapWidget::loadSVGIcon(const QString &directory, const QString fileName, 
 
 void MapWidget::loadVehicleIcons()
 {
-  double iconPixelSize=getProjection().ConvertWidthToPixel(vehicle.iconSize);
+  double iconPixelSize=getProjection().ConvertWidthToPixel(vehicle.iconSize * vehicleScaleFactor);
   QString iconDirectory=OSMScoutQt::GetInstance().GetIconDirectory();
 
   vehicle.standardIcon=loadSVGIcon(iconDirectory, vehicle.standardIconFile, iconPixelSize);
@@ -850,6 +849,13 @@ bool MapWidget::toggleInfo()
     osmscout::log.Info(!osmscout::log.IsInfo());
 
     return osmscout::log.IsInfo();
+}
+
+void MapWidget::setVehicleScaleFactor(float factor)
+{
+  vehicleScaleFactor = factor;
+  loadVehicleIcons();
+  redraw();
 }
 
 QString MapWidget::GetRenderingType() const


### PR DESCRIPTION
Using device with HiDPI, painted items are not positioned correctly.
Only the client app knows the ratio to compute the right position. The pixel ratio can be
configured with "setPixelRatio()". Obviously the default is 1.0.