### PR TITLE
add unittest for string normalization for lookup

### DIFF
--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -121,11 +121,6 @@ TEST_CASE("Lowercase 3")
 
 TEST_CASE("Normalize for lookup")
 {
-  // Normalized string should be converted to lowercase,
-  // all whitespaces* should be converted to standard space
-  // and multiple following spaces should be collapsed to one.
-  //
-  // *) tabular, no-break space (&nbsp;), figure space, narrow no-break space...
   auto transformed=osmscout::UTF8NormForLookup(
           "Baker \t \u00A0 \u2007 \u202F Street");
 

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -119,6 +119,20 @@ TEST_CASE("Lowercase 3")
           "لم تفهم شيئًا من بساطتي ، لا شيء ، يا ولدي المسكين! ومع جبين لا معنى له ، منزعج أن تهرب من قبل.");
 }
 
+TEST_CASE("Normalize for lookup")
+{
+  // Normalized string should be converted to lowercase,
+  // all whitespaces* should be converted to standard space
+  // and multiple following spaces should be collapsed to one.
+  //
+  // *) tabular, no-break space (&nbsp;), figure space, narrow no-break space...
+  auto transformed=osmscout::UTF8NormForLookup(
+          "Baker \t \u00A0 \u2007 \u202F Street");
+
+  REQUIRE(transformed ==
+          "baker street");
+}
+
 TEST_CASE("Parse illegal UTF8 sequence")
 {
   auto transformed=osmscout::UTF8Transliterate(u8"\xef\xbb\xbf\x2f\xc0\xae\x2e\x2f");

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -495,11 +495,13 @@ namespace osmscout {
    * for example street name, where string are not binary equals,
    * but are "same" for human - for example "Baker Street" and "Baker  street"
    *
+   * Normalized string is converted to lowercase, all whitespaces are converted
+   * to standard space and multiple following spaces are collapsed to one.
+   *
    * @param text
    *    Text to get converted
    * @return
    *    Converted text
-   *
    */
   extern OSMSCOUT_API std::string UTF8NormForLookup(const std::string& text);
 


### PR DESCRIPTION
I'm bit late with utf8helper review. Great work @janbar !  I just noticed that we don't have unittest for `UTF8NormForLookup`...