### PR TITLE
Asynchronous work

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -4,6 +4,9 @@ osmscout_test_project(NAME AccessParse SOURCES src/AccessParse.cpp)
 #---- AsyncProcessing
 osmscout_test_project(NAME AsyncProcessing SOURCES src/AsyncProcessing.cpp)
 
+#---- AsyncWorker
+osmscout_test_project(NAME AsyncWorker SOURCES src/AsyncWorker.cpp)
+
 #---- Bearing
 osmscout_test_project(NAME Bearing SOURCES src/Bearing.cpp)
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -19,6 +19,9 @@ osmscout_test_project(NAME CachePerformance SOURCES src/CachePerformance.cpp COM
 #---- CalculateResolution
 osmscout_test_project(NAME CalculateResolution SOURCES src/CalculateResolution.cpp)
 
+#---- CancelableFuture
+osmscout_test_project(NAME CancelableFuture SOURCES src/CancelableFuture.cpp)
+
 #---- CmdLineParsing
 osmscout_test_project(NAME CmdLineParsing SOURCES src/CmdLineParsing.cpp)
 

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -79,6 +79,16 @@ CalculateResolution = executable('CalculateResolution',
 
 test('Check position accuracy with coordinate bits', CalculateResolution)
 
+CancelableFuture = executable('CancelableFuture',
+             'src/CancelableFuture.cpp',
+             include_directories: [testIncDir, osmscoutIncDir],
+             dependencies: [mathDep, openmpDep],
+             link_with: [osmscout],
+             install: true,
+             install_dir: testInstallDir)
+
+test('Check cancelable future', CancelableFuture)
+
 CmdLineParsing = executable('CmdLineParsing',
              'src/CmdLineParsing.cpp',
              include_directories: [testIncDir, osmscoutIncDir],

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -20,6 +20,16 @@ AsyncProcessing =  executable('AsyncProcessing',
              install: true,
              install_dir: testInstallDir)
 
+AsyncWorker =  executable('AsyncWorker',
+             'src/AsyncWorker.cpp',
+             include_directories: [testIncDir, osmscoutIncDir],
+             dependencies: [mathDep, openmpDep],
+             link_with: [osmscout],
+             install: true,
+             install_dir: testInstallDir)
+
+test('Check asynchronous worker', AsyncWorker)
+
 TimeParse =  executable('TimeParse',
              'src/TimeParse.cpp',
              include_directories: [testIncDir, osmscoutIncDir],

--- a/Tests/src/AsyncWorker.cpp
+++ b/Tests/src/AsyncWorker.cpp
@@ -1,0 +1,44 @@
+
+#include <osmscout/util/AsyncWorker.h>
+
+#include <TestMain.h>
+
+using namespace std::chrono_literals;
+
+static auto   taskDuration=1s;
+
+class TestWorker: public osmscout::AsyncWorker
+{
+public:
+  TestWorker(): osmscout::AsyncWorker("Test")
+  {
+    // no code
+  }
+
+  ~TestWorker() override = default;
+
+  osmscout::CancelableFuture<int> Compute()
+  {
+    return Async<int>([](osmscout::Breaker&){
+      std::this_thread::sleep_for(taskDuration);
+      return 42;
+    });
+  }
+};
+
+
+TEST_CASE("Start and stop") {
+  TestWorker worker;
+}
+
+TEST_CASE("Simple asynchronous computation") {
+  TestWorker worker;
+  REQUIRE(worker.Compute().StdFuture().get() == 42);
+}
+
+TEST_CASE("Delete later") {
+  auto worker=new TestWorker();
+  worker->DeleteLater();
+  worker=nullptr;
+  std::this_thread::sleep_for(1s);
+}

--- a/Tests/src/CancelableFuture.cpp
+++ b/Tests/src/CancelableFuture.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+
+#include <osmscout/util/CancelableFuture.h>
+
+#include <TestMain.h>
+
+TEST_CASE("Call callback immediately") {
+  osmscout::CancelableFuture<int>::Promise promise;
+  osmscout::CancelableFuture<int> future=promise.Future();
+
+  REQUIRE(future.Value() == std::nullopt);
+
+  int value=0;
+  future.OnComplete([&value](const int &computed) {
+    value=computed;
+  });
+  REQUIRE(value == 0);
+  promise.SetValue(42);
+  REQUIRE(future.Value() == std::make_optional<int>(42));
+  REQUIRE(value == 42);
+
+  int value2=0;
+  future.OnComplete([&value2](const int &computed) {
+    value2=computed;
+  });
+  REQUIRE(value2 == 42);
+}
+
+TEST_CASE("Value is idempotent") {
+  osmscout::CancelableFuture<int>::Promise promise;
+  osmscout::CancelableFuture<int> future=promise.Future();
+
+  REQUIRE(future.Value() == std::nullopt);
+
+  int counter=0;
+  int value=0;
+  future.OnComplete([&value, &counter](const int &computed) {
+    value=computed;
+    counter++;
+  });
+  promise.SetValue(42);
+  promise.SetValue(43); // no effect
+  REQUIRE(future.Value() == std::make_optional<int>(42));
+  REQUIRE(value == 42);
+  REQUIRE(counter == 1);
+}
+
+TEST_CASE("Cancel is idempotent") {
+  osmscout::CancelableFuture<int>::Promise promise;
+  osmscout::CancelableFuture<int> future=promise.Future();
+
+  REQUIRE(future.Value() == std::nullopt);
+
+  int counter=0;
+  future.OnCancel([&counter]() {
+    counter++;
+  });
+  promise.Cancel();
+  promise.Cancel(); // no effect
+  future.Cancel(); // no effect
+  REQUIRE(future.IsCanceled());
+  REQUIRE(promise.IsCanceled());
+  REQUIRE(counter == 1);
+}

--- a/Tests/src/CancelableFuture.cpp
+++ b/Tests/src/CancelableFuture.cpp
@@ -17,6 +17,7 @@ TEST_CASE("Call callback immediately") {
   REQUIRE(value == 0);
   promise.SetValue(42);
   REQUIRE(future.Value() == std::make_optional<int>(42));
+  REQUIRE(future.StdFuture().get() == 42);
   REQUIRE(value == 42);
 
   int value2=0;

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -150,6 +150,7 @@ set(HEADER_FILES_SYSTEM
     include/osmscout/system/Thread.h)
 
 set(HEADER_FILES_UTIL
+    include/osmscout/util/AsyncWorker.h
     include/osmscout/util/Base64.h
     include/osmscout/util/Bearing.h
     include/osmscout/util/Breaker.h
@@ -262,15 +263,16 @@ set(SOURCE_FILES
     src/osmscout/routing/RouteDataFile.cpp
     src/osmscout/system/SSEMath.cpp
     src/osmscout/system/Thread.cpp
+    src/osmscout/util/AsyncWorker.cpp
     src/osmscout/util/Bearing.cpp
     src/osmscout/util/Breaker.cpp
     src/osmscout/util/Cache.cpp
     src/osmscout/util/Color.cpp
     src/osmscout/util/Distance.cpp
     src/osmscout/util/Exception.cpp
-        src/osmscout/io/File.cpp
-        src/osmscout/io/FileScanner.cpp
-        src/osmscout/io/FileWriter.cpp
+    src/osmscout/io/File.cpp
+    src/osmscout/io/FileScanner.cpp
+    src/osmscout/io/FileWriter.cpp
     src/osmscout/util/HTMLWriter.cpp
     src/osmscout/util/LaneTurn.cpp
     src/osmscout/util/Locale.cpp

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -154,6 +154,7 @@ set(HEADER_FILES_UTIL
     include/osmscout/util/Bearing.h
     include/osmscout/util/Breaker.h
     include/osmscout/util/Cache.h
+    include/osmscout/util/CancelableFuture.h
     include/osmscout/util/Color.h
     include/osmscout/util/CmdLineParsing.h
     include/osmscout/util/Distance.h

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -76,6 +76,7 @@ osmscoutHeader = [
             'osmscout/system/SSEMathPublic.h',
             'osmscout/system/SystemTypes.h',
             'osmscout/system/Thread.h',
+            'osmscout/util/AsyncWorker.h',
             'osmscout/util/Base64.h',
             'osmscout/util/Bearing.h',
             'osmscout/util/Breaker.h',

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -80,6 +80,7 @@ osmscoutHeader = [
             'osmscout/util/Bearing.h',
             'osmscout/util/Breaker.h',
             'osmscout/util/Cache.h',
+            'osmscout/util/CancelableFuture.h',
             'osmscout/util/CmdLineParsing.h',
             'osmscout/util/Color.h',
             'osmscout/util/Distance.h',

--- a/libosmscout/include/osmscout/util/AsyncWorker.h
+++ b/libosmscout/include/osmscout/util/AsyncWorker.h
@@ -1,0 +1,77 @@
+#ifndef LIBOSMSCOUT_ASYNCWORKER_H
+#define LIBOSMSCOUT_ASYNCWORKER_H
+
+/*
+ This source is part of the libosmscout library
+ Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/CoreImportExport.h>
+
+#include <osmscout/util/Breaker.h>
+#include <osmscout/util/CancelableFuture.h>
+#include <osmscout/util/WorkQueue.h>
+
+#include <thread>
+
+namespace osmscout {
+
+  /** Async worker provides simple tool for providing asynchronous method calls.
+   * Functions executed via Async method are executed in contex of worker thread.
+   * If all class fields are modified in context of worker thread, there is no
+   * need of synchronisation.
+   */
+  class OSMSCOUT_API AsyncWorker
+  {
+  private:
+    osmscout::ProcessingQueue<std::function<void()>> queue;
+    bool deleteOnExit=false;
+
+    // thread have to be initialized after queue
+    std::thread thread;
+
+  public:
+    explicit AsyncWorker(const std::string &name);
+    virtual ~AsyncWorker();
+
+    AsyncWorker(const AsyncWorker&) = delete;
+    AsyncWorker(AsyncWorker&&) = delete;
+
+    AsyncWorker& operator=(const AsyncWorker&) = delete;
+    AsyncWorker& operator=(AsyncWorker&&) = delete;
+
+    void Loop();
+
+    void DeleteLater();
+
+  protected:
+    template<typename T>
+    CancelableFuture<T> Async(const std::function<T(Breaker&)> &task)
+    {
+      typename CancelableFuture<T>::Promise promise;
+      queue.PushTask([promise, task]() mutable {
+        typename CancelableFuture<T>::FutureBreaker breaker=promise.Breaker();
+        T result = task(breaker);
+        promise.SetValue(result);
+      });
+      return promise.Future();
+    }
+  };
+
+}
+
+#endif //LIBOSMSCOUT_ASYNCWORKER_H

--- a/libosmscout/include/osmscout/util/CancelableFuture.h
+++ b/libosmscout/include/osmscout/util/CancelableFuture.h
@@ -112,15 +112,12 @@ namespace osmscout {
     public:
       Promise() = default;
 
-      virtual ~Promise()
-      {
-        state->Cancel();
-      };
+      virtual ~Promise() = default;
 
-      Promise(const Promise&) = delete;
+      Promise(const Promise&) = default;
       Promise(Promise&&) = default;
 
-      Promise& operator=(const Promise&) = delete;
+      Promise& operator=(const Promise&) = default;
       Promise& operator=(Promise&&) = default;
 
       CancelableFuture<T> Future() const {

--- a/libosmscout/include/osmscout/util/CancelableFuture.h
+++ b/libosmscout/include/osmscout/util/CancelableFuture.h
@@ -1,0 +1,185 @@
+#ifndef LIBOSMSCOUT_CANCELABLEFUTURE_H
+#define LIBOSMSCOUT_CANCELABLEFUTURE_H
+
+/*
+ This source is part of the libosmscout library
+ Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <future>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace osmscout {
+
+  /** Future provides mechanism to access result of asynchronous computation.
+   * Instead of std::future, this one provides callbacks. So the consumer
+   * of the value doesn't need to be blocked.
+   *
+   * @tparam T
+   */
+  template<typename T>
+  class CancelableFuture
+  {
+  public:
+    using DoneCallback = std::function<void(T const&)>;
+    using CancelCallback = std::function<void()>;
+
+    struct State
+    {
+      std::mutex mutex;
+      std::optional<T> value;
+      bool canceled=false;
+      std::vector<DoneCallback> callbacks;
+      std::vector<CancelCallback> cancelCallbacks;
+
+      void Cancel()
+      {
+        std::unique_lock lock(mutex);
+        if (canceled || value) {
+          return;
+        }
+        canceled=true;
+        for (const auto &callback: cancelCallbacks) {
+          callback();
+        }
+      }
+    };
+
+    class Promise
+    {
+    private:
+      std::shared_ptr<State> state=std::make_shared<State>();
+    public:
+      Promise() = default;
+
+      virtual ~Promise()
+      {
+        state->Cancel();
+      };
+
+      Promise(const Promise&) = delete;
+      Promise(Promise&&) = default;
+
+      Promise& operator=(const Promise&) = delete;
+      Promise& operator=(Promise&&) = default;
+
+      CancelableFuture<T> Future() const {
+        return CancelableFuture<T>(state);
+      }
+
+      void Cancel()
+      {
+        state->Cancel();
+      }
+
+      bool IsCanceled()
+      {
+        std::unique_lock lock(state->mutex);
+        return state->canceled;
+      }
+
+      void SetValue(const T &value)
+      {
+        std::unique_lock lock(state->mutex);
+        if (state->canceled || state->value) {
+          return;
+        }
+        state->value=value;
+        for (const auto &callback: state->callbacks) {
+          callback(value);
+        }
+      }
+    };
+
+  private:
+    std::shared_ptr<State> state;
+
+    CancelableFuture(const std::shared_ptr<State> &state): state(state)
+    {
+      // no code
+    };
+
+  public:
+    CancelableFuture(const CancelableFuture &) = default;
+    CancelableFuture(CancelableFuture &&) = default;
+
+    virtual ~CancelableFuture() = default;
+
+    CancelableFuture& operator=(const CancelableFuture &) = default;
+    CancelableFuture& operator=(CancelableFuture &&) = default;
+
+    /** Cancel the corresponding execution.
+     * Cancel callbacks are executed in context of caller.
+     */
+    void Cancel()
+    {
+      state->Cancel();
+    }
+
+    /**
+     * Callback triggered on future complete.
+     * When future is calceled, it is never called.
+     * It is called from thread of value producer.
+     * When future is completed already, callback is called immediately in thread of caller.
+     *
+     * @param callback
+     */
+    void OnComplete(const DoneCallback &callback)
+    {
+      std::unique_lock lock(state->mutex);
+      if (state->value) {
+        callback(state->value.value());
+      } else if (!state->canceled) {
+        state->callbacks.push_back(std::move(callback));
+      }
+    }
+
+    /**
+     * Callback triggered when future is canceled.
+     * It is called from thread that is canceling the execution.
+     * When future is completed already, callback is called immediately in thread of caller.
+     *
+     * @param callback
+     */
+    void OnCancel(const CancelCallback &callback)
+    {
+      std::unique_lock lock(state->mutex);
+      if (state->canceled) {
+        callback();
+      } else if (!state->value) {
+        state->cancelCallbacks.push_back(std::move(callback));
+      }
+    };
+
+    std::optional<T> Value()
+    {
+      std::unique_lock lock(state->mutex);
+      return state->value;
+    }
+
+    bool IsCanceled()
+    {
+      std::unique_lock lock(state->mutex);
+      return state->canceled;
+    }
+  };
+
+}
+
+#endif //LIBOSMSCOUT_CANCELABLEFUTURE_H

--- a/libosmscout/include/osmscout/util/CancelableFuture.h
+++ b/libosmscout/include/osmscout/util/CancelableFuture.h
@@ -178,6 +178,21 @@ namespace osmscout {
       std::unique_lock lock(state->mutex);
       return state->canceled;
     }
+
+    std::future<T> StdFuture()
+    {
+      auto promisePtr=std::make_shared<std::promise<T>>();
+
+      OnComplete([promisePtr](const T &value) {
+        promisePtr->set_value(value);
+      });
+
+      OnCancel([promisePtr]() {
+        promisePtr->set_exception(std::make_exception_ptr(std::runtime_error("Canceled")));
+      });
+
+      return promisePtr->get_future();
+    }
   };
 
 }

--- a/libosmscout/include/osmscout/util/WorkQueue.h
+++ b/libosmscout/include/osmscout/util/WorkQueue.h
@@ -44,7 +44,6 @@ namespace osmscout {
     explicit WorkQueue(size_t queueLimit);
     ~WorkQueue() override = default;
 
-    //void PushTask(Task& task);
     bool PopTask(Task& task);
   };
 

--- a/libosmscout/src/meson.build
+++ b/libosmscout/src/meson.build
@@ -67,6 +67,7 @@ osmscoutSrc = [
             'src/osmscout/routing/MultiDBRoutingState.cpp',
             'src/osmscout/system/SSEMath.cpp',
             'src/osmscout/system/Thread.cpp',
+            'src/osmscout/util/AsyncWorker.cpp',
             'src/osmscout/util/Breaker.cpp',
             'src/osmscout/util/Bearing.cpp',
             'src/osmscout/util/Cache.cpp',

--- a/libosmscout/src/osmscout/util/AsyncWorker.cpp
+++ b/libosmscout/src/osmscout/util/AsyncWorker.cpp
@@ -1,0 +1,64 @@
+/*
+ This source is part of the libosmscout library
+ Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/util/AsyncWorker.h>
+
+namespace osmscout {
+
+AsyncWorker::AsyncWorker(const std::string&):
+  thread(&AsyncWorker::Loop,this)
+{
+
+}
+
+AsyncWorker::~AsyncWorker()
+{
+  queue.Stop();
+  if (thread.joinable() && thread.get_id() != std::this_thread::get_id()) {
+    thread.join();
+  } else {
+    thread.detach();
+  }
+}
+
+void AsyncWorker::Loop()
+{
+  while (true) {
+    auto taskOpt = queue.PopTask();
+    if (!taskOpt) {
+      break;
+    }
+
+    taskOpt.value()();
+  }
+
+  if (deleteOnExit) {
+    delete this;
+  }
+}
+
+void AsyncWorker::DeleteLater()
+{
+  Async<bool>([this](Breaker &) -> bool {
+    queue.Stop();
+    deleteOnExit=true;
+    return true;
+  });
+}
+}


### PR DESCRIPTION
This is initial preparation for moving some logic from libosmscout-client-qt to libosmscout-client. As `std::future` doesn't have callbacks, I need some custom future to do asynchronous work without blocking UI thread. 