### PR TITLE
Qt: allow to render POIs and basemap even without databases

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/DBThread.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/DBThread.h
@@ -148,6 +148,9 @@ protected:
   osmscout::DatabaseParameter        databaseParameter;
   std::list<DBInstanceRef>           databases;
 
+  TypeConfigRef                      emptyTypeConfig; // type config just with special and custom poi types
+  StyleConfigRef                     emptyStyleConfig;
+
   QString                            stylesheetFilename;
   QString                            iconDirectory;
   std::unordered_map<std::string,bool>
@@ -178,6 +181,10 @@ protected:
   void LoadStyleInternal(QString stylesheetFilename,
                          std::unordered_map<std::string,bool> stylesheetFlags,
                          const QString &suffix="");
+
+  void registerCustomPoiTypes(TypeConfigRef typeConfig) const;
+
+  StyleConfigRef makeStyleConfig(TypeConfigRef typeConfig) const;
 
 public:
   DBThread(QThread *backgroundThread,
@@ -216,6 +223,12 @@ public:
   const QList<StyleError> &GetStyleErrors() const
   {
       return styleErrors;
+  }
+
+  StyleConfigRef GetEmptyStyleConfig() const
+  {
+    QReadLocker locker(&lock);
+    return emptyStyleConfig;
   }
 
   const QMap<QString,bool> GetStyleFlags() const;

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -47,7 +47,9 @@ private:
   bool success;
   bool drawCanvasBackground;
   bool renderBasemap;
+  bool renderDatabases;
   std::vector<OverlayObjectRef> overlayObjects;
+  StyleConfigRef emptyStyleConfig;
 
 public:
   DBRenderJob(osmscout::MercatorProjection renderProjection,
@@ -55,17 +57,23 @@ public:
               osmscout::MapParameter *drawParameter,
               QPainter *p,
               std::vector<OverlayObjectRef> overlayObjects,
+              StyleConfigRef emptyStyleConfig,
               bool drawCanvasBackground=true,
-              bool renderBasemap=true);
-  virtual ~DBRenderJob();
+              bool renderBasemap=true,
+              bool renderDatabases=true);
+
+  ~DBRenderJob() override = default;
 
   void Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
-           const std::list<DBInstanceRef> &databases,
+           const std::list<DBInstanceRef> &allDatabases,
            QReadLocker *locker) override;
 
   inline bool IsSuccess() const{
     return success;
   };
+
+private:
+  bool addOverlayObjectData(MapDataRef data, TypeConfigRef typeConfig) const;
 };
 
 /**

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -73,6 +73,7 @@ public:
   };
 
 private:
+  bool addBasemapData(MapDataRef data) const;
   bool addOverlayObjectData(MapDataRef data, TypeConfigRef typeConfig) const;
 };
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -147,7 +147,6 @@ void MapRenderer::addOverlayObject(int id, const OverlayObjectRef& obj)
     overlayObjectMap[id]=obj;
   }
   InvalidateVisualCache();
-  emit Redraw();
 }
 
 void MapRenderer::removeOverlayObject(int id)
@@ -219,8 +218,10 @@ DBRenderJob::DBRenderJob(osmscout::MercatorProjection renderProjection,
                          osmscout::MapParameter *drawParameter,
                          QPainter *p,
                          std::vector<OverlayObjectRef> overlayObjects,
+                         StyleConfigRef emptyStyleConfig,
                          bool drawCanvasBackground,
-                         bool renderBasemap):
+                         bool renderBasemap,
+                         bool renderDatabases):
   renderProjection(renderProjection),
   tiles(tiles),
   drawParameter(drawParameter),
@@ -228,25 +229,27 @@ DBRenderJob::DBRenderJob(osmscout::MercatorProjection renderProjection,
   success(false),
   drawCanvasBackground(drawCanvasBackground),
   renderBasemap(renderBasemap),
-  overlayObjects(overlayObjects)
-{
-}
-
-DBRenderJob::~DBRenderJob()
+  renderDatabases(renderDatabases),
+  overlayObjects(overlayObjects),
+  emptyStyleConfig(emptyStyleConfig)
 {
 }
 
 void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
-                      const std::list<DBInstanceRef> &databases,
+                      const std::list<DBInstanceRef> &allDatabases,
                       QReadLocker *locker)
 {
+  std::list<DBInstanceRef> databases; // enabled databases for rendering
+  if (renderDatabases) {
+    databases = allDatabases;
+  }
   DBJob::Run(basemapDatabase,databases,locker);
 
-  bool backgroundRendered=false;
   success=true;
 
   // draw background
   if (drawCanvasBackground){
+    bool backgroundRendered=false;
     for (const auto &db:databases){
       // fill background with "unknown" color
       if (!backgroundRendered && db->GetStyleConfig()){
@@ -262,15 +265,21 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
             break;
           }
       }
-      if (!backgroundRendered){
-        // as backup, when "unknown" style is not defined, use black color
+    }
+    if (!backgroundRendered && emptyStyleConfig) {
+      osmscout::FillStyleRef unknownFillStyle=emptyStyleConfig->GetUnknownFillStyle(renderProjection);
+      if (unknownFillStyle){
+        osmscout::Color backgroundColor=unknownFillStyle->GetFillColor();
         p->fillRect(QRectF(0,0,renderProjection.GetWidth(),renderProjection.GetHeight()),
-                    QBrush(QColor::fromRgbF(0,0,0,1)));
+                    QColor::fromRgbF(backgroundColor.GetR(),
+                                     backgroundColor.GetG(),
+                                     backgroundColor.GetB(),
+                                     1));
         backgroundRendered=true;
-        break;
       }
     }
     if (!backgroundRendered){
+      // as backup, when "unknown" style is not defined, use black color
       p->fillRect(QRectF(0,0,renderProjection.GetWidth(),renderProjection.GetHeight()),
                   QBrush(QColor::fromRgbF(0,0,0,1)));
     }
@@ -279,88 +288,69 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
   // prepare data for batch
   osmscout::MapPainterBatchQt batch(databases.size());
   size_t i=0;
-  for (const auto &db:databases){
-    bool first=(i==0);
-    bool last=(i==databases.size()-1);
-    bool skip=true;
+  for (const auto &db: databases) {
+    bool first = (i == 0);
+    bool last = (i == databases.size() - 1);
+    bool skip = true;
     ++i;
 
     std::list<osmscout::TileRef> tileList;
-    if (tiles.contains(db->path)){
+    if (tiles.contains(db->path)) {
       auto list = tiles[db->path].values();
-      tileList=std::list<osmscout::TileRef>(list.begin(), list.end());
-      skip=false;
+      tileList = std::list<osmscout::TileRef>(list.begin(), list.end());
+      skip = false;
     }
 
-    osmscout::MapDataRef data=std::make_shared<osmscout::MapData>();
-    db->GetMapService()->AddTileDataToMapData(tileList,*data);
+    osmscout::MapDataRef data = std::make_shared<osmscout::MapData>();
+    db->GetMapService()->AddTileDataToMapData(tileList, *data);
 
-    if (first){
+    if (first) {
       // draw base map
       if (renderBasemap && basemapDatabase) {
-        osmscout::WaterIndexRef waterIndex=basemapDatabase->GetWaterIndex();
+        osmscout::WaterIndexRef waterIndex = basemapDatabase->GetWaterIndex();
         if (waterIndex) {
-          osmscout::GeoBox                boundingBox;
+          osmscout::GeoBox boundingBox;
           renderProjection.GetDimensions(boundingBox);
           if (waterIndex->GetRegions(boundingBox,
                                      renderProjection.GetMagnification(),
                                      data->baseMapTiles)) {
           }
-          skip=false;
+          skip = false;
         }
       }
     }
 
-    if (last){
-      osmscout::TypeConfigRef typeConfig=db->GetDatabase()->GetTypeConfig();
-      for (auto const &o:overlayObjects){
-
-        if (o->getObjectType()==osmscout::RefType::refWay){
-          OverlayWay *ow=dynamic_cast<OverlayWay*>(o.get());
-          if (ow != nullptr) {
-            osmscout::WayRef w = std::make_shared<osmscout::Way>();
-            if (ow->toWay(w, *typeConfig)) {
-              data->poiWays.push_back(w);
-            }
-          }
-        } else if (o->getObjectType()==osmscout::RefType::refArea){
-          OverlayArea *oa=dynamic_cast<OverlayArea*>(o.get());
-          if (oa != nullptr) {
-            osmscout::AreaRef a = std::make_shared<osmscout::Area>();
-            if (oa->toArea(a, *typeConfig)) {
-              data->poiAreas.push_back(a);
-            }
-          }
-        } else if (o->getObjectType()==osmscout::RefType::refNode){
-          OverlayNode *oo=dynamic_cast<OverlayNode*>(o.get());
-          if (oo != nullptr) {
-            osmscout::NodeRef n = std::make_shared<osmscout::Node>();
-            if (oo->toNode(n, *typeConfig)) {
-              data->poiNodes.push_back(n);
-            }
-          }
-        }
-      }
-      skip&=overlayObjects.empty();
+    if (last) {
+      osmscout::TypeConfigRef typeConfig = db->GetDatabase()->GetTypeConfig();
+      skip &= !addOverlayObjectData(data, typeConfig);
     }
 
-    if (skip){
+    if (skip) {
       osmscout::log.Debug() << "Skip database " << db->path.toStdString();
       continue;
     }
 
     if (drawParameter->GetRenderSeaLand()) {
       db->GetMapService()->GetGroundTiles(renderProjection,
-                                       data->groundTiles);
+                                          data->groundTiles);
     }
 
-    auto *painter=db->GetPainter();
+    auto *painter = db->GetPainter();
     if (painter != nullptr) {
       batch.addData(data, painter);
-    }else{
+    } else {
       osmscout::log.Warn() << "Painter is not available for database: " << db->path.toStdString();
-      success=false;
+      success = false;
     }
+  }
+
+  std::unique_ptr<MapPainterQt> painter;
+  if (databases.empty()) {
+    osmscout::MapDataRef data = std::make_shared<osmscout::MapData>();
+    addOverlayObjectData(data, emptyStyleConfig->GetTypeConfig());
+    painter=std::make_unique<osmscout::MapPainterQt>(emptyStyleConfig);
+    MapPainterQt *p = painter.get();
+    batch.addData(data, p);
   }
 
   // draw databases
@@ -368,5 +358,39 @@ void DBRenderJob::Run(const osmscout::BasemapDatabaseRef& basemapDatabase,
                          *drawParameter,
                          p);
   Close();
+}
+
+bool DBRenderJob::addOverlayObjectData(MapDataRef data, TypeConfigRef typeConfig) const
+{
+  for (auto const &o: overlayObjects) {
+
+    if (o->getObjectType() == osmscout::RefType::refWay) {
+      OverlayWay *ow = dynamic_cast<OverlayWay *>(o.get());
+      if (ow != nullptr) {
+        osmscout::WayRef w = std::make_shared<osmscout::Way>();
+        if (ow->toWay(w, *typeConfig)) {
+          data->poiWays.push_back(w);
+        }
+      }
+    } else if (o->getObjectType() == osmscout::RefType::refArea) {
+      OverlayArea *oa = dynamic_cast<OverlayArea *>(o.get());
+      if (oa != nullptr) {
+        osmscout::AreaRef a = std::make_shared<osmscout::Area>();
+        if (oa->toArea(a, *typeConfig)) {
+          data->poiAreas.push_back(a);
+        }
+      }
+    } else if (o->getObjectType() == osmscout::RefType::refNode) {
+      OverlayNode *oo = dynamic_cast<OverlayNode *>(o.get());
+      if (oo != nullptr) {
+        osmscout::NodeRef n = std::make_shared<osmscout::Node>();
+        if (oo->toNode(n, *typeConfig)) {
+          data->poiNodes.push_back(n);
+        }
+      }
+    }
+  }
+
+  return !overlayObjects.empty();
 }
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -390,6 +390,7 @@ void PlaneMapRenderer::DrawMap()
                       &drawParameter,
                       &p,
                       overlayObjects,
+                      dbThread->GetEmptyStyleConfig(),
                       /*drawCanvasBackground*/ true);
       dbThread->RunJob(&job);
       success=job.IsSuccess();

--- a/libosmscout-map/include/osmscoutmap/StyleConfig.h
+++ b/libosmscout-map/include/osmscoutmap/StyleConfig.h
@@ -543,7 +543,7 @@ namespace osmscout {
    *
    * Internals:
    * * Fastpath: Fastpath means, that we can directly return the style definition from the style sheet. This is normally
-   * the case, if there is excactly one match in the style sheet. If there are multiple matches a new style has to be
+   * the case, if there is exactly one match in the style sheet. If there are multiple matches a new style has to be
    * allocated and composed from all matches.
    */
   class OSMSCOUT_MAP_API StyleConfig


### PR DESCRIPTION
...or with disabled offline rendering.

Some users are confused when my application is not showing them GPX tracks until they download offline database, or when they disable offline rendering... It is not so hard to render just "poi" objects. It just requires creation of "empty" type config, load stylesheet with it and then use it with painter.