### PR TITLE
fix coord buffer leak, make it member of MapPainter

### DIFF
--- a/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscout/MapPainterAgg.h
@@ -207,7 +207,6 @@ namespace osmscout {
     explicit MapPainterAgg(const StyleConfigRef& styleConfig);
     ~MapPainterAgg() override;
 
-
     bool DrawMap(const Projection& projection,
                  const MapParameter& parameter,
                  const MapData& data,

--- a/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscout/MapPainterAgg.cpp
@@ -39,8 +39,7 @@
 namespace osmscout {
 
   MapPainterAgg::MapPainterAgg(const StyleConfigRef& styleConfig)
-  : MapPainter(styleConfig,
-               new CoordBuffer()),
+  : MapPainter(styleConfig),
     labelLayouter(this)
   {
     // no code
@@ -574,12 +573,12 @@ namespace osmscout {
 
     for (size_t i=transStart; i<=transEnd; i++) {
       if (i==transStart) {
-        p.move_to(coordBuffer->buffer[i].GetX(),
-                  coordBuffer->buffer[i].GetY());
+        p.move_to(coordBuffer.buffer[i].GetX(),
+                  coordBuffer.buffer[i].GetY());
       }
       else {
-        p.line_to(coordBuffer->buffer[i].GetX(),
-                  coordBuffer->buffer[i].GetY());
+        p.line_to(coordBuffer.buffer[i].GetX(),
+                  coordBuffer.buffer[i].GetY());
       }
     }
 
@@ -652,11 +651,11 @@ namespace osmscout {
       rasterizer->filling_rule(agg::fill_non_zero);
     }
 
-    path.move_to(coordBuffer->buffer[area.coordRange.GetStart()].GetX(),
-                 coordBuffer->buffer[area.coordRange.GetStart()].GetY());
+    path.move_to(coordBuffer.buffer[area.coordRange.GetStart()].GetX(),
+                 coordBuffer.buffer[area.coordRange.GetStart()].GetY());
     for (size_t i=area.coordRange.GetStart()+1; i<=area.coordRange.GetEnd(); i++) {
-      path.line_to(coordBuffer->buffer[i].GetX(),
-                   coordBuffer->buffer[i].GetY());
+      path.line_to(coordBuffer.buffer[i].GetX(),
+                   coordBuffer.buffer[i].GetY());
     }
     path.close_polygon();
 
@@ -666,11 +665,11 @@ namespace osmscout {
       for (const auto& data : area.clippings) {
         agg::path_storage clipPath;
 
-         clipPath.move_to(coordBuffer->buffer[data.transStart].GetX(),
-                          coordBuffer->buffer[data.transStart].GetY());
+         clipPath.move_to(coordBuffer.buffer[data.transStart].GetX(),
+                          coordBuffer.buffer[data.transStart].GetY());
         for (size_t i=data.transStart+1; i<=data.transEnd; i++) {
-          clipPath.line_to(coordBuffer->buffer[i].GetX(),
-                           coordBuffer->buffer[i].GetY());
+          clipPath.line_to(coordBuffer.buffer[i].GetX(),
+                           coordBuffer.buffer[i].GetY());
         }
         clipPath.close_polygon();
 

--- a/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscout/MapPainterCairo.cpp
@@ -260,8 +260,7 @@ namespace osmscout {
   }
 
   MapPainterCairo::MapPainterCairo(const StyleConfigRef &styleConfig)
-      : MapPainter(styleConfig,
-                   new CoordBuffer()),
+      : MapPainter(styleConfig),
         labelLayouter(this)
   {
     // no code
@@ -608,18 +607,18 @@ namespace osmscout {
     for (size_t j = transStart; j <= transEnd; j++) {
       if (j == transStart) {
         cairo_move_to(draw,
-                      coordBuffer->buffer[j].GetX(),
-                      coordBuffer->buffer[j].GetY());
+                      coordBuffer.buffer[j].GetX(),
+                      coordBuffer.buffer[j].GetY());
       } else {
         cairo_line_to(draw,
-                      coordBuffer->buffer[j].GetX(),
-                      coordBuffer->buffer[j].GetY());
-        lineLength += sqrt(pow(coordBuffer->buffer[j].GetX() - xo, 2) +
-                           pow(coordBuffer->buffer[j].GetY() - yo, 2));
+                      coordBuffer.buffer[j].GetX(),
+                      coordBuffer.buffer[j].GetY());
+        lineLength += sqrt(pow(coordBuffer.buffer[j].GetX() - xo, 2) +
+                           pow(coordBuffer.buffer[j].GetY() - yo, 2));
       }
 
-      xo = coordBuffer->buffer[j].GetX();
-      yo = coordBuffer->buffer[j].GetY();
+      xo = coordBuffer.buffer[j].GetX();
+      yo = coordBuffer.buffer[j].GetY();
     }
 
     cairo_path_t *path = cairo_copy_path_flat(draw);
@@ -1274,13 +1273,13 @@ namespace osmscout {
       if (i==transStart) {
         cairo_new_path(draw);
         cairo_move_to(draw,
-                      coordBuffer->buffer[i].GetX(),
-                      coordBuffer->buffer[i].GetY());
+                      coordBuffer.buffer[i].GetX(),
+                      coordBuffer.buffer[i].GetY());
       }
       else {
         cairo_line_to(draw,
-                      coordBuffer->buffer[i].GetX(),
-                      coordBuffer->buffer[i].GetY());
+                      coordBuffer.buffer[i].GetX(),
+                      coordBuffer.buffer[i].GetY());
       }
     }
 
@@ -1296,11 +1295,11 @@ namespace osmscout {
         cairo_set_line_width(draw,width);
 
         cairo_move_to(draw,
-                      coordBuffer->buffer[transStart].GetX(),
-                      coordBuffer->buffer[transStart].GetY());
+                      coordBuffer.buffer[transStart].GetX(),
+                      coordBuffer.buffer[transStart].GetY());
         cairo_line_to(draw,
-                      coordBuffer->buffer[transStart].GetX(),
-                      coordBuffer->buffer[transStart].GetY());
+                      coordBuffer.buffer[transStart].GetX(),
+                      coordBuffer.buffer[transStart].GetY());
         cairo_stroke(draw);
       }
 
@@ -1311,11 +1310,11 @@ namespace osmscout {
         cairo_set_line_width(draw,width);
 
         cairo_move_to(draw,
-                      coordBuffer->buffer[transEnd].GetX(),
-                      coordBuffer->buffer[transEnd].GetY());
+                      coordBuffer.buffer[transEnd].GetX(),
+                      coordBuffer.buffer[transEnd].GetY());
         cairo_line_to(draw,
-                      coordBuffer->buffer[transEnd].GetX(),
-                      coordBuffer->buffer[transEnd].GetY());
+                      coordBuffer.buffer[transEnd].GetX(),
+                      coordBuffer.buffer[transEnd].GetY());
         cairo_stroke(draw);
       }
     }
@@ -1333,12 +1332,12 @@ namespace osmscout {
 
     cairo_new_path(draw);
     cairo_move_to(draw,
-                  coordBuffer->buffer[area.coordRange.GetStart()].GetX(),
-                  coordBuffer->buffer[area.coordRange.GetStart()].GetY());
+                  coordBuffer.buffer[area.coordRange.GetStart()].GetX(),
+                  coordBuffer.buffer[area.coordRange.GetStart()].GetY());
     for (size_t i=area.coordRange.GetStart()+1; i<=area.coordRange.GetEnd(); i++) {
       cairo_line_to(draw,
-                    coordBuffer->buffer[i].GetX(),
-                    coordBuffer->buffer[i].GetY());
+                    coordBuffer.buffer[i].GetX(),
+                    coordBuffer.buffer[i].GetY());
     }
     cairo_close_path(draw);
 
@@ -1348,12 +1347,12 @@ namespace osmscout {
         cairo_new_sub_path(draw);
         cairo_set_line_width(draw,0.0);
         cairo_move_to(draw,
-                      coordBuffer->buffer[data.transStart].GetX(),
-                      coordBuffer->buffer[data.transStart].GetY());
+                      coordBuffer.buffer[data.transStart].GetX(),
+                      coordBuffer.buffer[data.transStart].GetY());
         for (size_t i=data.transStart+1; i<=data.transEnd; i++) {
           cairo_line_to(draw,
-                        coordBuffer->buffer[i].GetX(),
-                        coordBuffer->buffer[i].GetY());
+                        coordBuffer.buffer[i].GetX(),
+                        coordBuffer.buffer[i].GetY());
         }
         cairo_close_path(draw);
       }

--- a/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscout/MapPainterDirectX.cpp
@@ -809,12 +809,12 @@ namespace osmscout
       hr = pPathGeometry->Open(&pSink);
       if (SUCCEEDED(hr))
       {
-        pSink->BeginFigure(POINTF(coordBuffer->buffer[transStart].GetX(),
-                                  coordBuffer->buffer[transStart].GetY()),
+        pSink->BeginFigure(POINTF(coordBuffer.buffer[transStart].GetX(),
+                                  coordBuffer.buffer[transStart].GetY()),
                                   D2D1_FIGURE_BEGIN_HOLLOW);
 
         for (size_t i = transStart + 1; i <= transEnd; i++) {
-          pSink->AddLine(POINTF(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY()));
+          pSink->AddLine(POINTF(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY()));
         }
         pSink->EndFigure(D2D1_FIGURE_END_OPEN);
         hr = pSink->Close();
@@ -872,7 +872,7 @@ namespace osmscout
       hr = pPathGeometry->Open(&pSink);
       if (SUCCEEDED(hr))
       {
-        Vertex2D* coords = coordBuffer->buffer;
+        Vertex2D* coords = coordBuffer.buffer;
         size_t start, end;
         int delta;
         if (coords[transStart].GetX() <= coords[transEnd].GetX()) {
@@ -960,9 +960,9 @@ namespace osmscout
       hr = pPathGeometry->Open(&pSink);
       if (SUCCEEDED(hr))
       {
-        pSink->BeginFigure(POINTF(coordBuffer->buffer[area.coordRange.GetStart()].GetX(), coordBuffer->buffer[area.coordRange.GetStart()].GetY()), D2D1_FIGURE_BEGIN_FILLED);
+        pSink->BeginFigure(POINTF(coordBuffer.buffer[area.coordRange.GetStart()].GetX(), coordBuffer.buffer[area.coordRange.GetStart()].GetY()), D2D1_FIGURE_BEGIN_FILLED);
         for (size_t i = area.coordRange.GetStart() + 1; i <= area.coordRange.GetEnd(); i++) {
-          pSink->AddLine(POINTF(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY()));
+          pSink->AddLine(POINTF(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY()));
         }
         pSink->EndFigure(D2D1_FIGURE_END_CLOSED);
         hr = pSink->Close();
@@ -988,10 +988,10 @@ namespace osmscout
         hr = pPathGeometry->Open(&pSink);
         if (SUCCEEDED(hr))
         {
-          pSink->BeginFigure(POINTF(coordBuffer->buffer[data.transStart].GetX(), coordBuffer->buffer[data.transStart].GetY()), D2D1_FIGURE_BEGIN_FILLED);
+          pSink->BeginFigure(POINTF(coordBuffer.buffer[data.transStart].GetX(), coordBuffer.buffer[data.transStart].GetY()), D2D1_FIGURE_BEGIN_FILLED);
 
           for (size_t i = data.transStart + 1; i <= data.transEnd; i++) {
-            pSink->AddLine(POINTF(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY()));
+            pSink->AddLine(POINTF(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY()));
           }
           pSink->EndFigure(D2D1_FIGURE_END_CLOSED);
           hr = pSink->Close();
@@ -1010,7 +1010,7 @@ namespace osmscout
   MapPainterDirectX::MapPainterDirectX(const StyleConfigRef& styleConfig,
                                        ID2D1Factory* pDirect2dFactory,
                                        IDWriteFactory* pWriteFactory)
-    : MapPainter(styleConfig, new CoordBuffer()),
+    : MapPainter(styleConfig),
     m_dashLessStrokeStyle(nullptr),
     m_pDirect2dFactory(pDirect2dFactory),
     m_pWriteFactory(pWriteFactory),

--- a/libosmscout-map-gdi/src/osmscout/MapPainterGDI.cpp
+++ b/libosmscout-map-gdi/src/osmscout/MapPainterGDI.cpp
@@ -323,7 +323,7 @@ namespace osmscout {
 	};
 
 	MapPainterGDI::MapPainterGDI(const StyleConfigRef& styleConfig)
-		: MapPainter(styleConfig, new CoordBuffer())
+		: MapPainter(styleConfig)
 		, m_labelLayouter(this)
 		, m_pBuffer(NULL)
 	{
@@ -682,7 +682,7 @@ namespace osmscout {
 		PointFBuffer points;
 		for (size_t i = transStart; i <= transEnd; i++)
 		{
-			points.AddPoint(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY());
+			points.AddPoint(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY());
 		}
 		pRender->m_pGraphics->DrawLines(pPen, points.m_Data, (INT)points.m_Size);
 	}
@@ -737,7 +737,7 @@ namespace osmscout {
 		PointFBuffer areaPoints;
 		for (size_t i = area.coordRange.GetStart(); i <= area.coordRange.GetEnd(); i++)
 		{
-			areaPoints.AddPoint(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY());
+			areaPoints.AddPoint(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY());
 		}
 		areaPoints.Close();
 		struct clippingRegion
@@ -754,7 +754,7 @@ namespace osmscout {
 			clippingRegion cr;
 			cr.points = new PointFBuffer();
 			for (size_t i = data.transStart; i <= data.transEnd; i++) {
-				cr.points->AddPoint(coordBuffer->buffer[i].GetX(), coordBuffer->buffer[i].GetY());
+				cr.points->AddPoint(coordBuffer.buffer[i].GetX(), coordBuffer.buffer[i].GetY());
 			}
 			cr.points->Close();
 			cr.path = new Gdiplus::GraphicsPath();

--- a/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
@@ -33,7 +33,7 @@
 namespace osmscout {
 
     MapPainterIOS::MapPainterIOS(const StyleConfigRef& styleConfig)
-    : MapPainter(styleConfig, new CoordBuffer()), labelLayouter(this){
+    : MapPainter(styleConfig), labelLayouter(this){
 #if TARGET_OS_IPHONE
         contentScale = [[UIScreen mainScreen] scale];
 #else
@@ -550,14 +550,14 @@ namespace osmscout {
                                        bool isClosed, bool keepOrientation) {
         hnd.i = 0;
         hnd.nVertex = transEnd - transStart;
-        bool isReallyClosed = (coordBuffer->buffer[transStart] == coordBuffer->buffer[transEnd]);
+        bool isReallyClosed = (coordBuffer.buffer[transStart] == coordBuffer.buffer[transEnd]);
         if(isClosed && !isReallyClosed){
             hnd.nVertex++;
             hnd.closeWay = true;
         } else {
             hnd.closeWay = false;
         }
-        if(keepOrientation || coordBuffer->buffer[transStart].GetX()<coordBuffer->buffer[transEnd].GetX()){
+        if(keepOrientation || coordBuffer.buffer[transStart].GetX()<coordBuffer.buffer[transEnd].GetX()){
             hnd.transStart = transStart;
             hnd.transEnd = transEnd;
         } else {
@@ -565,7 +565,7 @@ namespace osmscout {
             hnd.transEnd = transStart;
         }
         hnd.direction = (hnd.transStart < hnd.transEnd) ? 1 : -1;
-        origin.Set(coordBuffer->buffer[hnd.transStart].GetX(), coordBuffer->buffer[hnd.transStart].GetY());
+        origin.Set(coordBuffer.buffer[hnd.transStart].GetX(), coordBuffer.buffer[hnd.transStart].GetY());
     }
 
     bool MapPainterIOS::followPath(FollowPathHandle &hnd, double l, Vertex2D &origin) {
@@ -576,11 +576,11 @@ namespace osmscout {
         double deltaX, deltaY, len, fracToGo;
         while(hnd.i < hnd.nVertex) {
             if(hnd.closeWay && hnd.nVertex - hnd.i == 1){
-                x2 = coordBuffer->buffer[hnd.transStart].GetX();
-                y2 = coordBuffer->buffer[hnd.transStart].GetY();
+                x2 = coordBuffer.buffer[hnd.transStart].GetX();
+                y2 = coordBuffer.buffer[hnd.transStart].GetY();
             } else {
-                x2 = coordBuffer->buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetX();
-                y2 = coordBuffer->buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetY();
+                x2 = coordBuffer.buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetX();
+                y2 = coordBuffer.buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetY();
             }
             deltaX = (x2 - x);
             deltaY = (y2 - y);
@@ -813,21 +813,21 @@ namespace osmscout {
             CGContextSetLineCap(cg, kCGLineCapButt);
         }
         CGContextBeginPath(cg);
-        CGContextMoveToPoint(cg,coordBuffer->buffer[transStart].GetX(),coordBuffer->buffer[transStart].GetY());
+        CGContextMoveToPoint(cg,coordBuffer.buffer[transStart].GetX(),coordBuffer.buffer[transStart].GetY());
         for (size_t i=transStart+1; i<=transEnd; i++) {
-            CGContextAddLineToPoint (cg,coordBuffer->buffer[i].GetX(),coordBuffer->buffer[i].GetY());
+            CGContextAddLineToPoint (cg,coordBuffer.buffer[i].GetX(),coordBuffer.buffer[i].GetY());
         }
         CGContextStrokePath(cg);
         if (startCap==LineStyle::capRound) {
             CGContextSetRGBFillColor(cg, color.GetR(), color.GetG(), color.GetB(), color.GetA());
-            CGContextFillEllipseInRect(cg, CGRectMake(coordBuffer->buffer[transStart].GetX()-width/2,
-                                                     coordBuffer->buffer[transStart].GetY()-width/2,
+            CGContextFillEllipseInRect(cg, CGRectMake(coordBuffer.buffer[transStart].GetX()-width/2,
+                                                     coordBuffer.buffer[transStart].GetY()-width/2,
                                                      width,width));
         }
         if (endCap==LineStyle::capRound) {
             CGContextSetRGBFillColor(cg, color.GetR(), color.GetG(), color.GetB(), color.GetA());
-            CGContextFillEllipseInRect(cg, CGRectMake(coordBuffer->buffer[transEnd].GetX()-width/2,
-                                                     coordBuffer->buffer[transEnd].GetY()-width/2,
+            CGContextFillEllipseInRect(cg, CGRectMake(coordBuffer.buffer[transEnd].GetX()-width/2,
+                                                     coordBuffer.buffer[transEnd].GetY()-width/2,
                                                      width,width));
         }
         CGContextRestoreGState(cg);
@@ -904,14 +904,14 @@ namespace osmscout {
                                 const MapPainter::AreaData& area) {
         CGContextSaveGState(cg);
         CGContextBeginPath(cg);
-        CGContextMoveToPoint(cg,coordBuffer->buffer[area.coordRange.GetStart()].GetX(),
-                    coordBuffer->buffer[area.coordRange.GetStart()].GetY());
+        CGContextMoveToPoint(cg,coordBuffer.buffer[area.coordRange.GetStart()].GetX(),
+                    coordBuffer.buffer[area.coordRange.GetStart()].GetY());
         for (size_t i=area.coordRange.GetStart()+1; i<=area.coordRange.GetEnd(); i++) {
-            CGContextAddLineToPoint(cg,coordBuffer->buffer[i].GetX(),
-                        coordBuffer->buffer[i].GetY());
+            CGContextAddLineToPoint(cg,coordBuffer.buffer[i].GetX(),
+                        coordBuffer.buffer[i].GetY());
         }
-        CGContextAddLineToPoint(cg,coordBuffer->buffer[area.coordRange.GetStart()].GetX(),
-                                coordBuffer->buffer[area.coordRange.GetEnd()].GetY());
+        CGContextAddLineToPoint(cg,coordBuffer.buffer[area.coordRange.GetStart()].GetX(),
+                                coordBuffer.buffer[area.coordRange.GetEnd()].GetY());
 
         if (!area.clippings.empty()) {
             for (std::list<PolyData>::const_iterator c=area.clippings.begin();
@@ -919,14 +919,14 @@ namespace osmscout {
                  c++) {
                 const PolyData& data=*c;
 
-                CGContextMoveToPoint(cg,coordBuffer->buffer[data.transStart].GetX(),
-                            coordBuffer->buffer[data.transStart].GetY());
+                CGContextMoveToPoint(cg,coordBuffer.buffer[data.transStart].GetX(),
+                            coordBuffer.buffer[data.transStart].GetY());
                 for (size_t i=data.transStart+1; i<=data.transEnd; i++) {
-                    CGContextAddLineToPoint(cg,coordBuffer->buffer[i].GetX(),
-                                coordBuffer->buffer[i].GetY());
+                    CGContextAddLineToPoint(cg,coordBuffer.buffer[i].GetX(),
+                                coordBuffer.buffer[i].GetY());
                 }
-                CGContextAddLineToPoint(cg,coordBuffer->buffer[data.transStart].GetX(),
-                                        coordBuffer->buffer[data.transStart].GetY());
+                CGContextAddLineToPoint(cg,coordBuffer.buffer[data.transStart].GetX(),
+                                        coordBuffer.buffer[data.transStart].GetY());
             }
         }
 

--- a/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscout/MapPainterQt.cpp
@@ -38,8 +38,7 @@
 namespace osmscout {
 
   MapPainterQt::MapPainterQt(const StyleConfigRef& styleConfig)
-  : MapPainter(styleConfig,
-               new CoordBuffer()),
+  : MapPainter(styleConfig),
     painter(nullptr),
     labelLayouter(this)
   {
@@ -498,7 +497,7 @@ namespace osmscout {
   {
     hnd.i=0;
     hnd.nVertex=transEnd >= transStart ? transEnd - transStart : transStart-transEnd;
-    bool isReallyClosed=(coordBuffer->buffer[transStart]==coordBuffer->buffer[transEnd]);
+    bool isReallyClosed=(coordBuffer.buffer[transStart]==coordBuffer.buffer[transEnd]);
 
     if (isClosed && !isReallyClosed) {
       hnd.nVertex++;
@@ -509,7 +508,7 @@ namespace osmscout {
     }
 
     if (keepOrientation ||
-        coordBuffer->buffer[transStart].GetX()<coordBuffer->buffer[transEnd].GetX()) {
+        coordBuffer.buffer[transStart].GetX()<coordBuffer.buffer[transEnd].GetX()) {
       hnd.transStart=transStart;
       hnd.transEnd=transEnd;
     }
@@ -519,7 +518,7 @@ namespace osmscout {
     }
 
     hnd.direction=(hnd.transStart < hnd.transEnd) ? 1 : -1;
-    origin.Set(coordBuffer->buffer[hnd.transStart].GetX(), coordBuffer->buffer[hnd.transStart].GetY());
+    origin.Set(coordBuffer.buffer[hnd.transStart].GetX(), coordBuffer.buffer[hnd.transStart].GetY());
   }
 
   bool MapPainterQt::FollowPath(FollowPathHandle &hnd,
@@ -533,12 +532,12 @@ namespace osmscout {
 
     while (hnd.i<hnd.nVertex) {
       if (hnd.closeWay && hnd.nVertex-hnd.i==1) {
-        x2=coordBuffer->buffer[hnd.transStart].GetX();
-        y2=coordBuffer->buffer[hnd.transStart].GetY();
+        x2=coordBuffer.buffer[hnd.transStart].GetX();
+        y2=coordBuffer.buffer[hnd.transStart].GetY();
       }
       else {
-        x2=coordBuffer->buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetX();
-        y2=coordBuffer->buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetY();
+        x2=coordBuffer.buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetX();
+        y2=coordBuffer.buffer[hnd.transStart+(hnd.i+1)*hnd.direction].GetY();
       }
       deltaX=(x2-x);
       deltaY=(y2-y);
@@ -848,11 +847,11 @@ namespace osmscout {
 
     QPainterPath p;
 
-    p.moveTo(coordBuffer->buffer[transStart].GetX(),
-             coordBuffer->buffer[transStart].GetY());
+    p.moveTo(coordBuffer.buffer[transStart].GetX(),
+             coordBuffer.buffer[transStart].GetY());
     for (size_t i=transStart+1; i<=transEnd; i++) {
-      p.lineTo(coordBuffer->buffer[i].GetX(),
-               coordBuffer->buffer[i].GetY());
+      p.lineTo(coordBuffer.buffer[i].GetX(),
+               coordBuffer.buffer[i].GetY());
     }
 
     painter->strokePath(p,pen);
@@ -866,8 +865,8 @@ namespace osmscout {
                                                 color.GetB(),
                                                 color.GetA())));
 
-      painter->drawEllipse(QPointF(coordBuffer->buffer[transStart].GetX(),
-                                   coordBuffer->buffer[transStart].GetY()),
+      painter->drawEllipse(QPointF(coordBuffer.buffer[transStart].GetX(),
+                                   coordBuffer.buffer[transStart].GetY()),
                                    width/2,width/2);
     }
 
@@ -880,8 +879,8 @@ namespace osmscout {
                                                 color.GetB(),
                                                 color.GetA())));
 
-      painter->drawEllipse(QPointF(coordBuffer->buffer[transEnd].GetX(),
-                                   coordBuffer->buffer[transEnd].GetY()),
+      painter->drawEllipse(QPointF(coordBuffer.buffer[transEnd].GetX(),
+                                   coordBuffer.buffer[transEnd].GetY()),
                                    width/2,width/2);
     }
   }
@@ -892,22 +891,22 @@ namespace osmscout {
   {
     QPainterPath path;
 
-    path.moveTo(coordBuffer->buffer[area.coordRange.GetStart()].GetX(),
-                coordBuffer->buffer[area.coordRange.GetStart()].GetY());
+    path.moveTo(coordBuffer.buffer[area.coordRange.GetStart()].GetX(),
+                coordBuffer.buffer[area.coordRange.GetStart()].GetY());
     for (size_t i=area.coordRange.GetStart()+1; i<=area.coordRange.GetEnd(); i++) {
-      path.lineTo(coordBuffer->buffer[i].GetX(),
-                  coordBuffer->buffer[i].GetY());
+      path.lineTo(coordBuffer.buffer[i].GetX(),
+                  coordBuffer.buffer[i].GetY());
     }
     path.closeSubpath();
 
     if (!area.clippings.empty()) {
       for (const auto& data : area.clippings) {
-        path.moveTo(coordBuffer->buffer[data.transStart].GetX(),
-                    coordBuffer->buffer[data.transStart].GetY());
+        path.moveTo(coordBuffer.buffer[data.transStart].GetX(),
+                    coordBuffer.buffer[data.transStart].GetY());
 
         for (size_t i=data.transStart+1; i<=data.transEnd; i++) {
-          path.lineTo(coordBuffer->buffer[i].GetX(),
-                      coordBuffer->buffer[i].GetY());
+          path.lineTo(coordBuffer.buffer[i].GetX(),
+                      coordBuffer.buffer[i].GetY());
         }
 
         path.closeSubpath();
@@ -941,8 +940,8 @@ namespace osmscout {
 
       if (idx<patterns.size() && !patterns[idx].textureImage().isNull()) {
         patterns[idx].setTransform(QTransform::fromTranslate(
-                                          remainder(coordBuffer->buffer[area.coordRange.GetStart()].GetX(),patterns[idx].textureImage().width()),
-                                          remainder(coordBuffer->buffer[area.coordRange.GetStart()].GetY(),patterns[idx].textureImage().height())));
+                                          remainder(coordBuffer.buffer[area.coordRange.GetStart()].GetX(),patterns[idx].textureImage().width()),
+                                          remainder(coordBuffer.buffer[area.coordRange.GetStart()].GetY(),patterns[idx].textureImage().height())));
         painter->setBrush(patterns[idx]);
         restoreTransform = true;
       }

--- a/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscout/MapPainterSVG.cpp
@@ -37,8 +37,7 @@ namespace osmscout {
   static const char* valueChar="0123456789abcdef";
 
   MapPainterSVG::MapPainterSVG(const StyleConfigRef& styleConfig)
-  : MapPainter(styleConfig,
-               new CoordBuffer()),
+  : MapPainter(styleConfig),
     labelLayouter(this),
     stream(nullptr),
     typeConfig(nullptr)
@@ -899,7 +898,7 @@ namespace osmscout {
         stream << " ";
       }
 
-      stream << coordBuffer->buffer[i].GetX() << "," << coordBuffer->buffer[i].GetY();
+      stream << coordBuffer.buffer[i].GetX() << "," << coordBuffer.buffer[i].GetY();
 
     }
 
@@ -926,7 +925,7 @@ namespace osmscout {
         stream << " ";
       }
 
-      stream << coordBuffer->buffer[i].GetX() << "," << coordBuffer->buffer[i].GetY();
+      stream << coordBuffer.buffer[i].GetX() << "," << coordBuffer.buffer[i].GetY();
 
     }
 
@@ -996,9 +995,9 @@ namespace osmscout {
 
     stream << "          d=\"";
 
-    stream << "M " << coordBuffer->buffer[area.coordRange.GetStart()].GetX() << " " << coordBuffer->buffer[area.coordRange.GetStart()].GetY();
+    stream << "M " << coordBuffer.buffer[area.coordRange.GetStart()].GetX() << " " << coordBuffer.buffer[area.coordRange.GetStart()].GetY();
     for (size_t i=area.coordRange.GetStart()+1; i<=area.coordRange.GetEnd(); i++) {
-      stream << " L " << coordBuffer->buffer[i].GetX() << " " << coordBuffer->buffer[i].GetY();
+      stream << " L " << coordBuffer.buffer[i].GetX() << " " << coordBuffer.buffer[i].GetY();
     }
     stream << " Z";
 
@@ -1007,9 +1006,9 @@ namespace osmscout {
         ++c) {
       const PolyData    &data=*c;
 
-      stream << "M " << coordBuffer->buffer[data.transStart].GetX() << " " << coordBuffer->buffer[data.transStart].GetY();
+      stream << "M " << coordBuffer.buffer[data.transStart].GetX() << " " << coordBuffer.buffer[data.transStart].GetY();
       for (size_t i=data.transStart+1; i<=data.transEnd; i++) {
-        stream << " L " << coordBuffer->buffer[i].GetX() << " " << coordBuffer->buffer[i].GetY();
+        stream << " L " << coordBuffer.buffer[i].GetX() << " " << coordBuffer.buffer[i].GetY();
       }
       stream << " Z";
     }

--- a/libosmscout-map/include/osmscout/MapPainter.h
+++ b/libosmscout-map/include/osmscout/MapPainter.h
@@ -206,7 +206,7 @@ namespace osmscout {
    */
     //@{
     TransBuffer                  transBuffer;       //!< Internal buffer for coordinate transformation from geo coordinates to display coordinates
-    CoordBuffer                  *coordBuffer;      //!< Reference to the coordinate buffer
+    CoordBuffer                  coordBuffer;       //!< Coordinate buffer
     //@}
 
     TextStyleRef                 debugLabel;
@@ -649,8 +649,7 @@ namespace osmscout {
     std::vector<OffsetRel> ParseLaneTurns(const LanesFeatureValue&);
 
   public:
-    MapPainter(const StyleConfigRef& styleConfig,
-               CoordBuffer *buffer);
+    MapPainter(const StyleConfigRef& styleConfig);
     virtual ~MapPainter();
 
     bool Draw(const Projection& projection,

--- a/libosmscout-map/include/osmscout/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscout/MapPainterNoOp.h
@@ -97,6 +97,8 @@ namespace osmscout {
   public:
     explicit MapPainterNoOp(const StyleConfigRef& styleConfig);
 
+    ~MapPainterNoOp() override = default;
+
     bool DrawMap(const Projection& projection,
                  const MapParameter& parameter,
                  const MapData& data);

--- a/libosmscout-map/src/osmscout/MapPainter.cpp
+++ b/libosmscout-map/src/osmscout/MapPainter.cpp
@@ -149,10 +149,8 @@ namespace osmscout {
     return a.position<b.position;
   }
 
-  MapPainter::MapPainter(const StyleConfigRef& styleConfig,
-                         CoordBuffer *buffer)
-  : coordBuffer(buffer),
-    styleConfig(styleConfig),
+  MapPainter::MapPainter(const StyleConfigRef& styleConfig)
+  : styleConfig(styleConfig),
     nameReader(*styleConfig->GetTypeConfig()),
     nameAltReader(*styleConfig->GetTypeConfig()),
     refReader(*styleConfig->GetTypeConfig()),
@@ -899,7 +897,7 @@ namespace osmscout {
     }
 
     if (lineOffset!=0.0) {
-      range=coordBuffer->GenerateParallelWay(range,
+      range=coordBuffer.GenerateParallelWay(range,
                                              lineOffset);
     }
 
@@ -908,8 +906,8 @@ namespace osmscout {
 
     for (size_t j=range.GetStart(); j<=range.GetEnd(); j++) {
       labelPath.AddPoint(
-          coordBuffer->buffer[j].GetX(),
-          coordBuffer->buffer[j].GetY());
+          coordBuffer.buffer[j].GetX(),
+          coordBuffer.buffer[j].GetY());
     }
 
     PathLabelData labelData;
@@ -951,7 +949,7 @@ namespace osmscout {
     }
 
     if (lineOffset!=0.0) {
-      range=coordBuffer->GenerateParallelWay(range,
+      range=coordBuffer.GenerateParallelWay(range,
                                              lineOffset);
     }
 
@@ -1073,7 +1071,7 @@ namespace osmscout {
 
         for (const OffsetRel &laneTurn: laneTurns) {
           if (pathSymbolStyle->GetOffsetRel() == laneTurn) {
-            range=coordBuffer->GenerateParallelWay(range,
+            range=coordBuffer.GenerateParallelWay(range,
                                                    laneOffset);
 
             DrawContourSymbol(projection,
@@ -1098,7 +1096,7 @@ namespace osmscout {
         }
 
         if (lineOffset != 0.0) {
-          range=coordBuffer->GenerateParallelWay(range,
+          range=coordBuffer.GenerateParallelWay(range,
                                                  lineOffset);
         }
 
@@ -1188,7 +1186,7 @@ namespace osmscout {
     }
 
     if (lineOffset!=0.0) {
-      range=coordBuffer->GenerateParallelWay(range,
+      range=coordBuffer.GenerateParallelWay(range,
                                              lineOffset);
     }
 
@@ -1206,8 +1204,8 @@ namespace osmscout {
 
     for (size_t j=range.GetStart(); j<=range.GetEnd(); j++) {
       labelPath.AddPoint(
-          coordBuffer->buffer[j].GetX(),
-          coordBuffer->buffer[j].GetY());
+          coordBuffer.buffer[j].GetX(),
+          coordBuffer.buffer[j].GetY());
     }
     RegisterContourLabel(projection, parameter, labelData, labelPath);
 
@@ -1254,7 +1252,7 @@ namespace osmscout {
 
       transRange=TransformWay(points,
                               transBuffer,
-                              *coordBuffer,
+                              coordBuffer,
                               projection,
                               parameter.GetOptimizeWayNodes(),
                               errorTolerancePixel);
@@ -1288,7 +1286,7 @@ namespace osmscout {
 
       transRange=TransformWay(points,
                               transBuffer,
-                              *coordBuffer,
+                              coordBuffer,
                               projection,
                               parameter.GetOptimizeWayNodes(),
                               errorTolerancePixel);
@@ -1330,7 +1328,7 @@ namespace osmscout {
       if (ring.segments.size() <= 1){
         CoordBufferRange range=TransformArea(ring.nodes,
                                              transBuffer,
-                                             *coordBuffer,
+                                             coordBuffer,
                                              projection,
                                              parameter.GetOptimizeAreaNodes(),
                                              errorTolerancePixel);
@@ -1353,7 +1351,7 @@ namespace osmscout {
 
         CoordBufferRange range=TransformArea(nodes,
                                              transBuffer,
-                                             *coordBuffer,
+                                             coordBuffer,
                                              projection,
                                              parameter.GetOptimizeAreaNodes(),
                                              errorTolerancePixel);
@@ -1458,7 +1456,7 @@ namespace osmscout {
         }
 
         if (offset!=0.0) {
-          range=coordBuffer->GenerateParallelWay(range,
+          range=coordBuffer.GenerateParallelWay(range,
                                                  offset);
         }
 
@@ -1571,7 +1569,7 @@ namespace osmscout {
     if (way.segments.size() <= 1) {
       pathData.coordRange=TransformWay(way.nodes,
                                        transBuffer,
-                                       *coordBuffer,
+                                       coordBuffer,
                                        projection,
                                        parameter.GetOptimizeWayNodes(),
                                        errorTolerancePixel);
@@ -1590,7 +1588,7 @@ namespace osmscout {
 
       pathData.coordRange=TransformWay(nodes,
                                        transBuffer,
-                                       *coordBuffer,
+                                       coordBuffer,
                                        projection,
                                        parameter.GetOptimizeWayNodes(),
                                        errorTolerancePixel);
@@ -1740,7 +1738,7 @@ namespace osmscout {
       }
 
       if (lineOffset!=0.0) {
-        data.coordRange=coordBuffer->GenerateParallelWay(pathData.coordRange,
+        data.coordRange=coordBuffer.GenerateParallelWay(pathData.coordRange,
                                                          lineOffset);
       }
 
@@ -1765,7 +1763,7 @@ namespace osmscout {
         double  laneOffset=-pathData.mainSlotWidth/2.0+lanesSpace;
 
         for (size_t lane=1; lane<lanes; lane++) {
-          data.coordRange=coordBuffer->GenerateParallelWay(pathData.coordRange,
+          data.coordRange=coordBuffer.GenerateParallelWay(pathData.coordRange,
                                                            laneOffset);
           wayData.push_back(data);
           laneOffset+=lanesSpace;
@@ -1797,7 +1795,7 @@ namespace osmscout {
 
         for (const OffsetRel &laneTurn: laneTurns) {
           if (lineStyle->GetOffsetRel() == laneTurn) {
-            data.coordRange=coordBuffer->GenerateParallelWay(pathData.coordRange,
+            data.coordRange=coordBuffer.GenerateParallelWay(pathData.coordRange,
                                                              laneOffset);
             wayData.push_back(data);
           }
@@ -2052,7 +2050,7 @@ namespace osmscout {
             transEnd=pathData->coordRange.GetEnd();
           }
           else {
-            CoordBufferRange range=coordBuffer->GenerateParallelWay(pathData->coordRange,
+            CoordBufferRange range=coordBuffer.GenerateParallelWay(pathData->coordRange,
                                                                     lineOffset);
 
             transStart=range.GetStart();
@@ -2074,20 +2072,20 @@ namespace osmscout {
               // insert connecting segment between end of lastSegment and transStart
               Vertex2D lastEnd;
               if (lastSegment.direction==Route::MemberDirection::forward){
-                lastEnd=coordBuffer->buffer[lastSegment.transEnd];
+                lastEnd=coordBuffer.buffer[lastSegment.transEnd];
               }
               else{
-                lastEnd=coordBuffer->buffer[lastSegment.transStart];
+                lastEnd=coordBuffer.buffer[lastSegment.transStart];
               }
               Vertex2D currentStart;
               if (member.direction==Route::MemberDirection::forward){
-                currentStart=coordBuffer->buffer[transStart];
+                currentStart=coordBuffer.buffer[transStart];
               }
               else{
-                currentStart=coordBuffer->buffer[transEnd];
+                currentStart=coordBuffer.buffer[transEnd];
               }
-              RouteSegmentData segmentConnection{coordBuffer->PushCoord(lastEnd.GetX(),lastEnd.GetY()),
-                                                 coordBuffer->PushCoord(currentStart.GetX(),currentStart.GetY()),
+              RouteSegmentData segmentConnection{coordBuffer.PushCoord(lastEnd.GetX(),lastEnd.GetY()),
+                                                 coordBuffer.PushCoord(currentStart.GetX(),currentStart.GetY()),
                                                  Route::MemberDirection::forward};
               routeTmp.transSegments.push_back(segmentConnection);
 
@@ -2167,7 +2165,7 @@ namespace osmscout {
     shieldGridSizeHoriz=360.0/(std::pow(2,projection.GetMagnification().GetLevel()+1));
     shieldGridSizeVert=180.0/(std::pow(2,projection.GetMagnification().GetLevel()+1));
 
-    coordBuffer->Reset();
+    coordBuffer.Reset();
 
     standardFontSize=GetFontHeight(projection,
                                    parameter,
@@ -2405,7 +2403,7 @@ static void DumpGroundTile(const GroundTile& tile)
 #endif
         CoordBufferRange range=TransformBoundingBox(groundTileData.boundingBox,
                                                     transBuffer,
-                                                    *coordBuffer,
+                                                    coordBuffer,
                                                     projection,
                                                     TransPolygon::none,
                                                     errorTolerancePixel);
@@ -2458,7 +2456,7 @@ static void DumpGroundTile(const GroundTile& tile)
             y=transBuffer.points[i].y;
           }
 
-          size_t idx=coordBuffer->PushCoord(x,y);
+          size_t idx=coordBuffer.PushCoord(x,y);
 
           if (i==transBuffer.GetStart()) {
             start=idx;
@@ -2939,7 +2937,7 @@ static void DumpGroundTile(const GroundTile& tile)
 
                 CoordBufferRange range=TransformWay(path,
                                                     transBuffer,
-                                                    *coordBuffer,
+                                                    coordBuffer,
                                                     projection,
                                                     TransPolygon::none,
                                                     errorTolerancePixel);
@@ -2975,7 +2973,7 @@ static void DumpGroundTile(const GroundTile& tile)
 
                 CoordBufferRange range=TransformWay(path,
                                                     transBuffer,
-                                                    *coordBuffer,
+                                                    coordBuffer,
                                                     projection,
                                                     TransPolygon::none,
                                                     errorTolerancePixel);
@@ -3011,7 +3009,7 @@ static void DumpGroundTile(const GroundTile& tile)
 
                 CoordBufferRange range=TransformWay(path,
                                                     transBuffer,
-                                                    *coordBuffer,
+                                                    coordBuffer,
                                                     projection,
                                                     TransPolygon::none,
                                                     errorTolerancePixel);
@@ -3048,7 +3046,7 @@ static void DumpGroundTile(const GroundTile& tile)
 
                 CoordBufferRange range=TransformWay(path,
                                                     transBuffer,
-                                                    *coordBuffer,
+                                                    coordBuffer,
                                                     projection,
                                                     TransPolygon::none,
                                                     errorTolerancePixel);
@@ -3131,7 +3129,7 @@ static void DumpGroundTile(const GroundTile& tile)
 
               CoordBufferRange range=TransformBoundingBox(tileBoundingBox,
                                                           transBuffer,
-                                                          *coordBuffer,
+                                                          coordBuffer,
                                                           projection,
                                                           TransPolygon::none,
                                                           errorTolerancePixel);
@@ -3268,7 +3266,7 @@ static void DumpGroundTile(const GroundTile& tile)
             if (hillShadingFill) {
               CoordBufferRange range=TransformBoundingBox(tileData.boundingBox,
                                                           transBuffer,
-                                                          *coordBuffer,
+                                                          coordBuffer,
                                                           projection,
                                                           TransPolygon::none,
                                                           errorTolerancePixel);

--- a/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscout/MapPainterNoOp.cpp
@@ -25,8 +25,7 @@ namespace osmscout {
   //static double FONT_WIDTH_HEIGHT_FACTOR=1; //!< Width of an individual character in relation to its height
 
   MapPainterNoOp::MapPainterNoOp(const StyleConfigRef& styleConfig)
-          : MapPainter(styleConfig,
-                       new CoordBuffer())
+          : MapPainter(styleConfig)
   {
     // no code
   }


### PR DESCRIPTION
When I tried to run unittests with address sanitizer, it shows me that coord buffer is leaking from MapPainter. It seems to me that there is no reason to have it as pointer passed by constructor, it may be (protected) member of MapPainter.