### PR TITLE
fix routing when starting node is in "restricted" area

### DIFF
--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -148,17 +148,14 @@ public:
   {
   }
 
-  virtual ~RoutingServiceAnimation()
-  {
-  }
+  ~RoutingServiceAnimation() override = default;
 
-  virtual bool WalkToOtherDatabases(const osmscout::RoutingProfile& /*state*/,
-                                    osmscout::RoutingService::RNodeRef &current,
-                                    osmscout::RouteNodeRef &/*currentRouteNode*/,
-                                    osmscout::RoutingService::OpenList &openList,
-                                    osmscout::RoutingService::OpenMap &/*openMap*/,
-                                    const osmscout::RoutingService::ClosedSet &closedSet,
-                                    const ClosedSet &closedRestrictedSet)
+  bool WalkToOtherDatabases(const osmscout::RoutingProfile& /*state*/,
+                            osmscout::RoutingService::RNodeRef &current,
+                            osmscout::RouteNodeRef &/*currentRouteNode*/,
+                            osmscout::RoutingService::OpenList &openList,
+                            osmscout::RoutingService::OpenMap &/*openMap*/,
+                            const osmscout::RoutingService::ClosedSet &closedSet) override
   {
     if (stepCounter<startStep || (endStep>0 && (int64_t)stepCounter>endStep)){
       stepCounter++;
@@ -193,9 +190,6 @@ public:
     pen.setWidth(5);
 
     // draw ways in closedSet
-    painter.setBrush(QBrush(red));
-    pen.setColor(red);
-
     for (const auto &closedNode:closedSet){
       if (!closedNode.currentNode.IsValid() ||
           !closedNode.previousNode.IsValid()){
@@ -206,24 +200,12 @@ public:
         return false;
       }
 
-      projection.GeoToPixel(n1->GetCoord(),x1,y1);
-      projection.GeoToPixel(n2->GetCoord(),x2,y2);
-      painter.setPen(pen);
-      painter.drawLine(x1,y1,x2,y2);
-    }
-
-    // closed, restricted
-    painter.setBrush(QBrush(grey));
-    pen.setColor(grey);
-
-    for (const auto &closedNode:closedRestrictedSet){
-      if (!closedNode.currentNode.IsValid() ||
-          !closedNode.previousNode.IsValid()){
-        continue;
-      }
-      if (!GetRouteNode(closedNode.currentNode,n1) ||
-          !GetRouteNode(closedNode.previousNode,n2)){
-        return false;
+      if (closedNode.currentRestricted){
+        painter.setBrush(QBrush(grey));
+        pen.setColor(grey);
+      } else {
+        painter.setBrush(QBrush(red));
+        pen.setColor(red);
       }
 
       projection.GeoToPixel(n1->GetCoord(),x1,y1);

--- a/libosmscout/include/osmscout/routing/AbstractRoutingService.h
+++ b/libosmscout/include/osmscout/routing/AbstractRoutingService.h
@@ -248,9 +248,8 @@ constexpr bool debugRouting = false;
     virtual bool GetAreasByOffset(const std::set<DBFileOffset> &areaOffsets,
                                   std::unordered_map<DBFileOffset,AreaRef> &areaMap) = 0;
 
-    void ResolveRNodeChainToList(DBId finalRouteNode,
+    void ResolveRNodeChainToList(const RNode &finalRouteNode,
                                  const ClosedSet& closedSet,
-                                 const ClosedSet& closedRestrictedSet,
                                  std::list<VNode>& nodes);
 
     virtual bool ResolveRouteDataJunctions(RouteData& route) = 0;
@@ -341,8 +340,7 @@ constexpr bool debugRouting = false;
                                       RouteNodeRef &currentRouteNode,
                                       OpenList &openList,
                                       OpenMap &openMap,
-                                      const ClosedSet &closedSet,
-                                      const ClosedSet &closedRestrictedSet);
+                                      const ClosedSet &closedSet);
 
     virtual bool WalkPaths(const RoutingState& state,
                            RNodeRef &current,
@@ -350,7 +348,6 @@ constexpr bool debugRouting = false;
                            OpenList &openList,
                            OpenMap &openMap,
                            ClosedSet &closedSet,
-                           ClosedSet &closedRestrictedSet,
                            RoutingResult &result,
                            const RoutingParameter& parameter,
                            const GeoCoord &targetCoord,

--- a/libosmscout/include/osmscout/routing/RouteNode.h
+++ b/libosmscout/include/osmscout/routing/RouteNode.h
@@ -100,7 +100,6 @@ namespace osmscout {
       Id         id;          //!< id of the targeting route node
       uint8_t    objectIndex; //!< The index of the way to use from this route node to the target route node
       uint8_t    flags;       //!< Certain flags
-      //uint8_t    bearing;   //!< Encoded initial and final bearing of this path
 
       bool IsRestricted(Vehicle vehicle) const
       {


### PR DESCRIPTION
Routing should be able to leave area with access=private or access=destination ways to non-restricted ways when restricted area is the route start.

fixing https://github.com/janbar/osmin/issues/35 https://github.com/Framstag/libosmscout/issues/1372

I hope that I don't break some corner case.