### PR TITLE
use AdminRegionInfo in all QML models for lookup

### DIFF
--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -2,7 +2,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 set(HEADER_FILES
-    include/osmscoutclientqt/ClientQtImportExport.h
+		include/osmscoutclientqt/AdminRegionInfo.h
+		include/osmscoutclientqt/ClientQtImportExport.h
     include/osmscoutclientqt/DBThread.h
     include/osmscoutclientqt/DBInstance.h
     include/osmscoutclientqt/ElevationChartWidget.h

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -1,6 +1,7 @@
 osmscoutclientqtIncDir = include_directories('.')
 
 osmscoutclientqtHeader = [
+            'osmscoutclientqt/AdminRegionInfo.h',
             'osmscoutclientqt/ClientQtImportExport.h',
             'osmscoutclientqt/DBThread.h',
             'osmscoutclientqt/DBInstance.h',

--- a/libosmscout-client-qt/include/osmscoutclientqt/AdminRegionInfo.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/AdminRegionInfo.h
@@ -1,0 +1,70 @@
+#ifndef OSMSCOUT_CLIENT_QT_ADMINREGIONINFO_H
+#define OSMSCOUT_CLIENT_QT_ADMINREGIONINFO_H
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2017 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <QObject>
+#include <QString>
+
+#include <memory>
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+
+#include <osmscout/Location.h>
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ */
+class OSMSCOUT_CLIENT_QT_API AdminRegionInfo
+{
+public:
+  QString database;
+  osmscout::AdminRegionRef adminRegion;
+  QString type; //!< adminRegion->object's type
+  int adminLevel{-1};
+
+public:
+  std::string name() const
+  {
+    return adminRegion->name;
+  }
+
+  QString qStringName() const
+  {
+    return QString::fromStdString(adminRegion->name);
+  }
+
+  std::string altName() const
+  {
+    return adminRegion->altName;
+  }
+
+  QString qStringAltName() const
+  {
+    return QString::fromStdString(adminRegion->altName);
+  }
+};
+
+typedef std::shared_ptr<AdminRegionInfo> AdminRegionInfoRef;
+
+}
+
+#endif //OSMSCOUT_CLIENT_QT_ADMINREGIONINFO_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
@@ -30,6 +30,7 @@
 #include <osmscout/LocationService.h>
 
 #include <osmscoutclientqt/ClientQtImportExport.h>
+#include <osmscoutclientqt/AdminRegionInfo.h>
 
 namespace osmscout {
 
@@ -59,7 +60,7 @@ private:
   Type                           type;
   QString                        label;
   QString                        objectType;
-  QStringList                    adminRegionList;
+  QList<AdminRegionInfoRef>      adminRegionList;
   QString                        database;
   QList<osmscout::ObjectFileRef> references;
   osmscout::GeoCoord             coord;
@@ -69,7 +70,7 @@ public:
   LocationEntry(Type type,
                 const QString& label,
                 const QString& objectType,
-                const QStringList& adminRegionList,
+                const QList<AdminRegionInfoRef>& adminRegionList,
                 const QString database,
                 const osmscout::GeoCoord coord,
                 const osmscout::GeoBox bbox,
@@ -103,7 +104,7 @@ public:
   QString getTypeString() const;
   QString getObjectType() const;
   QString getLabel() const;
-  QStringList getAdminRegionList() const;
+  QList<AdminRegionInfoRef> getAdminRegionList() const;
   QString getDatabase() const;
   osmscout::GeoCoord getCoord() const;
   osmscout::GeoBox getBBox() const;

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
@@ -77,7 +77,8 @@ public:
         WebsiteRole = Qt::UserRole+9,
         PhoneRole = Qt::UserRole+10,
         AddressLocationRole = Qt::UserRole+11,
-        AddressNumberRole = Qt::UserRole+12
+        AddressNumberRole = Qt::UserRole+12,
+        IndexedAdminRegionRole = Qt::UserRole+13
     };
     Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
@@ -57,7 +57,7 @@ public slots:
     void onLocationDescription(const osmscout::GeoCoord location, 
                                const QString database, 
                                const osmscout::LocationDescription description,
-                               const QStringList regions);
+                               const QList<AdminRegionInfoRef> regions);
     void onLocationDescriptionFinished(const osmscout::GeoCoord);
 
     void onLocationAdminRegions(const osmscout::GeoCoord,QList<AdminRegionInfoRef>);
@@ -112,7 +112,7 @@ public:
 private: 
    void addToModel(const QString database,
                    const osmscout::LocationAtPlaceDescriptionRef description,
-                   const QStringList regions);
+                   const QList<AdminRegionInfoRef> regions);
  
 private:
     bool ready;
@@ -122,7 +122,7 @@ private:
     QList<ObjectKey> objectSet; // set of objects already inserted to model
     QList<QMap<int, QVariant>> model;
     LookupModule* lookupModule;
-    
+    SettingsRef settings;
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LookupModule.h
@@ -144,6 +144,18 @@ public:
    */
   static QStringList AdminRegionNames(const QList<AdminRegionInfoRef> &regionList, bool useAltNames);
 
+  /** Helper method that returns names of admin region in indexed array.
+   * Array length is 12. When some level is not present, empty string is used.
+   * Level 2 are counties. Levels > 2 are country specific.
+   * See https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative for meaning
+   * of individual levels.
+   *
+   * @param regionList
+   * @param useAltNames
+   * @return list of admin region names, indexed by admin region level
+   */
+  static QStringList IndexedAdminRegionNames(const QList<AdminRegionInfoRef> &regionList, bool useAltNames);
+
 private:
 
   void addObjectInfo(QList<ObjectInfo> &objectList, // output

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
@@ -118,6 +118,7 @@ private:
   QList<osmscout::MapData> mapData;
   double mapDpi;
   LookupModule* lookupModule;
+  SettingsRef settings;
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NearPOIModel.h
@@ -115,6 +115,7 @@ private:
   QStringList types;
 
   POILookupModule *poiModule{nullptr};
+  SettingsRef settings;
 
 public:
   NearPOIModel();

--- a/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
@@ -148,6 +148,7 @@ private:
   bool searching;
   SearchModule* searchModule;
   LookupModule* lookupModule;
+  SettingsRef settings;
   osmscout::GeoCoord searchCenter;
   int resultLimit;
   osmscout::BreakerRef breaker;

--- a/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
@@ -166,7 +166,8 @@ public:
     LonRole = Qt::UserRole +4,
     DistanceRole = Qt::UserRole +5,
     BearingRole = Qt::UserRole +6,
-    LocationObjectRole = Qt::UserRole +7
+    LocationObjectRole = Qt::UserRole +7,
+    IndexedAdminRegionRole = Qt::UserRole+8
   };
 
 public:

--- a/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
@@ -28,7 +28,7 @@ namespace osmscout {
 LocationEntry::LocationEntry(Type type,
                              const QString& label,
                              const QString& objectType,
-                             const QStringList& adminRegionList,
+                             const QList<AdminRegionInfoRef>& adminRegionList,
                              const QString database,
                              const osmscout::GeoCoord coord,
                              const osmscout::GeoBox bbox,
@@ -166,7 +166,7 @@ QString LocationEntry::getObjectType() const
     return objectType;
 }
 
-QStringList LocationEntry::getAdminRegionList() const
+QList<AdminRegionInfoRef> LocationEntry::getAdminRegionList() const
 {
     return adminRegionList;
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LocationInfoModel.cpp
@@ -118,6 +118,7 @@ QHash<int, QByteArray> LocationInfoModel::roleNames() const
     roles[PhoneRole] = "phone";
     roles[AddressLocationRole] = "addressLocation";
     roles[AddressNumberRole] = "addressNumber";
+    roles[IndexedAdminRegionRole] = "indexedAdminRegion";
 
     return roles;
 }
@@ -244,6 +245,7 @@ void LocationInfoModel::addToModel(const QString database,
   obj[PhoneRole] = phone;
   obj[AddressLocationRole] = addressLocation;
   obj[AddressNumberRole] = addressNumber;
+  obj[IndexedAdminRegionRole] = LookupModule::IndexedAdminRegionNames(regions, settings->GetShowAltLanguage());
 
   model << obj;
 
@@ -339,6 +341,7 @@ void LocationInfoModel::onLocationAdminRegions(const osmscout::GeoCoord location
   obj[PhoneRole] = "";
   obj[AddressLocationRole] = "";
   obj[AddressNumberRole] = "";
+  obj[IndexedAdminRegionRole] = QStringList();
 
   model << obj;
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LookupModule.cpp
@@ -76,7 +76,7 @@ void LookupModule::requestObjectsOnView(const MapViewStruct &view,
 void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                                  const NodeRef &n,
                                  const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
-                                 LocationServiceRef &locationService,
+                                 const DBInstanceRef &db,
                                  std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
 {
   std::vector<osmscout::Point> nodes;
@@ -88,15 +88,15 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                 n->GetCoords(),
                 n,
                 reverseLookupMap,
-                locationService,
+                db,
                 regionMap);
 }
 
 void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                                  const WayRef &w,
-                   const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
-                   LocationServiceRef &locationService,
-                   std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
+                                 const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
+                                 const DBInstanceRef &db,
+                                 std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
 {
   addObjectInfo(objectList,
                 "way",
@@ -105,14 +105,14 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                 w->GetBoundingBox().GetCenter(),
                 w,
                 reverseLookupMap,
-                locationService,
+                db,
                 regionMap);
 }
 
 void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                                  const AreaRef &a,
                                  const std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> &reverseLookupMap,
-                                 LocationServiceRef &locationService,
+                                 const DBInstanceRef &db,
                                  std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
 {
   for (const auto &ring:a->rings) {
@@ -120,7 +120,7 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
     if (type->GetIgnore()) {
       continue;
     }
-    // Master ring don't contains nodes! Use intersection of all outer rings instead
+    // Master ring don't contain nodes! Use intersection of all outer rings instead
     osmscout::GeoBox bbox=(ring.nodes.empty() ? a->GetBoundingBox() : ring.GetBoundingBox());
 
     addObjectInfo(objectList,
@@ -131,7 +131,7 @@ void LookupModule::addObjectInfo(QList<ObjectInfo> &objectList, // output
                   type,
                   ring.GetFeatureValueBuffer(),
                   reverseLookupMap,
-                  locationService,
+                  db,
                   regionMap);
   }
 }
@@ -173,7 +173,6 @@ void LookupModule::requestObjects(const LocationEntry &entry, bool reverseLookup
           MapData mapData;
 
           auto database=db->GetDatabase();
-          auto locationService=db->GetLocationService();
           database->GetAreasByOffset(areaOffsets, mapData.areas);
           database->GetWaysByOffset(wayOffsets, mapData.ways);
           database->GetNodesByOffset(nodeOffsets, mapData.nodes);
@@ -191,17 +190,17 @@ void LookupModule::requestObjects(const LocationEntry &entry, bool reverseLookup
           }
 
           for (auto const &n:mapData.nodes){
-            addObjectInfo(objectList,n,reverseLookupMap,locationService,regionMap);
+            addObjectInfo(objectList,n,reverseLookupMap,db,regionMap);
           }
 
           //std::cout << "ways:  " << d.ways.size() << std::endl;
           for (auto const &w:mapData.ways){
-            addObjectInfo(objectList,w,reverseLookupMap,locationService,regionMap);
+            addObjectInfo(objectList,w,reverseLookupMap,db,regionMap);
           }
 
           //std::cout << "areas: " << d.areas.size() << std::endl;
           for (auto const &a:mapData.areas){
-            addObjectInfo(objectList,a,reverseLookupMap,locationService,regionMap);
+            addObjectInfo(objectList,a,reverseLookupMap,db,regionMap);
           }
         }
       }
@@ -223,7 +222,7 @@ void LookupModule::filterObjectInView(const osmscout::MapData &mapData,
   // TODO: add reverse lookup for objects on the view
   std::map<ObjectFileRef,LocationDescriptionService::ReverseLookupResult> reverseLookupMap;
   std::map<osmscout::FileOffset,osmscout::AdminRegionRef> regionMap;
-  LocationServiceRef locationService;
+  DBInstanceRef db;
 
   double x;
   double y;
@@ -234,7 +233,7 @@ void LookupModule::filterObjectInView(const osmscout::MapData &mapData,
   for (auto const &n:mapData.nodes){
     projection.GeoToPixel(n->GetCoords(),x,y);
     if (filterRectangle.contains(x,y)){
-      addObjectInfo(objectList,n,reverseLookupMap,locationService,regionMap);
+      addObjectInfo(objectList, n, reverseLookupMap, db, regionMap);
     }
   }
 
@@ -245,7 +244,7 @@ void LookupModule::filterObjectInView(const osmscout::MapData &mapData,
     projection.GeoToPixel(bbox.GetMinCoord(),x,y);
     projection.GeoToPixel(bbox.GetMaxCoord(),x2,y2);
     if (filterRectangle.intersects(QRectF(QPointF(x,y),QPointF(x2,y2)))){
-      addObjectInfo(objectList,w,reverseLookupMap,locationService,regionMap);
+      addObjectInfo(objectList, w, reverseLookupMap, db, regionMap);
     }
   }
 
@@ -256,7 +255,7 @@ void LookupModule::filterObjectInView(const osmscout::MapData &mapData,
     projection.GeoToPixel(bbox.GetMinCoord(),x,y);
     projection.GeoToPixel(bbox.GetMaxCoord(),x2,y2);
     if (filterRectangle.intersects(QRectF(QPointF(x,y),QPointF(x2,y2)))){
-      addObjectInfo(objectList,a,reverseLookupMap,locationService,regionMap);
+      addObjectInfo(objectList, a, reverseLookupMap, db, regionMap);
     }
   }
 }
@@ -299,7 +298,7 @@ void LookupModule::requestLocationDescription(const osmscout::GeoCoord location)
 
           auto place = description.GetAtAddressDescription()->GetPlace();
           emit locationDescription(location, db->path, description,
-                                   BuildAdminRegionList(db->GetLocationService(), place.GetAdminRegion(), regionMap));
+                                   BuildAdminRegionList(db, place.GetAdminRegion(), regionMap));
         }
 
         if (!db->GetLocationDescriptionService()->DescribeLocationByPOI(location, description)) {
@@ -312,7 +311,7 @@ void LookupModule::requestLocationDescription(const osmscout::GeoCoord location)
 
           auto place = description.GetAtPOIDescription()->GetPlace();
           emit locationDescription(location, db->path, description,
-                                   BuildAdminRegionList(db->GetLocationService(), place.GetAdminRegion(), regionMap));
+                                   BuildAdminRegionList(db, place.GetAdminRegion(), regionMap));
         }
       }
 
@@ -321,19 +320,22 @@ void LookupModule::requestLocationDescription(const osmscout::GeoCoord location)
   );
 }
 
-AdminRegionInfoRef LookupModule::buildAdminRegionInfo(DBInstanceRef &db,
+AdminRegionInfoRef LookupModule::buildAdminRegionInfo(const DBInstanceRef &db,
                                                       const osmscout::AdminRegionRef &region){
 
   AdminRegionInfoRef info=std::make_shared<AdminRegionInfo>();
-  info->database=db->path;
   info->adminRegion=region;
-  info->name=QString::fromStdString(region->name);
   info->adminLevel=-1;
+
+  if (!db) {
+    return info;
+  }
+
+  info->database=db->path;
 
   // read admin region features
   auto database=db->GetDatabase();
   osmscout::TypeConfigRef typeConfig=database->GetTypeConfig();
-  osmscout::FeatureValueReader<osmscout::NameAltFeature,osmscout::NameAltFeatureValue> altNameReader(*typeConfig);
   osmscout::FeatureValueReader<osmscout::AdminLevelFeature,osmscout::AdminLevelFeatureValue> adminLevelReader(*typeConfig);
 
   osmscout::FeatureValueBufferRef objectFeatureBuff;
@@ -341,27 +343,23 @@ AdminRegionInfoRef LookupModule::buildAdminRegionInfo(DBInstanceRef &db,
   osmscout::WayRef                way;
   osmscout::AreaRef               area;
 
-  osmscout::NameAltFeatureValue    *altNameValue=nullptr;
   osmscout::AdminLevelFeatureValue *adminLevelValue=nullptr;
 
   switch (region->object.GetType()){
     case osmscout::refNode:
       if (database->GetNodeByOffset(region->object.GetFileOffset(), node)) {
-        altNameValue=altNameReader.GetValue(node->GetFeatureValueBuffer());
         adminLevelValue=adminLevelReader.GetValue(node->GetFeatureValueBuffer());
         info->type=QString::fromStdString(node->GetType()->GetName());
       }
       break;
     case osmscout::refWay:
       if (database->GetWayByOffset(region->object.GetFileOffset(), way)) {
-        altNameValue=altNameReader.GetValue(way->GetFeatureValueBuffer());
         adminLevelValue=adminLevelReader.GetValue(way->GetFeatureValueBuffer());
         info->type=QString::fromStdString(way->GetType()->GetName());
       }
       break;
     case osmscout::refArea:
       if (database->GetAreaByOffset(region->object.GetFileOffset(), area)) {
-        altNameValue=altNameReader.GetValue(area->GetFeatureValueBuffer());
         adminLevelValue=adminLevelReader.GetValue(area->GetFeatureValueBuffer());
         info->type=QString::fromStdString(area->GetType()->GetName());
       }
@@ -372,10 +370,9 @@ AdminRegionInfoRef LookupModule::buildAdminRegionInfo(DBInstanceRef &db,
       break;
   }
 
-  if (altNameValue!=nullptr)
-    info->altName=QString::fromStdString(altNameValue->GetNameAlt());
-  if (adminLevelValue!=nullptr)
-    info->adminLevel=(int)adminLevelValue->GetAdminLevel();
+  if (adminLevelValue!=nullptr) {
+    info->adminLevel = (int) adminLevelValue->GetAdminLevel();
+  }
 
   return info;
 }
@@ -456,40 +453,46 @@ QList<AdminRegionInfoRef> LookupModule::BuildAdminRegionInfoList(AdminRegionInfo
   return result;
 }
 
-QStringList LookupModule::BuildAdminRegionList(const osmscout::AdminRegionRef& adminRegion,
-                                               std::map<osmscout::FileOffset,osmscout::AdminRegionRef> regionMap)
-{
-  return BuildAdminRegionList(osmscout::LocationServiceRef(), adminRegion, regionMap);
-}
-
-QStringList LookupModule::BuildAdminRegionList(const osmscout::LocationServiceRef& locationService,
-                                               const osmscout::AdminRegionRef& adminRegion,
-                                               std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
+QList<AdminRegionInfoRef> LookupModule::BuildAdminRegionList(const DBInstanceRef &db,
+                                                             const osmscout::AdminRegionRef& adminRegion,
+                                                             std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &regionMap)
 {
   if (!adminRegion){
-    return QStringList();
+    return QList<AdminRegionInfoRef>();
   }
 
-  QStringList list;
-  if (locationService){
-    locationService->ResolveAdminRegionHierachie(adminRegion, regionMap);
+  QList<AdminRegionInfoRef> list;
+  if (db) {
+    db->GetLocationService()->ResolveAdminRegionHierachie(adminRegion, regionMap);
   }
-  QString name = QString::fromStdString(adminRegion->name);
-  list << name;
-  QString last = name;
+
+  list << buildAdminRegionInfo(db, adminRegion);
   osmscout::FileOffset parentOffset = adminRegion->parentRegionOffset;
   while (parentOffset != 0){
     const auto &it = regionMap.find(parentOffset);
-    if (it==regionMap.end())
+    if (it==regionMap.end()) {
       break;
-    const osmscout::AdminRegionRef region=it->second;
-    name = QString::fromStdString(region->name);
-    if (last != name){ // skip duplicates in admin region names
-      list << name;
     }
-    last = name;
+    const osmscout::AdminRegionRef region=it->second;
+    list << buildAdminRegionInfo(db, region);
     parentOffset = region->parentRegionOffset;
   }
   return list;
+}
+
+QStringList LookupModule::AdminRegionNames(const QList<AdminRegionInfoRef> &regionList, bool useAltNames)
+{
+  QStringList result;
+
+  QString previousName;
+  QString name;
+  for (const auto &region: regionList) {
+    name = (useAltNames && !region->altName().empty()) ? region->qStringAltName() : region->qStringName();
+    if (previousName != name) {
+      result << name;
+      previousName = name;
+    }
+  }
+  return result;
 }
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/LookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LookupModule.cpp
@@ -495,4 +495,20 @@ QStringList LookupModule::AdminRegionNames(const QList<AdminRegionInfoRef> &regi
   }
   return result;
 }
+
+QStringList LookupModule::IndexedAdminRegionNames(const QList<AdminRegionInfoRef> &regionList, bool useAltNames)
+{
+  QStringList result;
+  result.reserve(12);
+  for (int i=0; i<=11; i++) {
+    result << "";
+  }
+  for (const auto &region:regionList) {
+    if (region->adminLevel >= 0 && region->adminLevel < result.size()) {
+      result[region->adminLevel] = (useAltNames && !region->altName().empty()) ? region->qStringAltName() : region->qStringName();
+    }
+  }
+  return result;
+}
+
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapObjectInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapObjectInfoModel.cpp
@@ -31,7 +31,8 @@ ready(false), setup(false), view(), lookupModule(nullptr)
 {
 
   lookupModule=OSMScoutQt::GetInstance().MakeLookupModule();
-  this->mapDpi=OSMScoutQt::GetInstance().GetSettings()->GetMapDPI();
+  settings=OSMScoutQt::GetInstance().GetSettings();
+  this->mapDpi=settings->GetMapDPI();
 
   connect(lookupModule, &LookupModule::initialisationFinished,
           this, &MapObjectInfoModel::dbInitialized,
@@ -178,7 +179,7 @@ QVariant MapObjectInfoModel::data(const QModelIndex &index, int role) const
     return QVariant::fromValue(QString::fromStdString(obj.reverseLookupRef->postalArea->name));
   }
   if (role==RegionRole){
-    return QVariant::fromValue(obj.adminRegionList);
+    return QVariant::fromValue(LookupModule::AdminRegionNames(obj.adminRegionList, settings->GetShowAltLanguage()));
   }
   if (role==LatRole){
     return QVariant::fromValue(obj.center.GetLat());

--- a/libosmscout-client-qt/src/osmscoutclientqt/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NearPOIModel.cpp
@@ -25,6 +25,7 @@ namespace osmscout {
 NearPOIModel::NearPOIModel()
 {
   poiModule=OSMScoutQt::GetInstance().MakePOILookupModule();
+  settings=OSMScoutQt::GetInstance().GetSettings();
 
   connect(this, &NearPOIModel::lookupPOIRequest,
           poiModule, &POILookupModule::lookupPOIRequest,
@@ -74,7 +75,7 @@ QVariant NearPOIModel::data(const QModelIndex &index, int role) const
       else
         return location->getObjectType();
     case RegionRole:
-      return location->getAdminRegionList();
+      return LookupModule::AdminRegionNames(location->getAdminRegionList(), settings->GetShowAltLanguage());
     case LatRole:
       return QVariant::fromValue(location->getCoord().GetLat());
     case LonRole:

--- a/libosmscout-client-qt/src/osmscoutclientqt/OverlayObject.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OverlayObject.cpp
@@ -111,7 +111,7 @@ LocationEntry* OverlayObject::getBBoxAsLocation() const
   return new LocationEntry(LocationEntry::Type::typeNone,
                            "bbox",
                            "bbox",
-                           QStringList(),
+                           QList<AdminRegionInfoRef>(),
                            "",
                            bbox.GetCenter(),
                            bbox);

--- a/libosmscout-client-qt/src/osmscoutclientqt/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/POILookupModule.cpp
@@ -44,8 +44,6 @@ LocationEntry buildLocationEntry(T obj,
                                  osmscout::GeoCoord coordinates,
                                  osmscout::GeoBox bbox)
 {
-  QStringList adminRegionList;
-
   QString title;
   QString objectType = QString::fromUtf8(obj->GetType()->GetName().c_str());
   const osmscout::FeatureValueBuffer &features=obj->GetFeatureValueBuffer();
@@ -62,7 +60,7 @@ LocationEntry buildLocationEntry(T obj,
     title=QString::fromStdString(ref->GetLabel(osmscout::Locale(), 0));
   }
 
-  LocationEntry location(LocationEntry::typeObject, title, objectType, adminRegionList,
+  LocationEntry location(LocationEntry::typeObject, title, objectType, QList<AdminRegionInfoRef>(),
                          dbPath, coordinates, bbox);
   location.addReference(obj->GetObjectFileRef());
   return LocationEntry(location); // explicit copy. some older compilers (GCC 7.5.0) fails when tries to use deleted move constructor

--- a/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
@@ -370,6 +370,8 @@ QVariant LocationListModel::data(const QModelIndex &index, int role) const
   case LocationObjectRole:
     // QML will take ownership
     return QVariant::fromValue(new LocationEntry(*location));
+  case IndexedAdminRegionRole:
+      return LookupModule::IndexedAdminRegionNames(location->getAdminRegionList(), settings->GetShowAltLanguage());;
   default:
     break;
   }
@@ -398,6 +400,7 @@ QHash<int, QByteArray> LocationListModel::roleNames() const
   roles[DistanceRole]="distance";
   roles[BearingRole]="bearing";
   roles[LocationObjectRole]="locationObject";
+  roles[IndexedAdminRegionRole]="indexedAdminRegion";
 
   return roles;
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
@@ -36,6 +36,7 @@ LocationListModel::LocationListModel(QObject* parent)
 {
   searchModule=OSMScoutQt::GetInstance().MakeSearchModule();
   lookupModule=OSMScoutQt::GetInstance().MakeLookupModule();
+  settings=OSMScoutQt::GetInstance().GetSettings();
 
   connect(this, &LocationListModel::SearchRequested,
           searchModule, &SearchModule::SearchForLocations,
@@ -254,7 +255,7 @@ void LocationListModel::onLocationAdminRegionFinished(const osmscout::GeoCoord l
       !pattern.isEmpty() &&
       defaultRegion &&
       lastRequestDefaultRegion!=defaultRegion){
-    osmscout::log.Debug() << "Search again with new default region: " << defaultRegion->name.toStdString();
+    osmscout::log.Debug() << "Search again with new default region: " << defaultRegion->name();
     setPattern(pattern);
   }
 }
@@ -311,11 +312,11 @@ void LocationListModel::setPattern(const QString& pattern)
   }
   if (searching){
     // we are still waiting for previous request, postpone current
-    qDebug() << "Clear (" << locations.size() << ") postpone search" << pattern << "(default region:" << (defaultRegion?defaultRegion->name:"NULL") << ")";
+    qDebug() << "Clear (" << locations.size() << ") postpone search" << pattern << "(default region:" << (defaultRegion?defaultRegion->qStringName():"NULL") << ")";
     return;
   }
   
-  qDebug() << "Clear (" << locations.size() << ") search" << pattern << "(default region:" << (defaultRegion?defaultRegion->name:"NULL") << ")";
+  qDebug() << "Clear (" << locations.size() << ") search" << pattern << "(default region:" << (defaultRegion?defaultRegion->qStringName():"NULL") << ")";
   searching = true;
   lastRequestPattern = pattern;
   lastRequestDefaultRegion=defaultRegion;
@@ -347,7 +348,7 @@ QVariant LocationListModel::data(const QModelIndex &index, int role) const
     else
       return location->getObjectType();
   case RegionRole:
-    return location->getAdminRegionList();
+    return LookupModule::AdminRegionNames(location->getAdminRegionList(), settings->GetShowAltLanguage());
   case LatRole:
     return QVariant::fromValue(location->getCoord().GetLat());
   case LonRole:

--- a/libosmscout-client-qt/src/osmscoutclientqt/SearchModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/SearchModule.cpp
@@ -280,7 +280,7 @@ bool SearchRunnable::BuildLocationEntry(const osmscout::ObjectFileRef& object,
                                         QList<LocationEntry> &locations
                                         )
 {
-    QStringList adminRegionList;
+    QList<AdminRegionInfoRef> adminRegionList;
     QString objectType;
     osmscout::GeoCoord coordinates;
     osmscout::GeoBox bbox;
@@ -320,11 +320,7 @@ bool SearchRunnable::BuildLocationEntry(const osmscout::LocationSearchResult::En
                                         QList<LocationEntry> &locations
                                         )
 {
-    if (entry.adminRegion){
-      db->GetLocationService()->ResolveAdminRegionHierachie(entry.adminRegion, adminRegionMap);
-    }
-
-    QStringList adminRegionList=LookupModule::BuildAdminRegionList(entry.adminRegion, adminRegionMap);
+    QList<AdminRegionInfoRef> adminRegionList=LookupModule::BuildAdminRegionList(db, entry.adminRegion, adminRegionMap);
     QString objectType;
     osmscout::GeoCoord coordinates;
     osmscout::GeoBox bbox;


### PR DESCRIPTION
It means in location search, near pois, map objects. Instead of simple QStringList admin regions, AdminRegionInfo allow to show admin region names in alternative languate and expose administration level.