### PR TITLE
fix disabling navigation voice

### DIFF
--- a/libosmscout-client-qt/src/osmscout/InstalledVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/InstalledVoicesModel.cpp
@@ -120,7 +120,12 @@ void InstalledVoicesModel::select(const QModelIndex &index)
     return;
   }
   auto voice=voices.at(index.row());
-  settings->SetVoiceDir(voice.getDir().absolutePath());
+  if (!voice.isValid()) {
+    // when voice is invalid, directory may be still valid (default-constructed QDir pointing to $PWD)
+    settings->SetVoiceDir("");
+  } else {
+    settings->SetVoiceDir(voice.getDir().absolutePath());
+  }
 }
 
 void InstalledVoicesModel::playSample(const QModelIndex &index, const QStringList &sample)

--- a/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/NavigationModule.cpp
@@ -233,6 +233,7 @@ void NavigationModule::onTimeout()
 
 void NavigationModule::onVoiceChanged(const QString dir)
 {
+  qDebug() << "Voice dir changed to:" << dir;
   voiceDir = dir;
   if (!QDir(voiceDir).exists()){
     voiceDir.clear(); // disable voice


### PR DESCRIPTION
Navigation voice is disabled when configured voice directory
is empty string. But when user choose "no voice" option, configuration
is setup incorrectly to $PWD in `InstalledVoicesModel`.
In such case, voice instructions are not played ($PWD doesn't contain
voice samples usually), but Qt player may still interfere with system
music player (music is paused when navigation instructions are played).

fixes https://github.com/Karry/osmscout-sailfish/issues/258