### PR TITLE
allow to have multiple files with list of online providers (tiles, databases, voices)

### DIFF
--- a/Demos/src/QtDemoApp.cpp
+++ b/Demos/src/QtDemoApp.cpp
@@ -167,9 +167,9 @@ int QtDemoApp::Run(const Arguments &args, const QUrl &qmlFileUrl)
       .WithIconDirectory(args.iconDirectory)
       .WithMapLookupDirectories(args.mapLookupDirectories)
       .WithBasemapLookupDirectory(args.basemapDir)
-      .WithOnlineTileProviders(":/resources/online-tile-providers.json")
-      .WithMapProviders(":/resources/map-providers.json")
-      .WithVoiceProviders(":/resources/voice-providers.json")
+      .AddOnlineTileProviders(":/resources/online-tile-providers.json")
+      .AddMapProviders(":/resources/map-providers.json")
+      .AddVoiceProviders(":/resources/voice-providers.json")
       .WithUserAgent(QApplication::applicationName(), QApplication::applicationVersion());
 
   if (!builder.Init()){

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -216,9 +216,9 @@ int main(int argc, char* argv[])
     .WithStyleSheetFile(stylesheetFile.fileName())
     .WithIconDirectory(args.iconDirectory)
     .WithMapLookupDirectories(mapLookupDirectories)
-    .WithOnlineTileProviders(":/resources/online-tile-providers.json")
-    .WithMapProviders(":/resources/map-providers.json")
-    .WithVoiceProviders(":/resources/voice-providers.json")
+    .AddOnlineTileProviders(":/resources/online-tile-providers.json")
+    .AddMapProviders(":/resources/map-providers.json")
+    .AddVoiceProviders(":/resources/voice-providers.json")
     .WithUserAgent("OSMScout2DemoApp", "v?");
 
   if (!builder.Init()){

--- a/StyleEditor/src/StyleEditor.cpp
+++ b/StyleEditor/src/StyleEditor.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
   builder
     .WithIconDirectory(iconDirectory)
     .WithMapLookupDirectories(mapLookupDirectories)
-    .WithOnlineTileProviders(":/resources/online-tile-providers.json")
+    .AddOnlineTileProviders(":/resources/online-tile-providers.json")
     .WithUserAgent("OSMScoutStyleEditor", "v?");
 
   if (!builder.Init()){

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -50,9 +50,9 @@ class OSMSCOUT_CLIENT_QT_API OSMScoutQtBuilder{
 private:
   QSettings *settingsStorage{nullptr};
 
-  QString onlineTileProviders;
-  QString mapProviders;
-  QString voiceProviders;
+  QStringList onlineTileProviders;
+  QStringList mapProviders;
+  QStringList voiceProviders;
   QStringList mapLookupDirectories;
   QString basemapLookupDirectory;
   QString cacheLocation;
@@ -84,21 +84,21 @@ public:
     return *this;
   }
 
-  inline OSMScoutQtBuilder& WithOnlineTileProviders(const QString &onlineTileProviders)
+  inline OSMScoutQtBuilder& AddOnlineTileProviders(const QString &onlineTileProviders)
   {
-    this->onlineTileProviders=onlineTileProviders;
+    this->onlineTileProviders << onlineTileProviders;
     return *this;
   }
 
-  inline OSMScoutQtBuilder& WithMapProviders(const QString &mapProviders)
+  inline OSMScoutQtBuilder& AddMapProviders(const QString &mapProviders)
   {
-    this->mapProviders=mapProviders;
+    this->mapProviders << mapProviders;
     return *this;
   }
 
-  inline OSMScoutQtBuilder& WithVoiceProviders(const QString &voiceProviders)
+  inline OSMScoutQtBuilder& AddVoiceProviders(const QString &voiceProviders)
   {
-    this->voiceProviders=voiceProviders;
+    this->voiceProviders << voiceProviders;
     return *this;
   }
 
@@ -214,8 +214,8 @@ enum RenderingType {
  *      .WithStyleSheetFile(stylesheetFileName)
  *      .WithIconDirectory(iconDirectory)
  *      .WithMapLookupDirectories(mapLookupDirectories)
- *      .WithOnlineTileProviders(":/resources/online-tile-providers.json")
- *      .WithMapProviders(":/resources/map-providers.json")
+ *      .AddOnlineTileProviders(":/resources/online-tile-providers.json")
+ *      .AddMapProviders(":/resources/map-providers.json")
  *      .Init();
  *
  * if (!success){

--- a/libosmscout-client-qt/include/osmscoutclientqt/Settings.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/Settings.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include <QSettings>
+#include <QStringList>
 
 #include <osmscout/routing/RoutingProfile.h>
 #include <osmscoutclientqt/InputHandler.h>
@@ -119,9 +120,9 @@ public:
   const QString GetOnlineTileProviderId() const;
   void SetOnlineTileProviderId(QString id);
 
-  bool loadOnlineTileProviders(QString path);
-  bool loadMapProviders(QString path);
-  bool loadVoiceProviders(QString path);
+  bool loadOnlineTileProviders(const QStringList &paths);
+  bool loadMapProviders(const QStringList &paths);
+  bool loadVoiceProviders(const QStringList &paths);
 
   bool GetOfflineMap() const;
   void SetOfflineMap(bool);


### PR DESCRIPTION
My app is loading list of online map servers from application directory (`/usr/share/harbour-osmscout/resources/online-tile-providers.json`). Users may add custom map servers there, but this file is overwritten by every upgrade. For that reason, it would be nice to load providers from two files - one provided with the app and second one provided by the users...