### PR TITLE
revert fast food and restaurant symbols

### DIFF
--- a/stylesheets/include/man_made.oss
+++ b/stylesheets/include/man_made.oss
@@ -156,10 +156,12 @@ STYLE
    [TYPE amenity,
          amenity_bank,
          amenity_cafe,
+         amenity_fast_food,
          amenity_fuel,
          amenity_kindergarten,
          amenity_library,
          amenity_recycling,
+         amenity_restaurant,
          amenity_school] {
          NODE.ICON { symbol: amenity; }
    }


### PR DESCRIPTION
When some object has both, symbol and icon, icon has precedence in renderers. But some renderers do not support icons, or icons may be missing in installation / configuration. For that reason, it is useful to define both.