### PR TITLE
Buildsystem improvements

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/meson.build
+++ b/libosmscout-client-qt/include/osmscoutclientqt/meson.build
@@ -1,5 +1,6 @@
 clientqtFeaturesCfg = configuration_data()
 
 configure_file(output: 'ClientQtFeatures.h',
+               install_dir: 'include/osmscoutclientqt',
                configuration: clientqtFeaturesCfg)
 

--- a/libosmscout-client-qt/meson.build
+++ b/libosmscout-client-qt/meson.build
@@ -33,4 +33,5 @@ endforeach
                              version: libraryVersion,
                              install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutclientqt)

--- a/libosmscout-client/include/osmscoutclient/meson.build
+++ b/libosmscout-client/include/osmscoutclient/meson.build
@@ -2,5 +2,6 @@ clientFeaturesCfg = configuration_data()
 clientFeaturesCfg.set('OSMSCOUT_CLIENT_MESON_BUILD',true, description: 'we are building using meson')
 
 configure_file(output: 'ClientFeatures.h',
+               install_dir: 'include/osmscoutclient',
                configuration: clientFeaturesCfg)
 

--- a/libosmscout-client/meson.build
+++ b/libosmscout-client/meson.build
@@ -33,4 +33,5 @@ osmscoutclient = library('osmscout_client',
                          version: libraryVersion,
                          install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutclient)

--- a/libosmscout-gpx/include/osmscoutgpx/meson.build
+++ b/libosmscout-gpx/include/osmscoutgpx/meson.build
@@ -3,5 +3,6 @@ gpxFeaturesCfg.set('OSMSCOUT_GPX_HAVE_LIB_XML',xml2Dep.found(), description: '*.
 gpxFeaturesCfg.set('OSMSCOUT_GPX_MESON_BUILD',true, description: 'we are building using meson')
 
 configure_file(output: 'GPXFeatures.h',
+               install_dir: 'include/osmscoutgpx',
                configuration: gpxFeaturesCfg)
 

--- a/libosmscout-gpx/meson.build
+++ b/libosmscout-gpx/meson.build
@@ -22,4 +22,5 @@ osmscoutgpx = library('osmscout_gpx',
                       version: libraryVersion,
                       install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutgpx)

--- a/libosmscout-import/include/osmscoutimport/meson.build
+++ b/libosmscout-import/include/osmscoutimport/meson.build
@@ -7,5 +7,6 @@ importFeaturesCfg.set('OSMSCOUT_DEBUG_COASTLINE',false, description: 'Extra debu
 importFeaturesCfg.set('OSMSCOUT_DEBUG_TILING',false, description: 'Extra debugging of water index tiling')
 
 configure_file(output: 'ImportFeatures.h',
+               install_dir: 'include/osmscoutimport',
                configuration: importFeaturesCfg)
 

--- a/libosmscout-import/meson.build
+++ b/libosmscout-import/meson.build
@@ -29,4 +29,5 @@ osmscoutimport = library('osmscout_import',
                          version: libraryVersion,
                          install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutimport)

--- a/libosmscout-map-agg/include/osmscoutmapagg/meson.build
+++ b/libosmscout-map-agg/include/osmscoutmapagg/meson.build
@@ -1,5 +1,6 @@
 mapaggFeaturesCfg = configuration_data()
 
 configure_file(output: 'MapAggFeatures.h',
+               install_dir: 'include/osmscoutmapagg',
                configuration: mapaggFeaturesCfg)
 

--- a/libosmscout-map-agg/meson.build
+++ b/libosmscout-map-agg/meson.build
@@ -32,4 +32,5 @@ osmscoutmapagg = library('osmscout_map_agg',
                            version: libraryVersion,
                            install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapagg)

--- a/libosmscout-map-cairo/include/osmscoutmapcairo/meson.build
+++ b/libosmscout-map-cairo/include/osmscoutmapcairo/meson.build
@@ -3,5 +3,6 @@ mapcairoFeaturesCfg = configuration_data()
 mapcairoFeaturesCfg.set('OSMSCOUT_MAP_CAIRO_HAVE_LIB_PANGO',pangoDep.found() and pangocairoDep.found(), description: 'text drawing using pango is supported')
 
 configure_file(output: 'MapCairoFeatures.h',
+               install_dir: 'include/osmscoutmapcairo',
                configuration: mapcairoFeaturesCfg)
 

--- a/libosmscout-map-cairo/meson.build
+++ b/libosmscout-map-cairo/meson.build
@@ -23,4 +23,5 @@ osmscoutmapcairo = library('osmscout_map_cairo',
                            version: libraryVersion,
                            install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapcairo)

--- a/libosmscout-map-directx/include/osmscoutmapdirectx/meson.build
+++ b/libosmscout-map-directx/include/osmscoutmapdirectx/meson.build
@@ -1,5 +1,6 @@
 mapdirectxFeaturesCfg = configuration_data()
 
 configure_file(output: 'MapDirectXFeatures.h',
+               install_dir: 'include/osmscoutmapdirectx',
                configuration: mapdirectxFeaturesCfg)
 

--- a/libosmscout-map-directx/meson.build
+++ b/libosmscout-map-directx/meson.build
@@ -22,4 +22,5 @@ osmscoutmapdirectx = library('osmscout_map_directx',
                              version: libraryVersion,
                              install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapdirectx)

--- a/libosmscout-map-gdi/meson.build
+++ b/libosmscout-map-gdi/meson.build
@@ -22,4 +22,5 @@ osmscoutmapgdi = library('osmscout_map_gdi',
                          version: libraryVersion,
                          install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapgdi)

--- a/libosmscout-map-iosx/meson.build
+++ b/libosmscout-map-iosx/meson.build
@@ -16,4 +16,5 @@ osmscoutmapiosx = library('osmscout_map_iosx',
                            version: libraryVersion,
                            install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapiosx)

--- a/libosmscout-map-opengl/include/osmscoutmapopengl/meson.build
+++ b/libosmscout-map-opengl/include/osmscoutmapopengl/meson.build
@@ -4,5 +4,6 @@ mapopenglFeaturesCfg.set('SHADER_INSTALL_DIR','"shaders"', description: 'OpenGL 
 mapopenglFeaturesCfg.set('DEFAULT_FONT_FILE','"LiberationSans-Regular.ttf"', description: 'OpenGL default font path')
 
 configure_file(output: 'MapOpenGLFeatures.h',
+               install_dir: 'include/osmscoutmapopengl',
                configuration: mapopenglFeaturesCfg)
 

--- a/libosmscout-map-opengl/meson.build
+++ b/libosmscout-map-opengl/meson.build
@@ -22,4 +22,5 @@ osmscoutmapopengl = library('osmscout_map_opengl',
                             version: libraryVersion,
                             install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapopengl)

--- a/libosmscout-map-qt/include/osmscoutmapqt/meson.build
+++ b/libosmscout-map-qt/include/osmscoutmapqt/meson.build
@@ -1,5 +1,6 @@
 mapqtFeaturesCfg = configuration_data()
 
 configure_file(output: 'MapQtFeatures.h',
+               install_dir: 'include/osmscoutmapqt',
                configuration: mapqtFeaturesCfg)
 

--- a/libosmscout-map-qt/meson.build
+++ b/libosmscout-map-qt/meson.build
@@ -22,4 +22,5 @@ osmscoutmapqt = library('osmscout_map_qt',
                       version: libraryVersion,
                       install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapqt)

--- a/libosmscout-map-svg/include/osmscoutmapsvg/meson.build
+++ b/libosmscout-map-svg/include/osmscoutmapsvg/meson.build
@@ -1,5 +1,6 @@
 mapsvgFeaturesCfg = configuration_data()
 
 configure_file(output: 'MapSVGFeatures.h',
+               install_dir: 'include/osmscoutmapsvg',
                configuration: mapsvgFeaturesCfg)
 

--- a/libosmscout-map-svg/meson.build
+++ b/libosmscout-map-svg/meson.build
@@ -22,4 +22,5 @@ osmscoutmapsvg = library('osmscout_map_svg',
                          version: libraryVersion,
                          install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmapsvg)

--- a/libosmscout-map/include/osmscoutmap/meson.build
+++ b/libosmscout-map/include/osmscoutmap/meson.build
@@ -3,5 +3,6 @@ mapFeaturesCfg.set('OSMSCOUT_DEBUG_LABEL_LAYOUTER',false, description: 'Extra de
 mapFeaturesCfg.set('OSMSCOUT_DEBUG_GROUNDTILES',false, description: 'Extra debugging of ground tiles rendering')
 
 configure_file(output: 'MapFeatures.h',
+               install_dir: 'include/osmscoutmap',
                configuration: mapFeaturesCfg)
 

--- a/libosmscout-map/meson.build
+++ b/libosmscout-map/meson.build
@@ -22,4 +22,5 @@ osmscoutmap = library('osmscout_map',
                       version: libraryVersion,
                       install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscoutmap)

--- a/libosmscout-test/include/osmscout-test/meson.build
+++ b/libosmscout-test/include/osmscout-test/meson.build
@@ -2,5 +2,6 @@ testFeaturesCfg = configuration_data()
 testFeaturesCfg.set('OSMSCOUT_TEST_MESON_BUILD',true, description: 'we are building using meson')
 
 configure_file(output: 'TestFeatures.h',
+               install_dir: 'include/osmscout-test',
                configuration: testFeaturesCfg)
 

--- a/libosmscout-test/meson.build
+++ b/libosmscout-test/meson.build
@@ -22,4 +22,5 @@ osmscouttest = library('osmscout_test',
                        version: libraryVersion,
                        install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscouttest)

--- a/libosmscout/include/osmscout/lib/meson.build
+++ b/libosmscout/include/osmscout/lib/meson.build
@@ -5,5 +5,6 @@ coreFeaturesCfg.set('OSMSCOUT_HAVE_LIB_MARISA',marisaDep.found(), description: '
 coreFeaturesCfg.set('OSMSCOUT_DEBUG_ROUTING',false, description: 'Extra debugging of routing')
 
 configure_file(output: 'CoreFeatures.h',
+               install_dir: 'include/osmscout/lib',
                configuration: coreFeaturesCfg)
 

--- a/libosmscout/meson.build
+++ b/libosmscout/meson.build
@@ -32,4 +32,5 @@ osmscout = library('osmscout',
                    version: libraryVersion,
                    install: true)
 
-# TODO: Generate PKG_CONFIG file
+pkg = import('pkgconfig')
+pkg.generate(osmscout)


### PR DESCRIPTION
Hi, I'm trying to use libosmscout in my CMake Qt6 project, but libosmscout's CMake doesn't support Qt6 yet.  Meson does support Qt6, but there isn't any meson->cmake integration, so I need libosmscout to generate pkgconfig files.

Some of the generated headers also needed to be installed, so I've changed that also.