### PR TITLE
make sure that areas optimized for low-zoom are simple

### DIFF
--- a/libosmscout-import/src/osmscoutimport/GenOptimizeAreasLowZoom.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenOptimizeAreasLowZoom.cpp
@@ -203,7 +203,8 @@ namespace osmscout
                         transBuffer,
                         projection,
                         optimizeAreaMethod,
-                        pixel/8.0);
+                        pixel/8.0,
+                        TransPolygon::OutputConstraint::simple);
 
           transBuffer.GetBoundingBox(xmin,ymin,xmax,ymax);
 


### PR DESCRIPTION
Additional node filtering during OptimizeAreasLowZoomGenerator
import step makes it slower by 10%. But output areas
are more sane then, moreover, simple areas
(without line intersections) are required for OpenGL triangulation, 
they are skipped otherwise.