### PR TITLE
store motorway junction node as routing node object

### DIFF
--- a/libosmscout-import/src/osmscoutimport/GenRouteDat.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenRouteDat.cpp
@@ -816,6 +816,12 @@ namespace osmscout {
       } else {
         progress.Warning("Unknown type \"highway_mini_roundabout\".");
       }
+      TypeInfoRef motorwayJunction = typeConfig.GetTypeInfo("highway_motorway_junction");
+      if (motorwayJunction) {
+        junctionNodeTypes.Set(motorwayJunction);
+      } else {
+        progress.Warning("Unknown type \"highway_motorway_junction\".");
+      }
       if (!junctionNodeTypes.Empty()) {
         progress.Info("Scanning nodes");
 

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -402,11 +402,6 @@ namespace osmscout {
     RouteDescription::NameDescriptionRef GetNameDescription(DatabaseId dbId,
                                                             const Way& way) const;
 
-    bool LoadJunction(DatabaseId database,
-                      GeoCoord coord,
-                      std::string junctionRef,
-                      std::string junctionName) const;
-
     bool IsMotorwayLink(const RouteDescription::Node& node) const;
     bool IsMotorway(const RouteDescription::Node& node) const;
 


### PR DESCRIPTION
That way it is possible to easily use it as part
route postprocessing without loading nodes via area-node index.