### PR TITLE
"unhewn_cobblestone" surface type is heavily used at least in CZ

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -85,7 +85,7 @@ GRADES
     "asphalt"
     "cobblestone"
     "cobblestone:flattened"
-	"unhewn_cobblestone"
+    "unhewn_cobblestone"
     "concrete"
     "concrete:lanes"
     "concrete:plates"

--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -85,6 +85,7 @@ GRADES
     "asphalt"
     "cobblestone"
     "cobblestone:flattened"
+	"unhewn_cobblestone"
     "concrete"
     "concrete:lanes"
     "concrete:plates"


### PR DESCRIPTION
[unhewn_cobblestone](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dunhewn_cobblestone)