### PR TITLE
recover previous failed download or corrupted voice

### DIFF
--- a/libosmscout-client-qt/src/osmscout/VoiceManager.cpp
+++ b/libosmscout-client-qt/src/osmscout/VoiceManager.cpp
@@ -43,7 +43,7 @@ VoiceDownloadJob::~VoiceDownloadJob()
 
 void VoiceDownloadJob::start()
 {
-  if (target.exists()){
+  if (target.exists() && !isReplaceExisting()) {
     qWarning() << "Directory already exists"<<target.canonicalPath()<<"!";
     onJobFailed("Directory already exists", false);
     return;


### PR DESCRIPTION
HI, this fix a case when the voice download has been broken or when the voice content is corrupted, by allowing to override the existing folder when we launch a new download job.