### PR TITLE
improve GeoCoord string parsing

### DIFF
--- a/Tests/src/GeoCoordParse.cpp
+++ b/Tests/src/GeoCoordParse.cpp
@@ -103,4 +103,10 @@ TEST_CASE()
 
     // booking.com format
     REQUIRE(CheckParseSuccess("N 050° 5.14767, E 14° 24.62653", osmscout::GeoCoord(50.0857944, 14.4104422)));
+
+    // values outside lat/lon range
+    REQUIRE(CheckParseFail("99 7"));
+    REQUIRE(CheckParseFail("-99 7"));
+    REQUIRE(CheckParseFail("40 190"));
+    REQUIRE(CheckParseFail("40 -190"));
 }

--- a/Tests/src/GeoCoordParse.cpp
+++ b/Tests/src/GeoCoordParse.cpp
@@ -100,4 +100,7 @@ TEST_CASE()
     REQUIRE(CheckParseSuccess("40,123 -7,123", osmscout::GeoCoord(40.123, -7.123)));
     REQUIRE(CheckParseSuccess("50°5'8.860\"N 14°24'37.592\"E", osmscout::GeoCoord(50.0857944, 14.4104422)));
     REQUIRE(CheckParseSuccess("N 50°5.14767' E 14°24.62653'", osmscout::GeoCoord(50.0857944, 14.4104422)));
+
+    // booking.com format
+    REQUIRE(CheckParseSuccess("N 050° 5.14767, E 14° 24.62653", osmscout::GeoCoord(50.0857944, 14.4104422)));
 }

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -77,6 +77,11 @@ namespace osmscout {
   public:
     using GeoCoordBuffer = std::array<std::byte,7>;
 
+    static constexpr int MinLatitude = -90;
+    static constexpr int MaxLatitude = 90;
+    static constexpr int MinLongitude = -180;
+    static constexpr int MaxLongitude = 180;
+
   public:
     /**
      * The default constructor creates an uninitialized instance (for performance reasons).
@@ -199,7 +204,8 @@ namespace osmscout {
      */
     bool IsValid() const
     {
-      return lat >= -90 && lat <= 90 && lon >= -180 && lon <= +180;
+      return lat >= MinLatitude && lat <= MaxLatitude &&
+             lon >= MinLongitude && lon <= MaxLongitude;
     }
 
     /**

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -195,6 +195,14 @@ namespace osmscout {
     }
 
     /**
+     * Return true if latitude is in range <-90,+90> and longitude in range <-180,+180>
+     */
+    bool IsValid() const
+    {
+      return lat >= -90 && lat <= 90 && lon >= -180 && lon <= +180;
+    }
+
+    /**
      * Parse a textual representation of a geo coordinate from a string
      * to an GeoCoord instance.
      *

--- a/libosmscout/include/osmscout/GeoCoord.h
+++ b/libosmscout/include/osmscout/GeoCoord.h
@@ -205,6 +205,7 @@ namespace osmscout {
      * coordinate may have one of these formats:
      *  DDD[.DDDDD]
      *  DD°[D[.DDD]'[D[.DDD]"]]
+     *  DD°[D[.DDD]
      *
      * The means:
      * * You first define the latitude, then the longitude value

--- a/libosmscout/src/osmscout/GeoCoord.cpp
+++ b/libosmscout/src/osmscout/GeoCoord.cpp
@@ -163,8 +163,11 @@ namespace osmscout {
         currentPos += 2;
       }
 
-      // try pattern:
+      currentPos=EatWhitespace(text, currentPos);
+
+      // try patterns:
       // DD°[D[.DDD]'[D[.DDD]"]]
+      // DD°[D[.DDD]
       // parse minutes
       if (currentPos<text.length() &&
           text[currentPos]>='0' &&
@@ -173,9 +176,9 @@ namespace osmscout {
         if (!ScanNumber(text,currentPos,minutes,2)){
           return false;
         }
+        value+=(minutes/60.0);
         if (currentPos<text.length() &&
             text[currentPos]=='\''){
-          value+=(minutes/60.0);
           currentPos+=1;
 
           // parse seconds
@@ -194,9 +197,6 @@ namespace osmscout {
               return false;
             }
           }
-
-        }else{
-          return false;
         }
       }
     }
@@ -217,8 +217,7 @@ namespace osmscout {
     bool   lonPos=true;
     bool   lonDirectionGiven=false;
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
       return false;
@@ -249,22 +248,22 @@ namespace osmscout {
       currentPos++;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
       return false;
     }
 
-    if (!ScanCoordinate(text,
-                        currentPos,
-                        latitude,
-                        2)) {
+    if (!ScanCoordinate(text, currentPos, latitude, 3)) {
       return false;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
+    // optional ','
+    if (currentPos<text.length() && text[currentPos]==',') {
+      currentPos++;
+    }
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
       return false;
@@ -289,8 +288,7 @@ namespace osmscout {
       currentPos++;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
       return false;
@@ -325,22 +323,17 @@ namespace osmscout {
       currentPos++;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
       return false;
     }
 
-    if (!ScanCoordinate(text,
-                        currentPos,
-                        longitude,
-                        3)) {
+    if (!ScanCoordinate(text, currentPos, longitude, 3)) {
       return false;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos<text.length()) {
       if (text[currentPos]=='E') {
@@ -367,12 +360,10 @@ namespace osmscout {
       longitude=-longitude;
     }
 
-    currentPos=EatWhitespace(text,
-                             currentPos);
+    currentPos=EatWhitespace(text, currentPos);
 
     if (currentPos>=text.length()) {
-      coord.Set(latitude,
-                longitude);
+      coord.Set(latitude, longitude);
 
       return true;
     }

--- a/libosmscout/src/osmscout/GeoCoord.cpp
+++ b/libosmscout/src/osmscout/GeoCoord.cpp
@@ -365,7 +365,7 @@ namespace osmscout {
     if (currentPos>=text.length()) {
       coord.Set(latitude, longitude);
 
-      return true;
+      return coord.IsValid();
     }
 
     return false;

--- a/libosmscout/src/osmscout/OptimizeWaysLowZoom.cpp
+++ b/libosmscout/src/osmscout/OptimizeWaysLowZoom.cpp
@@ -157,11 +157,11 @@ namespace osmscout
       return;
     }
 
-    uint32_t minxc=(uint32_t)floor((boundingBox.GetMinLon()+180.0)/typeData.cellWidth);
-    uint32_t maxxc=(uint32_t)floor((boundingBox.GetMaxLon()+180.0)/typeData.cellWidth);
+    uint32_t minxc=(uint32_t)floor((boundingBox.GetMinLon()+double(GeoCoord::MaxLongitude))/typeData.cellWidth);
+    uint32_t maxxc=(uint32_t)floor((boundingBox.GetMaxLon()+double(GeoCoord::MaxLongitude))/typeData.cellWidth);
 
-    uint32_t minyc=(uint32_t)floor((boundingBox.GetMinLat()+90.0)/typeData.cellHeight);
-    uint32_t maxyc=(uint32_t)floor((boundingBox.GetMaxLat()+90.0)/typeData.cellHeight);
+    uint32_t minyc=(uint32_t)floor((boundingBox.GetMinLat()+double(GeoCoord::MaxLatitude))/typeData.cellHeight);
+    uint32_t maxyc=(uint32_t)floor((boundingBox.GetMaxLat()+double(GeoCoord::MaxLatitude))/typeData.cellHeight);
 
     minxc=std::max(minxc,typeData.cellXStart);
     maxxc=std::min(maxxc,typeData.cellXEnd);

--- a/libosmscout/src/osmscout/WaterIndex.cpp
+++ b/libosmscout/src/osmscout/WaterIndex.cpp
@@ -265,10 +265,10 @@ namespace osmscout {
 
       idx-=waterIndexMinMag;
 
-      cx1=(uint32_t)floor((boundingBox.GetMinLon()+180.0)/levels[idx].cellWidth);
-      cx2=(uint32_t)floor((boundingBox.GetMaxLon()+180.0)/levels[idx].cellWidth);
-      cy1=(uint32_t)floor((boundingBox.GetMinLat()+90.0)/levels[idx].cellHeight);
-      cy2=(uint32_t)floor((boundingBox.GetMaxLat()+90.0)/levels[idx].cellHeight);
+      cx1=(uint32_t)floor((boundingBox.GetMinLon()+double(GeoCoord::MaxLongitude))/levels[idx].cellWidth);
+      cx2=(uint32_t)floor((boundingBox.GetMaxLon()+double(GeoCoord::MaxLongitude))/levels[idx].cellWidth);
+      cy1=(uint32_t)floor((boundingBox.GetMinLat()+double(GeoCoord::MaxLatitude))/levels[idx].cellHeight);
+      cy2=(uint32_t)floor((boundingBox.GetMaxLat()+double(GeoCoord::MaxLatitude))/levels[idx].cellHeight);
 
       const Level &level=levels[idx];
 

--- a/libosmscout/src/osmscout/util/CmdLineParsing.cpp
+++ b/libosmscout/src/osmscout/util/CmdLineParsing.cpp
@@ -313,11 +313,11 @@ namespace osmscout {
       return CmdLineParseResult("Lon value of argument '"+GetArgumentName()+"' is not in valid format");
     }
 
-    if (lat<-90.0 || lat>90.0) {
+    if (lat<double(GeoCoord::MinLatitude) || lat>double(GeoCoord::MaxLatitude)) {
       return CmdLineParseResult("Lat value of argument '"+GetArgumentName()+"' is not in valid range [-90.0,90.0]");
     }
 
-    if (lon<-180.0 || lon>180.0) {
+    if (lon<double(GeoCoord::MinLongitude) || lon>double(GeoCoord::MaxLongitude)) {
       return CmdLineParseResult("Lon value of argument '"+GetArgumentName()+"' is not in valid range [-180.0,180.0]");
     }
 


### PR DESCRIPTION
We should be benevolent in format that we are able to parse. As `GeoCoord::Parse` is used in Qt's search model, it is handy to allow even coordinate format used on booking.com, like `N 046° 40.425, E 05° 31.362`.