### PR TITLE
try to place at least one label on short ways

### DIFF
--- a/libosmscout-map/include/osmscoutmap/LabelLayouter.h
+++ b/libosmscout-map/include/osmscoutmap/LabelLayouter.h
@@ -791,7 +791,7 @@ constexpr bool debugLabelLayouter = false;
       // We do not to see new label appear and disappear during zoom too often.
       // We want new labels to be "between" existing labels
       // We thus only draw labels in an amount of a multiple of 2
-      countLabels=(size_t)pow(2.0,floor(log2(double(countLabels))));
+      countLabels=std::max(size_t(1), size_t(pow(2.0,floor(log2(double(countLabels))))));
 
       double labelSpace=(pathLength-countLabels*label->width)/(countLabels+1);
       double offset=labelSpace;


### PR DESCRIPTION
even when we do not keep less space than requested (contourLabelSpace). It is better to show at least some label than use strict spacing.