### PR TITLE
via_ferrata_scale tag may be used with -/+ suffix

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -404,19 +404,19 @@ TYPES
         de: "Fußweg"
 
   TYPE highway_via_ferrata_easy
-    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="0") OR ("via_ferrata_scale"=="1")))
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="0") OR ("via_ferrata_scale"=="0+") OR ("via_ferrata_scale"=="1-") OR ("via_ferrata_scale"=="1") OR ("via_ferrata_scale"=="1+")))
       {Name, NameAlt}
 
   TYPE highway_via_ferrata_moderate
-    = WAY (("highway"=="via_ferrata") AND ("via_ferrata_scale"=="2"))
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="2-") OR ("via_ferrata_scale"=="2") OR ("via_ferrata_scale"=="2+")))
       {Name, NameAlt}
 
   TYPE highway_via_ferrata_difficult
-    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="3") OR ("via_ferrata_scale"=="4")))
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="3-") OR ("via_ferrata_scale"=="3") OR ("via_ferrata_scale"=="3+") OR ("via_ferrata_scale"=="4-") OR ("via_ferrata_scale"=="4") OR ("via_ferrata_scale"=="4+")))
       {Name, NameAlt}
 
   TYPE highway_via_ferrata_extreme
-    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="5") OR ("via_ferrata_scale"=="6")))
+    = WAY (("highway"=="via_ferrata") AND (("via_ferrata_scale"=="5-") OR ("via_ferrata_scale"=="5") OR ("via_ferrata_scale"=="5+") OR ("via_ferrata_scale"=="6-") OR ("via_ferrata_scale"=="6") OR ("via_ferrata_scale"=="6+")))
       {Name, NameAlt}
 
   TYPE highway_bridleway


### PR DESCRIPTION
see https://wiki.openstreetmap.org/wiki/Key:via_ferrata_scale

via_ferrata_scale is used describe the difficulty of a via ferrata...
... You can add a + or a - after the value to indicate that the via
ferrata is on bottom or top of the grade.