### PR TITLE
prefix dependent stylesheet flags with underscore

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
@@ -59,7 +59,7 @@ public:
   Q_ENUM(Roles)
 
   StyleFlagsModel();
-  virtual ~StyleFlagsModel();
+  ~StyleFlagsModel() override;
 
   Q_INVOKABLE virtual int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const
   {

--- a/libosmscout-client-qt/src/osmscoutclientqt/StyleFlagsModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/StyleFlagsModel.cpp
@@ -56,6 +56,11 @@ void StyleFlagsModel::onStyleFlagsChanged(QMap<QString,bool> flags)
 {
   beginResetModel();
   mapFlags=flags;
+  for (auto const &key: mapFlags.keys()){
+    if (key.startsWith('_')) {
+      mapFlags.remove(key);
+    }
+  }
   endResetModel();
 }
 

--- a/stylesheets/standard.oss
+++ b/stylesheets/standard.oss
@@ -20,18 +20,18 @@ FLAG
   elevationContours = true;
 
   IF daylight {
-    natural         = true;
-    railway         = true;
-    leisure         = true;
-    building        = true;
-    minorBuilding   = true;
+    _natural         = true;
+    _railway         = true;
+    _leisure         = true;
+    _building        = true;
+    _minorBuilding   = true;
   }
   ELSE {
-    natural         = false;
-    railway         = false;
-    leisure         = false;
-    building        = false;
-    minorBuilding   = false;
+    _natural         = false;
+    _railway         = false;
+    _leisure         = false;
+    _building        = false;
+    _minorBuilding   = false;
   }
 
   routes            = false; // routes are still a bit experimental and disrupting on standard stylesheet
@@ -694,7 +694,7 @@ STYLE
   // natural_* (without coastline)
   //
 
-  IF natural {
+  IF _natural {
     [MAG state-] {
       [TYPE natural_glacier] AREA { color: @glacierColor; }
       [TYPE natural_grassland] AREA { color: @grassColor; }
@@ -1446,7 +1446,7 @@ STYLE
  // railway
  //
 
- IF railway {
+ IF _railway {
    [MAG suburb-] {
      [TYPE railway_rail] {
        [SIZE 3m 0.25mm:3px<] {
@@ -1631,7 +1631,7 @@ STYLE
  // Leisure
  //
 
- IF leisure {
+ IF _leisure {
    [MAG county-] {
      [TYPE leisure_pitch,
            leisure_fitness_station] {
@@ -1918,7 +1918,7 @@ STYLE
    [TYPE leisure_stadium] AREA { color: #33cb98; }
  }
 
- IF building {
+ IF _building {
    [MAG @buildingMag-] {
      [TYPE landuse_farmyard_building] {
        AREA { color: #bcbcbc;}
@@ -1997,7 +1997,7 @@ STYLE
    }
  }
 
- IF minorBuilding {
+ IF _minorBuilding {
    [MAG @minorBuildingMag-] {
      [TYPE building_garage] AREA { color: #bcbcbc; }
    }
@@ -2032,7 +2032,7 @@ STYLE
    }
  }
 
- IF building {
+ IF _building {
    [MAG @labelBuildingMag-] {
      [FEATURE Address] {
        NODE.TEXT#address { label: Address.name; color: @buildingLabelColor; size: 0.7; priority: @labelPrioBuilding; position: 1; }

--- a/stylesheets/winter-sports.oss
+++ b/stylesheets/winter-sports.oss
@@ -20,18 +20,18 @@ FLAG
   elevationContours = true;
   
   IF daylight {
-    natural         = true;
-    railway         = true;
-    leisure         = true;
-    building        = true;
-    minorBuilding   = true;
+    _natural         = true;
+    _railway         = true;
+    _leisure         = true;
+    _building        = true;
+    _minorBuilding   = true;
   }
   ELSE {
-    natural         = false;
-    railway         = false;
-    leisure         = false;
-    building        = false;
-    minorBuilding   = false;
+    _natural         = false;
+    _railway         = false;
+    _leisure         = false;
+    _building        = false;
+    _minorBuilding   = false;
   }
 
 ORDER WAYS
@@ -545,7 +545,7 @@ STYLE
   // natural_* (without coastline)
   //
 
-  IF natural {
+  IF _natural {
     [MAG state-] {
       [TYPE natural_glacier] AREA { color: @glacierColor; }
       [TYPE natural_grassland] AREA { color: @grassColor; }
@@ -1177,7 +1177,7 @@ STYLE
  // railway
  //
 
- IF railway {
+ IF _railway {
    [MAG suburb-] {
      [TYPE railway_rail] {
        [SIZE 5m 0.25mm:3px<] {
@@ -1359,7 +1359,7 @@ STYLE
  // Leisure
  //
 
- IF leisure {
+ IF _leisure {
    [MAG county-] {
      [TYPE leisure_pitch,
            leisure_fitness_station] {
@@ -1658,7 +1658,7 @@ STYLE
    [TYPE leisure_stadium] AREA { color: #33cb98; }
  }
 
- IF building {
+ IF _building {
    [MAG @buildingMag-] {
      [TYPE landuse_farmyard_building] {
         AREA { color: #bcbcbc; }
@@ -1736,7 +1736,7 @@ STYLE
    }
  }
 
- IF minorBuilding {
+ IF _minorBuilding {
    [MAG @minorBuildingMag-] {
      [TYPE building_garage] AREA { color: #bcbcbc; }
    }
@@ -1771,7 +1771,7 @@ STYLE
    }
  }
 
- IF building {
+ IF _building {
    [MAG @labelBuildingMag-] {
      [FEATURE Address] {
        NODE.TEXT#address { label: Address.name; color: @buildingLabelColor; size: 0.7; priority: @labelPrioBuilding; position: 1; }


### PR DESCRIPTION
...and filter these flags in StyleFlagsModel, to hide them in UI.
Flags that depends on other flag (_building depends on daylight for example)
may be changed otherwise when "control" flag is changed after.
So the result depends on flag order. It may be confusing for user.