### PR TITLE
remove omp.h include

### DIFF
--- a/libosmscout/src/osmscout/Database.cpp
+++ b/libosmscout/src/osmscout/Database.cpp
@@ -21,10 +21,6 @@
 
 #include <algorithm>
 
-#if _OPENMP
-#include <omp.h>
-#endif
-
 #include <osmscout/system/Assert.h>
 #include <osmscout/system/Math.h>
 


### PR DESCRIPTION
I am trying to fix MacOS X build, it seems that OpenMP is not used anymore... Or I am blind?