### PR TITLE
gpx: import TrkExtension/gpxx:DisplayColor

### DIFF
--- a/libosmscout-gpx/include/osmscout/gpx/Track.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Track.h
@@ -24,6 +24,8 @@
 
 #include <osmscout/gpx/GPXImportExport.h>
 
+#include <osmscout/util/Color.h>
+
 #include <string>
 #include <vector>
 #include <optional>
@@ -35,6 +37,8 @@ public:
   std::optional<std::string> name;
   std::optional<std::string> desc;
   std::vector<TrackSegment> segments;
+
+  std::optional<osmscout::Color> displayColor;
 
   /**
    * Compute track length in meters

--- a/libosmscout-gpx/src/osmscout/gpx/Import.cpp
+++ b/libosmscout-gpx/src/osmscout/gpx/Import.cpp
@@ -50,7 +50,7 @@ public:
   virtual GpxParserContext* StartElement(const std::string &name,
                                          const std::unordered_map<std::string, std::string> &/*atts*/);
 
-  virtual void Characters(const std::string &/*str*/){};
+  virtual void Characters(const std::string &/*str*/){}
 };
 
 
@@ -351,12 +351,12 @@ public:
   const char *ContextName() const override
   {
     return name.c_str();
-  };
+  }
 
   void Characters(const std::string &str) override
   {
     buffer+=str;
-  };
+  }
 
 };
 
@@ -750,7 +750,7 @@ public:
   }
 
   GpxParserContext* StartElement(const std::string &name,
-                                 const std::unordered_map<std::string, std::string> &atts) override
+                                 const std::unordered_map<std::string, std::string> &/*atts*/) override
   {
     if (elem_equal(name, "TrackExtension")){
       return new TrkExtensionContext(ctxt, track, parser);
@@ -787,7 +787,7 @@ public:
   const char *ContextName() const override
   {
     return "Trk";
-  };
+  }
 
   GpxParserContext* StartElement(const std::string &name,
                                  const std::unordered_map<std::string, std::string> &/*atts*/) override

--- a/libosmscout/include/osmscout/util/Color.h
+++ b/libosmscout/include/osmscout/util/Color.h
@@ -50,6 +50,15 @@ namespace osmscout {
     static const Color TEAL;
     static const Color AQUA;
 
+    static const Color LIGHT_GRAY;
+    static const Color DARK_GRAY;
+    static const Color DARK_RED;
+    static const Color DARK_GREEN;
+    static const Color DARK_YELLOW;
+    static const Color DARK_BLUE;
+    static const Color DARK_FUCHSIA;
+    static const Color DARK_AQUA;
+
     static const Color LUCENT_WHITE;
 
   private:

--- a/libosmscout/src/osmscout/util/Color.cpp
+++ b/libosmscout/src/osmscout/util/Color.cpp
@@ -43,7 +43,17 @@ namespace osmscout {
   const Color Color::TEAL(0/255,128/255,128/255);
   const Color Color::AQUA(0/255,255/255,255/255);
 
+  const Color Color::LIGHT_GRAY(211/255,211/255,211/255);
+  const Color Color::DARK_GRAY(169/255,169/255,169/255);
+  const Color Color::DARK_RED(139/255,0/255,0/255);
+  const Color Color::DARK_GREEN(0/255,100/255,0/255);
+  const Color Color::DARK_YELLOW(255/255,215/255,0/255);
+  const Color Color::DARK_BLUE(0/255,0/255,139/255);
+  const Color Color::DARK_FUCHSIA(139/255,0/255,139/255);
+  const Color Color::DARK_AQUA(0/255,139/255,139/255);
+
   const Color Color::LUCENT_WHITE(1.0,1.0,1.0,1.0);
+
 
   static char GetHexChar(size_t value)
   {
@@ -178,7 +188,15 @@ namespace osmscout {
         {"navy", Color::NAVY}, // #000080
         {"blue", Color::BLUE}, // #0000FF
         {"teal", Color::TEAL}, // #008080
-        {"aqua", Color::AQUA}, {"cyan", Color::AQUA} // #00FFFF
+        {"aqua", Color::AQUA}, {"cyan", Color::AQUA}, // #00FFFF
+        {"lightgray", Color::LIGHT_GRAY}, {"lightgrey", Color::LIGHT_GRAY}, // #D3D3D3
+        {"darkgray", Color::DARK_GRAY}, {"darkgrey", Color::DARK_GRAY}, // #A9A9A9
+        {"darkred", Color::DARK_RED}, // #8B0000
+        {"darkgreen", Color::DARK_GREEN}, // #006400
+        {"darkyellow", Color::DARK_YELLOW}, // #FFD700
+        {"darkblue", Color::DARK_BLUE}, // #00008B
+        {"darkfuchsia", Color::DARK_FUCHSIA}, {"darkmagenta", Color::DARK_FUCHSIA},// #8B008B
+        {"darkaqua", Color::DARK_AQUA}, {"darkcyan", Color::DARK_AQUA} // #008B8B
     };
 
     auto it=w3cColorKeywords.find(colorKeyword);


### PR DESCRIPTION
This allows to retrieve the original color of track from GPX file.

Obviously you need to configure the OSS style to draw tracks with customized color as follow.

Sample of style:

ORDER WAYS
  GROUP _trackBlack, _trackDarkRed, _trackDarkGreen, _trackDarkYellow, _trackDarkBlue,
        _trackDarkMagenta, _trackDarkCyan, _trackDarkGray, _trackLightGray, _trackRed,
        _trackGreen, _trackYellow, _trackBlue, _trackMagenta, _trackCyan, _trackWhite
CONST
  COLOR trackBlackColor            = #000000;
  COLOR trackDarkRedColor          = #8b0000;
  COLOR trackDarkGreenColor        = #006400;
  COLOR trackDarkYellowColor       = #ffd700;
  COLOR trackDarkBlueColor         = #00008b;
  COLOR trackDarkMagentaColor      = #8b008b;
  COLOR trackDarkCyanColor         = #008b8b;
  COLOR trackDarkGrayColor         = #a9a9a9;
  COLOR trackLightGrayColor        = #d3d3d3;
  COLOR trackRedColor              = #ff0000;
  COLOR trackGreenColor            = #00ff00;
  COLOR trackYellowColor           = #ffff00;
  COLOR trackBlueColor             = #0000ff;
  COLOR trackMagentaColor          = #ff00ff;
  COLOR trackCyanColor             = #00ffff;
  COLOR trackWhiteColor            = #f8f8ff;
STYLE
  [TYPE _trackBlack] WAY {color: @trackBlackColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkRed] WAY {color: @trackDarkRedColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkGreen] WAY {color: @trackDarkGreenColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkYellow] WAY {color: @trackDarkYellowColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkBlue] WAY {color: @trackDarkBlueColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkMagenta] WAY {color: @trackDarkMagentaColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkCyan] WAY {color: @trackDarkCyanColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackDarkGray] WAY {color: @trackDarkGrayColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackLightGray] WAY {color: @trackLightGrayColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackRed] WAY {color: @trackRedColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackGreen] WAY {color: @trackGreenColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackYellow] WAY {color: @trackYellowColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackBlue] WAY {color: @trackBlueColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackMagenta] WAY {color: @trackMagentaColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackCyan] WAY {color: @trackCyanColor; displayWidth: 1.1mm; priority: 100; }
  [TYPE _trackWhite] WAY {color: @trackWhiteColor; displayWidth: 1.1mm; priority: 100; }