### PR TITLE
fix access to invalid std::list iterator

### DIFF
--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -1788,6 +1788,7 @@ namespace osmscout {
   {
     wayData.clear();
     wayPathData.clear();
+    routeLabelData.clear();
 
     for (const auto& way : data.ways) {
       if (way->nodes.size() >= 2) {
@@ -1843,6 +1844,8 @@ namespace osmscout {
                                  const MapParameter& parameter,
                                  const MapData& data)
   {
+    routeLabelData.clear();
+
     if (data.routes.empty()){
       return;
     }


### PR DESCRIPTION
routeLabelData contains iterator to wayPathData. So it needs to be
cleared when wayPathData iterators are invalidated (list is cleared).

___

issue introduced by removing this line: https://github.com/Framstag/libosmscout/pull/1225/files#diff-d0f955ffa82ef28ab95f89ee231bc47cbc98eb6717e841b985878d1800db13c4L2172