### PR TITLE
Add a route sections postprocessor 

### DIFF
--- a/libosmscout/include/osmscout/routing/AbstractRoutingService.h
+++ b/libosmscout/include/osmscout/routing/AbstractRoutingService.h
@@ -60,6 +60,7 @@ constexpr bool debugRouting = false;
     RouteData route;
     Distance  currentMaxDistance;
     Distance  overallDistance;
+    std::vector<int> sectionLengths;
 
   public:
     RoutingResult();
@@ -97,6 +98,21 @@ constexpr bool debugRouting = false;
     bool Success() const
     {
       return !route.IsEmpty();
+    }
+      
+    const std::vector<int>& GetSectionLenghts() const
+    {
+      return sectionLengths;
+    }
+      
+    void AppendSectionLength(int length)
+    {
+      this->sectionLengths.push_back(length);
+    }
+
+    void ClearSectionLengths()
+    {
+      this->sectionLengths.clear();
     }
   };
 

--- a/libosmscout/include/osmscout/routing/RouteDescription.h
+++ b/libosmscout/include/osmscout/routing/RouteDescription.h
@@ -92,7 +92,9 @@ namespace osmscout {
     static const char* const LANES_DESC;
     /** Constant for a description of suggested route lanes (SuggestedLaneDescription) */
     static const char* const SUGGESTED_LANES_DESC;
-
+    /** Constant for a description of the first node of a route section */
+    static const char* const NODE_VIA_DESC;
+      
   public:
     /**
      * \ingroup Routing
@@ -657,6 +659,28 @@ namespace osmscout {
 
     using SuggestedLaneDescriptionRef = std::shared_ptr<SuggestedLaneDescription>;
 
+    /**
+     * \ingroup Routing
+     * Start of the route
+     */
+     class OSMSCOUT_API ViaDescription : public Description
+     {
+     private:
+       int sectionNumber;
+       int nodeCount;
+
+      public:
+        explicit ViaDescription(int sectionNumber, int nodeCount) : sectionNumber(sectionNumber), nodeCount(nodeCount) {};
+
+        std::string GetDebugString() const override;
+
+        int GetSectionNumber() const { return sectionNumber; };
+         
+        int GetNodeCount() const { return nodeCount; };
+      };
+
+      using ViaDescriptionRef = std::shared_ptr<ViaDescription>;
+      
     /**
      * \ingroup Routing
      */

--- a/libosmscout/include/osmscout/routing/RouteDescriptionPostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RouteDescriptionPostprocessor.h
@@ -167,6 +167,14 @@ namespace osmscout {
        *    The POI information
        */
       virtual void OnPOIAtRoute(const RouteDescription::POIAtRouteDescriptionRef& poiAtRouteDescription);
+    
+      /**
+        * Called everytime we have a new section at the route when routing with some via points between start and target
+        *
+        * @param viaDescription
+        *    The via information
+        */
+      virtual void OnViaAtRoute(const RouteDescription::ViaDescriptionRef& viaDescription);
 
       /**
        * Always called before we analyse a node. It may be that other callback methods are called

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -377,6 +377,21 @@ namespace osmscout {
     private:
       Distance distanceBefore;
     };
+      
+    /**
+    * \ingroup Routing
+    * Adds section to the route if there is one or more via node
+    */
+    class OSMSCOUT_API SectionsPostprocessor : public Postprocessor
+    {
+    private:
+        std::vector<int> sectionLengths;
+    public:
+        explicit SectionsPostprocessor(const std::vector<int>& sectionLengths) : Postprocessor(), sectionLengths(sectionLengths) {};
+
+    bool Process(const RoutePostprocessor& postprocessor,
+                 RouteDescription& description) override;
+    };
 
     using SuggestedLanesPostprocessorRef = std::shared_ptr<SuggestedLanesPostprocessor>;
 

--- a/libosmscout/src/osmscout/routing/MultiDBRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/MultiDBRoutingService.cpp
@@ -458,7 +458,8 @@ namespace osmscout {
                                      parameter);
         if (!partialResult.Success()) {
           result.GetRoute().Clear();
-
+          result.ClearSectionLengths();
+            
           return result;
         }
 
@@ -469,6 +470,7 @@ namespace osmscout {
         }
 
         result.GetRoute().Append(partialResult.GetRoute());
+        result.AppendSectionLength(partialResult.GetRoute().Entries().size());
       }
 
       return result;

--- a/libosmscout/src/osmscout/routing/RouteDescription.cpp
+++ b/libosmscout/src/osmscout/routing/RouteDescription.cpp
@@ -65,6 +65,8 @@ namespace osmscout {
   const char* const RouteDescription::LANES_DESC             = "Lanes";
   /** Constant for a description of suggested route lanes (SuggestedLaneDescription) */
   const char* const RouteDescription::SUGGESTED_LANES_DESC   = "SuggestedLanes";
+  /** Constant for a description of a via on the rote (first node of a route section) */
+  const char* const RouteDescription::NODE_VIA_DESC          = "NodeVia";
 
   RouteDescription::StartDescription::StartDescription(const std::string& description)
   : description(description)
@@ -523,6 +525,11 @@ namespace osmscout {
     ss << (int)to;
     ss << ">";
     return ss.str();
+  }
+
+  std::string RouteDescription::ViaDescription::GetDebugString() const
+  {
+    return "Section number: "+std::to_string(sectionNumber)+" node count: "+std::to_string(nodeCount);
   }
 
   bool RouteDescription::Node::HasDescription(const char* name) const

--- a/libosmscout/src/osmscout/routing/RouteDescriptionPostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RouteDescriptionPostprocessor.cpp
@@ -104,6 +104,11 @@ namespace osmscout {
     // no code
   }
 
+  void RouteDescriptionPostprocessor::Callback::OnViaAtRoute(const RouteDescription::ViaDescriptionRef& /*viaDescription*/)
+  {
+    // no code
+  }
+
   void RouteDescriptionPostprocessor::Callback::BeforeNode(const RouteDescription::Node& /*node*/)
   {
     // no code
@@ -163,6 +168,7 @@ namespace osmscout {
       osmscout::RouteDescription::MaxSpeedDescriptionRef         maxSpeedDescription;
       osmscout::RouteDescription::TypeNameDescriptionRef         typeNameDescription;
       osmscout::RouteDescription::POIAtRouteDescriptionRef       poiAtRouteDescription;
+      osmscout::RouteDescription::ViaDescriptionRef              viaDescription;
 
       desc=node->GetDescription(osmscout::RouteDescription::WAY_NAME_DESC);
       if (desc) {
@@ -250,6 +256,11 @@ namespace osmscout {
         poiAtRouteDescription=std::dynamic_pointer_cast<osmscout::RouteDescription::POIAtRouteDescription>(desc);
       }
 
+        desc=node->GetDescription(osmscout::RouteDescription::NODE_VIA_DESC);
+        if (desc) {
+          viaDescription=std::dynamic_pointer_cast<osmscout::RouteDescription::ViaDescription>(desc);
+        }
+        
       callback.BeforeNode(*node);
 
       if (startDescription) {
@@ -260,6 +271,10 @@ namespace osmscout {
 
       if (targetDescription) {
         callback.OnTargetReached(targetDescription);
+      }
+        
+      if (viaDescription) {
+        callback.OnViaAtRoute(viaDescription);
       }
 
       if (roundaboutEnterDescription || roundaboutLeaveDescription) {

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -2447,4 +2447,40 @@ namespace osmscout {
 
     return true;
   }
+
+  bool RoutePostprocessor::SectionsPostprocessor::Process(const RoutePostprocessor& postprocessor,
+                                                          RouteDescription& description)
+  {
+    int nbSections = this->sectionLengths.size();
+    if (nbSections < 2) {
+      return true;
+    }
+
+    int sectionCount = 0;
+    int nodeCount = 1;
+    RouteDescription::Node *previousNode = nullptr;
+    for (auto &node : description.Nodes()) {
+        if (--nodeCount == 0) {
+            
+            if (previousNode) {
+                RouteDescription::ViaDescriptionRef desc=std::make_shared<RouteDescription::ViaDescription>(sectionCount, sectionLengths[sectionCount - 1]);
+                previousNode->AddDescription(RouteDescription::NODE_VIA_DESC, desc);
+            }
+
+            previousNode = &node;
+            nodeCount = sectionLengths[sectionCount++];
+            
+            if (sectionCount >= nbSections) {
+                break;
+            }
+        }
+    }
+      
+    if (previousNode) {
+        RouteDescription::ViaDescriptionRef desc=std::make_shared<RouteDescription::ViaDescription>(nbSections, sectionLengths[nbSections - 1]);
+        previousNode->AddDescription(RouteDescription::NODE_VIA_DESC, desc);
+    }
+      
+    return true;
+  }
 }

--- a/libosmscout/src/osmscout/routing/SimpleRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/SimpleRoutingService.cpp
@@ -425,6 +425,7 @@ namespace osmscout {
                                    parameter);
       if (!partialResult.Success()) {
         result.GetRoute().Clear();
+        result.ClearSectionLengths();
 
         return result;
       }
@@ -436,6 +437,7 @@ namespace osmscout {
       }
 
       result.GetRoute().Append(partialResult.GetRoute());
+      result.AppendSectionLength(partialResult.GetRoute().Entries().size());
     }
 
     return result;


### PR DESCRIPTION
The route sections postprocessor give information on the via point and section length between when computing route with via point between start and target.
The demo Routing application has been updated to take a optional --via parameter : 

```
% ./Routing --via 48.8571 2.3295 ~/Documents/OSM/France.osmscout 48.85690 2.34136 48.85934 2.33663
No speed for type 'highway_residential_area' defined!
No speed for type 'highway_service_area' defined!
No speed for type 'highway_track' defined!
Using 'CalculateRouteViaCoords' method
From:                48.85700 N 2.34143 E Way 565610149[1 *> 3759113579648971777]
To:                  48.85736 N 2.32890 E Way 565570763[3759113583642588161 >* 2]
Time:                0.000
Air-line distance:   0.9 km
Minimum cost:        29 s
Actual cost:         00:04:17
Cost limit:          00:14:38
Route nodes loaded:  176
Route nodes ignored: 350
Max. OpenList size:  25
Max. ClosedSet size: 176
Warning: Index intersections.idx has cache size 10000, but requires cache size 57825 to load index completely into cache!
From:                48.85736 N 2.32890 E Way 565570763[2 *> 3759113583642588161]
To:                  48.85968 N 2.33526 E Way 565604655[3759113613854439681 >* 4]
Time:                0.000
Air-line distance:   0.6 km
Minimum cost:        19 s
Actual cost:         00:02:37
Cost limit:          00:13:22
Route nodes loaded:  122
Route nodes ignored: 227
Max. OpenList size:  20
Max. ClosedSet size: 122
Warning: Index intersections.idx has cache size 10000, but requires cache size 57825 to load index completely into cache!
Loading path data: 0.000
Scanning locations: 0.032
Loading candidates: 0.032
Analysing candidates: 0.000
Postprocessing time: 0.033
----------------------------------------------------
     At| After|  Time| After|
----------------------------------------------------
  0.0km         0:00h        Start at 'Start'
                             Drive along highway_residential 'Place du Pont Neuf'
  0.0km  0.0km  0:00h  0:00h At crossing 'Place du Pont Neuf', 'Pont Neuf', 'Quai de l'Horloge'
                             Turn left into highway_residential 'Quai de l'Horloge'
  0.0km  0.0km  0:00h  0:00h Way changes name from 'Quai de l'Horloge' to 'Place du Pont Neuf'
  0.2km  0.0km  0:00h  0:00h Way changes name from 'Place du Pont Neuf' to 'Pont Neuf'
  0.2km  0.0km  0:00h  0:00h At crossing 'Pont Neuf', 'Quai de Conti', 'Quai des Grands Augustins', 'Rue Dauphine', 'Rue de Nevers'
                             Turn right into highway_primary 'Quai de Conti'
  0.5km  0.0km  0:01h  0:00h Way changes name from 'Quai de Conti' to 'Quai Malaquais'
  0.8km  0.0km  0:02h  0:00h At crossing 'Quai Malaquais', 'Quai Voltaire', 'Rue des Saints-Pères'
                             Turn left into highway_tertiary 'Rue des Saints-Pères'
  1.0km  0.0km  0:02h  0:00h At crossing 'Rue Jacob', 'Rue de l'Université', 'Rue des Saints-Pères'
                             Turn right into highway_residential 'Rue de l'Université'
  1.3km  0.1km  0:03h  0:00h Etap: 1
  1.3km  0.1km  0:03h  0:00h At crossing 'Rue de l'Université', 'Rue du Bac'
                             Turn right into highway_secondary 'Rue du Bac'
  1.4km  0.1km  0:03h  0:00h Pass: Jean Louis David
  1.6km  0.0km  0:03h  0:00h At crossing 'Pont Royal', 'Quai Valéry Giscard d'Estaing', 'Quai Voltaire', 'Rue du Bac'
                             Turn slightly right into highway_secondary 'Pont Royal'
  1.7km  0.1km  0:04h  0:00h At crossing 'Pont Royal'
                             Turn right into highway_secondary 'Pont Royal'
  1.7km  0.0km  0:04h  0:00h Way changes name from 'Pont Royal' to 'Quai François Mitterrand'
  2.1km         0:04h        Target reached 'Target'
Description generation time: 0.000
```
