### PR TITLE
thread finalizer utility

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -59,6 +59,9 @@ else()
 	message("Skip ThreadedDatabase test, libosmscout-map is missing.")
 endif()
 
+#---- ThreadFinalizer
+osmscout_test_project(NAME ThreadFinalizer SOURCES src/ThreadFinalizer.cpp)
+
 #---- TextLookupTest
 if(MARISA_FOUND)
 	osmscout_demo_project(NAME TextLookupTest SOURCES src/TextLookupTest.cpp TARGET OSMScout::OSMScout OSMScout::OSMScout)

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -434,6 +434,17 @@ test('Check threaded database', ThreadedDatabase, args : [
         meson.current_source_dir() + '/data/testregion',
         meson.current_source_dir() + '/../stylesheets/standard.oss'])
 
+
+ThreadFinalizer = executable('ThreadFinalizer',
+             'src/ThreadFinalizer.cpp',
+             include_directories: [testIncDir, osmscoutIncDir],
+             dependencies: [mathDep, threadDep, openmpDep],
+             link_with: [osmscout],
+             install: true,
+             install_dir: testInstallDir)
+
+test('Check thread finalizer', ThreadFinalizer)
+
 SunriseSunset = executable('SunriseSunset',
              'src/SunriseSunsetTest.cpp',
              include_directories: [testIncDir, osmscoutIncDir],

--- a/Tests/src/ThreadFinalizer.cpp
+++ b/Tests/src/ThreadFinalizer.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Thread finalizer") {
 
   std::thread t1([&threadEndSlot](){
     std::cout << "ThreadFn " << std::this_thread::get_id() << std::endl;
-    osmscout::threadFinalizer.threadExit.Connect(threadEndSlot);
+    osmscout::ThreadFinalizer().threadExit.Connect(threadEndSlot);
   });
 
   t1.join();

--- a/Tests/src/ThreadFinalizer.cpp
+++ b/Tests/src/ThreadFinalizer.cpp
@@ -1,0 +1,28 @@
+#include <osmscout/async/Signal.h>
+#include <osmscout/async/ThreadFinalizer.h>
+
+#include <TestMain.h>
+
+#include <thread>
+#include <atomic>
+
+TEST_CASE("Thread finalizer") {
+
+  auto cnt=std::atomic_int(0);
+
+  osmscout::Slot<std::thread::id> threadEndSlot([&cnt](const std::thread::id &id){
+    std::cout << "Thread " << id << " ended" << std::endl;
+    cnt.fetch_add(1);
+  });
+
+  REQUIRE(cnt==0);
+
+  std::thread t1([&threadEndSlot](){
+    std::cout << "ThreadFn " << std::this_thread::get_id() << std::endl;
+    osmscout::threadFinalizer.threadExit.Connect(threadEndSlot);
+  });
+
+  t1.join();
+
+  REQUIRE(cnt==1);
+}

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -40,6 +40,7 @@ set(HEADER_FILES_ASYNC
         include/osmscout/async/ProcessingQueue.h
         include/osmscout/async/Signal.h
         include/osmscout/async/Thread.h
+        include/osmscout/async/ThreadFinalizer.h
         include/osmscout/async/Worker.h
         include/osmscout/async/WorkQueue.h)
 
@@ -217,6 +218,7 @@ set(SOURCE_FILES
     src/osmscout/async/AsyncWorker.cpp
     src/osmscout/async/Breaker.cpp
     src/osmscout/async/Thread.cpp
+    src/osmscout/async/ThreadFinalizer.cpp
     src/osmscout/async/Worker.cpp
     src/osmscout/async/WorkQueue.cpp
     src/osmscout/feature/AccessFeature.cpp

--- a/libosmscout/include/meson.build
+++ b/libosmscout/include/meson.build
@@ -11,6 +11,7 @@ osmscoutHeader = [
             'osmscout/async/ProcessingQueue.h',
             'osmscout/async/Signal.h',
             'osmscout/async/Thread.h',
+            'osmscout/async/ThreadFinalizer.h',
             'osmscout/async/Worker.h',
             'osmscout/async/WorkQueue.h',
             'osmscout/feature/AccessFeature.h',

--- a/libosmscout/include/osmscout/async/Signal.h
+++ b/libosmscout/include/osmscout/async/Signal.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <set>
 #include <memory>
+#include <vector>
 
 namespace osmscout {
 

--- a/libosmscout/include/osmscout/async/ThreadFinalizer.h
+++ b/libosmscout/include/osmscout/async/ThreadFinalizer.h
@@ -50,7 +50,7 @@ namespace osmscout {
    * some threads may be still running on program exit. For example detached
    * thread, global scheduler threads, when std::exit is called...
    */
-  extern thread_local OSMSCOUT_API ThreadFinalizer threadFinalizer;
+  extern OSMSCOUT_API ThreadFinalizer& ThreadFinalizer();
 }
 
 #endif //LIBOSMSCOUT_THREADFINALIZER_H

--- a/libosmscout/include/osmscout/async/ThreadFinalizer.h
+++ b/libosmscout/include/osmscout/async/ThreadFinalizer.h
@@ -1,0 +1,56 @@
+#ifndef LIBOSMSCOUT_THREADFINALIZER_H
+#define LIBOSMSCOUT_THREADFINALIZER_H
+
+/*
+ This source is part of the libosmscout library
+ Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/lib/CoreImportExport.h>
+
+#include <osmscout/async/Signal.h>
+
+#include <thread>
+
+namespace osmscout {
+
+  struct OSMSCOUT_API ThreadFinalizer
+  {
+    osmscout::Signal<std::thread::id> threadExit;
+
+    ThreadFinalizer() = default;
+    ThreadFinalizer(const ThreadFinalizer &) = delete;
+    ThreadFinalizer(ThreadFinalizer &&) = delete;
+
+    virtual ~ThreadFinalizer()
+    {
+      threadExit.Emit(std::this_thread::get_id());
+    }
+
+    ThreadFinalizer &operator=(const ThreadFinalizer &) = delete;
+    ThreadFinalizer &operator=(ThreadFinalizer &&) = delete;
+  };
+
+  /** Thread local thread finalizer that provides signal on thread exit.
+   * It is not guaranteed that signal will be emitted for all threads,
+   * some threads may be still running on program exit. For example detached
+   * thread, global scheduler threads, when std::exit is called...
+   */
+  extern thread_local OSMSCOUT_API ThreadFinalizer threadFinalizer;
+}
+
+#endif //LIBOSMSCOUT_THREADFINALIZER_H

--- a/libosmscout/include/osmscout/log/Logger.h
+++ b/libosmscout/include/osmscout/log/Logger.h
@@ -420,7 +420,7 @@ namespace osmscout {
 
   /**
    * \ingroup Logging
-   * The one an donly global instance of the logger that should get used
+   * The one an only global instance of the logger that should get used
    * for all logging output.
    */
   extern OSMSCOUT_API Log log;

--- a/libosmscout/src/meson.build
+++ b/libosmscout/src/meson.build
@@ -6,6 +6,7 @@ osmscoutSrc = [
             'src/osmscout/async/AsyncWorker.cpp',
             'src/osmscout/async/Breaker.cpp',
             'src/osmscout/async/Thread.cpp',
+            'src/osmscout/async/ThreadFinalizer.cpp',
             'src/osmscout/async/Worker.cpp',
             'src/osmscout/async/WorkQueue.cpp',
             'src/osmscout/feature/AccessFeature.cpp',

--- a/libosmscout/src/osmscout/async/ThreadFinalizer.cpp
+++ b/libosmscout/src/osmscout/async/ThreadFinalizer.cpp
@@ -19,6 +19,15 @@
 
 #include <osmscout/async/ThreadFinalizer.h>
 
+namespace { // anonymous namespace
+  thread_local struct osmscout::ThreadFinalizer threadFinalizer{};
+}
+
 namespace osmscout {
-  thread_local ThreadFinalizer threadFinalizer{};
+
+  struct ThreadFinalizer& ThreadFinalizer()
+  {
+    return threadFinalizer;
+  }
+
 }

--- a/libosmscout/src/osmscout/async/ThreadFinalizer.cpp
+++ b/libosmscout/src/osmscout/async/ThreadFinalizer.cpp
@@ -1,0 +1,24 @@
+/*
+ This source is part of the libosmscout library
+ Copyright (C) 2023 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/async/ThreadFinalizer.h>
+
+namespace osmscout {
+  thread_local ThreadFinalizer threadFinalizer{};
+}


### PR DESCRIPTION
Thread finalizer provides signal on thread exit.
It is not guaranteed that signal will be emitted for all threads, some threads may be still running on program exit. For example detached thread, global scheduler threads, when std::exit is called...