### PR TITLE
scale symbol space together with contour symbols

### DIFF
--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -1059,6 +1059,7 @@ namespace osmscout {
 
         if (pathSymbolStyle->GetRenderMode()==PathSymbolStyle::RenderMode::scale) {
           symbolScale=data.mainSlotWidth*pathSymbolStyle->GetScale()/symbolBoundingBox.GetHeight();
+          symbolSpace*=symbolScale;
         }
         else {
           symbolScale=1.0;
@@ -1066,19 +1067,19 @@ namespace osmscout {
 
         double symbolWidth=symbolBoundingBox.GetWidth()*symbolScale;
         double length=data.coordRange.GetLength();
-        size_t countLabels=(length-symbolSpace)/(symbolWidth+symbolSpace);
-        size_t labelCountExp=log2(countLabels);
+        size_t countSymbols=(length-symbolSpace)/(symbolWidth+symbolSpace);
+        size_t labelCountExp=log2(countSymbols);
 
-        countLabels=pow(2,labelCountExp);
+        countSymbols=pow(2, labelCountExp);
 
-        double space=(length-countLabels*symbolWidth)/(countLabels+1);
+        double space = (length-countSymbols*symbolWidth) / (countSymbols+1);
 
         ContourSymbolData symbolData;
 
-        symbolData.symbolSpace =space;
-        symbolData.symbolOffset=space;
-        symbolData.coordRange  =range;
-        symbolData.symbolScale=symbolScale;
+        symbolData.symbolSpace = space;
+        symbolData.symbolOffset = space;
+        symbolData.coordRange = range;
+        symbolData.symbolScale = symbolScale;
 
         DrawContourSymbol(projection,
                           parameter,


### PR DESCRIPTION
When symbol is upscaled for high zoom level, space between symbols is upscaled accordingly.

before: 
![Screenshot_20220928_153435](https://user-images.githubusercontent.com/309458/192794518-fe3ebf87-ecf5-4b63-9826-6049e7b0c6b0.png)

after:
![Screenshot_20220928_153556](https://user-images.githubusercontent.com/309458/192794541-d58a694c-8d56-42e0-9c27-15a46f982e24.png)
