### PR TITLE
improve object names exposed by Qt models

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
@@ -44,6 +44,7 @@ class OSMSCOUT_CLIENT_QT_API LocationEntry : public QObject
 {
   Q_OBJECT
   Q_PROPERTY(QString label      READ getLabel      CONSTANT)
+  Q_PROPERTY(QString altName    READ getAltName    CONSTANT)
   Q_PROPERTY(QString type       READ getTypeString CONSTANT)
   Q_PROPERTY(QString objectType READ getObjectType CONSTANT)
   Q_PROPERTY(double  lat        READ getLat        CONSTANT)
@@ -59,6 +60,7 @@ public:
 private:
   Type                           type;
   QString                        label;
+  QString                        altName; // name in alternative language
   QString                        objectType;
   QList<AdminRegionInfoRef>      adminRegionList;
   QString                        database;
@@ -69,6 +71,7 @@ private:
 public:
   LocationEntry(Type type,
                 const QString& label,
+                const QString& altName,
                 const QString& objectType,
                 const QList<AdminRegionInfoRef>& adminRegionList,
                 const QString database,
@@ -104,6 +107,7 @@ public:
   QString getTypeString() const;
   QString getObjectType() const;
   QString getLabel() const;
+  QString getAltName() const;
   QList<AdminRegionInfoRef> getAdminRegionList() const;
   QString getDatabase() const;
   osmscout::GeoCoord getCoord() const;

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
@@ -78,7 +78,8 @@ public:
         PhoneRole = Qt::UserRole+10,
         AddressLocationRole = Qt::UserRole+11,
         AddressNumberRole = Qt::UserRole+12,
-        IndexedAdminRegionRole = Qt::UserRole+13
+        IndexedAdminRegionRole = Qt::UserRole+13,
+        AltLangName = Qt::UserRole+14
     };
     Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/LookupModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LookupModule.h
@@ -37,6 +37,7 @@ class OSMSCOUT_CLIENT_QT_API LookupModule:public QObject{
   Q_OBJECT
 
   friend class SearchRunnable;
+  friend class SearchLocationsRunnable;
 
 public:
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/NearPOIModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NearPOIModel.h
@@ -85,7 +85,8 @@ public:
     LonRole = Qt::UserRole +4,
     DistanceRole = Qt::UserRole +5,
     BearingRole = Qt::UserRole +6,
-    LocationObjectRole = Qt::UserRole +7
+    LocationObjectRole = Qt::UserRole +7,
+    AltLangName = Qt::UserRole +8
   };
   Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/SearchLocationModel.h
@@ -167,7 +167,8 @@ public:
     DistanceRole = Qt::UserRole +5,
     BearingRole = Qt::UserRole +6,
     LocationObjectRole = Qt::UserRole +7,
-    IndexedAdminRegionRole = Qt::UserRole+8
+    IndexedAdminRegionRole = Qt::UserRole +8,
+    AltLangName = Qt::UserRole +9
   };
 
 public:

--- a/libosmscout-client-qt/include/osmscoutclientqt/SearchModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/SearchModule.h
@@ -43,6 +43,8 @@ class OSMSCOUT_CLIENT_QT_API SearchRunnable : public QRunnable {
 protected:
   SearchModule *searchModule;
   DBInstanceRef db;
+  std::shared_ptr<NameFeatureValueReader> nameReader; // when non-null, object name is used as a title
+  std::shared_ptr<NameAltFeatureValueReader> altNameReader; // when non-null, alternative name is set to location
   QString searchPattern;
   int limit;
   osmscout::BreakerRef breaker;
@@ -59,28 +61,24 @@ public:
   std::future<bool> getFuture();
 
 protected:
-  bool BuildLocationEntry(const osmscout::ObjectFileRef& object,
-                          const QString &title,
-                          DBInstanceRef &db,
-                          std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap,
-                          QList<LocationEntry> &locations);
-
-  bool BuildLocationEntry(const osmscout::LocationSearchResult::Entry &entry,
-                          DBInstanceRef &db,
-                          std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap,
-                          QList<LocationEntry> &locations);
-
-  bool GetObjectDetails(DBInstanceRef &db,
-                        const osmscout::ObjectFileRef& object,
+  bool GetObjectDetails(const osmscout::ObjectFileRef& object,
                         QString &typeName,
+                        QString &name,
+                        QString &altName,
                         osmscout::GeoCoord& coordinates,
                         osmscout::GeoBox& bbox);
 
-  bool GetObjectDetails(DBInstanceRef &db,
-                        const std::vector<osmscout::ObjectFileRef>& objects,
+  bool GetObjectDetails(const std::vector<osmscout::ObjectFileRef>& objects,
                         QString &typeName,
+                        QString &name,
+                        QString &altName,
                         osmscout::GeoCoord& coordinates,
                         osmscout::GeoBox& bbox);
+
+    void GetObjectNames(const FeatureValueBuffer &features,
+                        QString &typeName,
+                        QString &name,
+                        QString &altName);
 };
 
 /**
@@ -108,6 +106,10 @@ private:
                        int limit,
                        osmscout::BreakerRef &breaker,
                        std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap);
+
+  bool BuildLocationEntry(const osmscout::LocationSearchResult::Entry &entry,
+                          std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap,
+                          QList<LocationEntry> &locations);
 };
 
 /**
@@ -129,6 +131,18 @@ private:
                       const QString &searchPattern,
                       int limit,
                       std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap);
+
+  /**
+   * @param object
+   * @param title location title
+   * @param adminRegionMap cached map of administrative regions
+   * @param locations list where new location is added
+   * @return true on success
+   */
+  bool BuildLocationEntry(const osmscout::ObjectFileRef& object,
+                          const QString &title,
+                          std::map<osmscout::FileOffset,osmscout::AdminRegionRef> &adminRegionMap,
+                          QList<LocationEntry> &locations);
 };
 
 /**

--- a/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
@@ -27,6 +27,7 @@ namespace osmscout {
 
 LocationEntry::LocationEntry(Type type,
                              const QString& label,
+                             const QString& altName,
                              const QString& objectType,
                              const QList<AdminRegionInfoRef>& adminRegionList,
                              const QString database,
@@ -36,6 +37,7 @@ LocationEntry::LocationEntry(Type type,
     : QObject(parent),
       type(type),
       label(label),
+      altName(altName),
       objectType(objectType),
       adminRegionList(adminRegionList),
       database(database),
@@ -46,8 +48,8 @@ LocationEntry::LocationEntry(Type type,
 }
 
 LocationEntry::LocationEntry(const QString& label,
-                   const osmscout::GeoCoord& coord,
-                   QObject* parent)
+                             const osmscout::GeoCoord& coord,
+                             QObject* parent)
     : QObject(parent),
       type(typeCoordinate),
       label(label),
@@ -67,6 +69,7 @@ LocationEntry::LocationEntry(const LocationEntry& other)
  : QObject(other.parent()), // make copy of Qt ownership
    type(other.type),
    label(other.label),
+   altName(other.altName),
    objectType(other.objectType),
    adminRegionList(other.adminRegionList),
    database(other.database),
@@ -82,6 +85,7 @@ LocationEntry& LocationEntry::operator=(const LocationEntry& other)
     // Qt ownership is unchanged
     type=other.type;
     label=other.label;
+    altName=other.altName;
     objectType=other.objectType;
     adminRegionList=other.adminRegionList;
     database=other.database;
@@ -95,6 +99,7 @@ LocationEntry::LocationEntry(LocationEntry&& other)
  : QObject(other.parent()), // make copy of Qt ownership
    type(std::move(other.type)),
    label(std::move(other.label)),
+   altName(std::move(other.altName)),
    objectType(std::move(other.objectType)),
    adminRegionList(std::move(other.adminRegionList)),
    database(std::move(other.database)),
@@ -109,6 +114,7 @@ LocationEntry& LocationEntry::operator=(LocationEntry&& other) {
     setParent(other.parent()); // make copy of Qt ownership
     type=std::move(other.type);
     label=std::move(other.label);
+    altName=std::move(other.altName);
     objectType=std::move(other.objectType);
     adminRegionList=std::move(other.adminRegionList);
     database=std::move(other.database);
@@ -179,6 +185,11 @@ QString LocationEntry::getDatabase() const
 QString LocationEntry::getLabel() const
 {
     return label;
+}
+
+QString LocationEntry::getAltName() const
+{
+  return altName;
 }
 
 osmscout::GeoCoord LocationEntry::getCoord() const

--- a/libosmscout-client-qt/src/osmscoutclientqt/LocationInfoModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LocationInfoModel.cpp
@@ -119,6 +119,7 @@ QHash<int, QByteArray> LocationInfoModel::roleNames() const
     roles[AddressLocationRole] = "addressLocation";
     roles[AddressNumberRole] = "addressNumber";
     roles[IndexedAdminRegionRole] = "indexedAdminRegion";
+    roles[AltLangName]="altLangName";
 
     return roles;
 }
@@ -201,6 +202,7 @@ void LocationInfoModel::addToModel(const QString database,
   QString postalCode;
   QString website;
   QString phone;
+  QString altName;
   if (place.GetObjectFeatures()){
     for (const auto& featureInstance :place.GetObjectFeatures()->GetType()->GetFeatures()){
       if (place.GetObjectFeatures()->HasFeature(featureInstance.GetIndex())){
@@ -208,19 +210,19 @@ void LocationInfoModel::addToModel(const QString database,
         if (feature->HasValue()){
           osmscout::FeatureValue *value=place.GetObjectFeatures()->GetValue(featureInstance.GetIndex());
 
-          const osmscout::PostalCodeFeatureValue *postalCodeValue = dynamic_cast<const osmscout::PostalCodeFeatureValue*>(value);
-          if (postalCodeValue!=nullptr){
+
+          if (const osmscout::PostalCodeFeatureValue *postalCodeValue = dynamic_cast<const osmscout::PostalCodeFeatureValue*>(value);
+              postalCodeValue!=nullptr){
             postalCode = QString::fromStdString(postalCodeValue->GetPostalCode());
-          }
-
-          const osmscout::WebsiteFeatureValue *websiteValue = dynamic_cast<const osmscout::WebsiteFeatureValue*>(value);
-          if (websiteValue!=nullptr){
+          } else if (const osmscout::WebsiteFeatureValue *websiteValue = dynamic_cast<const osmscout::WebsiteFeatureValue*>(value);
+                     websiteValue!=nullptr){
             website = QString::fromStdString(websiteValue->GetWebsite());
-          }
-
-          const osmscout::PhoneFeatureValue *phoneValue = dynamic_cast<const osmscout::PhoneFeatureValue*>(value);
-          if (phoneValue!=nullptr){
+          } else if (const osmscout::PhoneFeatureValue *phoneValue = dynamic_cast<const osmscout::PhoneFeatureValue*>(value);
+                     phoneValue!=nullptr){
             phone = QString::fromStdString(phoneValue->GetPhone());
+          } else if (const osmscout::NameAltFeatureValue *altNameValue = dynamic_cast<const osmscout::NameAltFeatureValue*>(value);
+                     altNameValue != nullptr){
+            altName = QString::fromStdString(altNameValue->GetNameAlt());
           }
         }
       }
@@ -246,6 +248,7 @@ void LocationInfoModel::addToModel(const QString database,
   obj[AddressLocationRole] = addressLocation;
   obj[AddressNumberRole] = addressNumber;
   obj[IndexedAdminRegionRole] = LookupModule::IndexedAdminRegionNames(regions, settings->GetShowAltLanguage());
+  obj[AltLangName] = altName;
 
   model << obj;
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/NearPOIModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NearPOIModel.cpp
@@ -96,6 +96,8 @@ QVariant NearPOIModel::data(const QModelIndex &index, int role) const
     case LocationObjectRole:
       // QML will take ownership
       return QVariant::fromValue(new LocationEntry(*location));
+    case AltLangName:
+      return location->getAltName();
     default:
       break;
   }
@@ -124,6 +126,7 @@ QHash<int, QByteArray> NearPOIModel::roleNames() const
   roles[DistanceRole]="distance";
   roles[BearingRole]="bearing";
   roles[LocationObjectRole]="locationObject";
+  roles[AltLangName]="altLangName";
 
   return roles;
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/OverlayObject.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OverlayObject.cpp
@@ -111,6 +111,7 @@ LocationEntry* OverlayObject::getBBoxAsLocation() const
   return new LocationEntry(LocationEntry::Type::typeNone,
                            "bbox",
                            "bbox",
+                           "",
                            QList<AdminRegionInfoRef>(),
                            "",
                            bbox.GetCenter(),

--- a/libosmscout-client-qt/src/osmscoutclientqt/POILookupModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/POILookupModule.cpp
@@ -45,6 +45,7 @@ LocationEntry buildLocationEntry(T obj,
                                  osmscout::GeoBox bbox)
 {
   QString title;
+  QString altName;
   QString objectType = QString::fromUtf8(obj->GetType()->GetName().c_str());
   const osmscout::FeatureValueBuffer &features=obj->GetFeatureValueBuffer();
 
@@ -60,7 +61,12 @@ LocationEntry buildLocationEntry(T obj,
     title=QString::fromStdString(ref->GetLabel(osmscout::Locale(), 0));
   }
 
-  LocationEntry location(LocationEntry::typeObject, title, objectType, QList<AdminRegionInfoRef>(),
+  if (const osmscout::NameAltFeatureValue *name=features.findValue<osmscout::NameAltFeatureValue>();
+    name!=nullptr) {
+    altName = QString::fromStdString(name->GetLabel(osmscout::Locale(), 0));
+  }
+
+  LocationEntry location(LocationEntry::typeObject, title, altName, objectType, QList<AdminRegionInfoRef>(),
                          dbPath, coordinates, bbox);
   location.addReference(obj->GetObjectFileRef());
   return LocationEntry(location); // explicit copy. some older compilers (GCC 7.5.0) fails when tries to use deleted move constructor

--- a/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/SearchLocationModel.cpp
@@ -372,6 +372,8 @@ QVariant LocationListModel::data(const QModelIndex &index, int role) const
     return QVariant::fromValue(new LocationEntry(*location));
   case IndexedAdminRegionRole:
       return LookupModule::IndexedAdminRegionNames(location->getAdminRegionList(), settings->GetShowAltLanguage());;
+  case AltLangName:
+    return location->getAltName();
   default:
     break;
   }
@@ -401,6 +403,7 @@ QHash<int, QByteArray> LocationListModel::roleNames() const
   roles[BearingRole]="bearing";
   roles[LocationObjectRole]="locationObject";
   roles[IndexedAdminRegionRole]="indexedAdminRegion";
+  roles[AltLangName]="altLangName";
 
   return roles;
 }


### PR DESCRIPTION
 - expose object names in alternative language in search, location info and near poi models.

 - use object name as label in prefix search, because text index may contains transliterated form of names, values from it are not suited for UI anymore.