### PR TITLE
Filter useless turn instructions

### DIFF
--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -235,6 +235,12 @@ namespace osmscout {
         link
       };
 
+      struct NodeExit {
+        ObjectFileRef ref;
+        size_t node;
+        Bearing bearing;
+      };
+
     private:
 
       bool                     inRoundabout{false};
@@ -265,8 +271,12 @@ namespace osmscout {
       bool HandleNameChange(std::list<RouteDescription::Node>::const_iterator& lastNode,
                             std::list<RouteDescription::Node>::iterator& node,
                             const std::list<RouteDescription::Node>::const_iterator &end);
-      bool HandleDirectionChange(std::list<RouteDescription::Node>::iterator& node,
+      bool HandleDirectionChange(const RoutePostprocessor& postprocessor,
+                                 std::list<RouteDescription::Node>::iterator& node,
                                  const std::list<RouteDescription::Node>::const_iterator& end);
+      // just ways are supported as exits
+      std::vector<NodeExit> CollectNodeExits(const RoutePostprocessor& postprocessor,
+                                             RouteDescription::Node& node);
 
     public:
       bool Process(const RoutePostprocessor& postprocessor,


### PR DESCRIPTION
When there is no other way in junction that can be used for driving from the junction,
we don't have to signalize turn.
There may be junction with one-way in forbidden direction
or way with forbidden type for current vehicle.
