### PR TITLE
allow to change map style from qml frontend

### DIFF
--- a/libosmscout-client-qt/include/osmscout/Settings.h
+++ b/libosmscout-client-qt/include/osmscout/Settings.h
@@ -196,6 +196,7 @@ class OSMSCOUT_CLIENT_QT_API QmlSettings: public QObject{
   Q_PROPERTY(bool     onlineTiles READ GetOnlineTilesEnabled WRITE SetOnlineTilesEnabled NOTIFY OnlineTilesEnabledChanged)
   Q_PROPERTY(QString  onlineTileProviderId READ GetOnlineTileProviderId WRITE SetOnlineTileProviderId NOTIFY OnlineTileProviderIdChanged)
   Q_PROPERTY(bool     offlineMap READ GetOfflineMap WRITE SetOfflineMap NOTIFY OfflineMapChanged)
+  Q_PROPERTY(QString  styleSheetFile READ GetStyleSheetFile WRITE SetStyleSheetFile NOTIFY StyleSheetFileChanged)
   Q_PROPERTY(bool     renderSea  READ GetRenderSea  WRITE SetRenderSea  NOTIFY RenderSeaChanged)
   Q_PROPERTY(QString  fontName    READ GetFontName            WRITE SetFontName     NOTIFY FontNameChanged)
   Q_PROPERTY(double   fontSize    READ GetFontSize            WRITE SetFontSize     NOTIFY FontSizeChanged)
@@ -211,6 +212,7 @@ signals:
   void OnlineTilesEnabledChanged(bool enabled);
   void OnlineTileProviderIdChanged(const QString id);
   void OfflineMapChanged(bool);
+  void StyleSheetFileChanged(const QString file);
   void RenderSeaChanged(bool);
   void FontNameChanged(const QString fontName);
   void FontSizeChanged(double fontSize);
@@ -237,6 +239,9 @@ public:
 
   bool GetOfflineMap() const;
   void SetOfflineMap(bool);
+
+  QString GetStyleSheetFile() const;
+  void SetStyleSheetFile(const QString file);
 
   bool GetRenderSea() const;
   void SetRenderSea(bool);

--- a/libosmscout-client-qt/src/osmscout/Settings.cpp
+++ b/libosmscout-client-qt/src/osmscout/Settings.cpp
@@ -396,6 +396,8 @@ QmlSettings::QmlSettings()
             this, &QmlSettings::OnlineTileProviderIdChanged);
     connect(settings.get(), &Settings::OfflineMapChanged,
             this, &QmlSettings::OfflineMapChanged);
+    connect(settings.get(), &Settings::StyleSheetFileChanged,
+            this, &QmlSettings::StyleSheetFileChanged);
     connect(settings.get(), &Settings::RenderSeaChanged,
             this, &QmlSettings::RenderSeaChanged);
     connect(settings.get(), &Settings::FontNameChanged,
@@ -459,6 +461,15 @@ bool QmlSettings::GetOfflineMap() const
 void QmlSettings::SetOfflineMap(bool b)
 {
     settings->SetOfflineMap(b);
+}
+
+QString QmlSettings::GetStyleSheetFile() const
+{
+    return settings->GetStyleSheetFile();
+}
+void QmlSettings::SetStyleSheetFile(const QString file)
+{
+    settings->SetStyleSheetFile(file);
 }
 
 bool QmlSettings::GetRenderSea() const


### PR DESCRIPTION
Introduce GetStyleSheetFile() and SetStyleSheetFile() to get/set the map stylesheet
from QML frontend. Setting style will change the map style online.