### PR TITLE
use proper node when routable object is start or target

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/Router.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/Router.h
@@ -99,10 +99,11 @@ public slots:
   void Initialize();
 
   /**
-   * Start Route computation. Router emits routeComputed or routeFailed later.
+   * Start Route computation. Router emits multiple routingProgress followed by
+   * routeComputed or routeFailed with requestId identifier.
    *
    * User of this function should use Qt::QueuedConnection for invoking
-   * this slot, search may generate IO load and may tooks long time.
+   * this slot, search may generate IO load and may took long time.
    *
    * Route computation can be long depending on the complexity of the route
    * (the further away the endpoints, the more difficult the routing).
@@ -132,10 +133,29 @@ signals:
 
 private:
 
+  /**
+   * Lookup routable node by Qt LocationEntry
+   *
+   * @param routingService
+   * @param location
+   * @return possible routable node. When no routable node node is found, nullopt is returned.
+   */
+  std::optional<RoutePosition> LocationToRoutePosition(osmscout::MultiDBRoutingServiceRef &routingService,
+                                                       const LocationEntryRef &location);
+
+  /**
+   * Synchronous method for routing. Emits multiple routingProgress followed by one of:
+   * routeComputed, routeCanceled or routeFailed.
+   *
+   * @param routingService
+   * @param start
+   * @param target
+   * @param requestId
+   * @param breaker
+   */
   void ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingService,
                            const LocationEntryRef &start,
                            const LocationEntryRef &target,
-                           osmscout::Vehicle vehicle,
                            int requestId,
                            const osmscout::BreakerRef &breaker);
 

--- a/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
+++ b/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
@@ -126,6 +126,17 @@ namespace osmscout {
 
     void Close();
 
+    /**
+     * Return first usable routable node from given object references.
+     *
+     * @param dbId
+     *      ID of database where objects exists.
+     * @param refs
+     *      References to possible routable objects
+     * @return routable node on object (way)
+     */
+    RoutePositionResult GetRoutableNode(const DatabaseId &dbId, const std::vector<ObjectFileRef> &refs);
+
     RoutePositionResult GetClosestRoutableNode(const GeoCoord &coord,
                                                const Distance &radius=Kilometers(1)) const;
 
@@ -147,6 +158,8 @@ namespace osmscout {
                                      const std::list<RoutePostprocessor::PostprocessorRef> &postprocessors);
 
     std::map<DatabaseId, std::string> GetDatabaseMapping() const override;
+
+    std::optional<DatabaseId> GetDatabaseId(const std::string& databasePath) const;
   };
 
   //! \ingroup Service

--- a/libosmscout/include/osmscout/routing/SimpleRoutingService.h
+++ b/libosmscout/include/osmscout/routing/SimpleRoutingService.h
@@ -205,6 +205,41 @@ namespace osmscout {
                                           const Distance &radius,
                                           const RoutingParameter& parameter);
 
+    /**
+     * Return routable node on specific object, when this object is routable
+     * and usable by provided profile.
+     *
+     * @param objRef
+     * @param profile
+     *      Routing profile to use. It defines Vehicle to use and allowed objects.
+     * @return routable node on object (way)
+     */
+    RoutePositionResult GetRoutableNode(const ObjectFileRef& objRef,
+                                        const RoutingProfile& profile) const;
+
+    /**
+     * Returns the closest routable object (area or way) relative
+     * to the given coordinate.
+     *
+     * The result should be use as input for the router to define
+     * routing start or end point.
+     *
+     * @note The returned node may in fact not be routable, it is just
+     * the closest node to the given position on a routable way or area.
+     *
+     * @note The actual object may not be within the given radius
+     * due to internal search index resolution.
+     *
+     * @param coord
+     *    coordinate of the search center
+     * @param profile
+     *    Routing profile to use. It defines Vehicle to use and allowed objects.
+     * @param radius
+     *    The maximum radius to search in from the search center
+     * @return
+     *    A reference to a node on a way or area that is routable (if returned
+     *    route position is valid)
+     */
     RoutePositionResult GetClosestRoutableNode(const GeoCoord& coord,
                                                const RoutingProfile& profile,
                                                const Distance &radius) const;

--- a/libosmscout/include/osmscout/util/Geometry.h
+++ b/libosmscout/include/osmscout/util/Geometry.h
@@ -48,14 +48,14 @@ namespace osmscout {
   /**
    * \defgroup Geometry Geometric helper
    *
-   * Collection of classes and methods releated to low level geometric
+   * Collection of classes and methods related to low level geometric
    * stuff.
    */
 
 
   /**
    * \ingroup Geometry
-   * @param deg angl ein degrees
+   * @param deg angle in degrees
    * @return angle in radians
    */
   inline double DegToRad(double deg)


### PR DESCRIPTION
Current implementation of Qt Router module takes LocationEntry center and lookup nearest routable node for route start or target. It works fine in most cases, when start or target is POI or address node. But When it is routable way (street) that is long and curved, its bounding box center may lead to selecting node on different routable object.

For example, when navigation is set to "Diskařská, Praha", router is setup destination to different street:
https://www.openstreetmap.org/way/530888942#map=17/50.08187/14.38507

This change first tests if LocationEntry contains reference to routable object, and select proper routable node. If it is not routable, it continue with previous logic.

fix for https://github.com/Karry/osmscout-sailfish/issues/280