### PR TITLE
Scalable contour symbols

### DIFF
--- a/libosmscout-map-agg/include/osmscoutmapagg/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscoutmapagg/MapPainterAgg.h
@@ -134,7 +134,8 @@ namespace osmscout {
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,
                     const Symbol& symbol,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawPath(const Projection& projection,
                   const MapParameter& parameter,

--- a/libosmscout-map-agg/src/osmscoutmapagg/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscoutmapagg/MapPainterAgg.cpp
@@ -465,7 +465,8 @@ namespace osmscout {
   void MapPainterAgg::DrawSymbol(const Projection& projection,
                                  const MapParameter& parameter,
                                  const Symbol& symbol,
-                                 double x, double y)
+                                 double x, double y,
+                                 double /*scaleFactor*/)
   {
     ScreenBox boundingBox=symbol.GetBoundingBox(projection);
     Vertex2D  center     =boundingBox.GetCenter();

--- a/libosmscout-map-cairo/include/osmscoutmapcairo/MapPainterCairo.h
+++ b/libosmscout-map-cairo/include/osmscoutmapcairo/MapPainterCairo.h
@@ -180,7 +180,8 @@ namespace osmscout {
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,
                     const Symbol& symbol,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawIcon(const IconStyle* style,
                   double centerX, double centerY,

--- a/libosmscout-map-cairo/src/osmscoutmapcairo/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscoutmapcairo/MapPainterCairo.cpp
@@ -1176,7 +1176,8 @@ namespace osmscout {
   void MapPainterCairo::DrawSymbol(const Projection& projection,
                                    const MapParameter& parameter,
                                    const Symbol& symbol,
-                                   double x, double y)
+                                   double x, double y,
+                                   double /*scaleFactor*/)
   {
     ScreenBox boundingBox=symbol.GetBoundingBox(projection);
 

--- a/libosmscout-map-directx/include/osmscoutmapdirectx/MapPainterDirectX.h
+++ b/libosmscout-map-directx/include/osmscoutmapdirectx/MapPainterDirectX.h
@@ -190,7 +190,8 @@ namespace osmscout {
     void DrawSymbol(const Projection &projection,
                     const MapParameter &parameter,
                     const Symbol &symbol,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawPath(const Projection &projection,
                   const MapParameter &parameter,

--- a/libosmscout-map-directx/src/osmscoutmapdirectx/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscoutmapdirectx/MapPainterDirectX.cpp
@@ -728,7 +728,8 @@ namespace osmscout
                                      const MapParameter& /*parameter*/,
                                      const Symbol& symbol,
                                      double x,
-                                     double y)
+                                     double y,
+                                     double /*scaleFactor*/)
   {
     ScreenBox boundingBox=symbol.GetBoundingBox(projection);
     Vertex2D center=boundingBox.GetCenter();

--- a/libosmscout-map-gdi/include/osmscoutmapgdi/MapPainterGDI.h
+++ b/libosmscout-map-gdi/include/osmscoutmapgdi/MapPainterGDI.h
@@ -130,7 +130,8 @@ namespace osmscout {
     void DrawSymbol(const Projection &projection,
                     const MapParameter &parameter,
                     const Symbol &style,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawIcon(const IconStyle *style,
                   double centerX, double centerY,

--- a/libosmscout-map-gdi/src/osmscoutmapgdi/MapPainterGDI.cpp
+++ b/libosmscout-map-gdi/src/osmscoutmapgdi/MapPainterGDI.cpp
@@ -639,7 +639,8 @@ namespace osmscout {
   void MapPainterGDI::DrawSymbol(const Projection &projection,
                                  const MapParameter & /*parameter*/,
                                  const Symbol &symbol,
-                                 double x, double y) {
+                                 double x, double y,
+                                 double /*scaleFactor*/) {
     Gdiplus::Pen *pPen;
 
     RENDEROBJECT(pRender);

--- a/libosmscout-map-iosx/include/osmscoutmapiosx/MapPainterIOS.h
+++ b/libosmscout-map-iosx/include/osmscoutmapiosx/MapPainterIOS.h
@@ -239,7 +239,8 @@ namespace osmscout {
         void DrawSymbol(const Projection& projection,
                         const MapParameter& parameter,
                         const Symbol& symbol,
-                        double x, double y) override;
+                        double x, double y,
+                        double scaleFactor) override;
 
         void DrawPath(const Projection& projection,
                       const MapParameter& parameter,

--- a/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
@@ -690,7 +690,8 @@ namespace osmscout {
     void MapPainterIOS::DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,
                     const Symbol& symbol,
-                    double x, double y){
+                    double x, double y,
+                    double scaleFactor){
         ScreenBox boundingBox=symbol.GetBoundingBox(projection);
         Vertex2D center=boundingBox.GetCenter();
 

--- a/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
@@ -650,7 +650,7 @@ namespace osmscout {
                     CGContextTranslateCTM(cg, x2, y2);
                     CGAffineTransform ct = CGAffineTransformConcat(transform, CGAffineTransformMakeRotation(slope));
                     CGContextConcatCTM(cg, ct);
-                    DrawSymbol(projection, parameter, symbol, 0, 0);
+                    DrawSymbol(projection, parameter, symbol, 0, 0,1.0);
                     CGContextRestoreGState(cg);
                     loop = followPath(followPathHnd, data.symbolSpace, origin);
                 }

--- a/libosmscout-map-qt/include/osmscoutmapqt/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscoutmapqt/MapPainterQt.h
@@ -203,7 +203,8 @@ namespace osmscout {
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,
                     const Symbol& symbol,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawPath(const Projection& projection,
                   const MapParameter& parameter,

--- a/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
@@ -632,7 +632,8 @@ namespace osmscout {
           DrawSymbol(projection,
                      parameter,
                      symbol,
-                     0,0);
+                     0,0,
+                     data.symbolScale);
           loop=FollowPath(followPathHnd,
                           data.coordRange,
                           space,
@@ -660,12 +661,14 @@ namespace osmscout {
   void MapPainterQt::DrawSymbol(const Projection& projection,
                                 const MapParameter& /*parameter*/,
                                 const Symbol& symbol,
-                                double x, double y)
+                                double x, double y,
+                                double scaleFactor)
   {
     SymbolRendererQt renderer(painter);
     renderer.Render(symbol,
                     Vertex2D(x, y),
-                    projection);
+                    projection,
+                    scaleFactor);
   }
 
   void MapPainterQt::DrawPath(const Projection& /*projection*/,

--- a/libosmscout-map-svg/include/osmscoutmapsvg/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscoutmapsvg/MapPainterSVG.h
@@ -1,3 +1,4 @@
+
 #ifndef OSMSCOUT_MAP_MAPPAINTERSVG_H
 #define OSMSCOUT_MAP_MAPPAINTERSVG_H
 
@@ -192,7 +193,8 @@ namespace osmscout {
     void DrawSymbol(const Projection& projection,
                     const MapParameter& parameter,
                     const Symbol& style,
-                    double x, double y) override;
+                    double x, double y,
+                    double scaleFactor) override;
 
     void DrawIcon(const IconStyle* style,
                   double centerX, double centerY,

--- a/libosmscout-map-svg/src/osmscoutmapsvg/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscoutmapsvg/MapPainterSVG.cpp
@@ -779,7 +779,8 @@ namespace osmscout {
   void MapPainterSVG::DrawSymbol(const Projection& projection,
                                  const MapParameter& /*parameter*/,
                                  const Symbol& symbol,
-                                 double x, double y)
+                                 double x, double y,
+                                 double /*scaleFactor*/)
   {
     ScreenBox boundingBox=symbol.GetBoundingBox(projection);
     Vertex2D center=boundingBox.GetCenter();

--- a/libosmscout-map/include/osmscoutmap/LabelLayouter.h
+++ b/libosmscout-map/include/osmscoutmap/LabelLayouter.h
@@ -638,7 +638,8 @@ namespace osmscout {
                           parameter,
                           *(el.labelData.iconStyle->GetSymbol()),
                           el.x + el.labelData.iconWidth/2,
-                          el.y + el.labelData.iconHeight/2);
+                          el.y + el.labelData.iconHeight/2,
+                          1.0);
 
           } else if (el.labelData.type==LabelData::Icon){
             p->DrawIcon(el.labelData.iconStyle.get(),

--- a/libosmscout-map/include/osmscoutmap/MapPainter.h
+++ b/libosmscout-map/include/osmscoutmap/MapPainter.h
@@ -205,6 +205,7 @@ namespace osmscout {
       double            symbolOffset; //!< Initial offset of the symbol
       double            symbolSpace;  //!< Space between individual symbols on the contour
       CoordBufferRange  coordRange;   //!< Range of coordinates of the path in transformation buffer
+      double            symbolScale;  //!< Potential magnification of the symbol
     };
 
   protected:
@@ -619,7 +620,8 @@ namespace osmscout {
     virtual void DrawSymbol(const Projection& projection,
                             const MapParameter& parameter,
                             const Symbol& symbol,
-                            double x, double y) = 0;
+                            double x, double y,
+                            double scaleFactor=1.0) = 0;
 
     /**
       Draw simple line with the given style,the given color, the given width

--- a/libosmscout-map/include/osmscoutmap/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscoutmap/MapPainterNoOp.h
@@ -71,7 +71,8 @@ namespace osmscout {
                     const MapParameter& parameter,
                     const Symbol& symbol,
                     double x,
-                    double y) override;
+                    double y,
+                    double scaleFactor) override;
 
     void DrawPath(const Projection& projection,
                   const MapParameter& parameter,

--- a/libosmscout-map/include/osmscoutmap/Styles.h
+++ b/libosmscout-map/include/osmscoutmap/Styles.h
@@ -1210,8 +1210,15 @@ namespace osmscout {
   class OSMSCOUT_MAP_API PathSymbolStyle CLASS_FINAL : public Style
   {
   public:
+    enum class RenderMode : int {
+      fixed,
+      scale
+    };
+
     enum Attribute {
       attrSymbol,
+      attrRenderMode,
+      attrScale,
       attrSymbolSpace,
       attrDisplayOffset,
       attrOffset,
@@ -1221,13 +1228,15 @@ namespace osmscout {
   private:
     std::string slot;
     SymbolRef   symbol;
-    double      symbolSpace;
-    double      displayOffset;
-    double      offset;
+    RenderMode  renderMode=RenderMode::fixed;
+    double      scale=1.0;
+    double      symbolSpace=15.0;
+    double      displayOffset=0.0;
+    double      offset=0.0;
     OffsetRel   offsetRel{OffsetRel::base};
 
   public:
-    PathSymbolStyle();
+    PathSymbolStyle() = default;
 
     void SetDoubleValue(int attribute, double value) override;
     void SetSymbolValue(int attribute, const SymbolRef& value) override;
@@ -1236,6 +1245,8 @@ namespace osmscout {
     PathSymbolStyle& SetSlot(const std::string& slot);
 
     PathSymbolStyle& SetSymbol(const SymbolRef& symbol);
+    PathSymbolStyle& SetRenderMode(RenderMode renderMode);
+    PathSymbolStyle& SetScale(double scale);
     PathSymbolStyle& SetSymbolSpace(double space);
     PathSymbolStyle& SetDisplayOffset(double value);
     PathSymbolStyle& SetOffset(double value);
@@ -1254,6 +1265,16 @@ namespace osmscout {
     const SymbolRef& GetSymbol() const
     {
       return symbol;
+    }
+
+    RenderMode GetRenderMode() const
+    {
+      return renderMode;
+    }
+
+    double GetScale() const
+    {
+      return scale;
     }
 
     double GetSymbolSpace() const
@@ -1293,6 +1314,20 @@ namespace osmscout {
   };
 
   using PathSymbolStyleRef = std::shared_ptr<PathSymbolStyle>;
+
+  class OSMSCOUT_MAP_API RenderModeEnumAttributeDescriptor CLASS_FINAL : public StyleEnumAttributeDescriptor
+  {
+  public:
+    RenderModeEnumAttributeDescriptor(const std::string& name,
+                                      int attribute)
+      : StyleEnumAttributeDescriptor(name,
+                                     attribute)
+    {
+      AddEnumValue("fixed",(int)PathSymbolStyle::RenderMode::fixed);
+      AddEnumValue("scale",(int)PathSymbolStyle::RenderMode::scale);
+    }
+  };
+
 }
 
 #endif

--- a/libosmscout-map/include/osmscoutmap/SymbolRenderer.h
+++ b/libosmscout-map/include/osmscoutmap/SymbolRenderer.h
@@ -43,7 +43,8 @@ public:
 
   virtual void Render(const Symbol &symbol,
                       const Vertex2D &center,
-                      const Projection &projection) const;
+                      const Projection &projection,
+                      double scaleFactor=1.0) const;
 
 protected:
   virtual void SetFill(const FillStyleRef &fillStyle) const = 0;

--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -1022,6 +1022,7 @@ namespace osmscout {
 
             data.symbolSpace=symbolSpace;
             data.symbolOffset=symbolSpace/2.0;
+            data.symbolScale=1.0;
             data.coordRange=range;
 
 
@@ -1054,7 +1055,16 @@ namespace osmscout {
 
         ScreenBox symbolBoundingBox=symbol->GetBoundingBox(projection);
 
-        double symbolWidth=symbolBoundingBox.GetWidth();
+        double symbolScale;
+
+        if (pathSymbolStyle->GetRenderMode()==PathSymbolStyle::RenderMode::scale) {
+          symbolScale=data.mainSlotWidth*pathSymbolStyle->GetScale()/symbolBoundingBox.GetHeight();
+        }
+        else {
+          symbolScale=1.0;
+        }
+
+        double symbolWidth=symbolBoundingBox.GetWidth()*symbolScale;
         double length=data.coordRange.GetLength();
         size_t countLabels=(length-symbolSpace)/(symbolWidth+symbolSpace);
         size_t labelCountExp=log2(countLabels);
@@ -1068,6 +1078,7 @@ namespace osmscout {
         symbolData.symbolSpace =space;
         symbolData.symbolOffset=space;
         symbolData.coordRange  =range;
+        symbolData.symbolScale=symbolScale;
 
         DrawContourSymbol(projection,
                           parameter,
@@ -1658,9 +1669,8 @@ namespace osmscout {
     if (layerValue!=nullptr) {
       return layerValue->GetLayer();
     }
-    else {
-      return 0;
-    }
+
+    return 0;
   }
 
   void MapPainter::CalculateWayPaths(const StyleConfig& styleConfig,

--- a/libosmscout-map/src/osmscoutmap/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainterNoOp.cpp
@@ -90,7 +90,8 @@ namespace osmscout {
                                   const MapParameter& /*parameter*/,
                                   const Symbol& /*symbol*/,
                                   double /*x*/,
-                                  double /*y*/)
+                                  double /*y*/,
+                                  double /*scaleFactor*/)
   {
     // no code
   }

--- a/libosmscout-map/src/osmscoutmap/Styles.cpp
+++ b/libosmscout-map/src/osmscoutmap/Styles.cpp
@@ -43,21 +43,24 @@ namespace osmscout {
     if (turn=="left" || turn=="merge_to_left" || turn=="slight_left" || turn=="sharp_left") {
       return OffsetRel::laneForwardLeft;
     }
-    else if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
+
+    if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
       return OffsetRel::laneForwardThroughLeft;
     }
-    else if (turn=="through") {
+
+    if (turn=="through") {
       return OffsetRel::laneForwardThrough;
     }
-    else if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
+
+    if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
       return OffsetRel::laneForwardThroughRight;
     }
-    else if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
+
+    if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
       return OffsetRel::laneForwardRight;
     }
-    else {
-      return OffsetRel::base;
-    }
+
+    return OffsetRel::base;
   }
 
   OffsetRel ParseBackwardTurnStringToOffset(const std::string& turn)
@@ -65,21 +68,24 @@ namespace osmscout {
     if (turn=="left" || turn=="merge_to_left" || turn=="slight_left" || turn=="sharp_left") {
       return OffsetRel::laneBackwardLeft;
     }
-    else if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
+
+    if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
       return OffsetRel::laneBackwardThroughLeft;
     }
-    else if (turn=="through") {
+
+    if (turn=="through") {
       return OffsetRel::laneBackwardThrough;
     }
-    else if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
+
+    if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
       return OffsetRel::laneBackwardThroughRight;
     }
-    else if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
+
+    if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
       return OffsetRel::laneBackwardRight;
     }
-    else {
-      return OffsetRel::base;
-    }
+
+    return OffsetRel::base;
   }
 
 
@@ -1705,6 +1711,8 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
     PathSymbolStyleDescriptor()
     {
       AddAttribute(std::make_shared<StyleSymbolAttributeDescriptor>("symbol",PathSymbolStyle::attrSymbol));
+      AddAttribute(std::make_shared<RenderModeEnumAttributeDescriptor>("renderMode",PathSymbolStyle::attrRenderMode));
+      AddAttribute(std::make_shared<StyleUDoubleAttributeDescriptor>("scale",PathSymbolStyle::attrScale));
       AddAttribute(std::make_shared<StyleUDisplayAttributeDescriptor>("symbolSpace",PathSymbolStyle::attrSymbolSpace));
       AddAttribute(std::make_shared<StyleDisplayAttributeDescriptor>("displayOffset",PathSymbolStyle::attrDisplayOffset));
       AddAttribute(std::make_shared<StyleUMapAttributeDescriptor>("offset",PathSymbolStyle::attrOffset));
@@ -1712,14 +1720,6 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
   };
 
   static const StyleDescriptorRef pathSymbolStyleDescriptor=std::make_shared<PathSymbolStyleDescriptor>();
-
-  PathSymbolStyle::PathSymbolStyle()
-  : symbolSpace(15),
-    displayOffset(0.0),
-    offset(0.0)
-  {
-    // no code
-  }
 
   PathSymbolStyle& PathSymbolStyle::SetSlot(const std::string& slot)
   {
@@ -1731,6 +1731,20 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
   PathSymbolStyle& PathSymbolStyle::SetSymbol(const SymbolRef& symbol)
   {
     this->symbol=symbol;
+
+    return *this;
+  }
+
+  PathSymbolStyle& PathSymbolStyle::SetRenderMode(RenderMode renderMode)
+  {
+    this->renderMode=renderMode;
+
+    return *this;
+  }
+
+  PathSymbolStyle& PathSymbolStyle::SetScale(double scale)
+  {
+    this->scale=scale;
 
     return *this;
   }
@@ -1776,6 +1790,12 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
       case attrSymbol:
         symbol=other.symbol;
         break;
+      case attrRenderMode:
+        renderMode=other.renderMode;
+        break;
+      case attrScale:
+        scale=other.scale;
+        break;
       case attrSymbolSpace:
         symbolSpace=other.symbolSpace;
         break;
@@ -1786,7 +1806,7 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
         offset=other.offset;
         break;
       case attrOffsetRel:
-        offset=other.offset;
+        offsetRel=other.offsetRel;
         break;
       }
     }
@@ -1796,6 +1816,9 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
                                        double value)
   {
     switch (attribute) {
+    case attrScale:
+      SetScale(value);
+      break;
     case attrOffset:
       SetOffset(value);
       break;
@@ -1822,16 +1845,18 @@ class LineStyleDescriptor CLASS_FINAL : public StyleDescriptor
     }
   }
 
-  void PathSymbolStyle::SetIntValue(int attribute, int value)
+  void PathSymbolStyle::SetIntValue(int attribute,
+                                    int value)
   {
     switch (attribute) {
-      case attrOffsetRel:
-        SetOffsetRel((OffsetRel)value);
-        break;
-      default:
-        assert(false);
+    case attrRenderMode:
+      SetRenderMode((PathSymbolStyle::RenderMode)value);
+      break;
+    case attrOffsetRel:
+      SetOffsetRel((OffsetRel)value);
+      break;
+    default:
+      assert(false);
     }
   }
-
 }
-

--- a/libosmscout-map/src/osmscoutmap/SymbolRenderer.cpp
+++ b/libosmscout-map/src/osmscoutmap/SymbolRenderer.cpp
@@ -90,7 +90,8 @@ void SymbolRenderer::Render(const Symbol &symbol,
 
 void SymbolRenderer::Render(const Symbol &symbol,
                             const Vertex2D &center,
-                            const Projection& projection) const
+                            const Projection& projection,
+                            double scaleFactor) const
 {
   ScreenBox boundingBox = symbol.GetBoundingBox(projection);
 
@@ -100,7 +101,8 @@ void SymbolRenderer::Render(const Symbol &symbol,
          Vertex2D(center.GetX()-boxCenter.GetY(),
                   center.GetY()-boxCenter.GetY()),
          projection.GetMeterInPixel(),
-         projection.ConvertWidthToPixel(1));
+         projection.ConvertWidthToPixel(1),
+         scaleFactor);
 }
 
 }

--- a/stylesheets/include/roads.oss
+++ b/stylesheets/include/roads.oss
@@ -517,7 +517,7 @@ STYLE
 
  [PATH
   MAG veryClose-
-  ONEWAY] WAY.SYMBOL {symbol: oneway_arrow; }
+  ONEWAY] WAY.SYMBOL {symbol: oneway_arrow; symbolSpace: 10mm; renderMode: scale; scale: 0.5; }
 
  // Special objects
 

--- a/webpage/content/documentation/stylesheet.md
+++ b/webpage/content/documentation/stylesheet.md
@@ -421,12 +421,14 @@ Currently allowed instances:
 * `WAY.SYMBOL`
 * `AREA.BORDERSYMBOL`
 
-Name         |Type         |Default |Description
--------------|-------------|--------|-----------
-symbol       |String       |        |The name of the symbol to draw
-symbolSpace  |ScreenSize   |15      |Space between each symbol on a path.
-displayOffset|ScreenSize   |0       |Offset of drawn symbol in relation to the actual path.
-offset       |GroundSize   |0       |Offset of the drawn symbol in relation to the actual path.
+Name         | Type           | Default |Description
+-------------|----------------|---------|-----------
+symbol       | String         |         |The name of the symbol to draw
+renderMode   | scale or fixed | fixed   |If scale, the symbol will be scaled in height by scale factor to the width of the way
+scale        | Double>0       | 1.0     | Scale factor if renderMode==scale
+symbolSpace  | ScreenSize     | 15      |Space between each symbol on a path.
+displayOffset| ScreenSize     | 0       |Offset of drawn symbol in relation to the actual path.
+offset       | GroundSize     | 0       |Offset of the drawn symbol in relation to the actual path.
 
 ## Label and icon placement
 


### PR DESCRIPTION
* Symbols can now have render mode scale and will we scale in height relative to the way width they are rendered on.
* Applied foroneway_arrows