### PR TITLE
Clickable map icons

### DIFF
--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -114,6 +114,7 @@ Window {
             Layout.fillHeight: true
             focus: true
             renderingType: "plane" // or "tiled"
+            interactiveIcons: true
 
             function getFreeRect() {
                 return Qt.rect(Theme.horizSpace,

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADER_FILES
     include/osmscoutclientqt/ElevationChartWidget.h
     include/osmscoutclientqt/ElevationModule.h
     include/osmscoutclientqt/FileDownloader.h
+    include/osmscoutclientqt/IconAnimation.h
     include/osmscoutclientqt/IconLookup.h
     include/osmscoutclientqt/InputHandler.h
     include/osmscoutclientqt/LocationEntry.h
@@ -66,6 +67,7 @@ set(SOURCE_FILES
     src/osmscoutclientqt/ElevationChartWidget.cpp
     src/osmscoutclientqt/ElevationModule.cpp
     src/osmscoutclientqt/FileDownloader.cpp
+    src/osmscoutclientqt/IconAnimation.cpp
     src/osmscoutclientqt/IconLookup.cpp
     src/osmscoutclientqt/InputHandler.cpp
     src/osmscoutclientqt/LocationEntry.cpp

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADER_FILES
     include/osmscoutclientqt/ElevationChartWidget.h
     include/osmscoutclientqt/ElevationModule.h
     include/osmscoutclientqt/FileDownloader.h
+    include/osmscoutclientqt/IconLookup.h
     include/osmscoutclientqt/InputHandler.h
     include/osmscoutclientqt/LocationEntry.h
     include/osmscoutclientqt/LocationInfoModel.h
@@ -65,6 +66,7 @@ set(SOURCE_FILES
     src/osmscoutclientqt/ElevationChartWidget.cpp
     src/osmscoutclientqt/ElevationModule.cpp
     src/osmscoutclientqt/FileDownloader.cpp
+    src/osmscoutclientqt/IconLookup.cpp
     src/osmscoutclientqt/InputHandler.cpp
     src/osmscoutclientqt/LocationEntry.cpp
     src/osmscoutclientqt/LocationInfoModel.cpp

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -29,6 +29,7 @@ osmscoutclientqtHeader = [
             'osmscoutclientqt/MapProvider.h',
             'osmscoutclientqt/AvailableMapsModel.h',
             'osmscoutclientqt/FileDownloader.h',
+            'osmscoutclientqt/IconLookup.h',
             'osmscoutclientqt/MapManager.h',
             'osmscoutclientqt/MapDownloadsModel.h',
             'osmscoutclientqt/MapObjectInfoModel.h',

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -29,6 +29,7 @@ osmscoutclientqtHeader = [
             'osmscoutclientqt/MapProvider.h',
             'osmscoutclientqt/AvailableMapsModel.h',
             'osmscoutclientqt/FileDownloader.h',
+            'osmscoutclientqt/IconAnimation.h',
             'osmscoutclientqt/IconLookup.h',
             'osmscoutclientqt/MapManager.h',
             'osmscoutclientqt/MapDownloadsModel.h',

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconAnimation.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconAnimation.h
@@ -1,0 +1,84 @@
+#ifndef OSMSCOUT_CLIENT_QT_ICONANIMATION_H
+#define OSMSCOUT_CLIENT_QT_ICONANIMATION_H
+
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2022  Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+
+#include <osmscout/util/Projection.h>
+#include <osmscoutclientqt/IconLookup.h>
+
+#include <QObject>
+#include <QTimer>
+#include <QPainter>
+
+namespace osmscout {
+
+class OSMSCOUT_CLIENT_QT_API IconAnimation : public QObject
+{
+  Q_OBJECT
+private:
+  static constexpr int animationDuration = 200;
+  QTimer timer;
+
+  enum class State {
+    FadeIn,
+    Full,
+    FadeOut
+  };
+
+  struct Animation {
+    MapIcon icon;
+    double size;
+    double startSize;
+    State state;
+    QElapsedTimer duration;
+
+    double MaxSize() const
+    {
+      return icon.image.width();
+    }
+
+    double MinSize() const
+    {
+      return icon.dimensions.width();
+    }
+  };
+
+  std::vector<Animation> icons;
+
+public slots:
+  void tick();
+
+signals:
+  void update();
+
+public:
+  IconAnimation();
+  ~IconAnimation() override = default;
+
+  void activate(const MapIcon &icon);
+  void deactivateAll();
+  void paint(QPainter *painter, const MercatorProjection &projection);
+};
+
+}
+
+#endif // OSMSCOUT_CLIENT_QT_ICONANIMATION_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -106,7 +106,7 @@ private:
 /**
  * \ingroup QtAPI
  */
-typedef std::shared_ptr<IconLookup> IconLookupRef;
+using IconLookupRef = std::shared_ptr<IconLookup> ;
 
 }
 #endif //OSMSCOUT_CLIENT_QT_ICONLOOKUP_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -47,6 +47,9 @@ struct OSMSCOUT_CLIENT_QT_API MapIcon {
   int poiId;
   QString type;
   QString name;
+  QString altName;
+  QString ref;
+  QString operatorName;
   QString phone;
   QString website;
   QImage image;

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -44,6 +44,7 @@ struct OSMSCOUT_CLIENT_QT_API MapIcon {
   IconStyleRef iconStyle;
   QString databasePath;
   ObjectFileRef objectRef;
+  int poiId;
   QString type;
   QString name;
   QString phone;
@@ -63,7 +64,7 @@ private:
   DBThreadRef dbThread;
   DBLoadJob   *loadJob;
   osmscout::MercatorProjection projection;
-  std::vector<OverlayObjectRef> overlayObjects;
+  std::map<int,OverlayObjectRef> overlayObjects;
   MapParameter drawParameter;
   QPoint lookupCoord;
   std::vector<MapIcon> findIcons;

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -40,6 +40,7 @@ struct OSMSCOUT_CLIENT_QT_API MapIcon {
   QPoint screenCoord;
   QRectF dimensions;
   GeoCoord coord;
+  double distanceSquare;
   IconStyleRef iconStyle;
   QString databasePath;
   ObjectFileRef objectRef;
@@ -57,6 +58,7 @@ class OSMSCOUT_CLIENT_QT_API IconLookup : public QObject {
   Q_OBJECT
 private:
   static constexpr int iconImageUpscale=3;
+  static constexpr double tapSize=4;
   QThread     *thread;
   DBThreadRef dbThread;
   DBLoadJob   *loadJob;

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -43,6 +43,7 @@ struct OSMSCOUT_CLIENT_QT_API MapIcon {
   IconStyleRef iconStyle;
   QString databasePath;
   ObjectFileRef objectRef;
+  QString type;
   QString name;
   QString phone;
   QString website;

--- a/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/IconLookup.h
@@ -1,0 +1,105 @@
+#ifndef OSMSCOUT_CLIENT_QT_ICONLOOKUP_H
+#define OSMSCOUT_CLIENT_QT_ICONLOOKUP_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2022 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutmap/DataTileCache.h>
+
+#include <osmscoutclientqt/DBThread.h>
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+#include <osmscoutclientqt/OverlayObject.h>
+
+#include <QObject>
+#include <QSettings>
+#include <QMutex>
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ */
+struct OSMSCOUT_CLIENT_QT_API MapIcon {
+  QPoint screenCoord;
+  QRectF dimensions;
+  GeoCoord coord;
+  IconStyleRef iconStyle;
+  QString databasePath;
+  ObjectFileRef objectRef;
+  QString name;
+  QString phone;
+  QString website;
+  QImage image;
+};
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API IconLookup : public QObject {
+  Q_OBJECT
+private:
+  static constexpr int iconImageUpscale=3;
+  QThread     *thread;
+  DBThreadRef dbThread;
+  DBLoadJob   *loadJob;
+  osmscout::MercatorProjection projection;
+  std::vector<OverlayObjectRef> overlayObjects;
+  MapParameter drawParameter;
+  QPoint lookupCoord;
+  std::vector<MapIcon> findIcons;
+
+public slots:
+  void onIconRequest(const MapViewStruct &view,
+                     const QPoint &coord,
+                     const std::map<int,OverlayObjectRef> &overlayObjects);
+  void onDatabaseLoaded(QString dbPath,QList<osmscout::TileRef> tiles);
+  void onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>> tiles);
+
+public:
+signals:
+  void iconRequested(const MapViewStruct &view,
+                     const QPoint &coord,
+                     const std::map<int,OverlayObjectRef> &overlayObjects);
+
+  void iconFound(QPoint lookupCoord, MapIcon icon);
+  void iconNotFound(QPoint lookupCoord);
+
+public:
+  IconLookup(QThread *thread, DBThreadRef dbThread, QString iconDirectory);
+  ~IconLookup() override;
+
+  void RequestIcon(const MapViewStruct &view,
+                   const QPoint &coord,
+                   const std::map<int,OverlayObjectRef> &overlayObjects);
+
+private:
+  void lookupIcons(const QString &databasePath,
+                   osmscout::MapData &data,
+                   const TypeConfigRef &typeConfig,
+                   const StyleConfigRef &styleConfig);
+};
+
+/**
+ * \ingroup QtAPI
+ */
+typedef std::shared_ptr<IconLookup> IconLookupRef;
+
+}
+#endif //OSMSCOUT_CLIENT_QT_ICONLOOKUP_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -253,6 +253,8 @@ public slots:
   OverlayArea *createOverlayArea(QString type="_highlighted");
   OverlayNode *createOverlayNode(QString type="_highlighted");
 
+  void deactivateIcons();
+
   bool toggleDebug();
   bool toggleInfo();
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -175,7 +175,7 @@ signals:
 
   void iconTapped(QPoint screenCoord, double lat, double lon, QString databasePath,
                   QString objectType, quint64 objectId, int poiId, QString type,
-                  QString name, QString phone, QString website);
+                  QString name, QString altName, QString ref, QString operatorName, QString phone, QString website);
 
   void stylesheetFilenameChanged();
   void styleErrorsChanged();

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -174,7 +174,7 @@ signals:
   void tapLongTap(const int screenX, const int screenY, const double lat, const double lon);
 
   void iconTapped(QPoint screenCoord, double lat, double lon, QString databasePath,
-                  QString objectType, quint64 objectId, QString type,
+                  QString objectType, quint64 objectId, int poiId, QString type,
                   QString name, QString phone, QString website);
 
   void stylesheetFilenameChanged();

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -35,6 +35,7 @@
 #include <osmscoutclientqt/OSMScoutQt.h>
 #include <osmscoutclientqt/OverlayObject.h>
 #include <osmscoutclientqt/VehiclePosition.h>
+#include <osmscoutclientqt/IconLookup.h>
 
 namespace osmscout {
 
@@ -89,6 +90,8 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_PROPERTY(QString vehicleInTunnelIconFile    READ getVehicleInTunnelIconFile     WRITE setVehicleInTunnelIconFile)
   Q_PROPERTY(double vehicleIconSize             READ getVehicleIconSize             WRITE setVehicleIconSize)
 
+  Q_PROPERTY(bool interactiveIcons READ hasInteractiveIcons WRITE setInteractiveIcons)
+
 private:
   MapRenderer      *renderer{nullptr};
 
@@ -96,6 +99,8 @@ private:
 
   InputHandler     *inputHandler{nullptr};
   TapRecognizer    tapRecognizer;
+
+  IconLookup       *iconLookup{nullptr};
 
   bool preventMouseStealing{false};
 
@@ -253,6 +258,8 @@ public slots:
    */
   void setVehicleScaleFactor(float factor);
 
+  void onIconFound(QPoint lookupCoord, MapIcon icon);
+
 private slots:
 
   virtual void onTap(const QPoint p);
@@ -299,6 +306,8 @@ public:
       changeView(*updated);
     }
   }
+
+  MapViewStruct GetViewStruct() const;
 
   inline VehiclePosition* GetVehiclePosition() const
   {
@@ -353,6 +362,13 @@ public:
     loadVehicleIcons();
     redraw();
   }
+
+  bool hasInteractiveIcons() const
+  {
+    return iconLookup!=nullptr;
+  }
+
+  void setInteractiveIcons(bool b);
 
   inline double GetLat() const
   {

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -35,6 +35,7 @@
 #include <osmscoutclientqt/OSMScoutQt.h>
 #include <osmscoutclientqt/OverlayObject.h>
 #include <osmscoutclientqt/VehiclePosition.h>
+#include <osmscoutclientqt/IconAnimation.h>
 #include <osmscoutclientqt/IconLookup.h>
 
 namespace osmscout {
@@ -101,6 +102,7 @@ private:
   TapRecognizer    tapRecognizer;
 
   IconLookup       *iconLookup{nullptr};
+  IconAnimation    iconAnimation;
 
   bool preventMouseStealing{false};
 
@@ -170,6 +172,10 @@ signals:
   void doubleTap(const int screenX, const int screenY, const double lat, const double lon);
   void longTap(const int screenX, const int screenY, const double lat, const double lon);
   void tapLongTap(const int screenX, const int screenY, const double lat, const double lon);
+
+  void iconTapped(QPoint screenCoord, double lat, double lon, QString databasePath,
+                  QString objectType, quint64 objectId, QString type,
+                  QString name, QString phone, QString website);
 
   void stylesheetFilenameChanged();
   void styleErrorsChanged();

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -33,6 +33,7 @@
 #include <osmscoutclientqt/POILookupModule.h>
 #include <osmscoutclientqt/VoiceManager.h>
 #include <osmscoutclientqt/ElevationModule.h>
+#include <osmscoutclientqt/IconLookup.h>
 
 #include <osmscoutclientqt/ClientQtImportExport.h>
 
@@ -306,6 +307,7 @@ public:
   StyleModule *MakeStyleModule();
   POILookupModule *MakePOILookupModule();
   ElevationModule *MakeElevationModule();
+  IconLookup *MakeIconLookup();
 
   QString GetUserAgent() const;
   QString GetCacheLocation() const;

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -26,6 +26,7 @@ osmscoutclientqtSrc = [
             'src/osmscoutclientqt/MapProvider.cpp',
             'src/osmscoutclientqt/AvailableMapsModel.cpp',
             'src/osmscoutclientqt/FileDownloader.cpp',
+            'src/osmscoutclientqt/IconLookup.cpp',
             'src/osmscoutclientqt/MapManager.cpp',
             'src/osmscoutclientqt/MapDownloadsModel.cpp',
             'src/osmscoutclientqt/MapObjectInfoModel.cpp',

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -26,6 +26,7 @@ osmscoutclientqtSrc = [
             'src/osmscoutclientqt/MapProvider.cpp',
             'src/osmscoutclientqt/AvailableMapsModel.cpp',
             'src/osmscoutclientqt/FileDownloader.cpp',
+            'src/osmscoutclientqt/IconAnimation.cpp',
             'src/osmscoutclientqt/IconLookup.cpp',
             'src/osmscoutclientqt/MapManager.cpp',
             'src/osmscoutclientqt/MapDownloadsModel.cpp',

--- a/libosmscout-client-qt/src/osmscoutclientqt/IconAnimation.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconAnimation.cpp
@@ -19,6 +19,8 @@
 
 #include <osmscoutclientqt/IconAnimation.h>
 
+#include <cmath>
+
 namespace osmscout {
 
 IconAnimation::IconAnimation():
@@ -63,6 +65,13 @@ void IconAnimation::paint(QPainter *painter, const MercatorProjection &projectio
     projection.GeoToPixel(animation.icon.coord, x, y);
     double w = animation.size;
     double h = animation.icon.image.height() * (w / animation.icon.image.width());
+
+    // draw semitransparent black circle as background
+    double r = std::sqrt(std::pow(w, 2) + std::pow(h, 2)) / 2;
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(QBrush(QColor::fromRgbF(0, 0, 0, 0.1)));
+    painter->drawEllipse(QPointF(x, y) ,r ,r);
+
     painter->drawImage(QRectF(x-w/2, y-h/2, w, h), animation.icon.image);
   }
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/IconAnimation.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconAnimation.cpp
@@ -1,0 +1,106 @@
+/*
+  OSMScout - a Qt backend for libosmscout and libosmscout-map
+  Copyright (C) 2022  Lukáš Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/IconAnimation.h>
+
+namespace osmscout {
+
+IconAnimation::IconAnimation():
+  QObject(nullptr)
+{
+  timer.setSingleShot(false);
+  timer.setInterval(16);
+
+  connect(&timer, &QTimer::timeout, this, &IconAnimation::tick);
+}
+
+void IconAnimation::activate(const MapIcon &icon)
+{
+  QElapsedTimer t;
+  t.start();
+  icons.push_back(Animation{icon, icon.dimensions.width(), icon.dimensions.width(), State::FadeIn, t});
+  if (!timer.isActive()) {
+    timer.start();
+  }
+  emit update();
+}
+
+void IconAnimation::deactivateAll()
+{
+  for (Animation &animation: icons) {
+    if (animation.state != State::FadeOut) {
+      animation.startSize=animation.size;
+      animation.state = State::FadeOut;
+      animation.duration.restart();
+    }
+  }
+  if (!timer.isActive() && !icons.empty()) {
+    timer.start();
+  }
+  emit update();
+}
+
+void IconAnimation::paint(QPainter *painter, const MercatorProjection &projection)
+{
+  for (Animation &animation: icons) {
+    double x,y;
+    projection.GeoToPixel(animation.icon.coord, x, y);
+    double w = animation.size;
+    double h = animation.icon.image.height() * (w / animation.icon.image.width());
+    painter->drawImage(QRectF(x-w/2, y-h/2, w, h), animation.icon.image);
+  }
+}
+
+void IconAnimation::tick()
+{
+  int running=0;
+  for (auto it=icons.begin(); it!=icons.end();) {
+    Animation &animation=*it;
+    if (animation.state==State::FadeIn) {
+      if (animation.duration.elapsed() >= animationDuration) {
+        animation.state=State::Full;
+        animation.size=animation.MaxSize();
+        it++;
+      } else {
+        double progress = double(animation.duration.elapsed()) / double(animationDuration);
+        animation.size = animation.startSize + (animation.MaxSize() - animation.startSize) * progress;
+        running++;
+        it++;
+      }
+    } else if (animation.state==State::FadeOut){
+      if (animation.duration.elapsed() >= animationDuration) {
+        it=icons.erase(it);
+      } else {
+        double progress = double(animation.duration.elapsed()) / double(animationDuration);
+        animation.size = animation.startSize - (animation.startSize - animation.MinSize()) * progress;
+        running++;
+        it++;
+      }
+    } else {
+      it++;
+    }
+  }
+  if (running==0) {
+    timer.stop();
+  }
+  emit update();
+}
+
+}
+

--- a/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
@@ -88,11 +88,26 @@ void IconLookup::lookupIcons(const QString &databasePath,
           std::pow(lookupCoord.x()-x,2)+std::pow(lookupCoord.y()-y,2);
 
         QString name;
+        QString altName;
+        QString ref;
+        QString operatorName;
         QString phone;
         QString website;
         if (const osmscout::NameFeatureValue *nameValue=featureBuffer.findValue<osmscout::NameFeatureValue>();
             nameValue!=nullptr){
           name=QString::fromStdString(nameValue->GetLabel(Locale(), 0));
+        }
+        if (const osmscout::NameAltFeatureValue *altNameValue=featureBuffer.findValue<osmscout::NameAltFeatureValue>();
+            altNameValue != nullptr){
+          altName=QString::fromStdString(altNameValue->GetLabel(Locale(), 0));
+        }
+        if (const osmscout::RefFeatureValue *refValue=featureBuffer.findValue<osmscout::RefFeatureValue>();
+            refValue != nullptr){
+          ref=QString::fromStdString(refValue->GetLabel(Locale(), 0));
+        }
+        if (const osmscout::OperatorFeatureValue *operatorValue=featureBuffer.findValue<osmscout::OperatorFeatureValue>();
+            operatorValue != nullptr){
+          operatorName=QString::fromStdString(operatorValue->GetLabel(Locale(), 0));
         }
         if (const osmscout::PhoneFeatureValue *phoneValue=featureBuffer.findValue<osmscout::PhoneFeatureValue>();
             phoneValue!=nullptr){
@@ -105,7 +120,7 @@ void IconLookup::lookupIcons(const QString &databasePath,
 
         findIcons.push_back(MapIcon{QPoint(x,y), iconRect, coord, distanceSquare, iconStyle,
                                     databasePath, objectRef, poiId, QString::fromStdString(featureBuffer.GetType()->GetName()),
-                                    name, phone, website, QImage()});
+                                    name, altName, ref, operatorName, phone, website, QImage()});
       }
     }
   };

--- a/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
@@ -1,0 +1,280 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2022 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/IconLookup.h>
+#include <QSvgRenderer>
+#include "osmscoutmapqt/SymbolRendererQt.h"
+
+namespace osmscout {
+
+IconLookup::IconLookup(QThread *thread, DBThreadRef dbThread, QString iconDirectory):
+  QObject(),
+  thread(thread),
+  dbThread(dbThread),
+  loadJob(nullptr)
+{
+  std::list<std::string> paths;
+  paths.push_back(iconDirectory.toStdString());
+
+  drawParameter.SetIconMode(osmscout::MapParameter::IconMode::Scalable);
+  drawParameter.SetPatternMode(osmscout::MapParameter::PatternMode::Scalable);
+  drawParameter.SetIconPaths(paths);
+  drawParameter.SetPatternPaths(paths);
+
+  connect(this, &IconLookup::iconRequested,
+          this, &IconLookup::onIconRequest,
+          Qt::QueuedConnection);
+}
+
+IconLookup::~IconLookup()
+{
+  if (thread != QThread::currentThread()) {
+    qWarning() << "Destroy" << this << "from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+  if (thread != nullptr) {
+    thread->quit();
+  }
+}
+
+void IconLookup::lookupIcons(const QString &databasePath,
+                             osmscout::MapData &data,
+                             const TypeConfigRef &typeConfig,
+                             const StyleConfigRef &styleConfig)
+{
+  for (auto const &o:overlayObjects){
+    if (o->getObjectType()==osmscout::RefType::refWay){
+      OverlayWay *ow=dynamic_cast<OverlayWay*>(o.get());
+      if (ow != nullptr) {
+        osmscout::WayRef w = std::make_shared<osmscout::Way>();
+        if (ow->toWay(w, *typeConfig)) {
+          data.poiWays.push_back(w);
+        }
+      }
+    } else if (o->getObjectType()==osmscout::RefType::refArea){
+      OverlayArea *oa=dynamic_cast<OverlayArea*>(o.get());
+      if (oa != nullptr) {
+        osmscout::AreaRef a = std::make_shared<osmscout::Area>();
+        if (oa->toArea(a, *typeConfig)) {
+          data.poiAreas.push_back(a);
+        }
+      }
+    } else if (o->getObjectType()==osmscout::RefType::refNode){
+      OverlayNode *oo=dynamic_cast<OverlayNode*>(o.get());
+      if (oo != nullptr) {
+        osmscout::NodeRef n = std::make_shared<osmscout::Node>();
+        if (oo->toNode(n, *typeConfig)) {
+          data.poiNodes.push_back(n);
+        }
+      }
+    }
+  }
+  overlayObjects.clear();
+
+  double iconSize = projection.ConvertWidthToPixel(drawParameter.GetIconSize());
+
+  auto CheckIcon=[&](const IconStyleRef &iconStyle,
+                     const GeoCoord &coord,
+                     const ObjectFileRef &objectRef,
+                     const FeatureValueBuffer& featureBuffer) {
+    if (iconStyle && iconStyle->IsVisible() && !iconStyle->IsOverlay()) {
+      double x, y;
+      projection.GeoToPixel(coord, x, y);
+      QRectF iconRect;
+
+      if (!iconStyle->GetIconName().empty()) {
+        iconRect=QRectF(x - iconSize/2, y-iconSize/2, iconSize, iconSize);
+      } else {
+        auto symbol=iconStyle->GetSymbol();
+        assert(symbol);
+        double w=symbol->GetWidth(projection);
+        double h=symbol->GetHeight(projection);
+        iconRect=QRectF(x - w/2, y-h/2, w, h);
+      }
+      if (iconRect.contains(lookupCoord)) {
+
+        QString name;
+        QString phone;
+        QString website;
+        if (const osmscout::NameFeatureValue *nameValue=featureBuffer.findValue<osmscout::NameFeatureValue>();
+            nameValue!=nullptr){
+          name=QString::fromStdString(nameValue->GetLabel(Locale(), 0));
+        }
+        if (const osmscout::PhoneFeatureValue *phoneValue=featureBuffer.findValue<osmscout::PhoneFeatureValue>();
+            phoneValue!=nullptr){
+          phone=QString::fromStdString(phoneValue->GetPhone());
+        }
+        if (const osmscout::WebsiteFeatureValue *websiteValue=featureBuffer.findValue<osmscout::WebsiteFeatureValue>();
+            websiteValue!=nullptr){
+          website=QString::fromStdString(websiteValue->GetWebsite());
+        }
+
+        findIcons.push_back(MapIcon{QPoint(x,y), iconRect, coord, iconStyle,
+                                    databasePath, objectRef,
+                                    name, phone, website, QImage()});
+      }
+    }
+  };
+
+  auto VisitArea=[&](const AreaRef a) {
+    a->VisitRings([&](size_t, const Area::Ring&r, const TypeInfoRef& type) -> bool {
+      if (!type->GetIgnore()) {
+        auto iconStyle = styleConfig->GetAreaIconStyle(type, r.GetFeatureValueBuffer(), projection);
+        auto coord = r.center.value_or(r.GetBoundingBox().GetCenter());
+        CheckIcon(iconStyle, coord, a->GetObjectFileRef(), a->GetFeatureValueBuffer());
+      }
+      return true;
+    });
+  };
+
+  for (auto const &n:data.nodes) {
+    auto iconStyle = styleConfig->GetNodeIconStyle(n->GetFeatureValueBuffer(), projection);
+    CheckIcon(iconStyle, n->GetCoords(), n->GetObjectFileRef(), n->GetFeatureValueBuffer());
+  }
+  for (auto const &n:data.poiNodes) {
+    auto iconStyle = styleConfig->GetNodeIconStyle(n->GetFeatureValueBuffer(), projection);
+    CheckIcon(iconStyle, n->GetCoords(), n->GetObjectFileRef(), n->GetFeatureValueBuffer());
+  }
+  for (auto const &a:data.areas) {
+    VisitArea(a);
+  }
+  for (auto const &a:data.poiAreas) {
+    VisitArea(a);
+  }
+}
+
+void IconLookup::onDatabaseLoaded(QString dbPath,QList<osmscout::TileRef> tiles)
+{
+  osmscout::MapData data;
+  loadJob->AddTileDataToMapData(dbPath,tiles,data);
+  dbThread->RunSynchronousJob([&](const std::list<DBInstanceRef> &databases){
+    for (auto &db: databases) {
+      if (db->path==dbPath){
+        TypeConfigRef typeConfig=db->GetDatabase()->GetTypeConfig();
+        StyleConfigRef styleConfig=db->GetStyleConfig();
+        this->lookupIcons(db->path, data, typeConfig, styleConfig);
+      }
+    }
+  });
+}
+
+
+void IconLookup::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>> /*tiles*/)
+{
+  std::stable_sort(findIcons.begin(), findIcons.end(), [](const MapIcon &a, const MapIcon &b){
+    if (a.iconStyle->GetPriority() == b.iconStyle->GetPriority()) {
+      return a.screenCoord.x() < b.screenCoord.x();
+    }
+    return a.iconStyle->GetPriority() < b.iconStyle->GetPriority();
+  });
+  if (!findIcons.empty()){
+
+    auto &findIcon=findIcons[0];
+    if (!findIcon.iconStyle->GetIconName().empty()) {
+      for (const auto &path: drawParameter.GetIconPaths()) {
+        std::string filename = AppendFileToDir(path, findIcon.iconStyle->GetIconName() + ".svg");
+
+        // Load SVG
+        QSvgRenderer renderer(QString::fromStdString(filename));
+        if (renderer.isValid()) {
+          findIcon.image = QImage(findIcon.dimensions.width()*iconImageUpscale,
+                                  findIcon.dimensions.height()*iconImageUpscale,
+                                  QImage::Format_ARGB32);
+          findIcon.image.fill(Qt::transparent);
+
+          QPainter painter(&findIcon.image);
+          renderer.render(&painter);
+          painter.end();
+          if (!findIcon.image.isNull()) {
+            break;
+          }
+        }
+      }
+    } else {
+      findIcon.image = QImage(findIcon.dimensions.width()*iconImageUpscale,
+                              findIcon.dimensions.height()*iconImageUpscale,
+                              QImage::Format_ARGB32);
+      findIcon.image.fill(Qt::transparent);
+
+      QPainter painter(&findIcon.image);
+      SymbolRendererQt renderer(&painter);
+      SymbolRef symbol=findIcon.iconStyle->GetSymbol();
+
+      double minX, minY, maxX, maxY;
+      symbol->GetBoundingBox(projection,minX,minY,maxX,maxY);
+      renderer.Render(*symbol,
+                      Vertex2D(minX*-1*iconImageUpscale,minY*-1*iconImageUpscale),
+                      projection.GetMeterInPixel()*iconImageUpscale,
+                      projection.ConvertWidthToPixel(iconImageUpscale));
+      painter.end();
+    }
+
+    emit iconFound(lookupCoord, findIcon);
+  } else {
+    emit iconNotFound(lookupCoord);
+  }
+
+  overlayObjects.clear();
+  findIcons.clear();
+}
+
+void IconLookup::onIconRequest(const MapViewStruct &view,
+                               const QPoint &coord,
+                               const std::map<int,OverlayObjectRef> &overlayObjectMap)
+{
+  if (thread != QThread::currentThread()) {
+    qWarning() << "Request from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+
+  if (loadJob!=nullptr){
+    delete loadJob;
+  }
+
+  // setup projection for data lookup
+  projection.Set(view.coord, view.angle.AsRadians(), view.magnification, view.dpi, view.width, view.height);
+  projection.SetLinearInterpolationUsage(view.magnification.GetLevel() >= 10);
+
+  overlayObjects.clear();
+  for (const auto &e: overlayObjectMap) {
+    overlayObjects.push_back(e.second);
+  }
+
+  unsigned long maximumAreaLevel=4;
+  if (view.magnification.GetLevel() >= 15) {
+    maximumAreaLevel=6;
+  }
+
+  lookupCoord=coord;
+  loadJob=new DBLoadJob(projection, maximumAreaLevel,/* lowZoomOptimization */ true);
+
+  connect(loadJob, &DBLoadJob::databaseLoaded,
+          this, &IconLookup::onDatabaseLoaded);
+  connect(loadJob, &DBLoadJob::finished,
+          this, &IconLookup::onLoadJobFinished);
+
+  dbThread->RunJob(loadJob);
+}
+
+
+void IconLookup::RequestIcon(const MapViewStruct &view,
+                             const QPoint &coord,
+                             const std::map<int,OverlayObjectRef> &overlayObjects)
+{
+  emit iconRequested(view, coord, overlayObjects);
+}
+}

--- a/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
@@ -125,7 +125,7 @@ void IconLookup::lookupIcons(const QString &databasePath,
         }
 
         findIcons.push_back(MapIcon{QPoint(x,y), iconRect, coord, iconStyle,
-                                    databasePath, objectRef,
+                                    databasePath, objectRef, QString::fromStdString(featureBuffer.GetType()->GetName()),
                                     name, phone, website, QImage()});
       }
     }

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -718,11 +718,13 @@ void MapWidget::onIconFound(QPoint /*lookupCoord*/, MapIcon icon)
   if (icon.iconStyle->IsVisible()) {
     if (!icon.iconStyle->GetIconName().empty()) {
       qDebug() << "Object:" << QString::fromStdString(icon.objectRef.GetName())
-               << "icon:" << QString::fromStdString(icon.iconStyle->GetIconName());
+               << "icon:" << QString::fromStdString(icon.iconStyle->GetIconName())
+               << "name:" << icon.name;
     } else {
       assert(icon.iconStyle->GetSymbol());
       qDebug() << "Object:" << QString::fromStdString(icon.objectRef.GetName())
-               << "symbol:" << QString::fromStdString(icon.iconStyle->GetSymbol()->GetName());
+               << "symbol:" << QString::fromStdString(icon.iconStyle->GetSymbol()->GetName())
+               << "name:" << icon.name;
     }
   }
 
@@ -730,7 +732,7 @@ void MapWidget::onIconFound(QPoint /*lookupCoord*/, MapIcon icon)
 
   emit iconTapped(icon.screenCoord, icon.coord.GetLat(), icon.coord.GetLon(), icon.databasePath,
                   QString(icon.objectRef.GetTypeName()), icon.objectRef.GetFileOffset(), icon.poiId,
-                  icon.type, icon.name, icon.phone, icon.website);
+                  icon.type, icon.name, icon.altName, icon.ref, icon.operatorName, icon.phone, icon.website);
 }
 
 void MapWidget::onDoubleTap(const QPoint p)

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -700,6 +700,10 @@ OverlayNode *MapWidget::createOverlayNode(QString type)
   return result;
 }
 
+void MapWidget::deactivateIcons()
+{
+  iconAnimation.deactivateAll();
+}
 
 void MapWidget::onTap(const QPoint p)
 {

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -729,7 +729,7 @@ void MapWidget::onIconFound(QPoint /*lookupCoord*/, MapIcon icon)
   iconAnimation.activate(icon);
 
   emit iconTapped(icon.screenCoord, icon.coord.GetLat(), icon.coord.GetLon(), icon.databasePath,
-                  QString(icon.objectRef.GetTypeName()), icon.objectRef.GetFileOffset(),
+                  QString(icon.objectRef.GetTypeName()), icon.objectRef.GetFileOffset(), icon.poiId,
                   icon.type, icon.name, icon.phone, icon.website);
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -167,6 +167,8 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<OverlayNode*>("OverlayNode*");
   qRegisterMetaType<QList<LookupModule::ObjectInfo>>("QList<LookupModule::ObjectInfo>");
   qRegisterMetaType<ElevationModule::ElevationPoints>("ElevationModule::ElevationPoints");
+  qRegisterMetaType<std::map<int,OverlayObjectRef>>("std::map<int,OverlayObjectRef>");
+  qRegisterMetaType<MapIcon>("MapIcon");
 
   // register osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");
@@ -363,6 +365,15 @@ ElevationModule *OSMScoutQt::MakeElevationModule()
   module->moveToThread(thread);
   thread->start();
   return module;
+}
+
+IconLookup* OSMScoutQt::MakeIconLookup()
+{
+  QThread *thread=makeThread("IconLookup");
+  IconLookup *iconLookup=new IconLookup(thread, dbThread, iconDirectory);
+  iconLookup->moveToThread(thread);
+  thread->start();
+  return iconLookup;
 }
 
 MapRenderer* OSMScoutQt::MakeMapRenderer(RenderingType type)

--- a/libosmscout-map-qt/CMakeLists.txt
+++ b/libosmscout-map-qt/CMakeLists.txt
@@ -4,10 +4,12 @@ set(CMAKE_AUTORCC ON)
 set(HEADER_FILES
 	include/osmscoutmapqt/MapQtImportExport.h
     include/osmscoutmapqt/MapPainterQt.h
+    include/osmscoutmapqt/SymbolRendererQt.h
 )
 
 set(SOURCE_FILES
     src/osmscoutmapqt/MapPainterQt.cpp
+    src/osmscoutmapqt/SymbolRendererQt.cpp
 )
 
 osmscout_library_project(

--- a/libosmscout-map-qt/include/meson.build
+++ b/libosmscout-map-qt/include/meson.build
@@ -2,7 +2,8 @@ osmscoutmapqtIncDir = include_directories('.')
 
 osmscoutmapqtHeader = [
             'osmscoutmapqt/MapQtImportExport.h',
-            'osmscoutmapqt/MapPainterQt.h'
+            'osmscoutmapqt/MapPainterQt.h',
+            'osmscoutmapqt/SymbolRendererQt.h'
           ]
 
 install_headers(osmscoutmapqtHeader)

--- a/libosmscout-map-qt/include/osmscoutmapqt/SymbolRendererQt.h
+++ b/libosmscout-map-qt/include/osmscoutmapqt/SymbolRendererQt.h
@@ -1,0 +1,58 @@
+#ifndef OSMSCOUT_MAP_QT_SYMBOLRENDERERQT_H
+#define OSMSCOUT_MAP_QT_SYMBOLRENDERERQT_H
+
+/*
+  This source is part of the libosmscout-map library
+  Copyright (C) 2010  Tim Teulings
+  Copyright (C) 2022  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <QPainter>
+
+#include <osmscoutmapqt/MapQtImportExport.h>
+#include <osmscoutmap/SymbolRenderer.h>
+
+#include <osmscoutmap/Styles.h>
+
+namespace osmscout {
+
+/**
+ * \ingroup Renderer
+ */
+class OSMSCOUT_MAP_QT_API SymbolRendererQt: public SymbolRenderer {
+private:
+  QPainter *painter; // not owning
+public:
+  explicit SymbolRendererQt(QPainter *painter);
+  SymbolRendererQt(const SymbolRendererQt&) = default;
+  SymbolRendererQt(SymbolRendererQt&&) = default;
+
+  ~SymbolRendererQt() override = default;
+
+  SymbolRendererQt& operator=(const SymbolRendererQt&) = default;
+  SymbolRendererQt& operator=(SymbolRendererQt&&) = default;
+
+protected:
+  void SetFill(const FillStyleRef &fillStyle) const override;
+  void SetBorder(const BorderStyleRef &borderStyle, double screenMmInPixel) const override;
+  void DrawPolygon(const std::vector<Vertex2D> &polygonPixels) const override;
+  void DrawRect(double x, double y, double w, double h) const override;
+  void DrawCircle(double x, double y, double radius) const override;
+};
+}
+
+#endif // OSMSCOUT_MAP_QT_SYMBOLRENDERERQT_H

--- a/libosmscout-map-qt/src/meson.build
+++ b/libosmscout-map-qt/src/meson.build
@@ -1,5 +1,6 @@
 osmscoutmapqtSrc = [
-            'src/osmscoutmapqt/MapPainterQt.cpp'
+            'src/osmscoutmapqt/MapPainterQt.cpp',
+            'src/osmscoutmapqt/SymbolRendererQt.cpp'
           ]
 
 

--- a/libosmscout-map-qt/src/osmscoutmapqt/SymbolRendererQt.cpp
+++ b/libosmscout-map-qt/src/osmscoutmapqt/SymbolRendererQt.cpp
@@ -1,0 +1,119 @@
+/*
+  This source is part of the libosmscout-map library
+  Copyright (C) 2010  Tim Teulings
+  Copyright (C) 2022  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/util/Logger.h>
+#include <osmscoutmapqt/SymbolRendererQt.h>
+
+#include <QPainterPath>
+
+namespace osmscout {
+SymbolRendererQt::SymbolRendererQt(QPainter *painter):
+  painter(painter)
+{}
+
+void SymbolRendererQt::SetFill(const FillStyleRef &fillStyle) const
+{
+  if (fillStyle) {
+    if (fillStyle->HasPattern()) {
+      log.Warn() << "Pattern is not supported for symbols";
+    }
+    if (fillStyle->GetFillColor().IsVisible()) {
+      painter->setBrush(QBrush(QColor::fromRgbF(fillStyle->GetFillColor().GetR(),
+                                                fillStyle->GetFillColor().GetG(),
+                                                fillStyle->GetFillColor().GetB(),
+                                                fillStyle->GetFillColor().GetA())));
+    } else {
+      painter->setBrush(Qt::NoBrush);
+    }
+  } else {
+    painter->setBrush(Qt::NoBrush);
+  }
+}
+
+void SymbolRendererQt::SetBorder(const BorderStyleRef &borderStyle, double screenMmInPixel) const
+{
+  if (borderStyle) {
+    double borderWidth=borderStyle->GetWidth() * screenMmInPixel;
+
+    if (borderWidth>=0) {
+      QPen pen;
+
+      pen.setColor(QColor::fromRgbF(borderStyle->GetColor().GetR(),
+                                    borderStyle->GetColor().GetG(),
+                                    borderStyle->GetColor().GetB(),
+                                    borderStyle->GetColor().GetA()));
+      pen.setWidthF(borderWidth);
+
+      if (borderStyle->GetDash().empty()) {
+        pen.setStyle(Qt::SolidLine);
+        pen.setCapStyle(Qt::RoundCap);
+      }
+      else {
+        QVector<qreal> dashes;
+
+        for (double i : borderStyle->GetDash()) {
+          dashes << i;
+        }
+
+        pen.setDashPattern(dashes);
+        pen.setCapStyle(Qt::FlatCap);
+      }
+
+      painter->setPen(pen);
+    }
+    else {
+      painter->setPen(Qt::NoPen);
+    }
+  } else {
+    painter->setPen(Qt::NoPen);
+  }
+}
+
+void SymbolRendererQt::DrawPolygon(const std::vector<Vertex2D> &polygonPixels) const
+{
+  QPainterPath path;
+
+  for (auto pixel=polygonPixels.begin();
+       pixel!=polygonPixels.end();
+       ++pixel) {
+    if (pixel==polygonPixels.begin()) {
+      path.moveTo(pixel->GetX(), pixel->GetY());
+    } else {
+      path.lineTo(pixel->GetX(), pixel->GetY());
+    }
+  }
+  painter->drawPath(path);
+}
+
+void SymbolRendererQt::DrawRect(double x, double y, double w, double h) const
+{
+  QPainterPath path;
+  path.addRect(x, y, w, h);
+  painter->drawPath(path);
+}
+
+void SymbolRendererQt::DrawCircle(double x, double y, double radius) const
+{
+    QPainterPath path;
+    path.addEllipse(QPointF(x,y), radius, radius);
+    painter->drawPath(path);
+}
+
+}

--- a/libosmscout-map/CMakeLists.txt
+++ b/libosmscout-map/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
 	include/osmscoutmap/DataTileCache.h
 	include/osmscoutmap/MapTileCache.h
 	include/osmscoutmap/MapPainterNoOp.h
+	include/osmscoutmap/SymbolRenderer.h
 	${CMAKE_CURRENT_BINARY_DIR}/include/osmscoutmap/MapFeatures.h
 )
 
@@ -36,6 +37,7 @@ set(SOURCE_FILES
 	src/osmscoutmap/DataTileCache.cpp
 	src/osmscoutmap/MapTileCache.cpp
 	src/osmscoutmap/MapPainterNoOp.cpp
+	src/osmscoutmap/SymbolRenderer.cpp
 )
 
 osmscout_library_project(

--- a/libosmscout-map/include/meson.build
+++ b/libosmscout-map/include/meson.build
@@ -17,7 +17,8 @@ osmscoutmapHeader = [
             'osmscoutmap/MapTileCache.h',
             'osmscoutmap/MapData.h',
             'osmscoutmap/MapService.h',
-            'osmscoutmap/MapPainterNoOp.h'
+            'osmscoutmap/MapPainterNoOp.h',
+            'osmscoutmap/SymbolRenderer.h'
           ]
 
 install_headers(osmscoutmapHeader)

--- a/libosmscout-map/include/osmscoutmap/SymbolRenderer.h
+++ b/libosmscout-map/include/osmscoutmap/SymbolRenderer.h
@@ -1,0 +1,56 @@
+#ifndef OSMSCOUT_MAP_SYMBOLRENDERER_H
+#define OSMSCOUT_MAP_SYMBOLRENDERER_H
+
+/*
+  This source is part of the libosmscout-map library
+  Copyright (C) 2010  Tim Teulings
+  Copyright (C) 2022  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscoutmap/MapImportExport.h>
+
+#include <osmscoutmap/Styles.h>
+
+namespace osmscout {
+
+/**
+ * \ingroup Renderer
+ */
+class OSMSCOUT_MAP_API SymbolRenderer
+{
+public:
+virtual ~SymbolRenderer() = default;
+
+virtual void Render(const Symbol &symbol, const Vertex2D &zeroCoord,
+                    double groundMeterInPixel, double screenMmInPixel) const;
+
+virtual void Render(const Symbol &symbol, const Vertex2D &center, const Projection &projection) const;
+
+protected:
+virtual void SetFill(const FillStyleRef &fillStyle) const = 0;
+
+virtual void SetBorder(const BorderStyleRef &borderStyle, double screenMmInPixel) const = 0;
+
+virtual void DrawPolygon(const std::vector<Vertex2D> &polygonPixels) const = 0;
+
+virtual void DrawRect(double x, double y, double w, double h) const = 0;
+
+virtual void DrawCircle(double x, double y, double radius) const = 0;
+};
+}
+
+#endif // OSMSCOUT_MAP_SYMBOLRENDERER_H

--- a/libosmscout-map/src/meson.build
+++ b/libosmscout-map/src/meson.build
@@ -15,5 +15,6 @@ osmscoutmapSrc = [
             'src/osmscoutmap/MapData.cpp',
             'src/osmscoutmap/MapService.cpp',
             'src/osmscoutmap/MapPainterNoOp.cpp',
+            'src/osmscoutmap/SymbolRenderer.cpp'
           ]
 

--- a/libosmscout-map/src/osmscoutmap/SymbolRenderer.cpp
+++ b/libosmscout-map/src/osmscoutmap/SymbolRenderer.cpp
@@ -1,0 +1,120 @@
+/*
+  This source is part of the libosmscout-map library
+  Copyright (C) 2010  Tim Teulings
+  Copyright (C) 2022  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/util/Logger.h>
+#include <osmscoutmap/SymbolRenderer.h>
+
+#include <cassert>
+
+namespace osmscout {
+
+void SymbolRenderer::Render(const Symbol &symbol, const Vertex2D &zeroCoord,
+                            double groundMeterInPixel, double screenMmInPixel) const
+{
+  for (const auto& primitive : symbol.GetPrimitives()) {
+    const DrawPrimitive *primitivePtr=primitive.get();
+
+    if (const auto *polygon = dynamic_cast<const PolygonPrimitive*>(primitivePtr);
+      polygon != nullptr) {
+
+      FillStyleRef   fillStyle=polygon->GetFillStyle();
+      BorderStyleRef borderStyle=polygon->GetBorderStyle();
+
+      SetFill(fillStyle);
+      SetBorder(borderStyle, screenMmInPixel);
+
+      std::vector<Vertex2D> polygonPixels;
+      polygonPixels.reserve(polygon->GetCoords().size());
+      if (polygon->GetProjectionMode()==DrawPrimitive::ProjectionMode::MAP) {
+        for (auto const &pixel: polygon->GetCoords()) {
+          polygonPixels.emplace_back(zeroCoord.GetX() + pixel.GetX() * screenMmInPixel,
+                                     zeroCoord.GetY() + pixel.GetY() * screenMmInPixel);
+        }
+      } else {
+        assert(polygon->GetProjectionMode()==DrawPrimitive::ProjectionMode::GROUND);
+        for (auto const &pixel: polygon->GetCoords()) {
+          polygonPixels.emplace_back(zeroCoord.GetX() + pixel.GetX() * groundMeterInPixel,
+                                     zeroCoord.GetY() + pixel.GetY() * groundMeterInPixel);
+        }
+      }
+      DrawPolygon(polygonPixels);
+    }
+    else if (const auto *rectangle = dynamic_cast<const RectanglePrimitive*>(primitivePtr);
+      rectangle != nullptr) {
+
+      FillStyleRef   fillStyle=rectangle->GetFillStyle();
+      BorderStyleRef borderStyle=rectangle->GetBorderStyle();
+
+      SetFill(fillStyle);
+      SetBorder(borderStyle, screenMmInPixel);
+
+      if (rectangle->GetProjectionMode()==DrawPrimitive::ProjectionMode::MAP) {
+        DrawRect(zeroCoord.GetX() + rectangle->GetTopLeft().GetX() * screenMmInPixel,
+                 zeroCoord.GetY() + rectangle->GetTopLeft().GetY() * screenMmInPixel,
+                 rectangle->GetWidth() * screenMmInPixel,
+                 rectangle->GetHeight() * screenMmInPixel);
+      }
+      else {
+        DrawRect(zeroCoord.GetX() + rectangle->GetTopLeft().GetX() * groundMeterInPixel,
+                 zeroCoord.GetY() + rectangle->GetTopLeft().GetY() * groundMeterInPixel,
+                 rectangle->GetWidth() * groundMeterInPixel,
+                 rectangle->GetHeight() * groundMeterInPixel);
+      }
+    }
+    else if (const auto *circle = dynamic_cast<const CirclePrimitive*>(primitivePtr);
+      circle != nullptr) {
+
+      FillStyleRef   fillStyle=circle->GetFillStyle();
+      BorderStyleRef borderStyle=circle->GetBorderStyle();
+
+      SetFill(fillStyle);
+      SetBorder(borderStyle, screenMmInPixel);
+
+      if (circle->GetProjectionMode()==DrawPrimitive::ProjectionMode::MAP) {
+        DrawCircle(zeroCoord.GetX() + circle->GetCenter().GetX() * screenMmInPixel,
+                   zeroCoord.GetY() + circle->GetCenter().GetY() * screenMmInPixel,
+                   circle->GetRadius() * screenMmInPixel);
+      } else {
+        DrawCircle(zeroCoord.GetX() + circle->GetCenter().GetX() * groundMeterInPixel,
+                   zeroCoord.GetY() + circle->GetCenter().GetY() * groundMeterInPixel,
+                   circle->GetRadius() * groundMeterInPixel);
+      }
+    }
+  }
+}
+
+void SymbolRenderer::Render(const Symbol &symbol, const Vertex2D &center, const Projection& projection) const
+{
+  double minX;
+  double minY;
+  double maxX;
+  double maxY;
+  double centerX;
+  double centerY;
+
+  symbol.GetBoundingBox(projection,minX,minY,maxX,maxY);
+
+  centerX=(minX+maxX)/2;
+  centerY=(minY+maxY)/2;
+
+  Render(symbol, Vertex2D(center.GetX()-centerX, center.GetY()-centerY), projection.GetMeterInPixel(), projection.ConvertWidthToPixel(1));
+}
+
+}


### PR DESCRIPTION
Make Qt MapWidget more interactive - optionally make map icons / symbols active, detect click (tap) on them, highlight them and provide details about map object (name, phone, web...) to QML UI... 

As Tim suggested here https://github.com/Framstag/libosmscout/pull/1231#issuecomment-1081034421 information about icon object is not transferred thru renderer (it is one of the most complicated part of library), but widget is trying to guess it, by `IconLookup` utility. As result, lookup process may choose different icon that is on the map (layouter work differently a bit), but result is good and errors are not so disruptive...