### PR TITLE
Keep sub directory structure in OSMScout framework headers

### DIFF
--- a/libosmscout-map-iosx/include/osmscout/MapPainterIOS.h
+++ b/libosmscout-map-iosx/include/osmscout/MapPainterIOS.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -39,7 +40,91 @@
 
 #import <CoreText/CoreText.h>
 #include <osmscout/MapPainter.h>
-#include <osmscout/private/cfref_ptr.hpp>
+
+template<class T>
+class cfref_ptr
+{
+public:
+    cfref_ptr()
+    : obj_(NULL)
+    {}
+    
+    cfref_ptr(T obj)
+    : obj_(obj)
+    {
+    }
+    
+    ~cfref_ptr()
+    {
+        if (obj_) {
+            CFRelease(obj_);
+        }
+    }
+    
+    cfref_ptr(cfref_ptr const& other)
+    : obj_(other.obj_)
+    {
+        if (obj_) {
+            CFRetain(obj_);
+        }
+    }
+    
+    cfref_ptr(cfref_ptr&& other) noexcept
+    {
+        *this = std::move(other);
+    }
+    
+    cfref_ptr& operator = (cfref_ptr const& other)
+    {
+        if (this != &other) {
+            cfref_ptr tmp(other);
+            tmp.swap(*this);
+        }
+        return *this;
+    }
+    
+    cfref_ptr& operator = (cfref_ptr&& other)
+    {
+        if (this != &other) {
+            obj_ = other.obj_;
+            other.obj_ = NULL;
+        }
+        return *this;
+    }
+    
+    bool boolean_test() const
+    {
+        return !!obj_;
+    }
+    
+    T get()
+    {
+        return obj_;
+    }
+    
+    T release()
+    {
+        T ret = obj_;
+        obj_ = NULL;
+        return ret;
+    }
+    
+    void swap(cfref_ptr& other)
+    {
+        std::swap(obj_, other.obj_);
+    }
+    
+    void reset(T obj = NULL)
+    {
+        if (obj_) {
+            CFRelease(obj_);
+        }
+        obj_ = obj;
+    }
+    
+private:
+    T obj_;
+};
 
 namespace osmscout {
     struct IOSGlyphInRun {

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -1,90 +1,7 @@
-set(HEADER_FILES_OST
-    include/osmscout/ost/Parser.h
-    include/osmscout/ost/Scanner.h)
+# Uncomment to force marisa lib
+#set(MARISA_FOUND 1)
 
-set(HEADER_FILES_SYSTEM
-    include/osmscout/system/Assert.h
-    include/osmscout/system/Compiler.h
-    include/osmscout/system/Math.h
-    include/osmscout/system/SSEMath.h
-    include/osmscout/system/SSEMathPublic.h
-	include/osmscout/system/SystemTypes.h)
-
-set(HEADER_FILES_UTIL
-    include/osmscout/util/Base64.h
-    include/osmscout/util/Bearing.h
-    include/osmscout/util/Breaker.h
-    include/osmscout/util/Cache.h
-    include/osmscout/util/Color.h
-    include/osmscout/util/CmdLineParsing.h
-    include/osmscout/util/Distance.h
-    include/osmscout/util/Exception.h
-    include/osmscout/util/File.h
-    include/osmscout/util/FileScanner.h
-    include/osmscout/util/FileWriter.h
-    include/osmscout/util/HTMLWriter.h
-    include/osmscout/util/Locale.h
-    include/osmscout/util/GeoBox.h
-    include/osmscout/util/Geometry.h
-    include/osmscout/util/Logger.h
-    include/osmscout/util/Magnification.h
-    include/osmscout/util/MemoryMonitor.h
-    include/osmscout/util/NodeUseMap.h
-    include/osmscout/util/Number.h
-    include/osmscout/util/NumberSet.h
-    include/osmscout/util/ObjectPool.h
-    include/osmscout/util/Parsing.h
-	include/osmscout/util/ProcessingQueue.h
-    include/osmscout/util/Progress.h
-    include/osmscout/util/Projection.h
-    include/osmscout/util/StopClock.h
-    include/osmscout/util/String.h
-    include/osmscout/util/StringMatcher.h
-    include/osmscout/util/TagErrorReporter.h
-    include/osmscout/util/Tiling.h
-    include/osmscout/util/Time.h
-    include/osmscout/util/TileId.h
-    include/osmscout/util/Transformation.h
-	include/osmscout/util/Worker.h
-	include/osmscout/util/WorkQueue.h)
-
-set(HEADER_FILES_ROUTING
-    include/osmscout/routing/RouteData.h
-	include/osmscout/routing/RouteDescription.h
-    include/osmscout/routing/RouteNode.h
-    include/osmscout/routing/RouteNodeDataFile.h
-    include/osmscout/routing/RoutePostprocessor.h
-    include/osmscout/routing/RoutingDB.h
-    include/osmscout/routing/RoutingProfile.h
-    include/osmscout/routing/RoutingService.h
-    include/osmscout/routing/AbstractRoutingService.h
-    include/osmscout/routing/SimpleRoutingService.h
-    include/osmscout/routing/MultiDBRoutingService.h
-    include/osmscout/routing/DBFileOffset.h
-    include/osmscout/routing/TurnRestriction.h
-    include/osmscout/routing/MultiDBRoutingState.h
-    include/osmscout/routing/RouteDescriptionPostprocessor.h)
-
-set(HEADER_FILES_NAVIGATION
-    include/osmscout/navigation/Agents.h
-    include/osmscout/navigation/ArrivalEstimateAgent.h
-    include/osmscout/navigation/DataAgent.h
-    include/osmscout/navigation/PositionAgent.h
-    include/osmscout/navigation/RouteStateAgent.h
-    include/osmscout/navigation/Engine.h
-    include/osmscout/navigation/Navigation.h
-    include/osmscout/navigation/BearingAgent.h
-    include/osmscout/navigation/RouteInstructionAgent.h
-    include/osmscout/navigation/SpeedAgent.h
-    include/osmscout/navigation/VoiceInstructionAgent.h
-    include/osmscout/navigation/LaneAgent.h)
-
-set(HEADER_FILES
-    ${HEADER_FILES_OST}
-    ${HEADER_FILES_SYSTEM}
-    ${HEADER_FILES_UTIL}
-    ${HEADER_FILES_ROUTING}
-    ${HEADER_FILES_NAVIGATION}
+set(HEADER_FILES_ROOT
     include/osmscout/CoreImportExport.h
     include/osmscout/Area.h
     include/osmscout/AreaAreaIndex.h
@@ -134,7 +51,89 @@ set(HEADER_FILES
     include/osmscout/OSMScoutTypes.h
     include/osmscout/WaterIndex.h
     include/osmscout/Way.h
-    include/osmscout/WayDataFile.h)
+    include/osmscout/WayDataFile.h
+    include/osmscout/CoreFeatures.h)
+
+set(HEADER_FILES_OST
+    include/osmscout/ost/Parser.h
+    include/osmscout/ost/Scanner.h)
+
+set(HEADER_FILES_SYSTEM
+    include/osmscout/system/Assert.h
+    include/osmscout/system/Compiler.h
+    include/osmscout/system/Math.h
+    include/osmscout/system/SSEMath.h
+    include/osmscout/system/SSEMathPublic.h
+    include/osmscout/system/SystemTypes.h)
+
+set(HEADER_FILES_UTIL
+    include/osmscout/util/Base64.h
+    include/osmscout/util/Bearing.h
+    include/osmscout/util/Breaker.h
+    include/osmscout/util/Cache.h
+    include/osmscout/util/Color.h
+    include/osmscout/util/CmdLineParsing.h
+    include/osmscout/util/Distance.h
+    include/osmscout/util/Exception.h
+    include/osmscout/util/File.h
+    include/osmscout/util/FileScanner.h
+    include/osmscout/util/FileWriter.h
+    include/osmscout/util/HTMLWriter.h
+    include/osmscout/util/Locale.h
+    include/osmscout/util/GeoBox.h
+    include/osmscout/util/Geometry.h
+    include/osmscout/util/Logger.h
+    include/osmscout/util/Magnification.h
+    include/osmscout/util/MemoryMonitor.h
+    include/osmscout/util/NodeUseMap.h
+    include/osmscout/util/Number.h
+    include/osmscout/util/NumberSet.h
+    include/osmscout/util/ObjectPool.h
+    include/osmscout/util/Parsing.h
+	include/osmscout/util/ProcessingQueue.h
+    include/osmscout/util/Progress.h
+    include/osmscout/util/Projection.h
+    include/osmscout/util/StopClock.h
+    include/osmscout/util/String.h
+    include/osmscout/util/StringMatcher.h
+    include/osmscout/util/TagErrorReporter.h
+    include/osmscout/util/Tiling.h
+    include/osmscout/util/Time.h
+    include/osmscout/util/TileId.h
+    include/osmscout/util/Transformation.h
+	include/osmscout/util/Worker.h
+	include/osmscout/util/WorkQueue.h)
+
+set(HEADER_FILES_ROUTING
+    include/osmscout/routing/RouteData.h
+    include/osmscout/routing/RouteDescription.h
+    include/osmscout/routing/RouteNode.h
+    include/osmscout/routing/RouteNodeDataFile.h
+    include/osmscout/routing/RoutePostprocessor.h
+    include/osmscout/routing/RoutingDB.h
+    include/osmscout/routing/RoutingProfile.h
+    include/osmscout/routing/RoutingService.h
+    include/osmscout/routing/AbstractRoutingService.h
+    include/osmscout/routing/SimpleRoutingService.h
+    include/osmscout/routing/MultiDBRoutingService.h
+    include/osmscout/routing/DBFileOffset.h
+    include/osmscout/routing/TurnRestriction.h
+    include/osmscout/routing/MultiDBRoutingState.h
+    include/osmscout/routing/RouteDescriptionPostprocessor.h)
+
+set(HEADER_FILES_NAVIGATION
+    include/osmscout/navigation/Agents.h
+    include/osmscout/navigation/ArrivalEstimateAgent.h
+    include/osmscout/navigation/DataAgent.h
+    include/osmscout/navigation/PositionAgent.h
+    include/osmscout/navigation/RouteStateAgent.h
+    include/osmscout/navigation/Engine.h
+    include/osmscout/navigation/Navigation.h
+    include/osmscout/navigation/BearingAgent.h
+    include/osmscout/navigation/RouteInstructionAgent.h
+    include/osmscout/navigation/SpeedAgent.h
+    include/osmscout/navigation/VoiceInstructionAgent.h
+    include/osmscout/navigation/LaneAgent.h)
 
 set(SOURCE_FILES
     src/osmscout/ost/Parser.cpp
@@ -172,8 +171,8 @@ set(SOURCE_FILES
     src/osmscout/util/WorkQueue.cpp
     src/osmscout/util/TagErrorReporter.cpp
     src/osmscout/routing/RouteData.cpp
-	src/osmscout/routing/RouteDescription.cpp
-	src/osmscout/routing/RouteNode.cpp
+    src/osmscout/routing/RouteDescription.cpp
+    src/osmscout/routing/RouteNode.cpp
     src/osmscout/routing/RouteNodeDataFile.cpp
     src/osmscout/routing/RoutePostprocessor.cpp
     src/osmscout/routing/RoutingDB.cpp
@@ -239,7 +238,7 @@ set(SOURCE_FILES
     src/osmscout/TypeFeatures.cpp
     src/osmscout/TypeInfoSet.cpp
     src/osmscout/FeatureReader.cpp
-	src/osmscout/OSMScoutTypes.cpp
+    src/osmscout/OSMScoutTypes.cpp
     src/osmscout/WaterIndex.cpp
     src/osmscout/Way.cpp
     src/osmscout/WayDataFile.cpp
@@ -248,20 +247,28 @@ set(SOURCE_FILES
 set(EXCLUDE_HEADER)
 
 if(MARISA_FOUND)
-    list(APPEND HEADER_FILES include/osmscout/TextSearchIndex.h)
+    list(APPEND HEADER_FILES_ROOT include/osmscout/TextSearchIndex.h)
     list(APPEND SOURCE_FILES src/osmscout/TextSearchIndex.cpp)
 else()
-	list(APPEND EXCLUDE_HEADER TextSearchIndex.h)
+    list(APPEND EXCLUDE_HEADER TextSearchIndex.h)
 endif()
 
+set(HEADER_FILES
+    ${HEADER_FILES_ROOT}
+    ${HEADER_FILES_OST}
+    ${HEADER_FILES_SYSTEM}
+    ${HEADER_FILES_UTIL}
+    ${HEADER_FILES_ROUTING}
+    ${HEADER_FILES_NAVIGATION})
+
 osmscout_library_project(
-	NAME OSMScout
-	ALIAS OSMScout
-	OUTPUT_NAME "osmscout"
-	SOURCE ${SOURCE_FILES}
-	HEADER ${HEADER_FILES}
-	TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/CoreFeatures.h.cmake
-	EXCLUDE ${EXCLUDE_HEADER}
+    NAME OSMScout
+    ALIAS OSMScout
+    OUTPUT_NAME "osmscout"
+    SOURCE ${SOURCE_FILES}
+    HEADER ${HEADER_FILES}
+    TEMPLATE ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout/CoreFeatures.h.cmake
+    EXCLUDE ${EXCLUDE_HEADER}
 )
 
 if(MARISA_FOUND)
@@ -275,25 +282,31 @@ if (ICONV_FOUND)
 endif()
 
 if(CMAKE_THREAD_LIBS_INIT)
-  target_link_libraries(OSMScout ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(OSMScout ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 if(APPLE AND OSMSCOUT_BUILD_FRAMEWORKS)
-	set_target_properties(OSMScout PROPERTIES
-		FRAMEWORK TRUE
-		FRAMEWORK_VERSION A
-		MACOSX_FRAMEWORK_IDENTIFIER com.cmake.dynamicFramework
-		#MACOSX_FRAMEWORK_INFO_PLIST Info.plist
-		PUBLIC_HEADER     "${HEADER_FILES}"
-		CODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
-		OUTPUT_NAME "OSMScout")
+    set_source_files_properties(${HEADER_FILES_ROOT}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers)
+    set_source_files_properties(${HEADER_FILES_OST}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers/ost)
+    set_source_files_properties(${HEADER_FILES_SYSTEM}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers/system)
+    set_source_files_properties(${HEADER_FILES_UTIL}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers/util)
+    set_source_files_properties(${HEADER_FILES_ROUTING}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers/routing)
+    set_source_files_properties(${HEADER_FILES_NAVIGATION}
+        PROPERTIES MACOSX_PACKAGE_LOCATION Headers/navigation)
 
-		set_property(SOURCE "${HEADER_FILES_OST}"
-			  PROPERTY MACOSX_PACKAGE_LOCATION Headers/ost)
-		set_property(SOURCE "${HEADER_FILES_SYSTEM}"
-			  PROPERTY MACOSX_PACKAGE_LOCATION Headers/system)
-		set_property(SOURCE "${HEADER_FILES_UTIL}"
-			  PROPERTY MACOSX_PACKAGE_LOCATION Headers/util)
-		set_property(SOURCE "${HEADER_FILES_ROUTING}"
-			  PROPERTY MACOSX_PACKAGE_LOCATION Headers/routing)
+    set_target_properties(OSMScout PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION A
+        MACOSX_FRAMEWORK_IDENTIFIER com.cmake.dynamicFramework
+        #MACOSX_FRAMEWORK_INFO_PLIST Info.plist
+        CODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
+        OUTPUT_NAME "OSMScout")
+
+     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/osmscout DESTINATION include FILES_MATCHING PATTERN "*.h" PATTERN "private/Config.h" EXCLUDE)
 endif()
+


### PR DESCRIPTION
Keep the subdirectory structure in libosmscout  headers when building Apple framework.
This is the first step to fix osmscout frameworks compilation, the second step would be to fix osmscout-map and osmscout-map-iosx because there is still a issue to merge the osmscout top dir accross several frameworks. 
Actually I use the following commands to copy manually osmscout-map and osmscout-map-iosx headers to osmscout framework : 

 cp libosmscout-map/OSMScoutMap.framework/Headers/*.h libosmscout/OSMScout.framework/Headers
 cp libosmscout-map-iosx/OSMScoutMapIOSX.framework/Headers/*.h libosmscout/OSMScout.framework/Headers 
 cp libosmscout-map/include/osmscout/MapFeatures.h  libosmscout/OSMScout.framework/Headers
