### PR TITLE
throw runtime_error from poly2tri on broken polygon

### DIFF
--- a/libosmscout-map-opengl/include/poly2tri/common/shapes.h
+++ b/libosmscout-map-opengl/include/poly2tri/common/shapes.h
@@ -158,9 +158,9 @@ bool constrained_edge[3];
 /// Flags to determine if an edge is a Delauney edge
 bool delaunay_edge[3];
 
-Point* GetPoint(const int& index);
-Point* PointCW(Point& point);
-Point* PointCCW(Point& point);
+Point* GetPoint(const int& index) const;
+Point* PointCW(const Point& point) const;
+Point* PointCCW(const Point& point) const;
 Point* OppositePoint(Triangle& t, Point& p);
 
 Triangle* GetNeighbor(const int& index);
@@ -283,7 +283,7 @@ inline Point Cross(const double s, const Point& a)
   return Point(-s * a.y, s * a.x);
 }
 
-inline Point* Triangle::GetPoint(const int& index)
+inline Point* Triangle::GetPoint(const int& index) const
 {
   return points_[index];
 }

--- a/libosmscout-map-opengl/include/poly2tri/common/utils.h
+++ b/libosmscout-map-opengl/include/poly2tri/common/utils.h
@@ -44,7 +44,7 @@ const double EPSILON = 1e-12;
 enum Orientation { CW, CCW, COLLINEAR };
 
 /**
- * Forumla to calculate signed area<br>
+ * Formula to calculate signed area<br>
  * Positive if CCW<br>
  * Negative if CW<br>
  * 0 if collinear<br>
@@ -53,7 +53,7 @@ enum Orientation { CW, CCW, COLLINEAR };
  *              =  (x1-x3)*(y2-y3) - (y1-y3)*(x2-x3)
  * </pre>
  */
-Orientation Orient2d(Point& pa, Point& pb, Point& pc)
+Orientation Orient2d(const Point& pa, const Point& pb, const Point& pc)
 {
   double detleft = (pa.x - pc.x) * (pb.y - pc.y);
   double detright = (pa.y - pc.y) * (pb.x - pc.x);

--- a/libosmscout-map-opengl/include/poly2tri/sweep/cdt.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/cdt.h
@@ -53,7 +53,7 @@ public:
    * 
    * @param polyline
    */
-  explicit CDT(std::vector<Point*> polyline);
+  explicit CDT(const std::vector<Point*> &polyline);
   
    /**
    * Destructor - clean up memory
@@ -65,7 +65,7 @@ public:
    * 
    * @param polyline
    */
-  void AddHole(std::vector<Point*> polyline);
+  void AddHole(const std::vector<Point*> &polyline);
   
   /**
    * Add a steiner point

--- a/libosmscout-map-opengl/include/poly2tri/sweep/sweep.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/sweep.h
@@ -33,7 +33,7 @@
  * Zalik, B.(2008)'Sweep-line algorithm for constrained Delaunay triangulation',
  * International Journal of Geographical Information Science
  *
- * "FlipScan" Constrained Edge Algorithm invented by Thomas Åhlén, thahlen@gmail.com
+ * "FlipScan" Constrained Edge Algorithm invented by Thomas Ã…hlÃ©n, thahlen@gmail.com
  */
 
 #ifndef SWEEP_H
@@ -257,7 +257,7 @@ private:
      * @param op
      * @return
      */
-  Point& NextFlipPoint(Point& ep, Point& eq, Triangle& ot, Point& op);
+  Point& NextFlipPoint(const Point& ep, const Point& eq, const Triangle& ot, const Point& op);
 
    /**
      * Scan part of the FlipScan algorithm<br>

--- a/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
+++ b/libosmscout-map-opengl/include/poly2tri/sweep/sweep_context.h
@@ -83,7 +83,7 @@ Point* GetPoints();
 
 void RemoveFromMap(Triangle* triangle);
 
-void AddHole(std::vector<Point*> polyline);
+void AddHole(const std::vector<Point*> &polyline);
 
 void AddPoint(Point* point);
 

--- a/libosmscout-map-opengl/src/poly2tri/common/shapes.cc
+++ b/libosmscout-map-opengl/src/poly2tri/common/shapes.cc
@@ -130,7 +130,7 @@ void Triangle::Legalize(Point& point)
   points_[2] = &point;
 }
 
-// Legalize triagnle by rotating clockwise around oPoint
+// Legalize triangle by rotating clockwise around oPoint
 void Triangle::Legalize(Point& opoint, Point& npoint)
 {
   if (&opoint == points_[0]) {
@@ -209,7 +209,7 @@ void Triangle::MarkConstrainedEdge(Point* p, Point* q)
 }
 
 // The point counter-clockwise to given point
-Point* Triangle::PointCW(Point& point)
+Point* Triangle::PointCW(const Point& point) const
 {
   if (&point == points_[0]) {
     return points_[2];
@@ -222,7 +222,7 @@ Point* Triangle::PointCW(Point& point)
 }
 
 // The point counter-clockwise to given point
-Point* Triangle::PointCCW(Point& point)
+Point* Triangle::PointCCW(const Point& point) const
 {
   if (&point == points_[0]) {
     return points_[1];

--- a/libosmscout-map-opengl/src/poly2tri/sweep/cdt.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/cdt.cc
@@ -32,13 +32,13 @@
 
 namespace p2t {
 
-CDT::CDT(std::vector<Point*> polyline)
+CDT::CDT(const std::vector<Point*> &polyline)
 {
   sweep_context_ = new SweepContext(polyline);
   sweep_ = new Sweep;
 }
 
-void CDT::AddHole(std::vector<Point*> polyline)
+void CDT::AddHole(const std::vector<Point*> &polyline)
 {
   sweep_context_->AddHole(polyline);
 }

--- a/libosmscout-map-opengl/src/poly2tri/sweep/sweep.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/sweep.cc
@@ -62,9 +62,15 @@ void Sweep::FinalizationPolygon(SweepContext& tcx)
 {
   // Get an Internal triangle to start with
   Triangle* t = tcx.front()->head()->next->triangle;
+  if (t==nullptr) {
+    throw std::runtime_error("Provided polygon is not simple");
+  }
   Point* p = tcx.front()->head()->next->point;
   while (!t->GetConstrainedEdgeCW(*p)) {
     t = t->NeighborCCW(*p);
+    if (t==nullptr) {
+      throw std::runtime_error("Provided polygon is not simple");
+    }
   }
 
   // Collect interior triangles constrained by edges
@@ -121,8 +127,7 @@ void Sweep::EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangl
       triangle = &triangle->NeighborAcross(point);
       EdgeEvent( tcx, ep, *p1, triangle, *p1 );
     } else {
-      std::runtime_error("EdgeEvent - collinear points not supported");
-      assert(0);
+      throw std::runtime_error("EdgeEvent - collinear points not supported");
     }
     return;
   }
@@ -138,8 +143,7 @@ void Sweep::EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangl
       triangle = &triangle->NeighborAcross(point);
       EdgeEvent( tcx, ep, *p2, triangle, *p2 );
     } else {
-      std::runtime_error("EdgeEvent - collinear points not supported");
-      assert(0);
+      throw std::runtime_error("EdgeEvent - collinear points not supported");
     }
     return;
   }
@@ -702,12 +706,6 @@ void Sweep::FlipEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* t, 
   Triangle& ot = t->NeighborAcross(p);
   Point& op = *ot.OppositePoint(*t, p);
 
-  //if (ot == nullptr) {
-  // If we want to integrate the fillEdgeEvent do it here
-  // With current implementation we should never get here
-  // throw new RuntimeException( "[BUG:FIXME] FLIP failed due to missing triangle");
-  //}
-
   if (InScanArea(p, *t->PointCCW(p), *t->PointCW(p), op)) {
     // Lets rotate shared edge one vertex CW
     RotateTrianglePair(*t, p, ot, op);
@@ -755,7 +753,7 @@ Triangle& Sweep::NextFlipTriangle(SweepContext& tcx, int o, Triangle& t, Triangl
   return ot;
 }
 
-Point& Sweep::NextFlipPoint(Point& ep, Point& eq, Triangle& ot, Point& op)
+Point& Sweep::NextFlipPoint(const Point& ep, const Point& eq, const Triangle& ot, const Point& op)
 {
   Orientation o2d = Orient2d(eq, op, ep);
   if (o2d == CW) {
@@ -765,8 +763,7 @@ Point& Sweep::NextFlipPoint(Point& ep, Point& eq, Triangle& ot, Point& op)
     // Left
     return *ot.PointCW(op);
   } else{
-    //throw new RuntimeException("[Unsupported] Opposing point on constrained edge");
-    assert(0);
+    throw std::runtime_error("[Unsupported] Opposing point on constrained edge");
   }
 }
 
@@ -775,12 +772,6 @@ void Sweep::FlipScanEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle&
 {
   Triangle& ot = t.NeighborAcross(p);
   Point& op = *ot.OppositePoint(t, p);
-
-  //if (&t.NeighborAcross(p) == nullptr) {
-  //  If we want to integrate the fillEdgeEvent do it here
-  //  With current implementation we should never get here
-  //  throw new RuntimeException( "[BUG:FIXME] FLIP failed due to missing triangle");
-  //}
 
   if (InScanArea(eq, *flip_triangle.PointCCW(eq), *flip_triangle.PointCW(eq), op)) {
     // flip with new edge op->eq

--- a/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
+++ b/libosmscout-map-opengl/src/poly2tri/sweep/sweep_context.cc
@@ -50,7 +50,7 @@ SweepContext::SweepContext(const std::vector<Point*> &polyline) :
   InitEdges(points_);
 }
 
-void SweepContext::AddHole(std::vector<Point*> polyline)
+void SweepContext::AddHole(const std::vector<Point*> &polyline)
 {
   InitEdges(polyline);
   for(unsigned int i = 0; i < polyline.size(); i++) {

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -93,6 +93,7 @@ set(HEADER_FILES_UTIL
     include/osmscout/util/ProcessingQueue.h
     include/osmscout/util/Progress.h
     include/osmscout/util/Projection.h
+    include/osmscout/util/ScopeGuard.h
     include/osmscout/util/StopClock.h
     include/osmscout/util/String.h
     include/osmscout/util/StringMatcher.h

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -36,6 +36,7 @@ osmscoutHeader = [
             'osmscout/util/ProcessingQueue.h',
             'osmscout/util/Progress.h',
             'osmscout/util/Projection.h',
+            'osmscout/util/ScopeGuard.h',
             'osmscout/util/StopClock.h',
             'osmscout/util/String.h',
             'osmscout/util/StringMatcher.h',

--- a/libosmscout/include/osmscout/util/ScopeGuard.h
+++ b/libosmscout/include/osmscout/util/ScopeGuard.h
@@ -1,0 +1,59 @@
+#ifndef OSMSCOUT_SCOPEGUARD_H
+#define OSMSCOUT_SCOPEGUARD_H
+
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2021  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+namespace osmscout {
+
+/**
+ * ScopeGuard utility calls its constructor parameter (callable type)
+ * in it's destructor (on the end of the scope)
+ *
+ * Examples:
+ * ```
+ *   ScopeGuard guard([]() noexcept {
+ *     log.Debug() << "End of scope";
+ *   });
+ * ```
+ *
+ * @tparam CB noexcept `callable`.
+ */
+template <typename CB>
+class ScopeGuard
+{
+private:
+  CB cb;
+  static_assert(std::is_nothrow_invocable_v<CB>, "Callback must be a nothrow (noexcept) callable");
+public:
+  explicit ScopeGuard(CB cb) noexcept(noexcept(std::move(cb))): cb{std::move(cb)}
+  {}
+
+  ScopeGuard(const ScopeGuard &) = delete;
+  ScopeGuard(ScopeGuard && other) = delete;
+  ScopeGuard& operator=(const ScopeGuard&) = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+  ~ScopeGuard() noexcept {
+    cb();
+  }
+};
+}
+
+#endif // OSMSCOUT_SCOPEGUARD_H


### PR DESCRIPTION
poly2tri algorithm can process just simple polygons (edges are not intersecting).
But AreaIsSimple check is really expensive, it consumes ~ 60% of cpu time
during OpenGL rendering. For that reason, it is more effective
to find the places where triangulation algorithm may fail and escape it
by throwing runtime_error. Problematic polygon may be skipped then.