### PR TITLE
magnification should be >= 1

### DIFF
--- a/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscout/PlaneMapRenderer.cpp
@@ -45,10 +45,8 @@ PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
   currentImage(nullptr),
   currentCoord(0.0,0.0),
   currentAngle(0.0),
-  currentMagnification(0),
   finishedImage(nullptr),
-  finishedCoord(0.0,0.0),
-  finishedMagnification(0)
+  finishedCoord(0.0,0.0)
 {
   pendingRenderingTimer.setSingleShot(true);
 

--- a/libosmscout/include/osmscout/util/Magnification.h
+++ b/libosmscout/include/osmscout/util/Magnification.h
@@ -170,6 +170,10 @@ namespace osmscout {
 
     Magnification(const Magnification& other) = default;
 
+    /**
+     * Create specific magnification.
+     * @param magnification value, have to be valid - greater or equals to 1 (magnification level >= 0)
+     */
     inline explicit Magnification(double magnification) noexcept
     {
       SetMagnification(magnification);
@@ -180,6 +184,10 @@ namespace osmscout {
       SetLevel(level);
     }
 
+    /**
+     * Set magnification.
+     * @param magnification value, have to be valid - greater or equals to 1 (magnification level >= 0)
+     */
     void SetMagnification(double magnification);
 
     void SetLevel(const MagnificationLevel& level);

--- a/libosmscout/src/osmscout/util/Magnification.cpp
+++ b/libosmscout/src/osmscout/util/Magnification.cpp
@@ -44,8 +44,9 @@ namespace osmscout {
 
   void Magnification::SetMagnification(double magnification)
   {
+    assert(magnification>=1);
     this->magnification=magnification;
-    this->level=(uint32_t)log2(this->magnification);
+    this->level=uint32_t(log2(this->magnification));
   }
 
   void Magnification::SetLevel(const MagnificationLevel& level)

--- a/libosmscout/src/osmscout/util/Projection.cpp
+++ b/libosmscout/src/osmscout/util/Projection.cpp
@@ -63,7 +63,6 @@ namespace osmscout {
   : lon(0),
     lat(0),
     angle(0),
-    magnification(0),
     dpi(0),
     width(0),
     height(0),


### PR DESCRIPTION
this commit fixes Clang UB sanitizer warning:
`-inf is outside the range of representable values of type 'unsigned int'`