### PR TITLE
GenMergeAreas refactoring

### DIFF
--- a/libosmscout-import/include/osmscout/import/GenMergeAreas.h
+++ b/libosmscout-import/include/osmscout/import/GenMergeAreas.h
@@ -71,29 +71,6 @@ namespace osmscout {
 
   private:
     /**
-     * Scan all areas for node ids that occur in more than one area. Only areas with
-     * nodes that are used in other areas, too, are candidates for merging.
-     *
-     * We only take nodes in the outer rings into account.
-     *
-     * @param parameter
-     *   ImportParameter
-     * @param progress
-     *   Progress
-     * @param typeConfig
-     *   TypeConfiguration
-     * @param mergeTypes
-     *   Set of types for which we do area merging
-     * @param mergeJobs
-     *   track data for the area merge job
-     */
-    void ScanAreaNodeIds(Progress& progress,
-                         const TypeConfig& typeConfig,
-                         FileScanner& scanner,
-                         const TypeInfoSet& mergeTypes,
-                         std::vector<AreaMergeJob>& mergeJobs);
-
-    /**
      * Load all areas which have at least one of the "used at least twice"
      * nodes in its nodeUseMap for all given types. If the number of areas
      * increases over a certain limit, data of some types is dropped

--- a/libosmscout-import/include/osmscout/import/GenMergeAreas.h
+++ b/libosmscout-import/include/osmscout/import/GenMergeAreas.h
@@ -40,6 +40,27 @@
 namespace osmscout {
 
   /**
+   * Input for a merge job for one area type
+   */
+  struct AreaMergeJob
+  {
+    TypeInfoRef            type;
+    std::unordered_set<Id> nodeUseSet;
+    size_t                 areaCount;  //!< Number of areas of this type
+    std::list<AreaRef>     areas;      //!< List of areas that are candidates for merging
+  };
+
+  /**
+   * Result of the merge job for one area type
+   */
+  struct AreaMergeResult
+  {
+    TypeInfoRef                    type;
+    std::list<AreaRef>             merges;     //!< List of areas that got merged
+    std::unordered_set<FileOffset> mergedAway; //!< List of file offsets of areas, that were merged into another area
+  };
+
+  /**
    * Merges areas of the same type (and where the type is flag as mergable), which
    * "touch" each other and share the same nodes (same node id).
    */
@@ -49,36 +70,6 @@ namespace osmscout {
     static const char* const AREAS2_TMP;
 
   private:
-    /**
-     * Input for a merge job for one area type
-     */
-    struct AreaMergeJob
-    {
-      std::unordered_set<Id>         nodeUseSet;
-      size_t                         areaCount;  //!< Number of areas of this type
-      std::list<AreaRef>             areas;      //!< List of areas that are candidates for merging
-    };
-
-    /**
-     * Result of the merge job for one area type
-     */
-    struct AreaMergeResult
-    {
-      std::list<AreaRef>             merges;     //!< List of areas that got merged
-      std::unordered_set<FileOffset> mergedAway; //!< List of file offsets of areas, that were merged into another area
-    };
-
-  private:
-    /**
-     * Return the index of the first outer ring that contains the given node id.
-     */
-    size_t GetFirstOuterRingWithId(const Area& area,
-                                   Id id) const;
-
-    void EraseAreaInCache(const std::unordered_set<Id>& nodeUseMap,
-                          const AreaRef& area,
-                          std::unordered_map<Id,std::set<AreaRef> >& idAreaMap);
-
     /**
      * Scan all areas for node ids that occur in more than one area. Only areas with
      * nodes that are used in other areas, too, are candidates for merging.
@@ -139,37 +130,6 @@ namespace osmscout {
                   FileWriter& writer,
                   std::vector<AreaMergeJob>& mergeJobs,
                   uint32_t& areasWritten);
-
-    /**
-     * Index areas by their "at least used twice" nodes
-     * @param nodeUseMap
-     *    Node use map
-     * @param areas
-     *    List of areas
-     * @param idAreaMap
-     *    Resulting index structure, mammping a node id to the
-     *    list of areas that hold this node in on of their outer
-     *    rings.
-     */
-    void IndexAreasByNodeIds(const std::unordered_set<Id>& nodeUseMap,
-                             const std::list<AreaRef>& areas,
-                             std::unordered_map<Id,std::set<AreaRef> >& idAreaMap);
-
-    bool TryMerge(const std::unordered_set<Id>& nodeUseMap,
-                  Area& area,
-                  std::unordered_map<Id,std::set<AreaRef> >& idAreaMap,
-                  std::set<Id>& finishedIds,
-                  std::unordered_set<FileOffset>& mergedAway);
-
-    /**
-     * Merge area data of one type
-     *
-     * @param progress
-     * @param nodeUseMap
-     * @param job
-     */
-    AreaMergeResult MergeAreas(Progress& progress,
-                               AreaMergeJob& job);
 
     void WriteMergeResult(Progress& progress,
                           const TypeConfig& typeConfig,

--- a/libosmscout-import/include/osmscout/import/GenMergeAreas.h
+++ b/libosmscout-import/include/osmscout/import/GenMergeAreas.h
@@ -93,7 +93,7 @@ namespace osmscout {
                          const TypeConfig& typeConfig,
                          FileScanner& scanner,
                          const TypeInfoSet& mergeTypes,
-                         std::unordered_set<Id>& nodeUseMap);
+                         std::vector<std::unordered_set<Id>>& nodeUseMap);
 
     /**
      * Load all areas which have at least one of the "used at least twice"
@@ -130,7 +130,7 @@ namespace osmscout {
                   const TypeConfig& typeConfig,
                   const TypeInfoSet& candidateTypes,
                   TypeInfoSet& loadedTypes,
-                  const std::unordered_set<Id>& nodeUseMap,
+                  const std::vector<std::unordered_set<Id>>& nodeUseMap,
                   FileScanner& scanner,
                   FileWriter& writer,
                   std::vector<AreaMergeData>& mergeJob,

--- a/libosmscout-import/include/osmscout/import/GenMergeAreas.h
+++ b/libosmscout-import/include/osmscout/import/GenMergeAreas.h
@@ -88,15 +88,9 @@ namespace osmscout {
      *   Set of types which have been loaded
      * @param scanner
      *   File Scanner for reading the area data
-     * @param writer
-     *   File writer for the writing area data which
-     *   are of a type that is not marked as mergable
      * @param mergeJobs
      * data structure for merging areas of one type, here passed to return
      * all merge candidates in 'areas'
-     * @param areasWritten
-     *   Number of areas directly written, because they
-     *   are of a type that is not marked as mergable
      */
     void GetAreas(const ImportParameter& parameter,
                   Progress& progress,
@@ -104,16 +98,14 @@ namespace osmscout {
                   const TypeInfoSet& candidateTypes,
                   TypeInfoSet& loadedTypes,
                   FileScanner& scanner,
-                  FileWriter& writer,
-                  std::vector<AreaMergeJob>& mergeJobs,
-                  uint32_t& areasWritten);
+                  std::vector<AreaMergeJob>& mergeJobs);
 
     void WriteMergeResult(Progress& progress,
                           const TypeConfig& typeConfig,
                           FileScanner& scanner,
                           FileWriter& writer,
                           const TypeInfoSet& loadedTypes,
-                          std::vector<AreaMergeResult>& mergeJob,
+                          const std::vector<AreaMergeResult>& mergeJob,
                           uint32_t& areasWritten);
 
   public:

--- a/libosmscout-import/include/osmscout/import/GenMergeAreas.h
+++ b/libosmscout-import/include/osmscout/import/GenMergeAreas.h
@@ -50,13 +50,20 @@ namespace osmscout {
 
   private:
     /**
-     * Data structure holding all information for merging
-     * areas of one type
+     * Input for a merge job for one area type
      */
-    struct AreaMergeData
+    struct AreaMergeJob
     {
+      std::unordered_set<Id>         nodeUseSet;
       size_t                         areaCount;  //!< Number of areas of this type
       std::list<AreaRef>             areas;      //!< List of areas that are candidates for merging
+    };
+
+    /**
+     * Result of the merge job for one area type
+     */
+    struct AreaMergeResult
+    {
       std::list<AreaRef>             merges;     //!< List of areas that got merged
       std::unordered_set<FileOffset> mergedAway; //!< List of file offsets of areas, that were merged into another area
     };
@@ -86,14 +93,14 @@ namespace osmscout {
      *   TypeConfiguration
      * @param mergeTypes
      *   Set of types for which we do area merging
-     * @param nodeUseMap
-     *   special structure to track multiple use of the same node id. We have one map for each type.
+     * @param mergeJobs
+     *   track data for the area merge job
      */
     void ScanAreaNodeIds(Progress& progress,
                          const TypeConfig& typeConfig,
                          FileScanner& scanner,
                          const TypeInfoSet& mergeTypes,
-                         std::vector<std::unordered_set<Id>>& nodeUseMap);
+                         std::vector<AreaMergeJob>& mergeJobs);
 
     /**
      * Load all areas which have at least one of the "used at least twice"
@@ -111,14 +118,12 @@ namespace osmscout {
      *   Set of types which should be loaded
      * @param loadedTypes
      *   Set of types which have been loaded
-     * @param nodeUseMap
-     *   Array of NodeUseMaps
      * @param scanner
      *   File Scanner for reading the area data
      * @param writer
      *   File writer for the writing area data which
      *   are of a type that is not marked as mergable
-     * @param mergeJob
+     * @param mergeJobs
      * data structure for merging areas of one type, here passed to return
      * all merge candidates in 'areas'
      * @param areasWritten
@@ -130,10 +135,9 @@ namespace osmscout {
                   const TypeConfig& typeConfig,
                   const TypeInfoSet& candidateTypes,
                   TypeInfoSet& loadedTypes,
-                  const std::vector<std::unordered_set<Id>>& nodeUseMap,
                   FileScanner& scanner,
                   FileWriter& writer,
-                  std::vector<AreaMergeData>& mergeJob,
+                  std::vector<AreaMergeJob>& mergeJobs,
                   uint32_t& areasWritten);
 
     /**
@@ -160,21 +164,19 @@ namespace osmscout {
     /**
      * Merge area data of one type
      *
+     * @param progress
      * @param nodeUseMap
-     * @param areas
-     * @param merges
-     * @param blacklist
+     * @param job
      */
-    void MergeAreas(Progress& progress,
-                    const std::unordered_set<Id>& nodeUseMap,
-                    AreaMergeData& job);
+    AreaMergeResult MergeAreas(Progress& progress,
+                               AreaMergeJob& job);
 
     void WriteMergeResult(Progress& progress,
                           const TypeConfig& typeConfig,
                           FileScanner& scanner,
                           FileWriter& writer,
                           const TypeInfoSet& loadedTypes,
-                          std::vector<AreaMergeData>& mergeJob,
+                          std::vector<AreaMergeResult>& mergeJob,
                           uint32_t& areasWritten);
 
   public:

--- a/libosmscout-import/src/osmscout/import/GenMergeAreas.cpp
+++ b/libosmscout-import/src/osmscout/import/GenMergeAreas.cpp
@@ -82,7 +82,7 @@ namespace osmscout {
   {
     for (const auto& ring: area->rings) {
       if (ring.IsTopOuter()) {
-        for (const auto node : ring.nodes) {
+        for (const auto& node : ring.nodes) {
           Id id=node.GetId();
 
           if (nodeUseMap.find(id)!=nodeUseMap.end()) {
@@ -138,7 +138,7 @@ namespace osmscout {
           continue;
         }
 
-        for (const auto node : ring.nodes) {
+        for (const auto& node : ring.nodes) {
           nodeIds.insert(node.GetId());
         }
       }
@@ -160,12 +160,15 @@ namespace osmscout {
   }
 
   /**
-   * Load areas which have one for the types given by types. If at least one node
+   * Load areas which have one of the types given by candidateTypes. If at least one node
    * in one of the outer rings of the areas is marked in nodeUseMap as "used at least twice",
-   * index it into the areas map.
+   * add it to the mergeJob type array.
    *
-   * If the number of indexed areas is bigger than parameter.GetRawWayBlockSize() types are
-   * dropped form areas until the number is again below the limit.
+   * If the number of indexed areas is bigger than parameter.GetRawWayBlockSize() mergeJobs for types are
+   * dropped until the number is again below the limit.
+   *
+   * At he same type write read areas that are not of a mergable type to the destination file -
+   * if we are called for the first time.
    */
 
   void MergeAreasGenerator::GetAreas(const ImportParameter& parameter,
@@ -233,7 +236,7 @@ namespace osmscout {
           continue;
         }
 
-        for (const auto node : ring.nodes) {
+        for (const auto& node : ring.nodes) {
           if (nodeUseMap[area->GetType()->GetIndex()].find(node.GetId())!=nodeUseMap[area->GetType()->GetIndex()].end()) {
             isMergeCandidate=true;
             break;
@@ -262,7 +265,7 @@ namespace osmscout {
         TypeInfoRef victimType;
 
         // Find the type with the smallest amount of ways loaded
-        for (const auto &loadedType : loadedTypes) {
+        for (const auto& loadedType : loadedTypes) {
           if (!mergeJob[loadedType->GetIndex()].areas.empty() &&
               (!victimType ||
                mergeJob[loadedType->GetIndex()].areas.size()<mergeJob[victimType->GetIndex()].areas.size())) {
@@ -298,7 +301,7 @@ namespace osmscout {
 
       for (const auto& ring: area->rings) {
         if (ring.IsTopOuter()) {
-          for (const auto node : ring.nodes) {
+          for (const auto& node : ring.nodes) {
             Id id=node.GetId();
 
             if (nodeIds.find(id)==nodeIds.end() &&
@@ -334,7 +337,7 @@ namespace osmscout {
       std::unordered_set<Id> nodeIds;
       std::set<AreaRef>      visitedAreas; // It is possible that two areas intersect in multiple nodes, to avoid multiple merge tests, we monitor the visited areas
 
-      for (const auto node : ring.nodes) {
+      for (const auto& node : ring.nodes) {
         Id id=node.GetId();
 
         if(finishedIds.find(id)!=finishedIds.end()) {

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -1427,7 +1427,6 @@ namespace osmscout {
     std::unordered_map<Id,size_t>                               nodeIdIndexMap;
     std::vector<Point>                                          nodes;
     std::list<Edge>                                             edges;
-    std::unordered_map<Id,std::list<std::list<Edge>::iterator>> idEdgeMap;
 
   private:
     void RemoveEliminatingEdges();

--- a/libosmscout/src/osmscout/util/StopClock.cpp
+++ b/libosmscout/src/osmscout/util/StopClock.cpp
@@ -24,8 +24,8 @@
 
 namespace osmscout {
 
-  typedef std::chrono::duration<double,std::milli> MilliDouble;
-  typedef std::chrono::duration<double,std::nano>  NanoDouble;
+  using MilliDouble = std::chrono::duration<double, std::milli>;
+  using NanoDouble = std::chrono::duration<double, std::nano>;
 
   StopClock::StopClock()
    : start(std::chrono::steady_clock::now()),


### PR DESCRIPTION
GenMergeAreas is one of the most expensive import steps for larger maps. Optimisations here should improve import time.

Goal is to refactor GenMergeAreas in a way, that we can make use of the new Thread/Work management code (likely with some necessary enhancements for thread pooling). 