### PR TITLE
fix parse error with qt moc 5.6

### DIFF
--- a/libosmscout-gpx/include/osmscout/gpx/Export.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Export.h
@@ -31,12 +31,14 @@
 #include <cstdio>
 #include <string>
 
-namespace osmscout::gpx {
+namespace osmscout {
+namespace gpx {
 
 extern OSMSCOUT_GPX_API bool ExportGpx(const GpxFile &gpxFile,
                                        const std::string &filePath,
                                        BreakerRef breaker = nullptr,
                                        ProcessCallbackRef callback = std::make_shared<ProcessCallback>());
+}
 }
 
 #endif //LIBOSMSCOUT_GPX_EXPORT_H

--- a/libosmscout-gpx/include/osmscout/gpx/Track.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Track.h
@@ -30,7 +30,8 @@
 #include <vector>
 #include <optional>
 
-namespace osmscout::gpx {
+namespace osmscout {
+namespace gpx {
 
 class OSMSCOUT_GPX_API Track {
 public:
@@ -50,6 +51,7 @@ public:
 
   void FilterPoints(std::function<void(std::vector<TrackPoint> &)> filter);
 };
+}
 }
 
 #endif //OSMSCOUT_GPX_TRACK_H

--- a/libosmscout-gpx/include/osmscout/gpx/TrackPoint.h
+++ b/libosmscout-gpx/include/osmscout/gpx/TrackPoint.h
@@ -28,7 +28,8 @@
 #include <chrono>
 #include <optional>
 
-namespace osmscout::gpx {
+namespace osmscout {
+namespace gpx {
 
 class OSMSCOUT_GPX_API TrackPoint {
 public:
@@ -68,6 +69,7 @@ public:
   std::optional<double> vdop;
   std::optional<double> pdop;
 };
+}
 }
 
 #endif //OSMSCOUT_GPX_TRACKPOINT_H

--- a/libosmscout-gpx/include/osmscout/gpx/TrackSegment.h
+++ b/libosmscout-gpx/include/osmscout/gpx/TrackSegment.h
@@ -27,7 +27,8 @@
 
 #include <vector>
 
-namespace osmscout::gpx {
+namespace osmscout {
+namespace gpx {
 
 class OSMSCOUT_GPX_API TrackSegment {
 public:
@@ -39,6 +40,7 @@ public:
    */
   Distance GetLength() const;
 };
+}
 }
 
 #endif //OSMSCOUT_GPX_TRACKSEGMENT_H

--- a/libosmscout-gpx/include/osmscout/gpx/Utils.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Utils.h
@@ -26,7 +26,8 @@
 #include <memory>
 #include <vector>
 
-namespace osmscout::gpx {
+namespace osmscout {
+namespace gpx {
 
 class OSMSCOUT_GPX_API ProcessCallback {
 public:
@@ -67,6 +68,7 @@ extern OSMSCOUT_GPX_API void FilterNearPoints(std::vector<TrackPoint> &points,
 extern OSMSCOUT_GPX_API void FilterInaccuratePoints(std::vector<TrackPoint> &points,
                                                     double maxDilution=30);
 
+}
 }
 
 #endif //LIBOSMSCOUT_GPX_UTILS_H


### PR DESCRIPTION
This allows to compile project linked with libosmscout-gpx on SailfishOS 3.0/4.0. Seems Qt MOC 5.6 fails to parse concatenated namespace.