### PR TITLE
Zoom gesture with one finger

### DIFF
--- a/OSMScout2/src/AppSettings.cpp
+++ b/OSMScout2/src/AppSettings.cpp
@@ -40,7 +40,9 @@ MapView *AppSettings::GetMapView()
     view = new MapView(this,
               osmscout::GeoCoord(lat, lon),
               Bearing::Radians(angle),
-              osmscout::Magnification(mag),
+              std::max(osmscout::Magnification(osmscout::Magnification::magWorld),
+                       std::min(osmscout::Magnification(mag),
+                                osmscout::Magnification(osmscout::Magnification::magHouse))),
               OSMScoutQt::GetInstance().GetSettings()->GetMapDPI()
               );
   }

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -167,7 +167,7 @@ class OSMSCOUT_CLIENT_QT_API MapView: public QObject
   Q_PROPERTY(double   mapDpi    READ GetMapDpi    CONSTANT)
 
 public:
-  inline MapView(QObject *parent=nullptr): QObject(parent) {}
+  explicit inline MapView(QObject *parent=nullptr): QObject(parent) {}
 
   inline MapView(QObject *parent,
                  const osmscout::GeoCoord &center,
@@ -246,8 +246,8 @@ inline bool operator!=(const MapView& a, const MapView& b)
 class OSMSCOUT_CLIENT_QT_API InputHandler : public QObject{
     Q_OBJECT
 public:
-    InputHandler(const MapView &view);
-    ~InputHandler() override;
+    explicit InputHandler(const MapView &view);
+    ~InputHandler() override = default;
 
     virtual void painted();
     virtual bool animationInProgress();
@@ -299,8 +299,8 @@ private slots:
     void onTimeout();
 
 public:
-    MoveHandler(const MapView &view);
-    ~MoveHandler() override;
+    explicit MoveHandler(const MapView &view);
+    ~MoveHandler() override = default;
 
     bool animationInProgress() override;
 
@@ -344,11 +344,11 @@ private slots:
     void onTimeout();
 
 public:
-    JumpHandler(const MapView &view,
-                double moveAnimationDuration = (double)ANIMATION_DURATION,
-                double zoomAnimationDuration = (double)ANIMATION_DURATION);
+    explicit JumpHandler(const MapView &view,
+                         double moveAnimationDuration = (double)ANIMATION_DURATION,
+                         double zoomAnimationDuration = (double)ANIMATION_DURATION);
 
-    ~JumpHandler() override;
+    ~JumpHandler() override = default;
 
     bool animationInProgress() override;
     bool showCoordinates(const osmscout::GeoCoord &coord, const osmscout::Magnification &magnification, const osmscout::Bearing &bearing) override;
@@ -362,8 +362,8 @@ public:
 class OSMSCOUT_CLIENT_QT_API DragHandler : public MoveHandler {
     Q_OBJECT
 public:
-    DragHandler(const MapView &view);
-    ~DragHandler() override;
+    explicit DragHandler(const MapView &view);
+    ~DragHandler() override = default;
 
     bool animationInProgress() override;
 
@@ -392,8 +392,8 @@ private:
 class OSMSCOUT_CLIENT_QT_API MultitouchHandler : public MoveHandler {
     Q_OBJECT
 public:
-    MultitouchHandler(const MapView &view);
-    ~MultitouchHandler() override;
+    explicit MultitouchHandler(const MapView &view);
+    ~MultitouchHandler() override = default;
 
     bool animationInProgress() override;
 
@@ -427,6 +427,8 @@ public:
       JumpHandler(view), window(widgetSize)
     {};
 
+    ~LockHandler() override = default;
+
     bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition) override;
     bool showCoordinates(const osmscout::GeoCoord &coord, const osmscout::Magnification &magnification, const osmscout::Bearing &bearing) override;
     bool isLockedToPosition() override;
@@ -445,6 +447,7 @@ class OSMSCOUT_CLIENT_QT_API VehicleFollowHandler : public JumpHandler {
 Q_OBJECT
 public:
   VehicleFollowHandler(const MapView &view, const QSizeF &widgetSize);
+  ~VehicleFollowHandler() override = default;
 
   bool vehiclePosition(const VehiclePosition &vehiclePosition) override;
   bool isLockedToPosition() override;

--- a/libosmscout-client-qt/include/osmscout/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscout/InputHandler.h
@@ -47,12 +47,13 @@ namespace osmscout {
  *  - **Tap**: touch shorter than holdInterval (1000 ms) followed with pause longer than tapInterval (200 ms)
  *  - **Long tap**: touch longer than holdInterval (1000 ms)
  *  - **Double tap**: tap followed by second one within tapInterval (200 ms)
+ *  - **Tap, drag**: tap followed by drag
  *  - **Tap, long tap**: tap followed by long tap within tapInterval (200 ms)
  *
  * Physical DPI of display should be setup before first use. TapRecognizer use some small move
- * tolerance (~ 2.5 mm), it means that events are emited even that touch point is moving within
+ * tolerance (~ 2.5 mm), it means that events are emitted even that touch point is moving within
  * this tolerance. For double tap, when second tap is farther than this tolerance,
- * double-tap event is not emited.
+ * double-tap event is not emitted.
  */
 class OSMSCOUT_CLIENT_QT_API TapRecognizer : public QObject{
   Q_OBJECT
@@ -60,8 +61,8 @@ class OSMSCOUT_CLIENT_QT_API TapRecognizer : public QObject{
 private:
   enum TapRecState{
     INACTIVE = 0,
-    PRESSED = 1, // timer started with hold interval, if expired - long-tap is emited
-    RELEASED = 2, // timer started with tap interval, if expired - tap is emited
+    PRESSED = 1, // timer started with hold interval, if expired - long-tap is emitted
+    RELEASED = 2, // timer started with tap interval, if expired - tap is emitted
     PRESSED2 = 3, // timer started with hold interval, if expired - tap-long-tap
   };
 
@@ -105,6 +106,7 @@ signals:
   void doubleTap(const QPoint p);
   void longTap(const QPoint p);
   void tapLongTap(const QPoint p);
+  void tapAndDrag(const QPoint p);
 };
 
 /**
@@ -317,6 +319,31 @@ public:
     bool rotateTo(double angle) override;
     bool rotateBy(double angleChange) override;
     bool touch(const QTouchEvent &event) override;
+};
+
+/**
+ * \ingroup QtAPI
+ *
+ * Handler for zoom gesture with one finger, activated by tap and press usually.
+ */
+class OSMSCOUT_CLIENT_QT_API ZoomGestureHandler : public InputHandler
+{
+  Q_OBJECT
+private:
+  Magnification startMag;
+  QPoint gestureStart;
+  double zoomDistance;
+
+public:
+  /**
+   * @param view
+   * @param p - where the gesture start
+   * @param zoomDistance - distance [in pixels] where zoom is doubled/halved
+   */
+  ZoomGestureHandler(const MapView &view, const QPoint &p, double zoomDistance);
+  ~ZoomGestureHandler() override = default;
+
+  bool touch(const QTouchEvent &event) override;
 };
 
 /**

--- a/libosmscout-client-qt/include/osmscout/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscout/MapWidget.h
@@ -247,6 +247,7 @@ private slots:
   virtual void onDoubleTap(const QPoint p);
   virtual void onLongTap(const QPoint p);
   virtual void onTapLongTap(const QPoint p);
+  virtual void onTapAndDrag(const QPoint p);
 
   void onMapDPIChange(double dpi);
 

--- a/libosmscout-client-qt/src/osmscout/InputHandler.cpp
+++ b/libosmscout-client-qt/src/osmscout/InputHandler.cpp
@@ -177,10 +177,7 @@ QVector2D MoveAccumulator::collect()
 InputHandler::InputHandler(const MapView &view): view(view)
 {
 }
-InputHandler::~InputHandler()
-{
-    // noop
-}
+
 void InputHandler::painted()
 {
     // noop
@@ -245,10 +242,6 @@ MoveHandler::MoveHandler(const MapView &view): InputHandler(view)
     timer.setSingleShot(false);
 }
 
-MoveHandler::~MoveHandler()
-{
-    // noop
-}
 bool MoveHandler::touch(const QTouchEvent &event)
 {
     // move handler consumes finger release
@@ -466,10 +459,6 @@ JumpHandler::JumpHandler(const MapView &view,
     timer.setSingleShot(false);
 }
 
-JumpHandler::~JumpHandler()
-{
-    // noop
-}
 void JumpHandler::onTimeout()
 {
     double progress = (double)(animationStart.elapsed() + ANIMATION_TICK) / moveAnimationDuration;
@@ -533,9 +522,7 @@ DragHandler::DragHandler(const MapView &view):
         startX(-1), startY(-1), ended(false)
 {
 }
-DragHandler::~DragHandler()
-{
-}
+
 bool DragHandler::touch(const QTouchEvent &event)
 {
     if (ended)
@@ -599,10 +586,6 @@ MultitouchHandler::MultitouchHandler(const MapView &view):
 {
 }
 
-MultitouchHandler::~MultitouchHandler()
-{
-
-}
 bool MultitouchHandler::animationInProgress()
 {
     return moving || MoveHandler::animationInProgress();

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -64,6 +64,7 @@ MapWidget::MapWidget(QQuickItem* parent)
     connect(&tapRecognizer, &TapRecognizer::doubleTap,  this, &MapWidget::onDoubleTap);
     connect(&tapRecognizer, &TapRecognizer::longTap,    this, &MapWidget::onLongTap);
     connect(&tapRecognizer, &TapRecognizer::tapLongTap, this, &MapWidget::onTapLongTap);
+    connect(&tapRecognizer, &TapRecognizer::tapAndDrag, this, &MapWidget::onTapAndDrag);
 
     connect(this, &QQuickItem::widthChanged, this, &MapWidget::onResize);
     connect(this, &QQuickItem::heightChanged, this, &MapWidget::onResize);
@@ -701,9 +702,19 @@ void MapWidget::onLongTap(const QPoint p)
     emit longTap(p.x(), p.y(), lat, lon);
 }
 
+void MapWidget::onTapAndDrag(const QPoint p)
+{
+    // discard current input handler
+    DBThreadRef dbThread = OSMScoutQt::GetInstance().GetDBThread();
+    setupInputHandler(new ZoomGestureHandler(*view, p, dbThread->GetPhysicalDpi()));
+}
+
 void MapWidget::onTapLongTap(const QPoint p)
 {
-    zoomOut(2.0, p);
+    // discard current input handler
+    DBThreadRef dbThread = OSMScoutQt::GetInstance().GetDBThread();
+    setupInputHandler(new ZoomGestureHandler(*view, p, dbThread->GetPhysicalDpi()));
+
     double lat;
     double lon;
     getProjection().PixelToGeo(p.x(), p.y(), lon, lat);

--- a/libosmscout-client-qt/src/osmscout/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscout/MapWidget.cpp
@@ -182,17 +182,17 @@ void MapWidget::touchEvent(QTouchEvent *event)
 {
     assert(event);
     vehicle.lastGesture.restart();
+
+    tapRecognizer.touch(*event);
+
     if (!inputHandler->touch(*event)){
         if (event->touchPoints().size() == 1){
-            QTouchEvent::TouchPoint tp = event->touchPoints()[0];
             setupInputHandler(new DragHandler(*view));
         }else{
             setupInputHandler(new MultitouchHandler(*view));
         }
         inputHandler->touch(*event);
     }
-
-    tapRecognizer.touch(*event);
 
     event->accept();
  }


### PR DESCRIPTION
Gesture is activated by finger tap followed by dragging.
similar gesture is used by some other map applications,
dragging to the top - zoom out the map, dragging to the bottom - zoom in.