### PR TITLE
fix crash in segment bounding box computation

### DIFF
--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -1243,6 +1243,7 @@ namespace osmscout {
   {
     if (path.empty() || from>=to){
       boundingBox.Invalidate();
+      return;
     }
 
     double minLon=path[from%path.size()].GetLon();


### PR DESCRIPTION
it fixes zero division with empty segment