### PR TITLE
fix infinite loop on roundabout node postprocessing

### DIFF
--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -239,6 +239,7 @@ namespace osmscout {
         ObjectFileRef ref;
         size_t node;
         Bearing bearing;
+        bool canBeUsedAsExit;
       };
 
     private:
@@ -276,7 +277,8 @@ namespace osmscout {
                                  const std::list<RouteDescription::Node>::const_iterator& end);
       // just ways are supported as exits
       std::vector<NodeExit> CollectNodeExits(const RoutePostprocessor& postprocessor,
-                                             RouteDescription::Node& node);
+                                             RouteDescription::Node& node,
+                                             bool includeInputs=false);
 
     public:
       bool Process(const RoutePostprocessor& postprocessor,


### PR DESCRIPTION
Oneway entering roundabout is not considered
as a roundabout exit. But it is necessary to include such oneways to postprocessing to be able find
the entering way to roundabout. We will get infinite loop othervise, because we will never "enter" roundabout during posprocessing node roundabouts (mini roundabout in OSM terminology).