### PR TITLE
check existence of tbb::task_scheduler_init

### DIFF
--- a/cmake/Config.h.cmake
+++ b/cmake/Config.h.cmake
@@ -206,6 +206,11 @@
 #cmakedefine HAVE_STD_EXECUTION 1
 #endif
 
+/* Define to 1 or 0, depending whether the tbb::task_scheduler_init exists. */
+#ifndef TBB_HAS_SCHEDULER_INIT
+#cmakedefine TBB_HAS_SCHEDULER_INIT 1
+#endif
+
 /* int16_t is available */
 #ifndef OSMSCOUT_HAVE_INT16_T
 #cmakedefine OSMSCOUT_HAVE_INT16_T 1

--- a/cmake/TestTBBSchedulerInit.cpp
+++ b/cmake/TestTBBSchedulerInit.cpp
@@ -1,0 +1,7 @@
+#include "tbb/task_scheduler_init.h"
+
+int main()
+{
+  [[maybe_unused]] tbb::task_scheduler_init task_scheduler;
+  return 0;
+}

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -223,6 +223,11 @@ if(THREADS_HAVE_PTHREAD_ARG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${THREADS_PTHREAD_ARG}")
 endif()
 find_package(TBB QUIET)
+if (TBB_FOUND)
+  try_compile(TBB_HAS_SCHEDULER_INIT "${PROJECT_BINARY_DIR}"
+      "${PROJECT_SOURCE_DIR}/cmake/TestTBBSchedulerInit.cpp"
+      LINK_LIBRARIES TBB::tbb)
+endif()
 
 find_program(HUGO_PATH hugo)
 

--- a/libosmscout-import/src/osmscoutimport/Import.cpp
+++ b/libosmscout-import/src/osmscoutimport/Import.cpp
@@ -75,7 +75,7 @@
 #include <osmscoutimport/GenTextIndex.h>
 #endif
 
-#if defined(HAVE_STD_EXECUTION)
+#if defined(HAVE_STD_EXECUTION) and defined(TBB_HAS_SCHEDULER_INIT)
 #include "tbb/task_scheduler_init.h"
 #endif
 
@@ -332,7 +332,7 @@ namespace osmscout {
 
   bool Importer::Import(ImportProgress& progress)
   {
-#if defined(HAVE_STD_EXECUTION)
+#if defined(HAVE_STD_EXECUTION) and defined(TBB_HAS_SCHEDULER_INIT)
     // create tbb scheduler explicitly to avoid leaks by default scheduler
     // NOTE that task_scheduler_init is deprecated, but there is no way to destruct global scheduler - it is leaking
     [[maybe_unused]] tbb::task_scheduler_init task_scheduler;

--- a/libosmscout-import/src/osmscoutimport/Import.cpp
+++ b/libosmscout-import/src/osmscoutimport/Import.cpp
@@ -335,6 +335,7 @@ namespace osmscout {
 #if defined(HAVE_STD_EXECUTION) and defined(TBB_HAS_SCHEDULER_INIT)
     // create tbb scheduler explicitly to avoid leaks by default scheduler
     // NOTE that task_scheduler_init is deprecated, but there is no way to destruct global scheduler - it is leaking
+    // TODO: use oneapi::tbb::finalize when it becomes official
     [[maybe_unused]] tbb::task_scheduler_init task_scheduler;
 #endif
 


### PR DESCRIPTION
...and use just in case when it is available.
task_scheduler_init is deprecated and removed in oneTBB 2021.
But TBB is leaking resources with default scheduler.
So it is better to initialize scheduler explicitly with this deprecated
api to get clean results with ASAN.