### PR TITLE
fix UB in CoordBuffer::GenerateParallelWay

### DIFF
--- a/Tests/src/Geometry.cpp
+++ b/Tests/src/Geometry.cpp
@@ -271,3 +271,23 @@ TEST_CASE("Distance conversions")
   // TO Distance static template method
   REQUIRE(Meters(1000).As<Kilometer>() == 1);
 }
+
+TEST_CASE("Vector normalize")
+{
+  double nx,ny;
+
+  osmscout::Normalize(1,0,nx,ny);
+  REQUIRE(nx==1);
+  REQUIRE(ny==0);
+
+  osmscout::Normalize(0,10,nx,ny);
+  REQUIRE(nx==0);
+  REQUIRE(ny==1);
+
+  nx=42;
+  ny=42;
+  // vector length is zero, nx and ny should be unchanged
+  osmscout::Normalize(0,0,nx,ny);
+  REQUIRE(nx==42);
+  REQUIRE(ny==42);
+}

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -925,6 +925,8 @@ namespace osmscout {
   /**
    * \ingroup Geometry
    *
+   * Normalize vector [x,y], result is set to [nx,ny].
+   * When vector length is zero, nx,ny are unchanged.
    */
   inline void Normalize(double x,
                         double y,
@@ -933,8 +935,10 @@ namespace osmscout {
   {
     double length=sqrt(x*x+y*y);
 
-    nx=x/length;
-    ny=y/length;
+    if (length!=0) {
+      nx=x/length;
+      ny=y/length;
+    }
   }
 
   /**

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -375,6 +375,14 @@ namespace osmscout {
 
     void Reset();
 
+    /**
+     * Push coordinate to the buffer.
+     *
+     * @param x
+     * @param y
+     * @return position (index) of the new coordinate coordinate in the buffer
+     * @note x and y have to be valid, NaN is not allowed
+     */
     size_t PushCoord(double x, double y);
 
     /**

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -351,7 +351,7 @@ namespace osmscout {
    * The initial size of the buffer should be able to hold "enough" data. If you thus get reallocation
    * log warnings this is not an error, but if it happens too often you are either not reusing
    * CoordBuffer instances as much as possible or are pushing more geometric data than we expect to
-   * be sensible for mobile or desktop rendering. Check your allocation strategy for MapPainte rinstances
+   * be sensible for mobile or desktop rendering. Check your allocation strategy for MapPainter instances
    * or style sheet in this case,
    *
    * CoordBuffer also allows also higher level operations on the buffer to generate copies

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -288,8 +288,8 @@ namespace osmscout {
     assert(org.GetEnd()<usedPoints);
 
     size_t start,end;
-    double oax,oay=0;
-    double obx,oby=0;
+    double oax=0,oay=0;
+    double obx=0,oby=0;
 
     Normalize(buffer[org.GetStart()].GetY()-buffer[org.GetStart()+1].GetY(),
               buffer[org.GetStart()+1].GetX()-buffer[org.GetStart()].GetX(),

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -288,9 +288,8 @@ namespace osmscout {
     assert(org.GetEnd()<usedPoints);
 
     size_t start,end;
-    double oax,oay;
-    double obx,oby;
-
+    double oax,oay=0;
+    double obx,oby=0;
 
     Normalize(buffer[org.GetStart()].GetY()-buffer[org.GetStart()+1].GetY(),
               buffer[org.GetStart()+1].GetX()-buffer[org.GetStart()].GetX(),

--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -259,6 +259,9 @@ namespace osmscout {
 
   size_t CoordBuffer::PushCoord(double x, double y)
   {
+    assert(!std::isnan(x));
+    assert(!std::isnan(y));
+
     if (usedPoints>=bufferSize) {
       bufferSize=bufferSize*2;
 


### PR DESCRIPTION
When two points in the way are on the same position,
`CoordBuffer::GenerateParallelWay` leads to zero-division,
that is undefined. To fix, Normalize function should
do nothing when vector size is zero.

Result may not be correct (parallel way), when two identical points
are on the way start, but it is deterministic at least.

