### PR TITLE
drop github action with Clang 10 (Ubuntu 20.04)

### DIFF
--- a/.github/workflows/build_and test_on_ubuntu_20_04.yml
+++ b/.github/workflows/build_and test_on_ubuntu_20_04.yml
@@ -9,38 +9,6 @@ on:
       - master
 
 jobs:
-  build_clang_meson:
-    name: clang and meson
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Update package list
-        run:  sudo apt-get update
-      - name: Install software-properties-common
-        run: sudo apt-get install software-properties-common
-      - name: Install clang compiler, meson and ninja
-        run: sudo apt-get -y install clang libc++-10-dev ccache libtool pkg-config meson ninja-build
-      - name: Install libosmscout dependencies
-        run: "sudo apt-get install -y
-              libxml2-dev
-              libprotobuf-dev protobuf-compiler
-              libagg-dev
-              libfreetype6-dev libcairo2-dev libpangocairo-1.0-0 libpango1.0-dev
-              qt5-default qtdeclarative5-dev libqt5svg5-dev qtlocation5-dev qtpositioning5-dev qttools5-dev-tools
-              qttools5-dev qtmultimedia5-dev
-              libglm-dev libglew-dev freeglut3 freeglut3-dev
-              libmarisa-dev"
-      - name: Configure build project
-        run: meson setup --buildtype debugoptimized --unity on debug
-        env:
-          CXX: clang++
-          CC: clang
-      - name: Build project
-        run: ninja -C debug
-      - name: Run tests
-        run: meson test -C debug --print-errorlogs
-
   build_gcc_meson:
     name: gcc and meson
     runs-on: ubuntu-20.04


### PR DESCRIPTION
It seems that Clang 10 has some issue that breaks CI build. Let's keep just build with newer Clang 14 (Ubuntu 22.04).