### PR TITLE
fix assertion in DrawWayDecoration when way width is zero

### DIFF
--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -953,6 +953,9 @@ constexpr bool debugGroundTiles = false;
     if (symbolStyles.empty()) {
       return false;
     }
+    if (data.mainSlotWidth==0) {
+      return false;
+    }
 
     const LanesFeatureValue *lanesValue=nullptr;
     std::vector<OffsetRel>  laneTurns; // cached turns


### PR DESCRIPTION
It is possible create stylesheet that produces ways with zero width on some zool levels. When such way have defined some scalable decorations (oneway usually), symbolScale is then zero also and renderering hits
`assert((symbolWidth+symbolSpace)>0)`

Renderer should be able to handle even such stylesheets and just skip symbol rendering on ways with zero width.