### PR TITLE
use semitransparent color for leisure_marina and leisure_fishing

### DIFF
--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -1648,8 +1648,12 @@ STYLE
      [TYPE leisure_common] AREA { color: #bde3cb; }
 
      [TYPE leisure_marina,
-           leisure_fishing,
-           leisure_ice_rink] AREA { color: #b5d6f1; }
+           leisure_fishing] AREA.BORDER { color: #b5d6f1; width: 0.3mm; dash: 6,6; }
+
+     [TYPE leisure_marina,
+           leisure_fishing] AREA { color: #b5d6f180; }
+
+     [TYPE leisure_ice_rink] AREA { color: #b5d6f1; }
    }
 
    [TYPE boundary_protected_area] {

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -1374,8 +1374,12 @@ STYLE
      [TYPE leisure_common] AREA { color: #bde3cb; }
 
      [TYPE leisure_marina,
-           leisure_fishing,
-           leisure_ice_rink] AREA { color: #b5d6f1; }
+           leisure_fishing] AREA.BORDER { color: #b5d6f1; width: 0.3mm; dash: 6,6; }
+
+     [TYPE leisure_marina,
+           leisure_fishing] AREA { color: #b5d6f180; }
+
+     [TYPE leisure_ice_rink] AREA { color: #b5d6f1; }
    }
 
    [TYPE boundary_protected_area] {


### PR DESCRIPTION
Some marina objects covers larger areas, sometimes even land partialy.
When it is rendered with opaque color, multiple structures may
be hidden (pier, breakwater...). For that reason, it is better
to render marina with semitransparent color, silimar as Carto style does.

https://wiki.openstreetmap.org/wiki/File:Rendering-leisure_marina.png