### PR TITLE
add type field to gpx track

### DIFF
--- a/libosmscout-gpx/include/osmscout/gpx/Track.h
+++ b/libosmscout-gpx/include/osmscout/gpx/Track.h
@@ -40,6 +40,7 @@ public:
   std::vector<TrackSegment> segments;
 
   std::optional<osmscout::Color> displayColor;
+  std::optional<std::string> type;
 
   /**
    * Compute track length in meters

--- a/libosmscout-gpx/src/osmscout/gpx/Export.cpp
+++ b/libosmscout-gpx/src/osmscout/gpx/Export.cpp
@@ -402,6 +402,11 @@ bool GpxWritter::WriteTrack(const Track &track)
       return false;
     }
   }
+  if (track.type){
+    if (!WriteTextElement("type", *track.type)){
+      return false;
+    }
+  }
 
   // see https://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd
   Extensions trkext; // store node $/extensions/TrackExtension

--- a/libosmscout-gpx/src/osmscout/gpx/Import.cpp
+++ b/libosmscout-gpx/src/osmscout/gpx/Import.cpp
@@ -843,6 +843,12 @@ public:
       });
     }
 
+    if (ns == NameSpace::Gpx && name=="type"){
+      return new SimpleValueContext("TypeContext", ctxt, parser, [&](const std::string &type){
+        track.type=std::make_optional<std::string>(type);
+      });
+    }
+
     if (ns == NameSpace::Gpx && name=="trkseg"){
       return new TrkSegContext(ctxt, track, parser);
     } else if (ns == NameSpace::Gpx && name=="extensions"){


### PR DESCRIPTION
...and support it for gpx import and export.

Track type may be used for sport tracker to store activity type.