### PR TITLE
comply with rule-of-five in Qt classes

### DIFF
--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -81,12 +81,14 @@ public:
 
   explicit LocationEntry(QObject* parent = nullptr);
 
-  /**
-   * copy constructor, note that it copy Qt ownership
-   * @param other
-   */
+  //! copy constructor, Qt ownership is copied
   LocationEntry(const LocationEntry& other);
+  LocationEntry(LocationEntry&& other) = delete;
   ~LocationEntry() override = default;
+
+  //! copy assignment, Qt ownership is not changed
+  LocationEntry &operator=(LocationEntry& other);
+  LocationEntry &operator=(LocationEntry&& other) = delete;
 
   void operator=(const LocationEntry&);
 

--- a/libosmscout-client-qt/include/osmscout/QtRouteData.h
+++ b/libosmscout-client-qt/include/osmscout/QtRouteData.h
@@ -52,18 +52,20 @@ private:
   PrivateDataRef data;
 
 public:
-  QtRouteData(QObject* parent=nullptr): QObject(parent) {};
-
-  QtRouteData(const QtRouteData &other, QObject* parent=nullptr);
+  explicit QtRouteData(QObject* parent=nullptr): QObject(parent) {};
+  //! copy constructor, Qt ownership is copied
+  QtRouteData(const QtRouteData &other);
 
   QtRouteData(osmscout::RouteDescription &&routeDescription,
               QList<RouteStep> &&routeSteps,
               osmscout::Way &&routeWay,
               QObject* parent=nullptr);
 
+  QtRouteData(QtRouteData &&) = delete;
   ~QtRouteData() override = default;
 
   QtRouteData& operator=(const QtRouteData&);
+  QtRouteData& operator=(const QtRouteData&&) = delete;
 
   inline operator bool() const {
     return (bool)data;

--- a/libosmscout-client-qt/include/osmscout/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscout/RoutingModel.h
@@ -98,8 +98,13 @@ public:
   using Roles = RouteStep::Roles;
 
 public:
-  explicit RoutingListModel(QObject* parent = 0);
+  explicit RoutingListModel(QObject* parent = nullptr);
+  RoutingListModel(const RoutingListModel&) = delete;
+  RoutingListModel(RoutingListModel&&) = delete;
   virtual ~RoutingListModel();
+
+  RoutingListModel& operator=(const RoutingListModel&) = delete;
+  RoutingListModel& operator=(RoutingListModel&&) = delete;
 
   QVariant data(const QModelIndex &index, int role) const;
 
@@ -148,6 +153,7 @@ public:
 
   inline QObject *getRoute() const
   {
+    assert(route.parent()==nullptr); // Ownership is copied. To transfer ownership to QML, parent have to be null.
     return new QtRouteData(route);
   }
 

--- a/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscout/SearchLocationModel.h
@@ -170,7 +170,12 @@ public:
 
 public:
   explicit LocationListModel(QObject* parent = nullptr);
+  LocationListModel(const LocationListModel&) = delete;
+  LocationListModel(LocationListModel&&) = delete;
   ~LocationListModel() override;
+
+  LocationListModel& operator=(const LocationListModel&) = delete;
+  LocationListModel& operator=(LocationListModel&&) = delete;
 
   QJSValue getCompare() const {
     return compareFn;

--- a/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
@@ -77,6 +77,19 @@ LocationEntry::LocationEntry(const LocationEntry& other)
     // no code
 }
 
+LocationEntry &LocationEntry::operator=(LocationEntry& other)
+{
+    type=other.type;
+    label=other.label;
+    objectType=other.objectType;
+    adminRegionList=other.adminRegionList;
+    database=other.database;
+    references=other.references;
+    coord=other.coord;
+    bbox=other.bbox;
+    return *this;
+}
+
 void LocationEntry::operator=(const LocationEntry& other)
 {
     type=other.type;

--- a/libosmscout-client-qt/src/osmscout/NavigationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModel.cpp
@@ -137,6 +137,7 @@ void NavigationModel::locationChanged(bool /*locationValid*/,
 
 QObject *NavigationModel::getRoute() const
 {
+  assert(route.parent()==nullptr); // Ownership is copied. To transfer ownership to QML, parent have to be null.
   return new QtRouteData(route);
 }
 

--- a/libosmscout-client-qt/src/osmscout/QtRouteData.cpp
+++ b/libosmscout-client-qt/src/osmscout/QtRouteData.cpp
@@ -22,9 +22,8 @@
 
 namespace osmscout {
 
-QtRouteData::QtRouteData(const QtRouteData &other,
-                         QObject* parent):
-  QObject(parent)
+QtRouteData::QtRouteData(const QtRouteData &other):
+  QObject(other.parent())
 {
   data=other.data;
 }


### PR DESCRIPTION
When some constructor is defined explicitly,
classes should have all five resource management methods explicit.
Unexpected things may happen otherwise.