### PR TITLE
lane turn utility

### DIFF
--- a/DumpData/src/DumpData.cpp
+++ b/DumpData/src/DumpData.cpp
@@ -526,12 +526,22 @@ static void DumpLanesFeatureValue(const osmscout::LanesFeatureValue& lanesValue,
 
   if (!lanesValue.GetTurnForward().empty()) {
     DumpIndent(indent+2);
-    std::cout << "TurnForward: " << lanesValue.GetTurnForward() << std::endl;
+    std::cout << "TurnForward: ";
+    for (auto turn: lanesValue.GetTurnForward()) {
+      std::cout << LaneTurnString(turn);
+      std::cout << " ";
+    }
+    std::cout << std::endl;
   }
 
   if (!lanesValue.GetTurnBackward().empty()) {
     DumpIndent(indent+2);
-    std::cout << "TurnBackward: " << lanesValue.GetTurnBackward() << std::endl;
+    std::cout << "TurnBackward: ";
+    for (auto turn: lanesValue.GetTurnForward()) {
+      std::cout << LaneTurnString(turn);
+      std::cout << " ";
+    }
+    std::cout << std::endl;
   }
 
   if (!lanesValue.GetDestinationForward().empty()) {

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
@@ -215,7 +215,7 @@ public:
   {
     QStringList result;
     for (const auto &turn : lane.turns){
-      result << QString::fromStdString(turn);
+      result << QString::fromStdString(LaneTurnString(turn));
     }
     return result;
   }

--- a/libosmscout-map/include/osmscoutmap/Styles.h
+++ b/libosmscout-map/include/osmscoutmap/Styles.h
@@ -28,6 +28,7 @@
 
 #include <osmscout/Pixel.h>
 #include <osmscout/util/Color.h>
+#include <osmscout/util/LaneTurn.h>
 #include <osmscout/util/Projection.h>
 #include <osmscout/util/ScreenBox.h>
 
@@ -61,8 +62,8 @@ namespace osmscout {
 
   extern bool IsLaneOffset(OffsetRel rel);
 
-  extern OffsetRel ParseForwardTurnStringToOffset(const std::string& turn);
-  extern OffsetRel ParseBackwardTurnStringToOffset(const std::string& turn);
+  extern OffsetRel ParseForwardTurnStringToOffset(LaneTurn turn);
+  extern OffsetRel ParseBackwardTurnStringToOffset(LaneTurn turn);
 
   /**
    * \ingroup Stylesheet

--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -1479,11 +1479,11 @@ constexpr bool debugGroundTiles = false;
 
     // backward
 
-    auto turns=SplitString(lanesValue.GetTurnBackward(), "|");
+    auto turns=lanesValue.GetTurnBackward();
     int lanes=lanesValue.GetBackwardLanes();
     int lane=0;
 
-    for (const std::string &turn: turns) {
+    for (const LaneTurn &turn: turns) {
       if (lane>=lanes){
         break;
       }
@@ -1497,11 +1497,11 @@ constexpr bool debugGroundTiles = false;
 
     // forward
 
-    turns=SplitString(lanesValue.GetTurnForward(), "|");
+    turns=lanesValue.GetTurnForward();
     lanes=lanesValue.GetForwardLanes();
     lane=0;
 
-    for (const std::string &turn: turns) {
+    for (const LaneTurn &turn: turns) {
       if (lane>=lanes){
         break;
       }

--- a/libosmscout-map/src/osmscoutmap/Styles.cpp
+++ b/libosmscout-map/src/osmscoutmap/Styles.cpp
@@ -38,50 +38,50 @@ namespace osmscout {
            rel==OffsetRel::laneBackwardRight;
   }
 
-  OffsetRel ParseForwardTurnStringToOffset(const std::string& turn)
+  OffsetRel ParseForwardTurnStringToOffset(LaneTurn turn)
   {
-    if (turn=="left" || turn=="merge_to_left" || turn=="slight_left" || turn=="sharp_left") {
+    if (turn==LaneTurn::Left || turn==LaneTurn::MergeToLeft || turn==LaneTurn::SlightLeft || turn==LaneTurn::SharpLeft) {
       return OffsetRel::laneForwardLeft;
     }
 
-    if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
+    if (turn==LaneTurn::Through_Left || turn==LaneTurn::Through_SlightLeft || turn==LaneTurn::Through_SharpLeft) {
       return OffsetRel::laneForwardThroughLeft;
     }
 
-    if (turn=="through") {
+    if (turn==LaneTurn::Through) {
       return OffsetRel::laneForwardThrough;
     }
 
-    if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
+    if (turn==LaneTurn::Through_Right || turn==LaneTurn::Through_SlightRight || turn==LaneTurn::Through_SharpRight) {
       return OffsetRel::laneForwardThroughRight;
     }
 
-    if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
+    if (turn==LaneTurn::Right || turn==LaneTurn::MergeToRight || turn==LaneTurn::SlightRight || turn==LaneTurn::SharpRight) {
       return OffsetRel::laneForwardRight;
     }
 
     return OffsetRel::base;
   }
 
-  OffsetRel ParseBackwardTurnStringToOffset(const std::string& turn)
+  OffsetRel ParseBackwardTurnStringToOffset(LaneTurn turn)
   {
-    if (turn=="left" || turn=="merge_to_left" || turn=="slight_left" || turn=="sharp_left") {
+    if (turn==LaneTurn::Left || turn==LaneTurn::MergeToLeft || turn==LaneTurn::SlightLeft || turn==LaneTurn::SharpLeft) {
       return OffsetRel::laneBackwardLeft;
     }
 
-    if (turn=="through;left" || turn=="through;slight_left" || turn=="through;sharp_left") {
+    if (turn==LaneTurn::Through_Left || turn==LaneTurn::Through_SlightLeft || turn==LaneTurn::Through_SharpLeft) {
       return OffsetRel::laneBackwardThroughLeft;
     }
 
-    if (turn=="through") {
+    if (turn==LaneTurn::Through) {
       return OffsetRel::laneBackwardThrough;
     }
 
-    if (turn=="through;right" || turn=="through;slight_right" || turn=="through;sharp_right") {
+    if (turn==LaneTurn::Through_Right || turn==LaneTurn::Through_SlightRight || turn==LaneTurn::Through_SharpRight) {
       return OffsetRel::laneBackwardThroughRight;
     }
 
-    if (turn=="right" || turn=="merge_to_right" || turn=="slight_right" || turn=="sharp_right") {
+    if (turn==LaneTurn::Right || turn==LaneTurn::MergeToRight || turn==LaneTurn::SlightRight || turn==LaneTurn::SharpRight) {
       return OffsetRel::laneBackwardRight;
     }
 

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -79,6 +79,7 @@ set(HEADER_FILES_UTIL
     include/osmscout/util/FileScanner.h
     include/osmscout/util/FileWriter.h
     include/osmscout/util/HTMLWriter.h
+    include/osmscout/util/LaneTurn.h
     include/osmscout/util/Locale.h
     include/osmscout/util/GeoBox.h
     include/osmscout/util/Geometry.h
@@ -156,6 +157,7 @@ set(SOURCE_FILES
     src/osmscout/util/FileScanner.cpp
     src/osmscout/util/FileWriter.cpp
     src/osmscout/util/HTMLWriter.cpp
+    src/osmscout/util/LaneTurn.cpp
     src/osmscout/util/Locale.cpp
     src/osmscout/util/GeoBox.cpp
     src/osmscout/util/Geometry.cpp

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -22,6 +22,7 @@ osmscoutHeader = [
             'osmscout/util/FileScanner.h',
             'osmscout/util/FileWriter.h',
             'osmscout/util/HTMLWriter.h',
+            'osmscout/util/LaneTurn.h',
             'osmscout/util/Locale.h',
             'osmscout/util/GeoBox.h',
             'osmscout/util/Geometry.h',

--- a/libosmscout/include/osmscout/TypeFeatures.h
+++ b/libosmscout/include/osmscout/TypeFeatures.h
@@ -28,6 +28,7 @@
 #include <osmscout/TypeFeature.h>
 
 #include <osmscout/util/Color.h>
+#include <osmscout/util/LaneTurn.h>
 
 namespace osmscout {
 
@@ -1883,8 +1884,8 @@ namespace osmscout {
   private:
 
     uint8_t     lanes=0;              //!< First two bits reserved, 3 bit for number of lanes in each direction
-    std::string turnForward;
-    std::string turnBackward;
+    std::vector<LaneTurn> turnForward;
+    std::vector<LaneTurn> turnBackward;
     std::string destinationForward;
     std::string destinationBackward;
 
@@ -1921,19 +1922,19 @@ namespace osmscout {
 
     uint8_t GetLanes() const;
 
-    void SetTurnLanes(const std::string& turnForward,
-                      const std::string& turnBawckard)
+    void SetTurnLanes(const std::vector<LaneTurn>& turnForward,
+                      const std::vector<LaneTurn>& turnBackward)
     {
       this->turnForward=turnForward;
-      this->turnBackward=turnBawckard;
+      this->turnBackward=turnBackward;
     }
 
-    std::string GetTurnForward() const
+    std::vector<LaneTurn> GetTurnForward() const
     {
       return turnForward;
     }
 
-    std::string GetTurnBackward() const
+    std::vector<LaneTurn> GetTurnBackward() const
     {
       return turnBackward;
     }
@@ -1949,10 +1950,10 @@ namespace osmscout {
     }
 
     void SetDestinationLanes(const std::string& destinationForward,
-                             const std::string& destinationBawckard)
+                             const std::string& destinationBackward)
     {
       this->destinationForward=destinationForward;
-      this->destinationBackward=destinationBawckard;
+      this->destinationBackward=destinationBackward;
     }
 
     std::string GetLabel(const Locale &/*locale*/, size_t /*labelIndex*/) const override

--- a/libosmscout/include/osmscout/navigation/LaneAgent.h
+++ b/libosmscout/include/osmscout/navigation/LaneAgent.h
@@ -39,7 +39,7 @@ public:
     bool suggested{false};
     int suggestedFrom{0};
     int suggestedTo{0};
-    std::vector<std::string> turns;
+    std::vector<LaneTurn> turns;
 
     Lane() = default;
 

--- a/libosmscout/include/osmscout/routing/RouteDescription.h
+++ b/libosmscout/include/osmscout/routing/RouteDescription.h
@@ -32,6 +32,7 @@
 #include <osmscout/GeoCoord.h>
 #include <osmscout/routing/DBFileOffset.h>
 #include <osmscout/util/Distance.h>
+#include <osmscout/util/LaneTurn.h>
 #include <osmscout/util/Time.h>
 
 namespace osmscout {
@@ -593,19 +594,14 @@ namespace osmscout {
        * turns in lanes from left one (drivers view)
        * vector size may be less than laneCount, even empty
        *
-       * usual variants:
-       *    left, slight_left, merge_to_left,
-       *    through;left, through;slight_left, through;sharp_left,
-       *    through,
-       *    through;right, through;slight_right, through;sharp_right,
-       *    right, slight_right, merge_to_right
+       * @see LanesFeatureValue::LaneTurn
        */
-      std::vector<std::string> laneTurns;
+      std::vector<LaneTurn> laneTurns;
 
     public:
       LaneDescription(bool oneway,
                       uint8_t laneCount,
-                      const std::vector<std::string> &laneTurns);
+                      const std::vector<LaneTurn> &laneTurns);
 
       std::string GetDebugString() const override;
 
@@ -619,7 +615,7 @@ namespace osmscout {
         return laneCount;
       }
 
-      const std::vector<std::string>& GetLaneTurns() const
+      const std::vector<LaneTurn>& GetLaneTurns() const
       {
         return laneTurns;
       }

--- a/libosmscout/include/osmscout/util/LaneTurn.h
+++ b/libosmscout/include/osmscout/util/LaneTurn.h
@@ -1,0 +1,68 @@
+#ifndef OSMSCOUT_UTIL_LANE_TURN_H
+#define OSMSCOUT_UTIL_LANE_TURN_H
+
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2023  Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <string>
+
+#include <osmscout/CoreImportExport.h>
+
+namespace osmscout {
+
+  /**
+   * \defgroup LaneTurn lane turn helpers
+   *
+   * Collection of utilities for dealing with route lane turn variants.
+   */
+
+  /**
+   * \ingroup LaneTurn
+   *
+   * Common lane turn variants.
+   *
+   * Note: Numeric values of variants are used for database serialization,
+   * do not change them without increasing database format version.
+   * Just append new variants to the end.
+   */
+  enum class OSMSCOUT_API LaneTurn: char {
+    Null = 0,
+    None = 1,
+    Left = 2,
+    MergeToLeft = 3,
+    SlightLeft = 4,
+    SharpLeft = 5,
+    Through_Left = 6,
+    Through_SlightLeft = 7,
+    Through_SharpLeft = 8,
+    Through = 9,
+    Through_Right = 10,
+    Through_SlightRight = 11,
+    Through_SharpRight = 12,
+    Right = 13,
+    MergeToRight = 14,
+    SlightRight = 15,
+    SharpRight = 16,
+    Unknown = 17,
+  };
+
+  std::string OSMSCOUT_API LaneTurnString(LaneTurn turn);
+}
+
+#endif //OSMSCOUT_UTIL_LANE_TURN_H

--- a/libosmscout/src/meson.build
+++ b/libosmscout/src/meson.build
@@ -14,6 +14,7 @@ osmscoutSrc = [
             'src/osmscout/util/FileScanner.cpp',
             'src/osmscout/util/FileWriter.cpp',
             'src/osmscout/util/HTMLWriter.cpp',
+            'src/osmscout/util/LaneTurn.cpp',
             'src/osmscout/util/Locale.cpp',
             'src/osmscout/util/GeoBox.cpp',
             'src/osmscout/util/Geometry.cpp',

--- a/libosmscout/src/osmscout/TypeFeatures.cpp
+++ b/libosmscout/src/osmscout/TypeFeatures.cpp
@@ -2753,9 +2753,21 @@ namespace osmscout {
   {
     lanes=scanner.ReadUInt8();
 
+    auto StrToTurns = [](const std::string &str) {
+      std::vector<LaneTurn> res;
+      for (char ch: str) {
+        if (ch > char(LaneTurn::Unknown)) {
+          res.push_back(LaneTurn::Unknown);
+        } else {
+          res.push_back(LaneTurn(ch));
+        }
+      }
+      return res;
+    };
+
     if ((lanes & 0x01u)!=0) {
-      turnForward=scanner.ReadString();
-      turnBackward=scanner.ReadString();
+      turnForward=StrToTurns(scanner.ReadString());
+      turnBackward=StrToTurns(scanner.ReadString());
       destinationForward=scanner.ReadString();
       destinationBackward=scanner.ReadString();
     }
@@ -2775,9 +2787,18 @@ namespace osmscout {
 
     writer.Write(lanes);
 
+    auto TurnsToStr = [](const std::vector<LaneTurn> &turns) {
+      std::string res;
+      res.reserve(turns.size());
+      for (LaneTurn t: turns) {
+        res.push_back(char(t));
+      }
+      return res;
+    };
+
     if ((lanes & 0x01u)!=0) {
-      writer.Write(turnForward);
-      writer.Write(turnBackward);
+      writer.Write(TurnsToStr(turnForward));
+      writer.Write(TurnsToStr(turnBackward));
       writer.Write(destinationForward);
       writer.Write(destinationBackward);
     }
@@ -3008,8 +3029,52 @@ namespace osmscout {
       value->SetLanes(lanesForward,lanesBackward);
     }
 
+    auto ParseLaneTurns = [&](const std::string &turnStr) {
+      auto turns=SplitString(turnStr, "|");
+      std::vector<LaneTurn> result;
+      for (const std::string &turn: turns) {
+        if (turn=="none" || turn=="") {
+          result.push_back(LaneTurn::None);
+        } else if (turn=="left") {
+          result.push_back(LaneTurn::Left);
+        } else if (turn=="merge_to_left") {
+          result.push_back(LaneTurn::MergeToLeft);
+        } else if (turn=="slight_left") {
+          result.push_back(LaneTurn::SlightLeft);
+        } else if (turn=="sharp_left") {
+          result.push_back(LaneTurn::SharpLeft);
+        } else if (turn=="through;left" || turn=="left;through") {
+          result.push_back(LaneTurn::Through_Left);
+        } else if (turn=="through;slight_left" || turn=="slight_left;through") {
+          result.push_back(LaneTurn::Through_SlightLeft);
+        } else if (turn=="through;sharp_left" || turn=="sharp_left;through") {
+          result.push_back(LaneTurn::Through_SharpLeft);
+        } else if (turn=="through") {
+          result.push_back(LaneTurn::Through);
+        } else if (turn=="through;right" || turn=="right;through") {
+          result.push_back(LaneTurn::Through_Right);
+        } else if (turn=="through;slight_right" || turn=="slight_right;through") {
+          result.push_back(LaneTurn::Through_SlightRight);
+        } else if (turn=="through;sharp_right" || turn=="sharp_right;through") {
+          result.push_back(LaneTurn::Through_SharpRight);
+        } else if (turn=="right") {
+          result.push_back(LaneTurn::Right);
+        } else if (turn=="merge_to_right") {
+          result.push_back(LaneTurn::MergeToRight);
+        } else if (turn=="slight_right") {
+          result.push_back(LaneTurn::SlightRight);
+        } else if (turn=="sharp_right") {
+          result.push_back(LaneTurn::SharpRight);
+        } else {
+          errorReporter.ReportTag(object,tags,std::string("Lane turn '")+turn+"' is unknown!");
+          result.push_back(LaneTurn::Unknown);
+        }
+      }
+      return result;
+    };
+
     if (additionalInfos) {
-      value->SetTurnLanes(turnForward,turnBackward);
+      value->SetTurnLanes(ParseLaneTurns(turnForward),ParseLaneTurns(turnBackward));
       value->SetDestinationLanes(destinationForward,destinationBackward);
     }
   }

--- a/libosmscout/src/osmscout/routing/RouteDescription.cpp
+++ b/libosmscout/src/osmscout/routing/RouteDescription.cpp
@@ -478,7 +478,7 @@ namespace osmscout {
 
   RouteDescription::LaneDescription::LaneDescription(bool oneway,
                                                      uint8_t laneCount,
-                                                     const std::vector<std::string> &laneTurns)
+                                                     const std::vector<LaneTurn> &laneTurns)
                                                      : oneway(oneway), laneCount(laneCount), laneTurns(laneTurns)
   {}
 
@@ -492,13 +492,9 @@ namespace osmscout {
     if (!laneTurns.empty()){
       ss << " :";
     }
-    for_each(laneTurns.begin(), laneTurns.end(), [&ss] (const std::string& s) {
+    for_each(laneTurns.begin(), laneTurns.end(), [&ss] (const LaneTurn& turn) {
       ss << " ";
-      if (s.empty()){
-        ss << "<unspecified>";
-      } else {
-        ss << s;
-      }
+      ss << LaneTurnString(turn);
     });
 
     return ss.str();

--- a/libosmscout/src/osmscout/util/LaneTurn.cpp
+++ b/libosmscout/src/osmscout/util/LaneTurn.cpp
@@ -1,0 +1,68 @@
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <osmscout/util/LaneTurn.h>
+
+#include <string>
+
+namespace osmscout {
+
+std::string LaneTurnString(LaneTurn turn)
+{
+  switch (turn) {
+    case LaneTurn::None:
+      return "none";
+    case LaneTurn::Left:
+      return "left";
+    case LaneTurn::MergeToLeft:
+      return "merge_to_left";
+    case LaneTurn::SlightLeft:
+      return "slight_left";
+    case LaneTurn::SharpLeft:
+      return "sharp_left";
+    case LaneTurn::Through_Left:
+      return "through;left";
+    case LaneTurn::Through_SlightLeft:
+      return "through;slight_left";
+    case LaneTurn::Through_SharpLeft:
+      return "through;sharp_left";
+    case LaneTurn::Through:
+      return "through";
+    case LaneTurn::Through_Right:
+      return "through;right";
+    case LaneTurn::Through_SlightRight:
+      return "through;slight_right";
+    case LaneTurn::Through_SharpRight:
+      return "through;sharp_right";
+    case LaneTurn::Right:
+      return "right";
+    case LaneTurn::MergeToRight:
+      return "merge_to_right";
+    case LaneTurn::SlightRight:
+      return "slight_right";
+    case LaneTurn::SharpRight:
+      return "sharp_right";
+    case LaneTurn::Unknown:
+      return "unknown";
+    default:
+      return "unknown";
+  }
+}
+
+}


### PR DESCRIPTION
Store lane turn feature as byte array, not original OSM tag value. It shrinks database size and removes parsing of turn string from multiple places - it is now done just during database import.

This change requires to increase database format version. But I would do that just once  - with elevation feature value change: https://github.com/Framstag/libosmscout/pull/1401