### PR TITLE
remove inconsistent noexcept in LocationInfoModel destructor

### DIFF
--- a/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscout/LocationInfoModel.cpp
@@ -61,7 +61,7 @@ LocationInfoModel::LocationInfoModel():
             Qt::QueuedConnection);
 }
 
-LocationInfoModel::~LocationInfoModel() noexcept
+LocationInfoModel::~LocationInfoModel()
 {
     if (lookupModule!=nullptr){
         lookupModule->deleteLater();


### PR DESCRIPTION
it solves clang warning:

function previously declared with an implicit exception
specification redeclared with an explicit exception
specification [-Wimplicit-exception-spec-mismatch]

desctructors are expected to be noexcept by default