### PR TITLE
github as primary source of sources

### DIFF
--- a/webpage/content/documentation/download.md
+++ b/webpage/content/documentation/download.md
@@ -15,14 +15,14 @@ menu:
 There are currently no regular source snapshots in form of downloadable archives
 or versioned tarballs. You have to download the library sources and the demo
 applications manually by cloning the git repository and build everything yourself.
-The sources use autoconf or cmake to setup the build.
+The sources use CMake or Meson to setup the build.
 
-You can browse the reprository at https://sourceforge.net/p/libosmscout/code/ci/master/tree/.
+You can browse the repository at https://github.com/Framstag/libosmscout.
 
 To clone the repository use
 
 ```bash
-  $ git clone git://git.code.sf.net/p/libosmscout/code libosmscout-code
+git clone https://github.com/Framstag/libosmscout.git
 ```
 
 See [Building]({{< relref "/documentation/source.md" >}}) for details on how to


### PR DESCRIPTION
As pointed by @cmosig, our documentation still refers to sourceforge sources... https://github.com/Framstag/libosmscout/issues/1357