### PR TITLE
test renderers (PerformanceTest) with address sanitizer

### DIFF
--- a/.github/workflows/build_and test_on_ubuntu_20_04.yml
+++ b/.github/workflows/build_and test_on_ubuntu_20_04.yml
@@ -90,6 +90,7 @@ jobs:
                qt5-default qtdeclarative5-dev libqt5svg5-dev qtlocation5-dev qtpositioning5-dev qttools5-dev-tools
                qttools5-dev qtmultimedia5-dev
                libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
+               xvfb
                libmarisa-dev"
       - name: Configure build project
         run: cmake -B build -DCMAKE_UNITY_BUILD=ON -Wno-dev -G "Ninja"
@@ -99,7 +100,7 @@ jobs:
       - name: Build project
         run: cmake --build build
       - name: Run tests
-        run: ctest -j 2 --output-on-failure
+        run: xvfb-run ctest -j 2 --output-on-failure
         env:
           QT_QPA_PLATFORM: offscreen
         working-directory: build

--- a/.github/workflows/build_and test_on_ubuntu_20_04.yml
+++ b/.github/workflows/build_and test_on_ubuntu_20_04.yml
@@ -89,7 +89,7 @@ jobs:
                libfreetype6-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev
                qt5-default qtdeclarative5-dev libqt5svg5-dev qtlocation5-dev qtpositioning5-dev qttools5-dev-tools
                qttools5-dev qtmultimedia5-dev
-               libglm-dev libglew-dev freeglut3 freeglut3-dev
+               libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
                libmarisa-dev"
       - name: Configure build project
         run: cmake -B build -DCMAKE_UNITY_BUILD=ON -Wno-dev -G "Ninja"

--- a/.github/workflows/build_and test_on_ubuntu_20_04.yml
+++ b/.github/workflows/build_and test_on_ubuntu_20_04.yml
@@ -99,6 +99,8 @@ jobs:
           CC: gcc-10
       - name: Build project
         run: cmake --build build
+      - name: Install project
+        run: sudo cmake --install build
       - name: Run tests
         run: xvfb-run ctest -j 2 --output-on-failure
         env:

--- a/.github/workflows/sanitize_on_ubuntu_20_04.yml
+++ b/.github/workflows/sanitize_on_ubuntu_20_04.yml
@@ -25,6 +25,7 @@ jobs:
         run: "sudo apt-get install -y
               libxml2-dev
               libprotobuf-dev protobuf-compiler
+              libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
               libmarisa-dev"
       - name: Configure build project
         run: "cmake -B build
@@ -49,7 +50,7 @@ jobs:
       - name: Build project
         run: cmake --build build
       - name: Run tests
-        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(opengl|agg|Qt|cairo)"
+        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build
 
   sanitize_gcc:
@@ -66,7 +67,8 @@ jobs:
         run:  "sudo apt-get update && sudo apt-get install -y
                libxml2-dev
                libprotobuf-dev protobuf-compiler
-               libmarisa-dev"
+               libmarisa-dev
+               libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev"
       - name: Configure build project
         run: "cmake -B build
               -DCMAKE_BUILD_TYPE=Debug
@@ -81,7 +83,8 @@ jobs:
               -DOSMSCOUT_DEBUG_GROUNDTILES=ON
               -DOSMSCOUT_DEBUG_COASTLINE=ON
               -DOSMSCOUT_DEBUG_TILING=ON
-              -DOSMSCOUT_DEBUG_ROUTING=ON -DCMAKE_CXX_FLAGS=\"-fsanitize=address -fsanitize=undefined\"
+              -DOSMSCOUT_DEBUG_ROUTING=ON
+              -DCMAKE_CXX_FLAGS=\"-fsanitize=address -fsanitize=undefined\"
               -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=address -fsanitize=undefined\"
               -DCMAKE_UNITY_BUILD=ON -Wno-dev -G \"Ninja\""
         env:
@@ -90,5 +93,5 @@ jobs:
       - name: Build project
         run: cmake --build build
       - name: Run tests
-        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(opengl|agg|Qt|cairo)"
+        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build

--- a/.github/workflows/sanitize_on_ubuntu_20_04.yml
+++ b/.github/workflows/sanitize_on_ubuntu_20_04.yml
@@ -53,7 +53,13 @@ jobs:
       - name: Install project
         run: sudo cmake --install build
       - name: Run tests
-        run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
+        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest"
+        working-directory: build
+      - name: Run PerformanceTest tests
+        # UI libraries leaks memory on exit, lets ignore it...
+        run: xvfb-run ctest -j 2 --output-on-failure --tests-regex "PerformanceTest"
+        env:
+          ASAN_OPTIONS: detect_leaks=0
         working-directory: build
 
   sanitize_gcc:
@@ -99,5 +105,11 @@ jobs:
       - name: Install project
         run: sudo cmake --install build
       - name: Run tests
-        run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
+        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest"
+        working-directory: build
+      - name: Run PerformanceTest tests
+        # UI libraries leaks memory on exit, lets ignore it...
+        run: xvfb-run ctest -j 2 --output-on-failure --tests-regex "PerformanceTest"
+        env:
+          ASAN_OPTIONS: detect_leaks=0
         working-directory: build

--- a/.github/workflows/sanitize_on_ubuntu_20_04.yml
+++ b/.github/workflows/sanitize_on_ubuntu_20_04.yml
@@ -26,7 +26,8 @@ jobs:
               libxml2-dev
               libprotobuf-dev protobuf-compiler
               libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
-              libmarisa-dev"
+              libmarisa-dev
+              xvfb"
       - name: Configure build project
         run: "cmake -B build
               -DCMAKE_BUILD_TYPE=Debug
@@ -50,7 +51,7 @@ jobs:
       - name: Build project
         run: cmake --build build
       - name: Run tests
-        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
+        run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build
 
   sanitize_gcc:
@@ -68,7 +69,8 @@ jobs:
                libxml2-dev
                libprotobuf-dev protobuf-compiler
                libmarisa-dev
-               libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev"
+               libglm-dev libglew-dev freeglut3 freeglut3-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
+               xvfb"
       - name: Configure build project
         run: "cmake -B build
               -DCMAKE_BUILD_TYPE=Debug
@@ -93,5 +95,5 @@ jobs:
       - name: Build project
         run: cmake --build build
       - name: Run tests
-        run: ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
+        run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build

--- a/.github/workflows/sanitize_on_ubuntu_20_04.yml
+++ b/.github/workflows/sanitize_on_ubuntu_20_04.yml
@@ -50,6 +50,8 @@ jobs:
           CC: clang
       - name: Build project
         run: cmake --build build
+      - name: Install project
+        run: sudo cmake --install build
       - name: Run tests
         run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build
@@ -94,6 +96,8 @@ jobs:
           CC: gcc-10
       - name: Build project
         run: cmake --build build
+      - name: Install project
+        run: sudo cmake --install build
       - name: Run tests
         run: xvfb-run ctest -j 2 --output-on-failure --exclude-regex "PerformanceTest-(agg|Qt|cairo)"
         working-directory: build

--- a/OSMScout2/translations/meson.build
+++ b/OSMScout2/translations/meson.build
@@ -18,6 +18,5 @@ osmscout2Trs = qt5.compile_translations(ts_files : [
                                             'en.ts',
                                         ],
                                         build_by_default : true,
-                                        install: true,
                                         install_dir: translationInstallDir
                                         )

--- a/Tests/src/PerformanceTest.cpp
+++ b/Tests/src/PerformanceTest.cpp
@@ -527,8 +527,8 @@ public:
 
 using PerformanceTestBackendRef = std::shared_ptr<PerformanceTestBackend>;
 
-PerformanceTestBackendRef PrepareBackend(int argc,
-                                         char* argv[],
+PerformanceTestBackendRef PrepareBackend([[maybe_unused]] int argc,
+                                         [[maybe_unused]] char* argv[],
                                          const Arguments &args,
                                          const osmscout::StyleConfigRef& styleConfig,
                                          [[maybe_unused]] const osmscout::MapParameter &drawParameter)


### PR DESCRIPTION
As 3rd party UI libraries are leaking memory on exit, PerformanceTest is executed with `ASAN_OPTIONS=detect_leaks=0` variable. That way, renderers are tested with asan, just memory leaks are ignored.