### PR TITLE
Hillshading infra

### DIFF
--- a/Demos/include/DrawMap.h
+++ b/Demos/include/DrawMap.h
@@ -30,13 +30,15 @@
 #include <iostream>
 
 struct Arguments {
-  bool help{false};
+  bool       help=false;
 #ifdef NDEBUG
-  bool debug{false};
+  bool       debug=false;
 #else
-  bool debug{true};
+  bool       debug=true;
 #endif
-  double dpi{96.0};
+  double     dpi=96.0;
+
+  bool renderHillShading=false;
 
   std::string map;
   std::string style;
@@ -138,6 +140,12 @@ public:
               }),
               "baseMap",
               "Directory with world base map",
+              false);
+    AddOption(osmscout::CmdLineBoolOption([this](const bool& value) {
+                args.renderHillShading=value;
+              }),
+              "hillshading",
+              "Enable hillshading",
               false);
     if (windowStyle == ARG_WS_WINDOW) {
         AddOption(osmscout::CmdLineSizeTOption([this](const size_t& value) {
@@ -253,11 +261,15 @@ public:
       return false;
     }
 
-    if (!args.fontName.empty()) drawParameter.SetFontName(args.fontName);
+    if (!args.fontName.empty()) {
+      drawParameter.SetFontName(args.fontName);
+    }
+
     drawParameter.SetFontSize(args.fontSize);
     drawParameter.SetRenderSeaLand(true);
     drawParameter.SetRenderUnknowns(false);
     drawParameter.SetRenderBackground(false);
+    drawParameter.SetRenderHillShading(args.renderHillShading);
 
     drawParameter.SetIconMode(args.iconMode);
     drawParameter.SetIconPaths(args.iconPaths);

--- a/Demos/include/DrawMap.h
+++ b/Demos/include/DrawMap.h
@@ -38,6 +38,7 @@ struct Arguments {
 #endif
   double     dpi=96.0;
 
+  bool renderContourLines=false;
   bool renderHillShading=false;
 
   std::string map;
@@ -146,6 +147,12 @@ public:
               }),
               "hillshading",
               "Enable hillshading",
+              false);
+    AddOption(osmscout::CmdLineBoolOption([this](const bool& value) {
+                args.renderContourLines=value;
+              }),
+              "contourlines",
+              "Enable contour lines",
               false);
     if (windowStyle == ARG_WS_WINDOW) {
         AddOption(osmscout::CmdLineSizeTOption([this](const size_t& value) {
@@ -269,6 +276,7 @@ public:
     drawParameter.SetRenderSeaLand(true);
     drawParameter.SetRenderUnknowns(false);
     drawParameter.SetRenderBackground(false);
+    drawParameter.SetRenderContourLines(args.renderContourLines);
     drawParameter.SetRenderHillShading(args.renderHillShading);
 
     drawParameter.SetIconMode(args.iconMode);

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -59,13 +59,16 @@ static int LogEnv(const QString& env)
   if (env.toUpper()=="DEBUG") {
     return DEBUG;
   }
-  else if (env.toUpper()=="INFO") {
+
+  if (env.toUpper()=="INFO") {
     return INFO;
   }
-  else if (env.toUpper()=="WARNING") {
+
+  if (env.toUpper()=="WARNING") {
     return INFO;
   }
-  else if (env.toUpper()=="ERROR") {
+
+  if (env.toUpper()=="ERROR") {
     return ERROR;
   }
 
@@ -73,18 +76,11 @@ static int LogEnv(const QString& env)
 }
 
 struct Arguments {
-  bool help;
-  QString databaseDirectory;
-  QString style;
-  QString iconDirectory;
+  bool    help=false;
+  QString databaseDirectory=".";
+  QString style="stylesheets/standard.oss";
+  QString iconDirectory="icons";
   QString translationDir;
-
-  Arguments() :
-      help(false),
-      databaseDirectory("."),
-      style("stylesheets/standard.oss"),
-      iconDirectory("icons")
-  {}
 };
 
 int main(int argc, char* argv[])
@@ -96,9 +92,9 @@ int main(int argc, char* argv[])
   QGuiApplication app(argc,argv);
   int             result;
 
-  app.setOrganizationName("libosmscout");
-  app.setOrganizationDomain("libosmscout.sf.net");
-  app.setApplicationName("OSMScout2");
+  QGuiApplication::setOrganizationName("libosmscout");
+  QGuiApplication::setOrganizationDomain("libosmscout.sf.net");
+  QGuiApplication::setApplicationName("OSMScout2");
 
   // register OSMScout library QML types
   OSMScoutQt::RegisterQmlTypes();
@@ -128,6 +124,7 @@ int main(int argc, char* argv[])
                                       argc,argv);
   std::vector<std::string>  helpArgs{"h","help"};
   Arguments                 args;
+
   argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
                         args.help=value;
                       }),
@@ -166,7 +163,8 @@ int main(int argc, char* argv[])
     std::cout << argParser.GetHelp() << std::endl;
     return 1;
   }
-  else if (args.help) {
+
+  if (args.help) {
     std::cout << argParser.GetHelp() << std::endl;
     return 0;
   }
@@ -193,7 +191,7 @@ int main(int argc, char* argv[])
   }
   if (translator.load(locale.name(), translationDir)) {
     qDebug() << "Install translator for locale " << locale << "/" << locale.name();
-    app.installTranslator(&translator);
+    QGuiApplication::installTranslator(&translator);
   }else{
     qWarning() << "Can't load translator for locale" << locale << "/" << locale.name() <<
                "(" << translationDir << ")";
@@ -230,7 +228,7 @@ int main(int argc, char* argv[])
 
   {
     QQmlApplicationEngine window(QUrl("qrc:/qml/main.qml"));
-    result = app.exec();
+    result = QGuiApplication::exec();
   }
 
   OSMScoutQt::FreeInstance();

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -71,8 +71,9 @@ namespace osmscout {
     PrepareNodeLabels     = 14,
     PrepareRouteLabels    = 15,
     DrawLabels            = 16,
-    Postrender            = 17, //!< Implementation specific final step
-    LastStep              = 17
+    DrawHillShading       = 17,
+    Postrender            = 18, //!< Implementation specific final step
+    LastStep              = 18
   };
 
   /**
@@ -574,6 +575,10 @@ namespace osmscout {
     virtual void DrawLabels(const Projection& projection,
                             const MapParameter& parameter,
                             const MapData& data) = 0;
+
+    virtual void DrawHillShading(const Projection& projection,
+                                 const MapParameter& parameter,
+                                 const MapData& data);
 
     /**
       Draw the Icon as defined by the IconStyle at the given pixel coordinate (icon center).

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -71,9 +71,10 @@ namespace osmscout {
     PrepareNodeLabels     = 14,
     PrepareRouteLabels    = 15,
     DrawLabels            = 16,
-    DrawHillShading       = 17,
-    Postrender            = 18, //!< Implementation specific final step
-    LastStep              = 18
+    DrawContourLines      = 17,
+    DrawHillShading       = 18,
+    Postrender            = 19, //!< Implementation specific final step
+    LastStep              = 19
   };
 
   /**
@@ -575,6 +576,10 @@ namespace osmscout {
     virtual void DrawLabels(const Projection& projection,
                             const MapParameter& parameter,
                             const MapData& data) = 0;
+
+    virtual void DrawContourLines(const Projection& projection,
+                                  const MapParameter& parameter,
+                                  const MapData& data);
 
     virtual void DrawHillShading(const Projection& projection,
                                  const MapParameter& parameter,

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -105,6 +105,7 @@ namespace osmscout {
     bool                                renderBackground;          //!< Render any background features, else render like the background should be transparent
     bool                                renderSeaLand;             //!< Rendering of sea/land tiles
     bool                                renderUnknowns;            //!< Unknown areas are not rendered (transparent)
+    bool                                renderHillShading;         //!< Render hill shades
 
     bool                                debugData;                 //!< Print out some performance relevant information about the data
     bool                                debugPerformance;          //!< Print out some performance information
@@ -172,6 +173,7 @@ namespace osmscout {
     void SetRenderBackground(bool render);
     void SetRenderSeaLand(bool render);
     void SetRenderUnknowns(bool render);
+    void SetRenderHillShading(bool render);
 
     void SetDebugData(bool debug);
     void SetDebugPerformance(bool debug);
@@ -364,6 +366,11 @@ namespace osmscout {
     inline bool GetRenderUnknowns() const
     {
       return renderUnknowns;
+    }
+
+    inline bool GetRenderHillShading() const
+    {
+      return renderHillShading;
     }
 
     inline bool IsDebugPerformance() const

--- a/libosmscout-map/include/osmscout/MapParameter.h
+++ b/libosmscout-map/include/osmscout/MapParameter.h
@@ -105,6 +105,7 @@ namespace osmscout {
     bool                                renderBackground;          //!< Render any background features, else render like the background should be transparent
     bool                                renderSeaLand;             //!< Rendering of sea/land tiles
     bool                                renderUnknowns;            //!< Unknown areas are not rendered (transparent)
+    bool                                renderContourLines;        //!< Render ContourLines
     bool                                renderHillShading;         //!< Render hill shades
 
     bool                                debugData;                 //!< Print out some performance relevant information about the data
@@ -173,6 +174,7 @@ namespace osmscout {
     void SetRenderBackground(bool render);
     void SetRenderSeaLand(bool render);
     void SetRenderUnknowns(bool render);
+    void SetRenderContourLines(bool render);
     void SetRenderHillShading(bool render);
 
     void SetDebugData(bool debug);
@@ -366,6 +368,11 @@ namespace osmscout {
     inline bool GetRenderUnknowns() const
     {
       return renderUnknowns;
+    }
+
+    inline bool GetRenderContourLines() const
+    {
+      return renderContourLines;
     }
 
     inline bool GetRenderHillShading() const

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -202,6 +202,7 @@ namespace osmscout {
     stepMethods[RenderSteps::PrepareNodeLabels]=&MapPainter::PrepareNodeLabels;
     stepMethods[RenderSteps::PrepareRouteLabels]=&MapPainter::PrepareRouteLabels;
     stepMethods[RenderSteps::DrawLabels]=&MapPainter::DrawLabels;
+    stepMethods[RenderSteps::DrawContourLines]=&MapPainter::DrawContourLines;
     stepMethods[RenderSteps::DrawHillShading]=&MapPainter::DrawHillShading;
     stepMethods[RenderSteps::Postrender]=&MapPainter::Postrender;
   }
@@ -2836,6 +2837,96 @@ static void DumpGroundTile(const GroundTile& tile)
     return floor(value);
   }
 
+  void MapPainter::DrawContourLines(const Projection& projection,
+                                    const MapParameter& parameter,
+                                    const MapData& /*data*/)
+  {
+    if (!parameter.GetRenderContourLines()) {
+      return;
+    }
+
+    log.Info() << "Draw contour lines";
+
+    TypeInfoRef srtmType=styleConfig->GetTypeConfig()->GetTypeInfo("srtm_tile");
+
+    if (!srtmType) {
+      log.Warn() << "Contour lines activated but no type 'srtm_tile' found";
+      return;
+    }
+
+    FeatureValueBuffer contourLinesBuffer;
+
+    contourLinesBuffer.SetType(srtmType);
+
+    std::vector<BorderStyleRef> areaBorderStyles;
+
+    styleConfig->GetAreaBorderStyles(srtmType,
+                                     contourLinesBuffer,
+                                     projection,
+                                     areaBorderStyles);
+
+    if (areaBorderStyles.empty()) {
+      log.Warn() << "Contour lines activated but no border style for type 'srtm_tile' found";
+    }
+
+    GeoBox mapBoundingBox=projection.GetDimensions();
+
+    log.Info() << "Initial bounding box: "  << mapBoundingBox.GetDisplayText();
+
+    double minLat=RoundDown(mapBoundingBox.GetMinLat());
+    double maxLat=RoundUp(mapBoundingBox.GetMaxLat());
+
+    double minLon=RoundDown(mapBoundingBox.GetMinLon());
+    double maxLon=RoundUp(mapBoundingBox.GetMaxLon());
+
+    log.Info() << "Even bounding box: "  << GeoBox(GeoCoord(minLat,minLon),GeoCoord(maxLat,maxLon)).GetDisplayText();
+
+    int minX=int(minLon);
+    int minY=int(minLat);
+
+    double factor=1.0/1201;
+
+    bool even=true;
+    for (int x=minX; x<int(maxLon); x++) {
+      for (int y=minY; y<int(maxLat); y++) {
+        for (int subX=0; subX<1201; subX++) {
+          for (int subY=0; subY<1201; subY++) {
+            even=!even;
+
+            if (!even) {
+              continue;
+            }
+
+            size_t   start,end;
+            double   xDelta=subX*factor;
+            double   yDelta=subY*factor;
+            GeoBox   tileBoundingBox=GeoBox(GeoCoord(y+yDelta,x+xDelta),
+                                            GeoCoord(y+yDelta+factor,x+xDelta+factor));
+
+            transBuffer.TransformBoundingBox(projection,
+                                             TransPolygon::none,
+                                             tileBoundingBox,
+                                             start,
+                                             end,
+                                             errorTolerancePixel);
+
+            for (const auto& borderStyle : areaBorderStyles) {
+              AreaData tileData;
+
+              tileData.borderStyle=borderStyle;
+              tileData.boundingBox=tileBoundingBox;
+              tileData.ref=ObjectFileRef();
+              tileData.transStart=start;
+              tileData.transEnd=end;
+
+              DrawArea(projection,parameter,tileData);
+            }
+          }
+        }
+      }
+    }
+  }
+
   void MapPainter::DrawHillShading(const Projection& projection,
                                    const MapParameter& parameter,
                                    const MapData& /*data*/)
@@ -2846,34 +2937,34 @@ static void DumpGroundTile(const GroundTile& tile)
 
     log.Info() << "Draw hillshading";
 
-    TypeInfoRef hillShadingType=styleConfig->GetTypeConfig()->GetTypeInfo("hillshading_tile");
+    TypeInfoRef srtmType=styleConfig->GetTypeConfig()->GetTypeInfo("srtm_tile");
 
-    if (!hillShadingType) {
-      log.Warn() << "HillShading activated but no type 'hillshading_tile' found";
+    if (!srtmType) {
+      log.Warn() << "HillShading activated but no type 'srtm_tile' found";
       return;
     }
 
     FeatureValueBuffer hillShadingBuffer;
 
-    hillShadingBuffer.SetType(hillShadingType);
+    hillShadingBuffer.SetType(srtmType);
 
-    FillStyleRef hillShadingFill=styleConfig->GetAreaFillStyle(hillShadingType,
+    FillStyleRef hillShadingFill=styleConfig->GetAreaFillStyle(srtmType,
                                                                hillShadingBuffer,
                                                                projection);
 
     if (!hillShadingFill) {
-      log.Warn() << "HillShading activated but no fill style for type 'hillshading_tile' found";
+      log.Warn() << "HillShading activated but no fill style for type 'srtm_tile' found";
     }
 
-    GeoBox boundingBox=projection.GetDimensions();
+    GeoBox mapBoundingBox=projection.GetDimensions();
 
-    log.Info() << "Initial bounding box: "  << boundingBox.GetDisplayText();
+    log.Info() << "Initial bounding box: "  << mapBoundingBox.GetDisplayText();
 
-    double minLat=RoundDown(boundingBox.GetMinLat());
-    double maxLat=RoundUp(boundingBox.GetMaxLat());
+    double minLat=RoundDown(mapBoundingBox.GetMinLat());
+    double maxLat=RoundUp(mapBoundingBox.GetMaxLat());
 
-    double minLon=RoundDown(boundingBox.GetMinLon());
-    double maxLon=RoundUp(boundingBox.GetMaxLon());
+    double minLon=RoundDown(mapBoundingBox.GetMinLon());
+    double maxLon=RoundUp(mapBoundingBox.GetMaxLon());
 
     log.Info() << "Even bounding box: "  << GeoBox(GeoCoord(minLat,minLon),GeoCoord(maxLat,maxLon)).GetDisplayText();
 

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -55,6 +55,7 @@ namespace osmscout {
     renderBackground(true),
     renderSeaLand(false),
     renderUnknowns(false),
+    renderHillShading(false),
     debugData(false),
     debugPerformance(false),
     warnObjectCountLimit(0),
@@ -223,6 +224,11 @@ namespace osmscout {
   void MapParameter::SetRenderUnknowns(bool render)
   {
     this->renderUnknowns=render;
+  }
+
+  void MapParameter::SetRenderHillShading(bool render)
+  {
+    this->renderHillShading=render;
   }
 
   void MapParameter::SetDebugData(bool debug)

--- a/libosmscout-map/src/osmscout/MapParameter.cpp
+++ b/libosmscout-map/src/osmscout/MapParameter.cpp
@@ -55,6 +55,7 @@ namespace osmscout {
     renderBackground(true),
     renderSeaLand(false),
     renderUnknowns(false),
+    renderContourLines(false),
     renderHillShading(false),
     debugData(false),
     debugPerformance(false),
@@ -224,6 +225,11 @@ namespace osmscout {
   void MapParameter::SetRenderUnknowns(bool render)
   {
     this->renderUnknowns=render;
+  }
+
+  void MapParameter::SetRenderContourLines(bool render)
+  {
+    this->renderContourLines=render;
   }
 
   void MapParameter::SetRenderHillShading(bool render)

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -366,6 +366,11 @@ namespace osmscout {
                       const std::vector<Point>& nodes,
                       size_t& start, size_t &end,
                       double optimizeErrorTolerance);
+    bool TransformBoundingBox(const Projection& projection,
+                              TransPolygon::OptimizeMethod optimize,
+                              const GeoBox& boundingBox,
+                              size_t& start, size_t &end,
+                              double optimizeErrorTolerance);
   };
 }
 

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -656,4 +656,33 @@ namespace osmscout {
 
     return true;
   }
+
+  bool TransBuffer::TransformBoundingBox(const Projection& projection,
+                                         TransPolygon::OptimizeMethod optimize,
+                                         const GeoBox& boundingBox,
+                                         size_t& start,
+                                         size_t& end,
+                                         double optimizeErrorTolerance)
+  {
+    transPolygon.TransformBoundingBox(projection, optimize, boundingBox, optimizeErrorTolerance);
+
+    if (transPolygon.IsEmpty()) {
+      return false;
+    }
+
+    bool isStart=true;
+    for (size_t i=transPolygon.GetStart(); i<=transPolygon.GetEnd(); i++) {
+      if (transPolygon.points[i].draw) {
+        end=buffer->PushCoord(transPolygon.points[i].x,
+                              transPolygon.points[i].y);
+
+        if (isStart) {
+          start=end;
+          isStart=false;
+        }
+      }
+    }
+
+    return true;
+  }
 }

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -2453,4 +2453,9 @@ TYPES
 
   TYPE compound_any IGNORE
     = RELATION ("type"=="compound")
+
+
+  // Debugging
+  TYPE hillshading_tile IGNORE
+    = AREA ("type"=="hillshading_tile")
 END

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -2456,6 +2456,6 @@ TYPES
 
 
   // Debugging
-  TYPE hillshading_tile IGNORE
-    = AREA ("type"=="hillshading_tile")
+  TYPE srtm_tile IGNORE
+    = AREA ("type"=="srtm_tile")
 END

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -2237,7 +2237,10 @@ STYLE
  //
 
  [MAG continent-] {
-   [TYPE hillshading_tile] AREA { color: #00000033; }
+   [TYPE srtm_tile] {
+     AREA { color: #00000033; }
+     AREA.BORDER { width: 0.1mm; color:  #555555; }
+   }
  }
 
 END

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -2231,4 +2231,13 @@ STYLE
     }
   }
 
+ // -------------------------------------------------------
+ //
+ // Debugging
+ //
+
+ [MAG continent-] {
+   [TYPE hillshading_tile] AREA { color: #00000033; }
+ }
+
 END


### PR DESCRIPTION
This is some code to setup some infrastructure for hillshading rendering.

It adds a command line option for hillshading to the draw demos and renderer.

It also draws a checkboard pattern of the size of the SRTM tiles (SRTM3) to get a feeling, what it is about.

Next steps:
* Do the same for contour lines
* --- different patch
* Extend MapData with SRTM data
* Add some code to get elevation lines from SRTM data