### PR TITLE
OSMScoutOpenGL demo: wait for data loading thread before exit

### DIFF
--- a/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
+++ b/OSMScoutOpenGL/src/OSMScoutOpenGL.cpp
@@ -409,6 +409,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  if (loadingInProgress) {
+    osmscout::log.Debug() << "Waiting for loading thread";
+    result.wait();
+    osmscout::log.Info() << "Data loading ended.";
+  }
+
   delete renderer;
   glfwDestroyWindow(window);
   glfwTerminate();


### PR DESCRIPTION
this change solve crash when OpenGL demo is closed while it is still loading data