### PR TITLE
expose ElevationChartWidget fields to child implementations

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/ElevationChartWidget.h
@@ -165,7 +165,7 @@ public:
 protected:
   void reset();
 
-private:
+protected:
   ElevationModule* elevationModule=nullptr;
   std::shared_ptr<OverlayWay> way;
   osmscout::BreakerRef breaker;


### PR DESCRIPTION
Elevation chart may be used with other data sources.
So it is beneficial to allow its inheritance and expose
internal field to child classes.

---

I am using ElevationChart for recorded track data from sqlite database in my app ;-)