### PR TITLE
Text index fix

### DIFF
--- a/libosmscout-import/src/osmscoutimport/GenTextIndex.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenTextIndex.cpp
@@ -563,7 +563,7 @@ namespace osmscout
       if (BuildKeyStr(UTF8NormForLookup(text),
                       offsetSizeBytes,
                       offset,
-                      refNode,
+                      reftype,
                       keyString)) {
         keyset->push_back(keyString.c_str(),
                           keyString.length());

--- a/libosmscout-import/src/osmscoutimport/GenTextIndex.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenTextIndex.cpp
@@ -544,9 +544,15 @@ namespace osmscout
                                      marisa::Keyset *keyset,
                                      ImportParameter::TextIndexVariant variant) const
   {
+    std::string textNorm = UTF8NormForLookup(text);
     if (variant==ImportParameter::TextIndexVariant::transliterate || variant==ImportParameter::TextIndexVariant::both) {
+      std::string textTrans = UTF8Transliterate(textNorm);
+      if (variant==ImportParameter::TextIndexVariant::both && textTrans==textNorm) {
+        // there is no reason to store the same string twice
+        variant = ImportParameter::TextIndexVariant::transliterate;
+      }
       std::string keyString;
-      if (BuildKeyStr(UTF8Transliterate(UTF8NormForLookup(text)),
+      if (BuildKeyStr(textTrans,
                       offsetSizeBytes,
                       offset,
                       reftype,
@@ -560,7 +566,7 @@ namespace osmscout
 
     if (variant==ImportParameter::TextIndexVariant::original || variant==ImportParameter::TextIndexVariant::both) {
       std::string keyString;
-      if (BuildKeyStr(UTF8NormForLookup(text),
+      if (BuildKeyStr(textNorm,
                       offsetSizeBytes,
                       offset,
                       reftype,

--- a/libosmscout/src/osmscout/TextSearchIndex.cpp
+++ b/libosmscout/src/osmscout/TextSearchIndex.cpp
@@ -175,7 +175,7 @@ namespace osmscout
                                           std::string& text,
                                           ObjectFileRef& ref) const
   {
-    // Get the index that marks the end of the
+    // Get the index that marks the end of
     // the text and where the FileOffset begins
 
     // Each result has only one offset that occupies


### PR DESCRIPTION
When text index is configured to store original form of strings, all indexes were stored as a nodes. Imported database is inconsistent then and search is using wrong file indexes...

copy - paste error :-(

and last commit just solves duplicate entries in text index