### PR TITLE
Fix/utf8helper

### DIFF
--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -234,6 +234,19 @@ TEST_CASE("Normalize for lookup")
   REQUIRE(transformed == "baker street");
 }
 
+TEST_CASE("Check UTF8 string buffer integrity")
+{
+  /* Transliterate 24 POUND SIGN: IN = 48 bytes , OUT = 72 bytes */
+  auto transformed=osmscout::UTF8Transliterate(
+    "\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3"
+    "\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3"
+    "\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3\xc2\xa3"
+  );
+
+  REQUIRE(transformed ==
+    "GBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBPGBP");
+}
+
 TEST_CASE("Parse illegal UTF8 sequence")
 {
   auto transformed=osmscout::UTF8Transliterate("\xef\xbb\xbf\x2f\xc0\xae\x2e\x2f");

--- a/libosmscout/src/osmscout/util/utf8helper.cpp
+++ b/libosmscout/src/osmscout/util/utf8helper.cpp
@@ -322,7 +322,7 @@ static Parser::Exit _p0(Parser* p, byte bb) {
       return Parser::Continue;
     p->u = u;
     p->context = c->category;
-    p->u_size = 1;
+    p->u_size = _u_size(p->u);
     return Parser::Done;
   }
   else if (bb < 0xc2) {
@@ -365,7 +365,7 @@ static Parser::Exit _p1_u2(Parser* p, byte bb) {
       p->u = (p->b[0] << 8) | bb;
       p->context = None;
     }
-    p->u_size = 2;
+    p->u_size = _u_size(p->u);
     return Parser::Done;
   }
   // invalid codepoint: restart
@@ -412,7 +412,7 @@ static Parser::Exit _p2_u3(Parser* p, byte bb) {
       p->u = (p->b[0] << 16) | (p->b[1] << 8) | bb;
       p->context = None;
     }
-    p->u_size = 3;
+    p->u_size = _u_size(p->u);
     return Parser::Done;
   }
   // invalid codepoint: restart
@@ -476,7 +476,7 @@ static Parser::Exit _p3_u4(Parser* p, byte bb) {
       p->u = (p->b[0] << 24) | (p->b[1] << 16) | (p->b[2] << 8) | bb;
       p->context = None;
     }
-    p->u_size = 4;
+    p->u_size = _u_size(p->u);
     return Parser::Done;
   }
   // invalid codepoint: restart


### PR DESCRIPTION
Hi, here a fix for the utf8helper. 

The rawsize member should be updated with the size in bytes of the stored code point.
Applying a transform operation could change the original code point to one with a different byte size. Therefore, the parser should store the size of the final code point resulting from the transform operation, not the size of the input code point.

The rawsize is used to size the buffer output string (ToStdString). Actually it is larger than required in some case, or can be shorter for border cases. Added test cases check that.