### PR TITLE
enable result limit for NearPOIModel

### DIFF
--- a/libosmscout-client-qt/include/osmscout/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscout/NearPOIModel.h
@@ -67,7 +67,7 @@ Q_OBJECT
   Q_PROPERTY(double   maxDistance READ GetMaxDistance WRITE SetMaxDistance)
 
   /**
-   * Limit of results for each database.
+   * Limit of lookup results.
    */
   Q_PROPERTY(int      resultLimit READ GetResultLimit WRITE SetResultLimit)
 

--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -176,6 +176,11 @@ void NearPOIModel::onLookupResult(int requestId, QList<LocationEntry> newLocatio
       position++;
     }
 
+    // do not care of result outside the limit
+    if (position > resultLimit) {
+      continue;
+    }
+
     emit beginInsertRows(QModelIndex(), position, position);
     locations.insert(position, new LocationEntry(location));
     qDebug() << "Put " << location.getObjectType() << location.getLabel() << " to position: " << position << "(distance" << distance.AsMeter() << " m)";


### PR DESCRIPTION
Break lookup result after reached limit