### PR TITLE
render symbol with margin to do not crop border

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/IconLookup.cpp
@@ -229,19 +229,23 @@ void IconLookup::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout:
         }
       }
     } else {
-      findIcon.image = QImage(findIcon.dimensions.width()*iconImageUpscale,
-                              findIcon.dimensions.height()*iconImageUpscale,
+      SymbolRef symbol=findIcon.iconStyle->GetSymbol();
+      double margin=symbol->GetMaxBorderWidth(projection)+1;
+      findIcon.image = QImage((findIcon.dimensions.width()+margin)*iconImageUpscale,
+                              (findIcon.dimensions.height()+margin)*iconImageUpscale,
                               QImage::Format_ARGB32);
       findIcon.image.fill(Qt::transparent);
 
       QPainter painter(&findIcon.image);
+      painter.setRenderHint(QPainter::Antialiasing, true);
+      painter.setRenderHint(QPainter::TextAntialiasing, true);
       SymbolRendererQt renderer(&painter);
-      SymbolRef symbol=findIcon.iconStyle->GetSymbol();
 
       double minX, minY, maxX, maxY;
       symbol->GetBoundingBox(projection,minX,minY,maxX,maxY);
       renderer.Render(*symbol,
-                      Vertex2D(minX*-1*iconImageUpscale,minY*-1*iconImageUpscale),
+                      Vertex2D((minX*-1 + margin/2) * iconImageUpscale,
+                               (minY*-1 + margin/2) * iconImageUpscale),
                       projection.GetMeterInPixel()*iconImageUpscale,
                       projection.ConvertWidthToPixel(iconImageUpscale));
       painter.end();

--- a/libosmscout-map/include/osmscoutmap/Styles.h
+++ b/libosmscout-map/include/osmscoutmap/Styles.h
@@ -1179,6 +1179,7 @@ namespace osmscout {
 
     BoundingBox mapBoundingBox;     //!< bounding box in map canvas coordinates [mm]
     BoundingBox groundBoundingBox;  //!< bounding box in ground coordinates [m]
+    double maxBorderWidth=0;        //!< maximum border width [mm]
 
   public:
     explicit Symbol(const std::string& name);
@@ -1199,10 +1200,10 @@ namespace osmscout {
      * bounding box in pixels for given projection
      */
     void GetBoundingBox(const Projection &projection,
-                               double& minX,
-                               double& minY,
-                               double& maxX,
-                               double& maxY) const
+                        double& minX,
+                        double& minY,
+                        double& maxX,
+                        double& maxY) const
     {
       minX=std::min(projection.ConvertWidthToPixel(mapBoundingBox.minX),
                     projection.GetMeterInPixel() * groundBoundingBox.minX);
@@ -1213,6 +1214,18 @@ namespace osmscout {
                     projection.GetMeterInPixel() * groundBoundingBox.maxX);
       maxY=std::max(projection.ConvertWidthToPixel(mapBoundingBox.maxY),
                     projection.GetMeterInPixel() * groundBoundingBox.maxY);
+    }
+
+    /**
+     * Maximum border width. As border is not accounted to bounding box and symbol dimension,
+     * it is good to use this value as symbol margin to make sure that symbol is to cropped.
+     *
+     * @param projection
+     * @return width in pixels
+     */
+    double GetMaxBorderWidth(const Projection &projection) const
+    {
+      return projection.ConvertWidthToPixel(maxBorderWidth);
     }
 
     /**

--- a/libosmscout-map/src/osmscoutmap/Styles.cpp
+++ b/libosmscout-map/src/osmscoutmap/Styles.cpp
@@ -1623,6 +1623,10 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
         assert(false);
     }
 
+    if (primitive->GetBorderStyle() && primitive->GetBorderStyle()->IsVisible()) {
+      maxBorderWidth=std::max(maxBorderWidth, primitive->GetBorderStyle()->GetWidth());
+    }
+
     primitives.push_back(primitive);
   }
 


### PR DESCRIPTION
this change fixing symbol cropping in Qt's IconLookup module:

![Screenshot_20220430_160744](https://user-images.githubusercontent.com/309458/166108917-84cd95af-930a-40db-b2f7-62c3e82bcc0e.png)

after change:
![Screenshot_20220430_161006](https://user-images.githubusercontent.com/309458/166108997-71142c81-8b49-40ca-b463-c7439084b7c9.png)

