### PR TITLE
Ground tile grid

### DIFF
--- a/libosmscout/include/osmscout/navigation/Navigation.h
+++ b/libosmscout/include/osmscout/navigation/Navigation.h
@@ -29,7 +29,6 @@
 #include <osmscout/util/Time.h>
 
 namespace osmscout {
-  static double one_degree_at_equator=111320.0;
 
   template<class NodeDescriptionTmpl>
   class OutputDescription
@@ -71,6 +70,9 @@ namespace osmscout {
       bool   found=false;
       double qx,qy;
       minDistance=std::numeric_limits<double>::max();
+      double snapDistanceInDegrees = GetDistanceInLonDegrees(snapDistanceInMeters,
+                                                             location.GetLat());
+
       for (auto node=nextNode++; node!=route->Nodes().end(); node++) {
         if (nextNode==route->Nodes().end()) {
           break;
@@ -86,8 +88,7 @@ namespace osmscout {
                                    qy);
         if (minDistance>=d) {
           minDistance=d;
-          if (d<=distanceInDegrees(snapDistanceInMeters,
-                                   location.GetLat())) {
+          if (d<=snapDistanceInDegrees) {
             foundNode    =node;
             foundAbscissa=abscissa;
             found        =true;
@@ -112,12 +113,6 @@ namespace osmscout {
         outputDescription(outputDescr),
         snapDistanceInMeters(Distance::Of<Meter>(25.0))
     {
-    }
-
-    static inline double distanceInDegrees(const Distance &d,
-                                           double latitude)
-    {
-      return d.AsMeter()/(one_degree_at_equator*cos(M_PI*latitude/180));
     }
 
     void SetRoute(RouteDescription* newRoute)

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -1109,6 +1109,16 @@ namespace osmscout {
 
   /**
    * \ingroup Geometry
+   * @param d distance
+   * @param latitude where degrees are computed.
+   *    Function is not defined on poles (+90, -90), it may leads to division by zero error.
+   * @return longitude degrees corresponding to distance
+   */
+  extern OSMSCOUT_API double GetDistanceInLonDegrees(const Distance &d,
+                                                     double latitude=0);
+
+  /**
+   * \ingroup Geometry
    * Normalizes the given angle (in degrees) to be in the interval [-180.0 - 180.0]
    */
   extern OSMSCOUT_API double NormalizeRelativeAngle(double angle);

--- a/libosmscout/src/osmscout/navigation/PositionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/PositionAgent.cpp
@@ -161,13 +161,6 @@ namespace osmscout {
       return position;
     }
 
-    static double one_degree_at_equator=111320.0;
-
-    double distanceInDegrees(const Distance &d, double latitude)
-    {
-      return d.AsMeter()/(one_degree_at_equator*cos(M_PI*latitude/180));
-    }
-
     double GetVehicleSpeed(osmscout::Vehicle vehicle,
                            const TypeConfig &/*typeConfig*/,
                            const TypeInfo &/*typeInfo*/)
@@ -390,8 +383,8 @@ namespace osmscout {
     double abscissa=0.0;
     bool   found=false;
     double qLon,qLat;
-    double snapDistanceInDegrees = distanceInDegrees(snapDistanceInMeters,
-                                                     location.GetLat());
+    double snapDistanceInDegrees = GetDistanceInLonDegrees(snapDistanceInMeters,
+                                                           location.GetLat());
 
     minDistance=std::numeric_limits<double>::max();
     for (auto node=nextNode++; node!=route->Nodes().end(); node++) {

--- a/libosmscout/src/osmscout/util/Geometry.cpp
+++ b/libosmscout/src/osmscout/util/Geometry.cpp
@@ -371,6 +371,14 @@ namespace osmscout {
     return Bearing::Radians(bearing);
   }
 
+  double GetDistanceInLonDegrees(const Distance &d,
+                                 double latitude)
+  {
+    static double oneDegreeAtEquator=111320.0;
+    return d.AsMeter()/(oneDegreeAtEquator * cos(M_PI * latitude / 180));
+  }
+
+
   double NormalizeRelativeAngle(double angle)
   {
     if (angle>180.0) {


### PR DESCRIPTION
Due to rounding errors during coordinate transformations there may be small
space between tiles. See @vyskocil comment here: https://github.com/Framstag/libosmscout/issues/1030#issuecomment-812742925
For that reason we should increase tile size approximately by 1 pixel to avoid visible grid.

Before creating `TransformBoundingBox` method, this issue was workarounded by using `ceil` and `floor` functions. But it doesn't helps when projection was rotated... 

Even now, grid is sometimes visible on coastline cells when map is rotated... 
![Screenshot_20210404_183817](https://user-images.githubusercontent.com/309458/113515457-f2f7c080-9574-11eb-829c-f445eba1c23a.png)
