### PR TITLE
fix compilation error with android ndk18b

### DIFF
--- a/libosmscout-client-qt/include/osmscout/OverlayObject.h
+++ b/libosmscout-client-qt/include/osmscout/OverlayObject.h
@@ -32,6 +32,8 @@
 #include <osmscout/ClientQtImportExport.h>
 #include <osmscout/LocationEntry.h>
 
+#include <optional>
+
 namespace osmscout {
 
 /**
@@ -60,7 +62,7 @@ protected:
   QString                             name;
   QString                             color;
   mutable QMutex                      lock;
-  std::optional<Color>                colorValue;
+  std::optional<osmscout::Color>      colorValue;
 
 public slots:
   void clear();


### PR DESCRIPTION
Explicit include for header 'optional'.

Arrrrg ! I haven't tested the build for android ndk18 after my commit 328da80a.

Edit: It fix also the build with macos 10.14 where I have the same issue.