### PR TITLE
limit number of emited signals on map view change

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -68,7 +68,7 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_PROPERTY(bool     databaseLoaded READ isDatabaseLoaded NOTIFY databaseLoaded)
   Q_PROPERTY(bool     finished READ IsFinished  NOTIFY finishedChanged)
   Q_PROPERTY(bool     showCurrentPosition READ getShowCurrentPosition WRITE setShowCurrentPosition)
-  Q_PROPERTY(bool     lockToPosition READ isLockedToPosition WRITE setLockToPosition NOTIFY lockToPossitionChanged)
+  Q_PROPERTY(bool     lockToPosition READ isLockedToPosition WRITE setLockToPosition NOTIFY lockToPositionChanged)
   Q_PROPERTY(bool     followVehicle READ isFollowVehicle WRITE setFollowVehicle NOTIFY followVehicleChanged)
   Q_PROPERTY(bool     vehicleAutoRotateMap READ isVehicleAutoRotateMap WRITE setVehicleAutoRotateMap NOTIFY vehicleAutoRotateMapChanged)
   Q_PROPERTY(QString  stylesheetFilename READ GetStylesheetFilename NOTIFY stylesheetFilenameChanged)
@@ -162,7 +162,7 @@ private:
 
 signals:
   void viewChanged();
-  void lockToPossitionChanged();
+  void lockToPositionChanged();
   void followVehicleChanged();
   void vehicleAutoRotateMapChanged();
   void finishedChanged(bool finished);

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -60,11 +60,12 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_OBJECT
   Q_PROPERTY(QObject  *view    READ GetView     WRITE SetMapView  NOTIFY viewChanged)
   Q_PROPERTY(QObject  *vehiclePosition READ GetVehiclePosition WRITE SetVehiclePosition)
-  Q_PROPERTY(double   lat      READ GetLat      NOTIFY viewChanged)
-  Q_PROPERTY(double   lon      READ GetLon      NOTIFY viewChanged)
-  Q_PROPERTY(int      zoomLevel READ GetMagLevel NOTIFY viewChanged)
-  Q_PROPERTY(QString  zoomLevelName READ GetZoomLevelName NOTIFY viewChanged)
-  Q_PROPERTY(double   pixelSize READ GetPixelSize NOTIFY viewChanged)
+  Q_PROPERTY(double   lat      READ GetLat      NOTIFY latChanged)
+  Q_PROPERTY(double   lon      READ GetLon      NOTIFY lonChanged)
+  Q_PROPERTY(double   angle    READ GetAngle    NOTIFY angleChanged)
+  Q_PROPERTY(int      zoomLevel READ GetMagLevel NOTIFY magLevelChanged)
+  Q_PROPERTY(QString  zoomLevelName READ GetZoomLevelName NOTIFY magLevelChanged)
+  Q_PROPERTY(double   pixelSize READ GetPixelSize NOTIFY pixelSizeChanged)
   Q_PROPERTY(bool     databaseLoaded READ isDatabaseLoaded NOTIFY databaseLoaded)
   Q_PROPERTY(bool     finished READ IsFinished  NOTIFY finishedChanged)
   Q_PROPERTY(bool     showCurrentPosition READ getShowCurrentPosition WRITE setShowCurrentPosition)
@@ -162,6 +163,11 @@ private:
 
 signals:
   void viewChanged();
+  void latChanged();
+  void lonChanged();
+  void angleChanged();
+  void magLevelChanged();
+  void pixelSizeChanged();
   void lockToPositionChanged();
   void followVehicleChanged();
   void vehicleAutoRotateMapChanged();
@@ -386,6 +392,11 @@ public:
   inline double GetLon() const
   {
       return view->center.GetLon();
+  }
+
+  inline double GetAngle() const
+  {
+      return view->angle.AsRadians();
   }
 
   inline osmscout::GeoCoord GetCenter() const

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -164,7 +164,7 @@ void MapWidget::setupInputHandler(InputHandler *newGesture)
             this, &MapWidget::changeView);
 
     if (locked != inputHandler->isLockedToPosition()){
-        emit lockToPossitionChanged();
+        emit lockToPositionChanged();
     }
     //qDebug() << "Input handler changed (" << (newGesture->animationInProgress()? "animation": "stationary") << ")";
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -178,11 +178,35 @@ void MapWidget::changeView(const MapView &updated)
 {
     //qDebug() << "viewChanged: " << QString::fromStdString(updated.center.GetDisplayText()) << "   level: " << updated.magnification.GetLevel();
     //qDebug() << "viewChanged (" << (inputHandler->animationInProgress()? "animation": "stationary") << ")";
+    assert(view);
     bool changed = *view != updated;
-    view->operator =( updated );
+    bool latChangedFlag = floor(view->GetLat()*10000) != floor(updated.GetLat()*10000);
+    bool lonChangedFlag = floor(view->GetLon()*10000) != floor(updated.GetLon()*10000);
+    bool angleChangedFlag = floor(view->angle.AsRadians()*10000) != floor(updated.angle.AsRadians()*10000);
+    bool magLevelChangedFlag = view->magnification.GetLevel() != updated.magnification.GetLevel();
+
+    double oldPixelSize = floor(GetPixelSize()*1000);
+    *view = updated;
+    bool pixelSizeChangedFlag = oldPixelSize != floor(GetPixelSize()*1000);
+
     // make sure that we render map with antialiasing. TODO: do it better
     if (changed || (!inputHandler->animationInProgress())){
         redraw();
+    }
+    if (latChangedFlag) {
+        emit latChanged();
+    }
+    if (lonChangedFlag) {
+        emit lonChanged();
+    }
+    if (angleChangedFlag) {
+        emit angleChanged();
+    }
+    if (magLevelChangedFlag) {
+        emit magLevelChanged();
+    }
+    if (pixelSizeChangedFlag) {
+        emit pixelSizeChanged();
     }
     if (changed){
         emit viewChanged();
@@ -790,7 +814,6 @@ void MapWidget::onMapDPIChange(double dpi)
 
     // discard current input handler
     setupInputHandler(new InputHandler(*view));
-    emit viewChanged();
 }
 
 void MapWidget::onResize()


### PR DESCRIPTION
Every view property (lat, lon, angle, zoom level, pixel size)
has its own signal now and it is emited just when this property
is changed more than threshold.

It improves performance of QML UI during map animations.

For example it is not necessary to evaluate rotation of compass 
icon when map is moved without changing angle.
