### PR TITLE
fix search result comparison

### DIFF
--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -79,7 +79,12 @@ public:
                 const osmscout::GeoCoord& coord,
                 QObject* parent = nullptr);
 
-  LocationEntry(QObject* parent = nullptr);
+  explicit LocationEntry(QObject* parent = nullptr);
+
+  /**
+   * copy constructor, note that it copy Qt ownership
+   * @param other
+   */
   LocationEntry(const LocationEntry& other);
   ~LocationEntry() override = default;
 

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -98,7 +98,7 @@ public:
   using Roles = RouteStep::Roles;
 
 public:
-  RoutingListModel(QObject* parent = 0);
+  explicit RoutingListModel(QObject* parent = nullptr);
   virtual ~RoutingListModel();
 
   QVariant data(const QModelIndex &index, int role) const;

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -169,7 +169,7 @@ public:
   };
 
 public:
-  LocationListModel(QObject* parent = nullptr);
+  explicit LocationListModel(QObject* parent = nullptr);
   ~LocationListModel() override;
 
   QJSValue getCompare() const {

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -171,8 +171,10 @@ void LocationListModel::onSearchResult(const QString searchPattern,
   }
 
   if (compareFn.isCallable()){
-    auto Compare = [&](LocationEntry &a, const LocationEntry &b) -> bool {
+    auto Compare = [&](const LocationEntry &a, const LocationEntry &b) -> bool {
       QJSValueList args;
+      // to transfer ownership to QML, parent have to be null. copy constructor copy ownership
+      assert(a.parent() == nullptr && b.parent() == nullptr);
       args << engine->newQObject(new LocationEntry(a));
       args << engine->newQObject(new LocationEntry(b));
       QJSValue result = compareFn.call(args);
@@ -194,7 +196,7 @@ void LocationListModel::onSearchResult(const QString searchPattern,
     auto position = 0;
     auto positionIt = locations.begin();
     for (auto &location : foundLocations) {
-      if (positionIt == locations.end() || Compare(location, *positionIt)){
+      if (positionIt == locations.end() || Compare(location, **positionIt)){
         emit beginInsertRows(QModelIndex(), position, position);
         positionIt = locations.insert(positionIt, new LocationEntry(location));
         // qDebug() << "Put " << location.getLabel() << " to position: " << position;

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -106,13 +106,15 @@ void LocationListModel::onSearchResult(const QString searchPattern,
   QQmlEngine *engine = qmlEngine(this);
   if (equalsFn.isCallable()){
     // try to merge locations that are equals
-    auto Equal = [&](LocationEntry &a, const LocationEntry &b) -> bool {
+    auto Equal = [&](const LocationEntry &a, const LocationEntry &b) -> bool {
       if (a.getLabel()==b.getLabel() &&
           a.getDatabase()==b.getDatabase() &&
           a.getType()==LocationEntry::typeObject &&
           b.getType()==LocationEntry::typeObject){
 
         QJSValueList args;
+        // to transfer ownership to QML, parent have to be null. copy constructor copy ownership
+        assert(a.parent() == nullptr && b.parent() == nullptr);
         args << engine->newQObject(new LocationEntry(a));
         args << engine->newQObject(new LocationEntry(b));
         QJSValue result = equalsFn.call(args);


### PR DESCRIPTION
`positionIt` is iterator to container with pointers.
To use it as reference for `Compare` lambda, it have to dereferenced twice.
Previous code was working, because `LocationEntry` constructor with
argument `(QObject* parent = nullptr)` was not explicit,
so this `LocationEntry` constructor was called implicitly with pointer
to original entry - it becomes a owner of a new entry.

`Compare` function is called with defaulted second entry,
comparison was not working obviously.

Moreover, entry is copied and transfered to QML with non-null parent,
so QML doesn't takes ownership of the entry. It may happen that
parent entry was deleted later in c++ code. In such case Qt deletes even
its children, that may be referenced from QML still.
Such scenario leads to crash.