### PR TITLE
add the color feature to custom poi types

### DIFF
--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -48,6 +48,7 @@ class OSMSCOUT_CLIENT_QT_API OverlayObject : public QObject
   Q_PROPERTY(QString objectType READ getObjectTypeStr)
   Q_PROPERTY(qint8 layer READ getLayer WRITE setLayer)
   Q_PROPERTY(QString name READ getName WRITE setName)
+  Q_PROPERTY(QString color READ getColor WRITE setColor)
   Q_PROPERTY(LocationEntry *boundingBox READ getBBoxAsLocation NOTIFY bboxChanged)
 
 protected:
@@ -57,7 +58,9 @@ protected:
   mutable osmscout::GeoBox            box;
   int8_t                              layer{std::numeric_limits<int8_t>::max()};
   QString                             name;
+  QString                             color;
   mutable QMutex                      lock;
+  std::optional<Color>                colorValue;
 
 public slots:
   void clear();
@@ -133,6 +136,14 @@ public:
     QMutexLocker locker(&lock);
     name = n;
   }
+
+  inline QString getColor() const
+  {
+    QMutexLocker locker(&lock);
+    return color;
+  }
+
+  void setColor(const QString &c);
 
   LocationEntry* getBBoxAsLocation() const;
   osmscout::GeoBox boundingBox() const;

--- a/libosmscout-client-qt/src/osmscout/DBThread.cpp
+++ b/libosmscout-client-qt/src/osmscout/DBThread.cpp
@@ -301,6 +301,10 @@ void DBThread::onDatabaseListChanged(QList<QDir> databaseDirectories)
           if (nameFeature)
             typeInfo->AddFeature(nameFeature);
 
+          osmscout::FeatureRef colorFeature = typeConfig->GetFeature(ColorFeature::NAME);
+          if (colorFeature)
+            typeInfo->AddFeature(colorFeature);
+
           typeConfig->RegisterType(typeInfo);
         }
 


### PR DESCRIPTION
Allows to set the preferred color for an overlay object.
Then if the type config is set accordingly as follows, the color will be applied.

Config in oss stylesheet:

[TYPE _custom] WAY { preferColorFeature: true; color: @trackColor; }