### PR TITLE
Location entry fixes

### DIFF
--- a/libosmscout-client-qt/include/osmscout/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscout/LocationEntry.h
@@ -87,10 +87,8 @@ public:
   ~LocationEntry() override = default;
 
   //! copy assignment, Qt ownership is not changed
-  LocationEntry &operator=(LocationEntry& other);
-  LocationEntry &operator=(LocationEntry&& other) = delete;
-
-  void operator=(const LocationEntry&);
+  LocationEntry& operator=(const LocationEntry& other);
+  LocationEntry& operator=(LocationEntry&& other) = delete;
 
   void addReference(const osmscout::ObjectFileRef reference);
 

--- a/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationEntry.cpp
@@ -77,7 +77,7 @@ LocationEntry::LocationEntry(const LocationEntry& other)
     // no code
 }
 
-LocationEntry &LocationEntry::operator=(LocationEntry& other)
+LocationEntry& LocationEntry::operator=(const LocationEntry& other)
 {
     type=other.type;
     label=other.label;
@@ -88,18 +88,6 @@ LocationEntry &LocationEntry::operator=(LocationEntry& other)
     coord=other.coord;
     bbox=other.bbox;
     return *this;
-}
-
-void LocationEntry::operator=(const LocationEntry& other)
-{
-    type=other.type;
-    label=other.label;
-    objectType=other.objectType;
-    adminRegionList=other.adminRegionList;
-    database=other.database;
-    references=other.references;
-    coord=other.coord;
-    bbox=other.bbox;
 }
 
 void LocationEntry::addReference(const osmscout::ObjectFileRef reference)

--- a/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscout/POILookupModule.cpp
@@ -65,7 +65,7 @@ LocationEntry buildLocationEntry(T obj,
   LocationEntry location(LocationEntry::typeObject, title, objectType, adminRegionList,
                          dbPath, coordinates, bbox);
   location.addReference(obj->GetObjectFileRef());
-  return location;
+  return LocationEntry(location); // explicit copy. some older compilers (GCC 7.5.0) fails when tries to use deleted move constructor
 }
 
 QList<LocationEntry> POILookupModule::doPOIlookup(DBInstanceRef db,


### PR DESCRIPTION
Some older compilers (GCC 7.5.0 on Ubuntu 18.04) fails when tries to use deleted move constructor.

```
/work/libosmscout/libosmscout-client-qt/src/osmscout/POILookupModule.cpp:68:10: error: use of deleted function ‘osmscout::LocationEntry::LocationEntry(osmscout::LocationEntry&&)’
   return location;
          ^~~~~~~~

```