### PR TITLE
use fixed ninja version with Debian Buster

### DIFF
--- a/ci/docker/debian_buster_gcc_meson/Dockerfile
+++ b/ci/docker/debian_buster_gcc_meson/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install -y \
           python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install meson ninja
+# meson fails to detect ninja 1.11
+RUN pip3 install meson ninja==1.10.2
 
 RUN mkdir /work
 


### PR DESCRIPTION
meson fails to detect ninja 1.11, it works fine with 1.10.2 release