### PR TITLE
simplify comparison operator using std::tuple

### DIFF
--- a/libosmscout-client-qt/src/osmscout/TileCache.cpp
+++ b/libosmscout-client-qt/src/osmscout/TileCache.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <tuple>
 
 #include <osmscout/TileCache.h>
 #include <osmscout/OSMTile.h>
@@ -42,11 +43,7 @@ bool operator==(const TileCacheKey &a, const TileCacheKey &b)
 
 bool operator<(const TileCacheKey &a, const TileCacheKey &b)
 {
-  if (a.zoomLevel != b.zoomLevel)
-    return a.zoomLevel < b.zoomLevel;
-  if (a.xtile != b.xtile)
-    return a.xtile < b.xtile;
-  return a.ytile < b.ytile;
+  return std::tie(a.zoomLevel, a.xtile, a.ytile) < std::tie(b.zoomLevel, b.xtile, b.ytile);
 }
 
 QDebug& operator<<(QDebug &out, const TileCacheKey &key)

--- a/libosmscout-map-qt/include/osmscout/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscout/MapPainterQt.h
@@ -21,6 +21,7 @@
 */
 
 #include <mutex>
+#include <tuple>
 
 #include <QPainter>
 #include <QMap>
@@ -68,19 +69,7 @@ namespace osmscout {
 
       bool operator<(const FontDescriptor& other) const
       {
-        if (fontName!=other.fontName) {
-          return fontName<other.fontName;
-        }
-
-        if (fontSize!=other.fontSize) {
-          return fontSize<other.fontSize;
-        }
-
-        if (weight!=other.weight) {
-          return weight<other.weight;
-        }
-
-        return italic<other.italic;
+        return std::tie(fontName, fontSize, weight, italic) < std::tie(other.fontName, other.fontSize, other.weight, other.italic);
       }
     };
 

--- a/libosmscout-map/src/osmscout/Styles.cpp
+++ b/libosmscout-map/src/osmscout/Styles.cpp
@@ -20,6 +20,7 @@
 #include <osmscout/Styles.h>
 
 #include <algorithm>
+#include <tuple>
 
 namespace osmscout {
 
@@ -374,55 +375,12 @@ namespace osmscout {
 
   bool LineStyle::operator<(const LineStyle& other) const
   {
-    if (slot!=other.slot) {
-      return slot<other.slot;
-    }
-
-    if (lineColor!=other.lineColor) {
-      return lineColor<other.lineColor;
-    }
-
-    if (gapColor!=other.gapColor) {
-      return gapColor<other.gapColor;
-    }
-
-    if (displayWidth!=other.displayWidth) {
-      return displayWidth<other.displayWidth;
-    }
-
-    if (width!=other.width) {
-      return width<other.width;
-    }
-
-    if (displayOffset!=other.displayOffset) {
-      return displayOffset<other.displayOffset;
-    }
-
-    if (offset!=other.offset) {
-      return offset<other.offset;
-    }
-
-    if (joinCap!=other.joinCap) {
-      return joinCap<other.joinCap;
-    }
-
-    if (endCap!=other.endCap) {
-      return endCap<other.endCap;
-    }
-
-    if (dash!=other.dash) {
-      return dash<other.dash;
-    }
-
-    if (priority!=other.priority) {
-      return priority<other.priority;
-    }
-
-    if (zIndex!=other.zIndex) {
-      return zIndex<other.zIndex;
-    }
-
-    return offsetRel<other.offsetRel;
+    return std::tie(slot, lineColor, gapColor, displayWidth, width,
+                    displayOffset, offset, joinCap, endCap, dash,
+                    priority, zIndex, offsetRel)
+           < std::tie(other.slot, other.lineColor, other.gapColor, other.displayWidth, other.width,
+                      other.displayOffset, other.offset, other.joinCap, other.endCap, other.dash,
+                      other.priority, other.zIndex, other.offsetRel);
   }
 
   class FillStyleDescriptor CLASS_FINAL : public StyleDescriptor
@@ -506,15 +464,7 @@ namespace osmscout {
 
   bool FillStyle::operator==(const FillStyle& other) const
   {
-    if (fillColor!=other.fillColor) {
-      return false;
-    }
-
-    if (pattern!=other.pattern) {
-      return false;
-    }
-
-    return patternMinMag!=other.patternMinMag;
+    return std::tie(fillColor, pattern, patternMinMag) == std::tie(other.fillColor, other.pattern, other.patternMinMag);;
   }
 
   bool FillStyle::operator!=(const FillStyle& other) const
@@ -524,15 +474,7 @@ namespace osmscout {
 
   bool FillStyle::operator<(const FillStyle& other) const
   {
-    if (fillColor!=other.fillColor) {
-      return fillColor<other.fillColor;
-    }
-
-    if (pattern!=other.pattern) {
-      return pattern<other.pattern;
-    }
-
-    return patternMinMag<other.patternMinMag;
+    return std::tie(fillColor, pattern, patternMinMag) < std::tie(other.fillColor, other.pattern, other.patternMinMag);
   }
 
   void FillStyle::SetStringValue(int attribute,
@@ -790,31 +732,8 @@ namespace osmscout {
 
   bool BorderStyle::operator<(const BorderStyle& other) const
   {
-    if (color!=other.color) {
-      return color<other.color;
-    }
-
-    if (gapColor!=other.gapColor) {
-      return gapColor<other.gapColor;
-    }
-
-    if (width!=other.width) {
-      return width<other.width;
-    }
-
-    if (displayOffset!=other.displayOffset) {
-      return displayOffset<other.displayOffset;
-    }
-
-    if (offset!=other.offset) {
-      return offset<other.offset;
-    }
-
-    if (dash!=other.dash) {
-      return dash<other.dash;
-    }
-
-    return priority<other.priority;
+    return std::tie(color, gapColor, width, displayOffset, offset, dash, priority)
+           < std::tie(other.color, other.gapColor, other.width, other.displayOffset, other.offset, other.dash, other.priority);
   }
 
   LabelStyle::LabelStyle()
@@ -1070,35 +989,10 @@ namespace osmscout {
       return false;
     }
 
-    if (slot!=other.slot) {
-      return false;
-    }
-
-    if (label!=other.label) {
-      return false;
-    }
-
-    if (position!=other.position) {
-      return false;
-    }
-
-    if (textColor!=other.textColor) {
-      return false;
-    }
-
-    if (style!=other.style) {
-      return false;
-    }
-
-    if (scaleAndFadeMag!=other.scaleAndFadeMag) {
-      return false;
-    }
-
-    if (autoSize!=other.autoSize) {
-      return false;
-    }
-
-    return true;
+    return std::tie(slot, label, position, textColor, style,
+                    scaleAndFadeMag, autoSize)
+           == std::tie(other.slot, other.label, other.position, other.textColor, other.style,
+                       other.scaleAndFadeMag, other.autoSize);
   }
 
   bool TextStyle::operator!=(const TextStyle& other) const
@@ -1116,31 +1010,10 @@ namespace osmscout {
       return GetSize()<other.GetSize();
     }
 
-    if (slot!=other.slot) {
-      return slot<other.slot;
-    }
-
-    if (label!=other.label) {
-      return label<other.label;
-    }
-
-    if (position!=other.position) {
-      return position<other.position;
-    }
-
-    if (textColor!=other.textColor) {
-      return textColor<other.textColor;
-    }
-
-    if (style!=other.style) {
-      return style<other.style;
-    }
-
-    if (scaleAndFadeMag!=other.scaleAndFadeMag) {
-      return scaleAndFadeMag<other.scaleAndFadeMag;
-    }
-
-    return autoSize<other.autoSize;
+    return std::tie(slot, label, position, textColor, style,
+                    scaleAndFadeMag, autoSize)
+           < std::tie(other.slot, other.label, other.position, other.textColor, other.style,
+                      other.scaleAndFadeMag, other.autoSize);
   }
 
   ShieldStyle::ShieldStyle()

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -23,6 +23,7 @@
 #include <osmscout/CoreImportExport.h>
 
 #include <string>
+#include <tuple>
 
 #include <osmscout/OSMScoutTypes.h>
 
@@ -278,8 +279,7 @@ namespace osmscout {
 
     inline bool operator<(const GeoCoord& other) const
     {
-      return lat<other.lat ||
-             (lat==other.lat && lon<other.lon);
+      return std::tie(lat, lon) < std::tie(other.lat, other.lon);
     }
 
     /**

--- a/libosmscout/include/osmscout/ObjectRef.h
+++ b/libosmscout/include/osmscout/ObjectRef.h
@@ -23,6 +23,7 @@
 #include <osmscout/CoreImportExport.h>
 
 #include <string>
+#include <tuple>
 
 #include <osmscout/OSMScoutTypes.h>
 
@@ -111,7 +112,7 @@ namespace osmscout {
     }
     inline bool operator<(const ObjectOSMRef& reference) const
     {
-      return type<reference.type || (type==reference.type &&  id<reference.id);
+      return std::tie(type, id) < std::tie(reference.type, reference.id);
     }
 
     inline bool operator==(const ObjectOSMRef& reference) const
@@ -209,7 +210,7 @@ namespace osmscout {
 
     inline bool operator<(const ObjectFileRef& reference) const
     {
-      return type<reference.type || (type==reference.type &&  offset<reference.offset);
+      return std::tie(type, offset) < std::tie(reference.type, reference.offset);
     }
 
     inline bool operator==(const ObjectFileRef& reference) const

--- a/libosmscout/include/osmscout/Pixel.h
+++ b/libosmscout/include/osmscout/Pixel.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <array>
 #include <type_traits>
+#include <tuple>
 
 namespace osmscout {
 
@@ -69,8 +70,7 @@ namespace osmscout {
 
     inline bool operator<(const Pixel& other) const
     {
-      return y<other.y ||
-      (y==other.y && x<other.x);
+      return std::tie(y, x) < std::tie(other.y, other.x);
     }
 
     /**
@@ -156,8 +156,7 @@ namespace osmscout {
 
     inline bool operator<(const Vertex2D& other) const
     {
-      return coords[1]<other.coords[1] ||
-             (coords[1]==other.coords[1] && coords[0]<other.coords[0]);
+      return std::tie(coords[1], coords[0]) < std::tie(other.coords[1], other.coords[0]);
     }
 
     inline double DistanceTo(const Vertex2D &other) const {
@@ -257,15 +256,7 @@ namespace osmscout {
 
     inline bool operator<(const Vertex3D& other) const
     {
-      if (x!=other.x) {
-        return x<other.x;
-      }
-
-      if (y!=other.y) {
-        return y<other.y;
-      }
-
-      return z<other.z;
+      return std::tie(x, y, z) < std::tie(other.x, other.y, other.z);
     }
   };
 }

--- a/libosmscout/include/osmscout/routing/DBFileOffset.h
+++ b/libosmscout/include/osmscout/routing/DBFileOffset.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <ostream>
+#include <tuple>
 #include <osmscout/OSMScoutTypes.h>
 
 namespace osmscout{
@@ -72,11 +73,7 @@ namespace osmscout{
 
     inline bool operator<(const DBId& other) const
     {
-      if (database!=other.database) {
-        return database<other.database;
-      }
-
-      return id<other.id;
+      return std::tie(database, id) < std::tie(other.database, other.id);
     }
   };
 
@@ -124,11 +121,7 @@ namespace osmscout{
 
     inline bool operator<(const DBFileOffset& other) const
     {
-      if (database!=other.database) {
-        return database<other.database;
-      }
-
-      return offset<other.offset;
+      return std::tie(database, offset) < std::tie(other.database, other.offset);
     }
 
     DBFileOffset& operator=(const DBFileOffset& other) = default;

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <tuple>
 
 #include <osmscout/CoreImportExport.h>
 
@@ -1143,15 +1144,7 @@ namespace osmscout {
 
     inline bool operator<(const ScanCell& other) const
     {
-      if (y<other.y) {
-        return true;
-      }
-
-      if (y==other.y) {
-        return x<other.x;
-      }
-
-      return false;
+      return std::tie(y, x) < std::tie(other.y, other.x);
     }
 
     inline bool IsEqual(const ScanCell& other) const

--- a/libosmscout/include/osmscout/util/TileId.h
+++ b/libosmscout/include/osmscout/util/TileId.h
@@ -21,6 +21,7 @@
 */
 
 #include <memory>
+#include <tuple>
 
 #include <osmscout/CoreImportExport.h>
 
@@ -98,11 +99,7 @@ namespace osmscout {
      */
     inline bool operator<(const TileId& other) const
     {
-      if (y!=other.y) {
-        return y<other.y;
-      }
-
-      return x<other.x;
+      return std::tie(y, x) < std::tie(other.y, other.x);
     }
 
     GeoCoord GetTopLeftCoord(const Magnification& magnification) const;

--- a/libosmscout/src/osmscout/routing/RouteNode.cpp
+++ b/libosmscout/src/osmscout/routing/RouteNode.cpp
@@ -20,6 +20,7 @@
 #include <osmscout/routing/RouteNode.h>
 
 #include <limits>
+#include <tuple>
 
 #include <osmscout/system/Math.h>
 
@@ -36,11 +37,7 @@ namespace osmscout {
       return type->GetIndex()<other.type->GetIndex();
     }
 
-    if (maxSpeed!=other.maxSpeed) {
-      return maxSpeed<other.maxSpeed;
-    }
-
-    return grade<other.grade;
+    return std::tie(maxSpeed, grade) < std::tie(other.maxSpeed, other.grade);
   }
 
   void ObjectVariantData::Read(const TypeConfig& typeConfig,

--- a/libosmscout/src/osmscout/util/Color.cpp
+++ b/libosmscout/src/osmscout/util/Color.cpp
@@ -21,6 +21,7 @@
 
 #include <osmscout/system/Math.h>
 #include <map>
+#include <tuple>
 
 namespace osmscout {
 
@@ -109,19 +110,7 @@ namespace osmscout {
 
   bool Color::operator<(const Color& other) const
   {
-    if (r!=other.r) {
-      return r<other.r;
-    }
-
-    if (g!=other.g) {
-      return g<other.g;
-    }
-
-    if (b!=other.b) {
-      return b<other.b;
-    }
-
-    return a<other.a;
+    return std::tie(r, g, b, a) < std::tie(other.r, other.g, other.b, other.a);
   }
 
   Color Color::FromHexString(const std::string& hexString)

--- a/libosmscout/src/osmscout/util/TileId.cpp
+++ b/libosmscout/src/osmscout/util/TileId.cpp
@@ -18,8 +18,9 @@
 */
 
 #include <osmscout/util/TileId.h>
-
 #include <osmscout/util/Geometry.h>
+
+#include <tuple>
 
 namespace osmscout {
 
@@ -202,11 +203,7 @@ namespace osmscout {
    */
   bool TileKey::operator<(const TileKey& other) const
   {
-    if (level!=other.level) {
-      return level<other.level;
-    }
-
-    return id<other.id;
+    return std::tie(level, id) < std::tie(other.level, other.id);
   }
 
   TileIdBox::TileIdBox(const TileId& a,


### PR DESCRIPTION
My colleague show me recently howto simplify manually written comparison (operator ==, !=, <) using tuple of references. I would like to start using it in library, [generated assembly](https://godbolt.org/z/TK8ecGWrz) is almost the same and code is shorter and  more readable IMHO.