### PR TITLE
do not use qAsConst introduced with qt 5.7

### DIFF
--- a/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/NearPOIModel.cpp
@@ -163,7 +163,7 @@ void NearPOIModel::onLookupResult(int requestId, QList<LocationEntry> newLocatio
     if (distance > maxDistance){
       continue;
     }
-    for (const LocationEntryRef& secondLocation:qAsConst(locations)) {
+    for (const LocationEntryRef& secondLocation:locations) {
       if (distance < osmscout::GetSphericalDistance(secondLocation->getCoord(), searchCenter)){
         break;
       }


### PR DESCRIPTION
As features require Qt >= 5.6, and 'qAsConst' was defined from qt 5.7, it reverts
its usage that I introduced in the commit 5569e50edd1cf59ef4f32a4ed4775ce503d51954.
So it allows to compile again the lib using qt 5.6, which still the mainline for
few OS.