### PR TITLE
expose marisa include dir as public from libosmscout-client-qt

### DIFF
--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -124,7 +124,7 @@ osmscout_library_project(
 )
 
 if(MARISA_FOUND)
-    target_include_directories(OSMScoutClientQt PRIVATE ${MARISA_INCLUDE_DIRS})
+    target_include_directories(OSMScoutClientQt PUBLIC ${MARISA_INCLUDE_DIRS})
     target_link_libraries(OSMScoutClientQt ${MARISA_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Hi @vyskocil can you check if this change fixes your issue https://github.com/Framstag/libosmscout/issues/1026 please?