### PR TITLE
fix placement of contour symbols for short ways

### DIFF
--- a/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
@@ -576,6 +576,8 @@ namespace osmscout {
     double symbolWidth=symbol.GetWidth(projection);
     double space=data.symbolSpace;
     double offset=data.symbolOffset;
+    assert(space>0);
+    assert(offset>0);
 
     bool             isClosed=false;
     Vertex2D         origin;

--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -1033,12 +1033,17 @@ constexpr bool debugGroundTiles = false;
 
         double symbolWidth=symbolBoundingBox.GetWidth()*symbolScale;
         double length=data.coordRange.GetLength();
-        size_t countSymbols=(length-symbolSpace)/(symbolWidth+symbolSpace);
+        if (length < (symbolWidth+symbolSpace)) {
+          continue; // too short way even for single symbol and required space
+        }
+        assert((symbolWidth+symbolSpace)>0);
+        size_t countSymbols=std::max(size_t(1), size_t((length - symbolSpace) / (symbolWidth + symbolSpace)));
         size_t labelCountExp=log2(countSymbols);
 
         countSymbols=pow(2, labelCountExp);
 
         double space = (length-countSymbols*symbolWidth) / (countSymbols+1);
+        assert(space>0);
 
         ContourSymbolData symbolData;
 

--- a/libosmscout/include/osmscout/util/Transformation.h
+++ b/libosmscout/include/osmscout/util/Transformation.h
@@ -466,7 +466,7 @@ namespace osmscout {
     }
 
     /**
-     * Returns the on-screen length of the path fro the first to the llast element
+     * Returns the on-screen length of the path from the first to the last element
      * @return length of path
      */
     double GetLength() const


### PR DESCRIPTION
When way length is shorter than required symbolSpace, computed label space is negative. It leads to infinite loop during rendering. We should skip contour symbol rendering in such cases.

It is strange that infinite loop happens just with clang, not gcc. But I was not looking for the reason. Negative symbol space should not happen at all.

cc @janbar , it should fix your issue https://github.com/Framstag/libosmscout/commit/ec7528d254393631446e735f5aacaca058fb5909#r88899667