### PR TITLE
reorder highway_bus_stop and railway_tram_stop

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -255,10 +255,6 @@ TYPES
     = NODE ("highway"=="mini_roundabout")
       {Name, NameAlt, ClockwiseDirection}
 
-  TYPE highway_bus_stop
-    = NODE ("highway"=="bus_stop" OR (!("bus" IN ["no", "false", "0"]) AND ("public_transport" IN ["platform", "stop_position"])))
-      {Name, NameAlt}
-
   TYPE highway_turning_cycle
     = NODE ("highway"=="turning_cycle")
       {Name, NameAlt}
@@ -430,6 +426,14 @@ TYPES
   TYPE railway_turntable
     = NODE AREA ("railway"=="turntable")
       {Bridge, Tunnel}
+
+  //
+  // Other public transport (not railway)
+  //
+
+  TYPE highway_bus_stop
+    = NODE ("highway"=="bus_stop" OR (!("bus" IN ["no", "false", "0"]) AND ("public_transport" IN ["platform", "stop_position"])))
+      {Name, NameAlt}
 
   TYPE public_transport_platform
      = WAY AREA ("public_transport"=="platform" OR


### PR DESCRIPTION
As import condition for bus stop [1] is more relaxed than tram stop [2], tram stop type should be evalutad first. All tram stops are evaluated as bus stops othervise, for example this node:
https://www.openstreetmap.org/node/6436144735

1) `!("bus" IN ["no", "false", "0"])`
2) `("tram" IN ["yes", "true", "1"])`