### PR TITLE
QT6 Build support for meson build variant

### DIFF
--- a/Demos/meson.build
+++ b/Demos/meson.build
@@ -81,78 +81,153 @@ ResourceConsumption = executable('ResourceConsumption',
                                  install: true)
 
 if buildMapQt
-  ResourceConsumptionQt = executable('ResourceConsumptionQt',
-                                     'src/ResourceConsumptionQt.cpp',
-                                     cpp_args: ['-fPIC'],
-                                     include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
-                                     dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
-                                     link_with: [osmscout, osmscoutmap, osmscoutmapqt],
-                                     install: true)
+  if get_option('qtVersion') == 5
+    ResourceConsumptionQt = executable('ResourceConsumptionQt',
+                                       'src/ResourceConsumptionQt.cpp',
+                                       cpp_args: ['-fPIC'],
+                                       include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
+                                       dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
+                                       link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                                       install: true)
+  elif get_option('qtVersion') == 6
+    ResourceConsumptionQt = executable('ResourceConsumptionQt',
+                                       'src/ResourceConsumptionQt.cpp',
+                                       cpp_args: ['-fPIC'],
+                                       include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
+                                       dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep],
+                                       link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                                       install: true)
+  endif
 endif
 
 if buildMapQt
-  RoutingAnimation = executable('RoutingAnimation',
-                                'src/RoutingAnimation.cpp',
-                                cpp_args: ['-fPIC'],
-                                include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
-                                dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
-                                link_with: [osmscout, osmscoutmap, osmscoutmapqt],
-                                install: true)
+  if get_option('qtVersion') == 5
+    RoutingAnimation = executable('RoutingAnimation',
+                                  'src/RoutingAnimation.cpp',
+                                  cpp_args: ['-fPIC'],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
+                                  dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                                  install: true)
+  elif get_option('qtVersion') == 6
+    RoutingAnimation = executable('RoutingAnimation',
+                                  'src/RoutingAnimation.cpp',
+                                  cpp_args: ['-fPIC'],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir],
+                                  dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                                  install: true)
+  endif
+
 endif
 
 if buildClientQt
+  if get_option('qtVersion') == 5
+    demoMocs = qt5.preprocess('qt-demo',
+                              moc_headers : ['include/QtDemoApp.h'],
+                              qresources: ['demo.qrc', '../OSMScout2/res.qrc'])
 
-  demoMocs = qt5.preprocess('qt-demo',
-                            moc_headers : ['include/QtDemoApp.h'],
-                            qresources: ['demo.qrc', '../OSMScout2/res.qrc'])
-
-  ElevationProfileChart = executable('ElevationProfileChart',
-                                ['src/ElevationProfileChart.cpp',
-                                 'src/QtDemoApp.cpp'],
-                                demoMocs,
-                                cpp_args: ['-fPIC'],
-                                include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir],
-                                dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
-                                link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
-                                override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
-                                install: true)
-
-  if buildGpx
-    navDemoMocs = qt5.preprocess(moc_headers : [
-                                  'include/PositionSimulator.h',
-                                  '../OSMScout2/src/Theme.h'
-                                 ])
-
-    NavigationSimulation = executable('NavigationSimulation',
-                                  ['src/NavigationSimulation.cpp',
-                                   'src/QtDemoApp.cpp',
-                                   'src/PositionSimulator.cpp',
-                                   '../OSMScout2/src/Theme.cpp'],
-                                  [demoMocs, navDemoMocs],
+    ElevationProfileChart = executable('ElevationProfileChart',
+                                  ['src/ElevationProfileChart.cpp',
+                                   'src/QtDemoApp.cpp'],
+                                  demoMocs,
                                   cpp_args: ['-fPIC'],
-                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, osmscoutgpxIncDir, demoIncDir, include_directories('../OSMScout2/src')],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir],
                                   dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
-                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt, osmscoutgpx],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
+                                  override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
+                                  install: true)
+  elif get_option('qtVersion') == 6
+    demoMocs = qt6.preprocess('qt-demo',
+                              moc_headers : ['include/QtDemoApp.h'],
+                              qresources: ['demo.qrc', '../OSMScout2/res.qrc'])
+
+    ElevationProfileChart = executable('ElevationProfileChart',
+                                  ['src/ElevationProfileChart.cpp',
+                                   'src/QtDemoApp.cpp'],
+                                  demoMocs,
+                                  cpp_args: ['-fPIC'],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir],
+                                  dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6SvgDep, qt6NetworkDep, qt6LocationDep, qt6MultimediaDep],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
                                   override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
                                   install: true)
   endif
 
+  if buildGpx
+    if get_option('qtVersion') == 5
+      navDemoMocs = qt5.preprocess(moc_headers : [
+                                    'include/PositionSimulator.h',
+                                    '../OSMScout2/src/Theme.h'
+                                   ])
 
-  routingParamsDemoMocs = qt5.preprocess(moc_headers : [
-                                '../OSMScout2/src/Theme.h'
-                               ])
+      NavigationSimulation = executable('NavigationSimulation',
+                                    ['src/NavigationSimulation.cpp',
+                                     'src/QtDemoApp.cpp',
+                                     'src/PositionSimulator.cpp',
+                                     '../OSMScout2/src/Theme.cpp'],
+                                    [demoMocs, navDemoMocs],
+                                    cpp_args: ['-fPIC'],
+                                    include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, osmscoutgpxIncDir, demoIncDir, include_directories('../OSMScout2/src')],
+                                    dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
+                                    link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt, osmscoutgpx],
+                                    override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
+                                    install: true)
+    elif get_option('qtVersion') == 6
+      navDemoMocs = qt6.preprocess(moc_headers : [
+                                    'include/PositionSimulator.h',
+                                    '../OSMScout2/src/Theme.h'
+                                   ])
 
-  RoutingParameters = executable('RoutingParameters',
-                                ['src/RoutingParameters.cpp',
-                                 'src/QtDemoApp.cpp',
-                                 '../OSMScout2/src/Theme.cpp'],
-                                [demoMocs, routingParamsDemoMocs],
-                                cpp_args: ['-fPIC'],
-                                include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir, include_directories('../OSMScout2/src')],
-                                dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
-                                link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
-                                override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
-                                install: true)
+      NavigationSimulation = executable('NavigationSimulation',
+                                    ['src/NavigationSimulation.cpp',
+                                     'src/QtDemoApp.cpp',
+                                     'src/PositionSimulator.cpp',
+                                     '../OSMScout2/src/Theme.cpp'],
+                                    [demoMocs, navDemoMocs],
+                                    cpp_args: ['-fPIC'],
+                                    include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, osmscoutgpxIncDir, demoIncDir, include_directories('../OSMScout2/src')],
+                                    dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6SvgDep, qt6NetworkDep, qt6LocationDep, qt6MultimediaDep],
+                                    link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt, osmscoutgpx],
+                                    override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
+                                    install: true)
+    endif
+  endif
+
+
+  if get_option('qtVersion') == 5
+    routingParamsDemoMocs = qt5.preprocess(moc_headers : [
+                                  '../OSMScout2/src/Theme.h'
+                                 ])
+
+    RoutingParameters = executable('RoutingParameters',
+                                  ['src/RoutingParameters.cpp',
+                                   'src/QtDemoApp.cpp',
+                                   '../OSMScout2/src/Theme.cpp'],
+                                  [demoMocs, routingParamsDemoMocs],
+                                  cpp_args: ['-fPIC'],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir, include_directories('../OSMScout2/src')],
+                                  dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
+                                  override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
+                                  install: true)
+  elif get_option('qtVersion') == 6
+    routingParamsDemoMocs = qt6.preprocess(moc_headers : [
+                                  '../OSMScout2/src/Theme.h'
+                                 ])
+
+    RoutingParameters = executable('RoutingParameters',
+                                  ['src/RoutingParameters.cpp',
+                                   'src/QtDemoApp.cpp',
+                                   '../OSMScout2/src/Theme.cpp'],
+                                  [demoMocs, routingParamsDemoMocs],
+                                  cpp_args: ['-fPIC'],
+                                  include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, osmscoutclientqtIncDir, demoIncDir, include_directories('../OSMScout2/src')],
+                                  dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6SvgDep, qt6NetworkDep, qt6LocationDep, qt6MultimediaDep],
+                                  link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclientqt],
+                                  override_options : ['unity=off'], # generated code for qt resources use static variables with the same name
+                                  install: true)
+  endif
 endif
 
 Routing = executable('Routing',
@@ -211,13 +286,23 @@ if buildMapCairo
 endif
 
 if buildMapQt
-  DrawMapQt = executable('DrawMapQt',
-                         'src/DrawMapQt.cpp',
-                         cpp_args: ['-fPIC'],
-                         include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, demoIncDir],
-                         dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
-                         link_with: [osmscout, osmscoutmap, osmscoutmapqt],
-                         install: true)
+  if get_option('qtVersion') == 5
+    DrawMapQt = executable('DrawMapQt',
+                           'src/DrawMapQt.cpp',
+                           cpp_args: ['-fPIC'],
+                           include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, demoIncDir],
+                           dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
+                           link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                           install: true)
+  elif get_option('qtVersion') == 6
+    DrawMapQt = executable('DrawMapQt',
+                           'src/DrawMapQt.cpp',
+                           cpp_args: ['-fPIC'],
+                           include_directories: [osmscoutIncDir, osmscoutmapIncDir, osmscoutmapqtIncDir, demoIncDir],
+                           dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep],
+                           link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                           install: true)
+  endif
 endif
 
 if buildMapOpenGL and glfwDep.found() and ftDep.found() and glewDep.found()

--- a/OSMScout2/meson.build
+++ b/OSMScout2/meson.build
@@ -6,21 +6,41 @@ osmscout2Src = [
 
 osmscout2IncDir = include_directories('src')
 
-osmscout2Mocs = qt5.preprocess(moc_headers : [
-                                'src/AppSettings.h',
-                                'src/Theme.h'
-                               ],
-                               include_directories: include_directories('src'),
-                               qresources: ['res.qrc'])
-
 subdir('translations')
 
-OSMScout2 = executable('OSMScout2',
-                       osmscout2Src,
-                       osmscout2Mocs,
-                       cpp_args: ['-fPIC'],
-                       include_directories: [osmscout2IncDir, osmscoutgpxIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
-                       dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
-                       link_with: [osmscoutgpx, osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
-                       install: true)
+if get_option('qtVersion') == 5
+  osmscout2Mocs = qt5.preprocess(moc_headers : [
+                                  'src/AppSettings.h',
+                                  'src/Theme.h'
+                                 ],
+                                 include_directories: include_directories('src'),
+                                 qresources: ['res.qrc'])
+
+
+  OSMScout2 = executable('OSMScout2',
+                         osmscout2Src,
+                         osmscout2Mocs,
+                         cpp_args: ['-fPIC'],
+                         include_directories: [osmscout2IncDir, osmscoutgpxIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                         dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
+                         link_with: [osmscoutgpx, osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
+                         install: true)
+elif get_option('qtVersion') == 6
+  osmscout2Mocs = qt6.preprocess(moc_headers : [
+                                  'src/AppSettings.h',
+                                  'src/Theme.h'
+                                 ],
+                                 include_directories: include_directories('src'),
+                                 qresources: ['res.qrc'])
+
+
+  OSMScout2 = executable('OSMScout2',
+                         osmscout2Src,
+                         osmscout2Mocs,
+                         cpp_args: ['-fPIC'],
+                         include_directories: [osmscout2IncDir, osmscoutgpxIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                         dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6SvgDep, qt6NetworkDep, qt6LocationDep, qt6MultimediaDep],
+                         link_with: [osmscoutgpx, osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
+                         install: true)
+endif
 

--- a/OSMScout2/translations/meson.build
+++ b/OSMScout2/translations/meson.build
@@ -13,10 +13,20 @@ if build_machine.system()=='windows'
 endif
 
 # https://github.com/mesonbuild/meson/blob/master/docs/markdown/Qt5-module.md
-osmscout2Trs = qt5.compile_translations(ts_files : [
-                                            'cs.ts',
-                                            'en.ts',
-                                        ],
-                                        build_by_default : true,
-                                        install_dir: translationInstallDir
-                                        )
+if get_option('qtVersion') == 5
+  osmscout2Trs = qt5.compile_translations(ts_files : [
+                                              'cs.ts',
+                                              'en.ts',
+                                          ],
+                                          build_by_default : true,
+                                          install_dir: translationInstallDir
+                                          )
+elif get_option('qtVersion') == 6
+  osmscout2Trs = qt6.compile_translations(ts_files : [
+                                              'cs.ts',
+                                              'en.ts',
+                                          ],
+                                          build_by_default : true,
+                                          install_dir: translationInstallDir
+                                          )
+endif

--- a/StyleEditor/meson.build
+++ b/StyleEditor/meson.build
@@ -9,22 +9,43 @@ styleeditorSrc = [
 
 styleeditorIncDir = include_directories('src')
 
-styleeditorMocs = qt5.preprocess(moc_headers : [
-                                    'src/MainWindow.h',
-                                    'src/SettingsDialog.h',
-                                    'src/FileIO.h',
-                                    'src/Highlighter.h',
-                                    'src/StyleAnalyser.h'
-                                    ],
-                                 include_directories: include_directories('src'),
-                                 qresources: ['StyleEditor.qrc'])
+if get_option('qtVersion') == 5
+  styleeditorMocs = qt5.preprocess(moc_headers : [
+                                      'src/MainWindow.h',
+                                      'src/SettingsDialog.h',
+                                      'src/FileIO.h',
+                                      'src/Highlighter.h',
+                                      'src/StyleAnalyser.h'
+                                      ],
+                                   include_directories: include_directories('src'),
+                                   qresources: ['StyleEditor.qrc'])
 
-OSMScout2 = executable('StyleEditor',
-                       styleeditorSrc,
-                       styleeditorMocs,
-                       cpp_args: ['-fPIC'],
-                       include_directories: [styleeditorIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
-                       dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
-                       link_with: [osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
-                       install: true)
+  OSMScout2 = executable('StyleEditor',
+                         styleeditorSrc,
+                         styleeditorMocs,
+                         cpp_args: ['-fPIC'],
+                         include_directories: [styleeditorIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                         dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5SvgDep, qt5NetworkDep, qt5LocationDep, qt5MultimediaDep],
+                         link_with: [osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
+                         install: true)
+elif get_option('qtVersion') == 6
+  styleeditorMocs = qt6.preprocess(moc_headers : [
+                                      'src/MainWindow.h',
+                                      'src/SettingsDialog.h',
+                                      'src/FileIO.h',
+                                      'src/Highlighter.h',
+                                      'src/StyleAnalyser.h'
+                                      ],
+                                   include_directories: include_directories('src'),
+                                   qresources: ['StyleEditor.qrc'])
+
+  OSMScout2 = executable('StyleEditor',
+                         styleeditorSrc,
+                         styleeditorMocs,
+                         cpp_args: ['-fPIC'],
+                         include_directories: [styleeditorIncDir, osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                         dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6SvgDep, qt6NetworkDep, qt6LocationDep, qt6MultimediaDep],
+                         link_with: [osmscoutclientqt, osmscoutmapqt, osmscoutmap, osmscout],
+                         install: true)
+endif
 

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -77,15 +77,27 @@ CoordinateEncoding = executable('CoordinateEncoding',
              install: false)
 
 if buildMapQt
-  drawtextMocs = qt5.preprocess(moc_headers : ['include/DrawWindow.h'])
+  if get_option('qtVersion') == 5
+    drawtextMocs = qt5.preprocess(moc_headers : ['include/DrawWindow.h'])
 
-  DrawTextQt = executable('DrawTextQt',
-               'src/DrawTextQt.cpp',
-               drawtextMocs,
-               include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
-               dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
-               link_with: [osmscoutmapqt, osmscoutmap, osmscout],
-               install: false)
+    DrawTextQt = executable('DrawTextQt',
+                 'src/DrawTextQt.cpp',
+                 drawtextMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                 dependencies: [mathDep, openmpDep, qt5GuiDep, qt5WidgetsDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout],
+                 install: false)
+  elif get_option('qtVersion') == 6
+    drawtextMocs = qt6.preprocess(moc_headers : ['include/DrawWindow.h'])
+
+    DrawTextQt = executable('DrawTextQt',
+                 'src/DrawTextQt.cpp',
+                 drawtextMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                 dependencies: [mathDep, openmpDep, qt6GuiDep, qt6WidgetsDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout],
+                 install: false)
+  endif
 endif
 
 EncodeNumber = executable('EncodeNumber',
@@ -200,7 +212,11 @@ if buildMapCairo or buildMapQt or buildMapAgg or buildMapOpenGL
 
   if buildMapQt
     includes += osmscoutmapqtIncDir
-    deps += [qt5WidgetsDep, qt5GuiDep]
+    if get_option('qtVersion') == 5
+      deps += [qt5WidgetsDep, qt5GuiDep]
+    elif get_option('qtVersion') == 6
+      deps += [qt6WidgetsDep, qt6GuiDep]
+    endif
     links += osmscoutmapqt
   endif
 
@@ -409,26 +425,50 @@ foreach stylesheet : stylesheets
 endforeach
 
 if buildClientQt
-  threadingMocs = qt5.preprocess(moc_headers : ['include/ClientQtThreading.h'])
+  if get_option('qtVersion') == 5
+    threadingMocs = qt5.preprocess(moc_headers : ['include/ClientQtThreading.h'])
 
-  ClientQtThreading = executable('ClientQtThreading',
-               'src/ClientQtThreading.cpp',
-               threadingMocs,
-               include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
-               dependencies: [mathDep, threadDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5NetworkDep, qt5MultimediaDep],
-               link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
-               install: false)
+    ClientQtThreading = executable('ClientQtThreading',
+                 'src/ClientQtThreading.cpp',
+                 threadingMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
+                 dependencies: [mathDep, threadDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5NetworkDep, qt5MultimediaDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
+                 install: false)
+  elif get_option('qtVersion') == 6
+    threadingMocs = qt6.preprocess(moc_headers : ['include/ClientQtThreading.h'])
+
+    ClientQtThreading = executable('ClientQtThreading',
+                 'src/ClientQtThreading.cpp',
+                 threadingMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
+                 dependencies: [mathDep, threadDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6NetworkDep, qt6MultimediaDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
+                 install: false)
+  endif
 endif
 
 if buildClientQt
-  testMocs = qt5.preprocess(moc_headers : ['include/DownloaderTest.h'])
+  if get_option('qtVersion') == 5
+    testMocs = qt5.preprocess(moc_headers : ['include/DownloaderTest.h'])
 
-  QtFileDownloader = executable('QtFileDownloader',
-               'src/QtFileDownloader.cpp',
-               testMocs,
-               include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
-               dependencies: [mathDep, threadDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5NetworkDep, qt5MultimediaDep],
-               link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
-               install: false)
+    QtFileDownloader = executable('QtFileDownloader',
+                 'src/QtFileDownloader.cpp',
+                 testMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
+                 dependencies: [mathDep, threadDep, openmpDep, qt5GuiDep, qt5WidgetsDep, qt5QmlDep, qt5QuickDep, qt5NetworkDep, qt5MultimediaDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
+                 install: false)
+  elif get_option('qtVersion') == 5
+    testMocs = qt6.preprocess(moc_headers : ['include/DownloaderTest.h'])
+
+    QtFileDownloader = executable('QtFileDownloader',
+                 'src/QtFileDownloader.cpp',
+                 testMocs,
+                 include_directories: [testIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir, osmscoutclientqtIncDir],
+                 dependencies: [mathDep, threadDep, openmpDep, qt6GuiDep, qt6WidgetsDep, qt6QmlDep, qt6QuickDep, qt6NetworkDep, qt6MultimediaDep],
+                 link_with: [osmscoutmapqt, osmscoutmap, osmscout, osmscoutclientqt],
+                 install: false)
+  endif
 endif
 

--- a/libosmscout-client-qt/meson.build
+++ b/libosmscout-client-qt/meson.build
@@ -2,7 +2,7 @@ cppArgs = []
 
 if get_option('default_library')=='shared'
   cppArgs += ['-DOSMScoutClientQt_EXPORTS']
-  
+
   if haveVisibility
     cppArgs += ['-fvisibility=hidden']
   endif
@@ -18,18 +18,32 @@ mocHeaders = []
 headerTemplate='@0@/@1@'
 foreach hdr : osmscoutclientqtHeader
   mocHeaders += headerTemplate.format('include/',hdr)
-endforeach  
+endforeach
 
-mocFiles = qt5.preprocess(moc_headers : mocHeaders,
-                          include_directories: include_directories('include'))
+if get_option('qtVersion') == 5
+  mocFiles = qt5.preprocess(moc_headers : mocHeaders,
+                            include_directories: include_directories('include'))
 
-osmscoutclientqt = library('osmscout_client_qt',
-                           mocFiles,
-                           osmscoutclientqtSrc,
-                           include_directories: [osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
-                           cpp_args: cppArgs,
-                           dependencies: [mathDep, threadDep, qt5GuiDep, qt5QmlDep, qt5QuickDep, qt5WidgetsDep, qt5NetworkDep, qt5SvgDep, qt5MultimediaDep],
-                           link_with: [osmscout, osmscoutmap, osmscoutmapqt],
-                           install: true)
-        
-# TODO: Generate PKG_CONFIG file        
+  osmscoutclientqt = library('osmscout_client_qt',
+                             mocFiles,
+                             osmscoutclientqtSrc,
+                             include_directories: [osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                             cpp_args: cppArgs,
+                             dependencies: [mathDep, threadDep, qt5GuiDep, qt5QmlDep, qt5QuickDep, qt5WidgetsDep, qt5NetworkDep, qt5SvgDep, qt5MultimediaDep],
+                             link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                             install: true)
+elif get_option('qtVersion') == 6
+  mocFiles = qt6.preprocess(moc_headers : mocHeaders,
+                            include_directories: include_directories('include'))
+
+  osmscoutclientqt = library('osmscout_client_qt',
+                             mocFiles,
+                             osmscoutclientqtSrc,
+                             include_directories: [osmscoutclientqtIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                             cpp_args: cppArgs,
+                             dependencies: [mathDep, threadDep, qt6GuiDep, qt6QmlDep, qt6QuickDep, qt6WidgetsDep, qt6NetworkDep, qt6SvgDep, qt6MultimediaDep],
+                             link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                             install: true)
+endif
+
+# TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-qt/meson.build
+++ b/libosmscout-map-qt/meson.build
@@ -2,7 +2,7 @@ cppArgs = []
 
 if get_option('default_library')=='shared'
   cppArgs += ['-DOSMScoutMapQt_EXPORTS']
-  
+
   if haveVisibility
     cppArgs += ['-fvisibility=hidden']
   endif
@@ -13,12 +13,22 @@ subdir('include/osmscoutmapqt')
 subdir('include/osmscoutmapqt/private')
 subdir('src')
 
-osmscoutmapqt = library('osmscout_map_qt',
-                        osmscoutmapqtSrc,
-                        include_directories: [osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
-                        cpp_args: cppArgs,
-                        dependencies: [mathDep, threadDep, qt5GuiDep, qt5SvgDep],
-                        link_with: [osmscout, osmscoutmap],
-                        install: true)
-        
-# TODO: Generate PKG_CONFIG file        
+if get_option('qtVersion') == 5
+  osmscoutmapqt = library('osmscout_map_qt',
+                          osmscoutmapqtSrc,
+                          include_directories: [osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                          cpp_args: cppArgs,
+                          dependencies: [mathDep, threadDep, qt5GuiDep, qt5SvgDep],
+                          link_with: [osmscout, osmscoutmap],
+                          install: true)
+elif get_option('qtVersion') == 6
+  osmscoutmapqt = library('osmscout_map_qt',
+                          osmscoutmapqtSrc,
+                          include_directories: [osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                          cpp_args: cppArgs,
+                          dependencies: [mathDep, threadDep, qt6GuiDep, qt6SvgDep],
+                          link_with: [osmscout, osmscoutmap],
+                          install: true)
+endif
+
+# TODO: Generate PKG_CONFIG file

--- a/meson.build
+++ b/meson.build
@@ -168,28 +168,56 @@ d2dlHeaderAvailable = compiler.has_header('d2d1.h')
 gdiplusDep = compiler.find_library('gdiplus', required: false)
 
 # Qt
-qt5 = import('qt5')
-qt5GuiDep = dependency('qt5', modules: [ 'Core', 'Gui'], required: false)
-qt5QmlDep = dependency('qt5', modules: 'Qml', required: false)
-qt5QuickDep = dependency('qt5', modules: 'Quick', required: false)
-qt5WidgetsDep = dependency('qt5', modules: 'Widgets', required: false)
-qt5SvgDep = dependency('qt5', modules: 'Svg', required: false)
-qt5NetworkDep = dependency('qt5', modules: 'Network', required: false)
-qt5LocationDep = dependency('qt5', modules: 'Location', required: false)
-qt5MultimediaDep = dependency('qt5', modules: 'Multimedia', required: false)
 
-message('Qt version : @0@ (required >= 5.6)'.format(qt5GuiDep.version()))
+if get_option('qtVersion') == 5
+  qt5 = import('qt5')
+  qt5GuiDep = dependency('qt5', modules: [ 'Core', 'Gui'], required: false)
+  qt5QmlDep = dependency('qt5', modules: 'Qml', required: false)
+  qt5QuickDep = dependency('qt5', modules: 'Quick', required: false)
+  qt5WidgetsDep = dependency('qt5', modules: 'Widgets', required: false)
+  qt5SvgDep = dependency('qt5', modules: 'Svg', required: false)
+  qt5NetworkDep = dependency('qt5', modules: 'Network', required: false)
+  qt5LocationDep = dependency('qt5', modules: 'Location', required: false)
+  qt5MultimediaDep = dependency('qt5', modules: 'Multimedia', required: false)
 
-if qt5GuiDep.found() and qt5GuiDep.version().version_compare('>=5.6') and qt5WidgetsDep.found() and get_option('enableMapQt')
-  buildMapQt=true
-else
-  buildMapQt=false
-endif
+  message('Qt5 version : @0@ (required >= 5.6)'.format(qt5GuiDep.version()))
 
-if buildMapQt and qt5MultimediaDep.found() and qt5QmlDep.found() and qt5QuickDep.found() and qt5NetworkDep.found() and get_option('enableClientQt')
-  buildClientQt=true
-else
-  buildClientQt=false
+  if qt5GuiDep.found() and qt5GuiDep.version().version_compare('>=5.6') and qt5WidgetsDep.found() and get_option('enableMapQt')
+    buildMapQt=true
+  else
+    buildMapQt=false
+  endif
+
+  if buildMapQt and qt5MultimediaDep.found() and qt5QmlDep.found() and qt5QuickDep.found() and qt5NetworkDep.found() and get_option('enableClientQt')
+    buildClientQt=true
+  else
+    buildClientQt=false
+  endif
+
+elif get_option('qtVersion') == 6
+  qt6 = import('qt6')
+  qt6GuiDep = dependency('qt6', modules: [ 'Core', 'Gui'], required: false)
+  qt6QmlDep = dependency('qt6', modules: 'Qml', required: false)
+  qt6QuickDep = dependency('qt6', modules: 'Quick', required: false)
+  qt6WidgetsDep = dependency('qt6', modules: 'Widgets', required: false)
+  qt6SvgDep = dependency('qt6', modules: 'Svg', required: false)
+  qt6NetworkDep = dependency('qt6', modules: 'Network', required: false)
+  qt6LocationDep = dependency('qt6', modules: 'Location', required: false)
+  qt6MultimediaDep = dependency('qt6', modules: 'Multimedia', required: false)
+
+  message('Qt6 version : @0@ (required >= 6.0)'.format(qt6GuiDep.version()))
+
+  if qt6GuiDep.found() and qt6GuiDep.version().version_compare('>=6.0') and qt6WidgetsDep.found() and get_option('enableMapQt')
+    buildMapQt=true
+  else
+    buildMapQt=false
+  endif
+
+  if buildMapQt and qt6MultimediaDep.found() and qt6QmlDep.found() and qt6QuickDep.found() and qt6NetworkDep.found() and get_option('enableClientQt')
+    buildClientQt=true
+  else
+    buildClientQt=false
+  endif
 endif
 
 # OpenGL
@@ -288,8 +316,13 @@ else
   buildBinding=false
 endif
 
-buildOSMScout2=buildGpx and buildMapQt and buildClientQt and qt5SvgDep.found()
-buildStyleEditor=buildMapQt and buildClientQt and qt5SvgDep.found()
+if get_option('qtVersion') == 5
+  buildOSMScout2=buildGpx and buildMapQt and buildClientQt and qt5SvgDep.found()
+  buildStyleEditor=buildMapQt and buildClientQt and qt5SvgDep.found()
+elif get_option('qtVersion') == 6
+  buildOSMScout2=buildGpx and buildMapQt and buildClientQt and qt6SvgDep.found()
+  buildStyleEditor=buildMapQt and buildClientQt and qt6SvgDep.found()
+endif
 
 message('Build OS:                @0@'.format(build_machine.system()))
 message('Host OS:                 @0@'.format(host_machine.system()))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,4 +12,6 @@ option('enableMapQt',      type: 'boolean', value: 'true', description: 'Build Q
 option('enableMapSvg',     type: 'boolean', value: 'true', description: 'Build SVG backend')
 option('enableClientQt',   type: 'boolean', value: 'true', description: 'Build Qt/QML library')
 option('enableXML',        type: 'boolean', value: 'true', description: 'Use libxml2')
+option('qtVersion',        type: 'integer', value: '5', min: 5, max: 6, description: 'QT version to use (5 or 6)')
+
 


### PR DESCRIPTION
* Handles issue #1280 
* Added meson qtVersion option, with allowed values 5 and 6
* Added configuration alternatives for Qt binaries, depending on option value.
* A Qt6 build can be started under Arch Linux with: PATH=/usr/lib/qt6:/usr/lib/qt6/bin:$PATH meson setup -D qtVersion=6 debug
* Set PATH variable seems to be needed, because of Qt6 installation problems under Arch Linux?
* Currently the resulting build - as expected - fails. Existing code requires conditional code to handle Qt6