### PR TITLE
fix colors initializer

### DIFF
--- a/libosmscout/src/osmscout/util/Color.cpp
+++ b/libosmscout/src/osmscout/util/Color.cpp
@@ -31,26 +31,26 @@ namespace osmscout {
   const Color Color::GREEN(0.0,1.0,0.0);
   const Color Color::BLUE(0.0,0.0,1.0);
 
-  const Color Color::SILVER(192/255,192/255,192/255);
-  const Color Color::GRAY(128/255,128/255,128/255);
-  const Color Color::MAROON(128/255,0/255,0/255);
-  const Color Color::PURPLE(128/255,0/255,128/255);
-  const Color Color::FUCHSIA(255/255,0/255,255/255);
-  const Color Color::LIME(0/255,255/255,0/255);
-  const Color Color::OLIVE(128/255,128/255,0/255);
-  const Color Color::YELLOW(255/255,255/255,0/255);
-  const Color Color::NAVY(0/255,0/255,128/255);
-  const Color Color::TEAL(0/255,128/255,128/255);
-  const Color Color::AQUA(0/255,255/255,255/255);
+  const Color Color::SILVER(192.0/255,192.0/255,192.0/255);
+  const Color Color::GRAY(128.0/255,128.0/255,128.0/255);
+  const Color Color::MAROON(128.0/255,0.0/255,0.0/255);
+  const Color Color::PURPLE(128.0/255,0/255,128.0/255);
+  const Color Color::FUCHSIA(255.0/255,0.0/255,255.0/255);
+  const Color Color::LIME(0.0/255,255.0/255,0.0/255);
+  const Color Color::OLIVE(128.0/255,128.0/255,0.0/255);
+  const Color Color::YELLOW(255.0/255,255.0/255,0.0/255);
+  const Color Color::NAVY(0.0/255,0.0/255,128.0/255);
+  const Color Color::TEAL(0.0/255,128.0/255,128.0/255);
+  const Color Color::AQUA(0.0/255,255.0/255,255.0/255);
 
-  const Color Color::LIGHT_GRAY(211/255,211/255,211/255);
-  const Color Color::DARK_GRAY(169/255,169/255,169/255);
-  const Color Color::DARK_RED(139/255,0/255,0/255);
-  const Color Color::DARK_GREEN(0/255,100/255,0/255);
-  const Color Color::DARK_YELLOW(255/255,215/255,0/255);
-  const Color Color::DARK_BLUE(0/255,0/255,139/255);
-  const Color Color::DARK_FUCHSIA(139/255,0/255,139/255);
-  const Color Color::DARK_AQUA(0/255,139/255,139/255);
+  const Color Color::LIGHT_GRAY(211.0/255,211.0/255,211.0/255);
+  const Color Color::DARK_GRAY(169.0/255,169.0/255,169.0/255);
+  const Color Color::DARK_RED(139.0/255,0.0/255,0.0/255);
+  const Color Color::DARK_GREEN(0.0/255,100.0/255,0.0/255);
+  const Color Color::DARK_YELLOW(255.0/255,215.0/255,0.0/255);
+  const Color Color::DARK_BLUE(0.0/255,0.0/255,139.0/255);
+  const Color Color::DARK_FUCHSIA(139.0/255,0.0/255,139.0/255);
+  const Color Color::DARK_AQUA(0.0/255,139.0/255,139.0/255);
 
   const Color Color::LUCENT_WHITE(1.0,1.0,1.0,1.0);
 


### PR DESCRIPTION
color silver: #000000
color gray: #000000
color maroon: #000000
color lightgray: #000000
color olive: #000000
color navy: #000000
color teal: #000000
color darkyellow: #ff0000
color darkblue: #000000
color darkred: #000000
color darkgreen: #000000
color darkgray: #000000
color darkfuchsia: #000000
color darkcyan: #000000
color lightgray: #000000

Fixed using type double when initializing colors:

color silver: #c0c0c0
color gray: #808080
color maroon: #800000
color lightgray: #800080
color olive: #808000
color navy: #000080
color teal: #008080
color darkyellow: #ffd700
color darkblue: #00008b
color darkred: #8b0000
color darkgreen: #006400
color darkgray: #a9a9a9
color darkfuchsia: #8b008b
color darkcyan: #008b8b
color lightgray: #d3d3d3