### PR TITLE
free text search improvements

### DIFF
--- a/libosmscout-client-qt/src/osmscout/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/SearchModule.cpp
@@ -167,31 +167,25 @@ bool SearchLocationsRunnable::SearchLocations(DBInstanceRef &db,
                       /*searchPOIs*/ true, /*searchLocations*/ true,
                       /*searchRegions*/ true, /*searchOther*/ true,
                       resultsTxt);
-    osmscout::TextSearchIndex::ResultsMap::iterator it;
-    int count = 0;
-    for(it=resultsTxt.begin();
-      it != resultsTxt.end() && count < limit;
-      ++it, ++count)
-    {
-      std::vector<osmscout::ObjectFileRef> &refs=it->second;
 
-      std::size_t maxPrintedOffsets=5;
-      std::size_t minRefCount=std::min(refs.size(),maxPrintedOffsets);
+    for(const auto &e: resultsTxt) {
+      if (locations.size()>=limit) {
+        break;
+      }
+      QString title=QString::fromStdString(e.first);
+      const std::vector<osmscout::ObjectFileRef> &refs=e.second;
 
-      for(size_t r=0; r < minRefCount; r++){
+      for (const auto &fref:refs){
         if (locations.size()>=limit) {
           break;
         }
-
-        osmscout::ObjectFileRef fref = refs[r];
 
         if (objectSet.contains(fref)) {
           continue;
         }
 
         objectSet << fref;
-        BuildLocationEntry(fref, QString::fromStdString(it->first),
-                           db, adminRegionMap, locations);
+        BuildLocationEntry(fref, title, db, adminRegionMap, locations);
       }
     }
 


### PR DESCRIPTION
Hi. I found out that my app doesn't show me one islet on the river ("Císařská louka"), but shows me streets on it with the same name. Problem is that search module limits number of results for unique string. This code was copied originally from LookupText demo.  It is not necessary limit search result anymore (such aggressively), because UI model is able group entries and sort them by relevance...

So I made two changes:
 - allow to parametrize number of printed results from LookupText demo
 - don't limit number of offsets in free text search in Qt search module