### PR TITLE
fix crash in CoordBuffer::GenerateParallelWay

### DIFF
--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1333,6 +1333,8 @@ namespace osmscout {
       // The master ring does not have any nodes, so we skip it
       // Rings with less than 3 nodes should be skipped, too (no area)
       if (ring.IsMaster() || ring.nodes.size() < 3) {
+        td[i].transStart=0;
+        td[i].transEnd=0;
         continue;
       }
 
@@ -1367,6 +1369,9 @@ namespace osmscout {
         // clipping inner ring, we will not render it, but still go deeper,
         // there may be nested outer rings
         return true;
+      }
+      if (td[i].transStart==td[i].transEnd) {
+        return false; // ring was skipped or reduced to single point
       }
 
       FillStyleRef                fillStyle;

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1834,6 +1834,9 @@ namespace osmscout {
     bool hasShieldLabels = styleConfig.HasWayPathShieldStyle(projection);
 
     for (const auto& way : data.ways) {
+      if (way->nodes.size() < 2) {
+        continue; // algorithms require at least two points
+      }
       CalculatePaths(styleConfig,
                      projection,
                      parameter,
@@ -1848,6 +1851,9 @@ namespace osmscout {
     }
 
     for (const auto& way : data.poiWays) {
+      if (way->nodes.size() < 2) {
+        continue; // algorithms require at least two points
+      }
       CalculatePaths(styleConfig,
                      projection,
                      parameter,

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -1424,7 +1424,7 @@ namespace osmscout {
       // we currently assume that it does not have alpha and paints over its region and clipping is
       // not required.
       area->VisitClippingRings(i, [&a, &td](size_t j, const Area::Ring &, const TypeInfoRef &type) -> bool {
-        if (type->GetIgnore()) {
+        if (type->GetIgnore() && td[j].transStart < td[j].transEnd) {
           a.clippings.push_back(td[j]);
         }
         return true;

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -324,6 +324,8 @@ namespace osmscout {
      * Result is stored after the last valid point. Generated way offsets are returned
      * in start and end.
      *
+     * Way have to have at least two nodes (orgEnd > orgStart)
+     *
      * @param orgStart original way start
      * @param orgEnd original way end (inclusive)
      * @param offset offset of parallel way - positive offset is left, negative right

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -208,7 +208,7 @@ namespace osmscout {
                                         size_t& start,
                                         size_t& end)
   {
-    assert(orgStart<=orgEnd);
+    assert(orgStart<orgEnd);
     assert(orgEnd<usedPoints);
 
     double oax,oay;


### PR DESCRIPTION
Source way have to have at least two nodes.