### PR TITLE
Separate project version from library version

### DIFF
--- a/libosmscout-client-qt/meson.build
+++ b/libosmscout-client-qt/meson.build
@@ -31,6 +31,7 @@ if get_option('qtVersion') == 5
                              cpp_args: cppArgs,
                              dependencies: [mathDep, threadDep, qt5GuiDep, qt5QmlDep, qt5QuickDep, qt5WidgetsDep, qt5NetworkDep, qt5SvgDep, qt5MultimediaDep],
                              link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                             version: libraryVersion,
                              install: true)
 elif get_option('qtVersion') == 6
   mocFiles = qt6.preprocess(moc_headers : mocHeaders,
@@ -43,6 +44,7 @@ elif get_option('qtVersion') == 6
                              cpp_args: cppArgs,
                              dependencies: [mathDep, threadDep, qt6GuiDep, qt6QmlDep, qt6QuickDep, qt6WidgetsDep, qt6NetworkDep, qt6SvgDep, qt6MultimediaDep],
                              link_with: [osmscout, osmscoutmap, osmscoutmapqt],
+                             version: libraryVersion,
                              install: true)
 endif
 

--- a/libosmscout-gpx/meson.build
+++ b/libosmscout-gpx/meson.build
@@ -19,6 +19,7 @@ osmscoutgpx = library('osmscout_gpx',
                       cpp_args: cppArgs,
                       dependencies: [mathDep, threadDep, xml2Dep, iconvDep, zlibDep],
                       link_with: [osmscout],
+                      version: libraryVersion,
                       install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-import/meson.build
+++ b/libosmscout-import/meson.build
@@ -26,6 +26,7 @@ osmscoutimport = library('osmscout_import',
                          cpp_args: cppArgs,
                          dependencies: [mathDep, threadDep, tbbDep, openmpDep, wsock32Dep, xml2Dep, marisaDep, protobufDep, zlibDep],
                          link_with: [osmscout],
+                         version: libraryVersion,
                          install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-agg/meson.build
+++ b/libosmscout-map-agg/meson.build
@@ -2,7 +2,7 @@ cppArgs = []
 
 if get_option('default_library')=='shared'
   cppArgs += ['-DOSMScoutMapAGG_EXPORTS']
-  
+
   if haveVisibility
     cppArgs += ['-fvisibility=hidden']
   endif
@@ -19,7 +19,7 @@ if aggftpicDep.found()
   mapaggDep += aggftpicDep
 else
   mapaggDep += aggftDep
-endif  
+endif
 
 mapaggDep += ftDep
 
@@ -29,6 +29,7 @@ osmscoutmapagg = library('osmscout_map_agg',
                            cpp_args: cppArgs,
                            dependencies: mapaggDep,
                            link_with: [osmscoutmap, osmscout],
+                           version: libraryVersion,
                            install: true)
-        
-# TODO: Generate PKG_CONFIG file        
+
+# TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-cairo/meson.build
+++ b/libosmscout-map-cairo/meson.build
@@ -20,6 +20,7 @@ osmscoutmapcairo = library('osmscout_map_cairo',
                            cpp_args: cppArgs,
                            dependencies: [mathDep, threadDep, cairoDep, pangoDep, pangocairoDep, pngDep, gobjectDep],
                            link_with: [osmscoutmap, osmscout],
+                           version: libraryVersion,
                            install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-directx/meson.build
+++ b/libosmscout-map-directx/meson.build
@@ -19,6 +19,7 @@ osmscoutmapdirectx = library('osmscout_map_directx',
                              cpp_args: cppArgs,
                              dependencies: [mathDep, threadDep, d2d1Dep, dwriteDep, winCodecsDep],
                              link_with: [osmscoutmap, osmscout],
+                             version: libraryVersion,
                              install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-gdi/meson.build
+++ b/libosmscout-map-gdi/meson.build
@@ -2,7 +2,7 @@ cppArgs = []
 
 if get_option('default_library')=='shared'
   cppArgs += ['-DOSMScoutMapGDI_EXPORTS']
-  
+
   if haveVisibility
     cppArgs += ['-fvisibility=hidden']
   endif
@@ -19,6 +19,7 @@ osmscoutmapgdi = library('osmscout_map_gdi',
                          cpp_args: cppArgs,
                          dependencies: [mathDep, threadDep, gdiplusDep],
                          link_with: [osmscoutmap, osmscout],
+                         version: libraryVersion,
                          install: true)
-        
-# TODO: Generate PKG_CONFIG file        
+
+# TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-iosx/meson.build
+++ b/libosmscout-map-iosx/meson.build
@@ -13,6 +13,7 @@ osmscoutmapiosx = library('osmscout_map_iosx',
                                           cocoaDep,
                                           appKitDep],
                            link_with: [osmscoutmap, osmscout],
+                           version: libraryVersion,
                            install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-opengl/meson.build
+++ b/libosmscout-map-opengl/meson.build
@@ -19,6 +19,7 @@ osmscoutmapopengl = library('osmscout_map_opengl',
                             cpp_args: cppArgs,
                             dependencies: [mathDep, threadDep, openGLDep, glmDep, glewDep, pngDep, ftDep],
                             link_with: [osmscout, osmscoutmap],
+                            version: libraryVersion,
                             install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-map-qt/meson.build
+++ b/libosmscout-map-qt/meson.build
@@ -20,6 +20,7 @@ if get_option('qtVersion') == 5
                           cpp_args: cppArgs,
                           dependencies: [mathDep, threadDep, qt5GuiDep, qt5SvgDep],
                           link_with: [osmscout, osmscoutmap],
+                          version: libraryVersion,
                           install: true)
 elif get_option('qtVersion') == 6
   osmscoutmapqt = library('osmscout_map_qt',
@@ -28,6 +29,7 @@ elif get_option('qtVersion') == 6
                           cpp_args: cppArgs,
                           dependencies: [mathDep, threadDep, qt6GuiDep, qt6SvgDep],
                           link_with: [osmscout, osmscoutmap],
+                          version: libraryVersion,
                           install: true)
 endif
 

--- a/libosmscout-map-svg/meson.build
+++ b/libosmscout-map-svg/meson.build
@@ -2,7 +2,7 @@ cppArgs = []
 
 if get_option('default_library')=='shared'
   cppArgs += ['-DOSMScoutMapSVG_EXPORTS']
-  
+
   if haveVisibility
     cppArgs += ['-fvisibility=hidden']
   endif
@@ -19,6 +19,7 @@ osmscoutmapsvg = library('osmscout_map_svg',
                          cpp_args: cppArgs,
                          dependencies: [mathDep, threadDep, pangoft2Dep],
                          link_with: [osmscoutmap, osmscout],
+                         version: libraryVersion,
                          install: true)
-        
-# TODO: Generate PKG_CONFIG file        
+
+# TODO: Generate PKG_CONFIG file

--- a/libosmscout-map/meson.build
+++ b/libosmscout-map/meson.build
@@ -19,6 +19,7 @@ osmscoutmap = library('osmscout_map',
                       cpp_args: cppArgs,
                       dependencies: [mathDep, threadDep],
                       link_with: [osmscout],
+                      version: libraryVersion,
                       install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout-test/meson.build
+++ b/libosmscout-test/meson.build
@@ -19,6 +19,7 @@ osmscouttest = library('osmscout_test',
                        cpp_args: cppArgs,
                        dependencies: [mathDep, threadDep],
                        link_with: [osmscout, osmscoutimport],
+                       version: libraryVersion,
                        install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/libosmscout/meson.build
+++ b/libosmscout/meson.build
@@ -29,6 +29,7 @@ osmscout = library('osmscout',
                    cpp_args: cppArgs,
                    dependencies: [mathDep, threadDep, openmpDep, iconvDep, marisaDep],
                    link_args: link_args,
+                   version: libraryVersion,
                    install: true)
 
 # TODO: Generate PKG_CONFIG file

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,11 @@
 project('libosmscout',
         'cpp',
+        version: '1.1.1',
         meson_version: '>=0.63.0',
         default_options: ['cpp_std=c++17', 'buildtype=debugoptimized', 'warning_level=3'],
-        license: ['LGPL'],
-        version: '1.1.1')
+        license: ['LGPL'])
+
+libraryVersion='1.1.1'
 
 if build_machine.system()=='darwin'
   add_languages(['objcpp'])
@@ -225,8 +227,6 @@ openGLDep = dependency('gl', required: false)
 glmDep = dependency('glm', required: false, fallback: ['glm', 'glm_dep'])
 glewDep = dependency('glew', required: false, fallback: ['glew', 'glew_dep'])
 
-# Workaround for dependency, else error under Ubuntu 14.04
-
 if build_machine.system()=='darwin' or build_machine.system()=='linux'
   glfwDep=dependency('glfw3', required: false)
 else
@@ -324,12 +324,15 @@ elif get_option('qtVersion') == 6
   buildStyleEditor=buildMapQt and buildClientQt and qt6SvgDep.found()
 endif
 
+message('Meson version:           @0@'.format(meson.version()))
+message('Project version:         @0@'.format(meson.project_version()))
+message('Library version:         @0@'.format(libraryVersion))
+message('Project license:         @0@'.format(meson.project_license()))
 message('Build OS:                @0@'.format(build_machine.system()))
 message('Host OS:                 @0@'.format(host_machine.system()))
 message('Target OS:               @0@'.format(target_machine.system()))
 message('compiler id:             @0@'.format(compiler.get_id()))
-# meson >= 0.49.0
-#message('compiler arg. syntax:    @0@'.format(compiler.get_argument_syntax()))
+message('compiler arg. syntax:    @0@'.format(compiler.get_argument_syntax()))
 message('openmp support:          @0@'.format(openmpDep.found()))
 message('C++17 execution support: @0@'.format(stdExecutionAvailable))
 message('libosmscout:             @0@'.format(true))
@@ -379,7 +382,6 @@ if buildMapGDI
 endif
 
 if buildMapIOSX
-# Does not yet work, because we are not able to active std11 support, fixed in meson trunk
   subdir('libosmscout-map-iosx')
 endif
 


### PR DESCRIPTION
This should allow us to make releases based on
https://chronver.org/ while still using
SEMVER for library versioning (if we care)