### PR TITLE
add missing roles for route step

### DIFF
--- a/libosmscout-client-qt/include/osmscout/RouteStep.h
+++ b/libosmscout-client-qt/include/osmscout/RouteStep.h
@@ -65,7 +65,14 @@ public:
     DescriptionRole = Qt::UserRole + 2,
     TypeRole = Qt::UserRole + 3,
     RoundaboutExitRole = Qt::UserRole + 4,
-    RoundaboutClockwiseRole = Qt::UserRole + 5
+    RoundaboutClockwiseRole = Qt::UserRole + 5,
+    latRole = Qt::UserRole + 6,
+    lonRole = Qt::UserRole + 7,
+    distanceRole = Qt::UserRole + 8,
+    distanceDeltaRole = Qt::UserRole + 9,
+    distanceToRole = Qt::UserRole + 10,
+    timeRole = Qt::UserRole + 11,
+    timeDeltaRole = Qt::UserRole + 12
   };
   Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/src/osmscout/RouteStep.cpp
+++ b/libosmscout-client-qt/src/osmscout/RouteStep.cpp
@@ -77,6 +77,20 @@ QVariant RouteStep::data(int role) const
       return getRoundaboutExit();
     case RoundaboutClockwiseRole:
       return getRoundaboutClockwise();
+    case latRole:
+      return getLat();
+    case lonRole:
+      return getLon();
+    case distanceRole:
+      return getDistance();
+    case distanceDeltaRole:
+      return getDistanceDelta();
+    case distanceToRole:
+      return getDistanceTo();
+    case timeRole:
+      return getTime();
+    case timeDeltaRole:
+      return getTimeDelta();
     default:
       break;
   }
@@ -91,6 +105,13 @@ QHash<int, QByteArray> RouteStep::roleNames(QHash<int, QByteArray> roles)
   roles[TypeRole] = "type";
   roles[RoundaboutExitRole] = "roundaboutExit";
   roles[RoundaboutClockwiseRole] = "roundaboutClockwise";
+  roles[latRole] = "lat";
+  roles[lonRole] = "lon";
+  roles[distanceRole] = "distance";
+  roles[distanceDeltaRole] = "distanceDelta";
+  roles[distanceToRole] = "distanceTo";
+  roles[timeRole] = "time";
+  roles[timeDeltaRole] = "timeDelta";
 
   return roles;
 }


### PR DESCRIPTION
It add roles to bind some properties of the route step for usage with qt abstract list view. The new bound properties are:
- lat
- lon
- distance
- distanceDelta
- distanceTo
- time
- timeDelta

We need them to display extra info on a route overview. 