### PR TITLE
install OpenGL font, use installed path as default

### DIFF
--- a/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
+++ b/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
@@ -39,7 +39,7 @@ struct Arguments {
   std::string iconDirectory;
   size_t width=0;
   size_t height=0;
-  std::string fontPath;
+  std::string fontPath=DEFAULT_FONT_FILE;
   long defaultTextSize=18;
   double dpi=0;
   std::string shaderPath=SHADER_INSTALL_DIR;
@@ -223,7 +223,7 @@ int main(int argc, char *argv[]) {
                         args.fontPath=value;
                       }),
                       "font",
-                      "Font file (.ttf)",
+                      "Font file (*.ttf, default: " + args.fontPath + ")",
                       false);
 
   argParser.AddOption(osmscout::CmdLineUIntOption([&args](const unsigned int& value) {

--- a/libosmscout-map-opengl/CMakeLists.txt
+++ b/libosmscout-map-opengl/CMakeLists.txt
@@ -36,16 +36,26 @@ set(SHADER_FILES
 	data/shaders/GroundVertexShader.vert
 	data/shaders/TextFragmentShader.frag)
 
+set(FONT_FILES
+	data/fonts/LiberationSans-Regular.ttf
+	data/fonts/LICENSE)
+
 # install shaders
 if(APPLE)
 	set(SHADER_INSTALL_DIR "/Library/Application Support/osmscout/shaders")
+	set(FONTS_INSTALL_DIR "/Library/Application Support/osmscout/fonts")
 elseif(WIN32)
 	set(SHADER_INSTALL_DIR "C:/ProgramData/osmscout/shaders")
+	set(FONTS_INSTALL_DIR "C:/ProgramData/osmscout/fonts")
 else() # Linux
 	set(SHADER_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/osmscout/shaders")
+	set(FONTS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/osmscout/fonts")
 endif()
 install(FILES ${SHADER_FILES}
 		DESTINATION ${SHADER_INSTALL_DIR})
+install(FILES ${FONT_FILES}
+	    DESTINATION ${FONTS_INSTALL_DIR})
+set(DEFAULT_FONT_FILE "${FONTS_INSTALL_DIR}/LiberationSans-Regular.ttf")
 
 osmscout_library_project(
 	NAME OSMScoutMapOpenGL

--- a/libosmscout-map-opengl/include/osmscoutmapopengl/MapOpenGLFeatures.h.cmake
+++ b/libosmscout-map-opengl/include/osmscoutmapopengl/MapOpenGLFeatures.h.cmake
@@ -5,4 +5,8 @@
 #cmakedefine SHADER_INSTALL_DIR "${SHADER_INSTALL_DIR}"
 #endif
 
+#ifndef DEFAULT_FONT_FILE
+#cmakedefine DEFAULT_FONT_FILE "${DEFAULT_FONT_FILE}"
+#endif
+
 #endif

--- a/libosmscout-map-opengl/include/osmscoutmapopengl/TextLoader.h
+++ b/libosmscout-map-opengl/include/osmscoutmapopengl/TextLoader.h
@@ -77,6 +77,8 @@ namespace osmscout {
 
   class OSMSCOUT_MAP_OPENGL_API TextLoader {
   private:
+    bool initialized = false;
+
     FT_Library ft;
     FT_Face face;
 
@@ -88,15 +90,18 @@ namespace osmscout {
     std::map<std::pair<char32_t, int>, int> characterIndices;
     std::vector<osmscout::CharacterTextureRef> characters;
 
-    void LoadFace();
-
-    void LoadFace(std::string);
+    bool LoadFace(const std::string &path, double dpi);
 
   public:
 
+    TextLoader(const std::string &path, long defaultSize, double dpi);
+
     ~TextLoader();
 
-    TextLoader(std::string path, long defaultSize);
+    bool IsInitialized() const
+    {
+      return initialized;
+    }
 
     /**
      * Returns width of a texture at given index in pixel.

--- a/libosmscout-map-opengl/include/osmscoutmapopengl/meson.build
+++ b/libosmscout-map-opengl/include/osmscoutmapopengl/meson.build
@@ -1,6 +1,7 @@
 mapopenglFeaturesCfg = configuration_data()
 # TODO: setup installation dir properly
 mapopenglFeaturesCfg.set('SHADER_INSTALL_DIR','"shaders"', description: 'OpenGL shader installation dir')
+mapopenglFeaturesCfg.set('DEFAULT_FONT_FILE','"LiberationSans-Regular.ttf"', description: 'OpenGL default font path')
 
 configure_file(output: 'MapOpenGLFeatures.h',
                configuration: mapopenglFeaturesCfg)

--- a/libosmscout-map-opengl/src/osmscoutmapopengl/MapPainterOpenGL.cpp
+++ b/libosmscout-map-opengl/src/osmscoutmapopengl/MapPainterOpenGL.cpp
@@ -39,12 +39,18 @@ namespace osmscout {
         dpi(dpi),
         screenWidth(screenWidth),
         screenHeight(screenHeight),
-        Textloader(fontPath, defaultTextSize)
+        Textloader(fontPath, defaultTextSize, dpi)
   {
+    if (!Textloader.IsInitialized()) {
+      log.Error() << "Failed to initialize text loader!";
+      return;
+    }
+
     glewExperimental = GL_TRUE;
     GLenum res = glewInit();
     if (res != GLEW_OK) {
-      log.Error() <<"Glew init error: " << glewGetErrorString(res);
+      log.Error() << "Glew init error: " << glewGetErrorString(res);
+      return;
     }
 
     if (!(AreaRenderer.LoadVertexShader(shaderDir, "AreaVertexShader.vert") &&
@@ -107,8 +113,8 @@ namespace osmscout {
   }
 
   void osmscout::MapPainterOpenGL::ProcessData(const osmscout::MapData &data, const osmscout::MapParameter &parameter,
-                                            const osmscout::Projection &projection,
-                                            const osmscout::StyleConfigRef &styleConfig) {
+                                               const osmscout::Projection &projection,
+                                               const osmscout::StyleConfigRef &styleConfig) {
     landFill=styleConfig.get()->GetLandFillStyle(projection);
     seaFill=styleConfig.get()->GetSeaFillStyle(projection);
 


### PR DESCRIPTION
OpenGL demo should not load font from build directory,
font should be installed together with the demo binary
and installation path should be used as default.

When TextLoader os not initialized properly, demo should
be terminated properly (with error message).