### PR TITLE
fix LocationEntry comparison

### DIFF
--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -104,7 +104,7 @@ void LocationListModel::onSearchResult(const QString searchPattern,
   if (equalsFn.isCallable()){
     // try to merge locations that are equals
     auto Equal = [&](const LocationEntryRef& a, const LocationEntryRef& b) -> bool {
-      assert(a != nullptr && a->parent() == nullptr && b != nullptr && b->parent() == nullptr);
+      assert(a != nullptr && b != nullptr);
       if (a->getLabel()==b->getLabel() &&
           a->getDatabase()==b->getDatabase() &&
           a->getType()==LocationEntry::typeObject &&

--- a/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchLocationModel.cpp
@@ -172,7 +172,10 @@ void LocationListModel::onSearchResult(const QString searchPattern,
 
   if (compareFn.isCallable()){
     auto Compare = [&](const LocationEntryRef& a, const LocationEntryRef& b) -> bool {
-      assert(a != nullptr && a->parent() == nullptr && b != nullptr && b->parent() == nullptr);
+      assert(a != nullptr && b != nullptr);
+      if (a.get() == b.get()) {
+        return false; // comp(a,a)==false
+      }
       QJSValueList args;
       // to transfer ownership to QML, parent have to be null. copy constructor copy ownership
       assert(a->parent() == nullptr && b->parent() == nullptr);
@@ -185,7 +188,7 @@ void LocationListModel::onSearchResult(const QString searchPattern,
         return false;
       }
       if (result.isNumber()){
-        return result.toNumber() <= 0;
+        return result.toNumber() < 0; // true if the first argument is less than (i.e. is ordered before) the second
       }
       return false;
     };


### PR DESCRIPTION
compare function should return true just in case that first argument
is less than second. in other words, comp(a,a) have to be false

I tested it and it seems to fix crashes on Android so far... @janbar 