### PR TITLE
fix Qt router

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -226,6 +226,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<MapIcon>("MapIcon");
   qRegisterMetaType<VoiceProvider>("VoiceProvider");
   qRegisterMetaType<MapProvider>("MapProvider");
+  qRegisterMetaType<QmlRoutingProfileRef>("QmlRoutingProfileRef");
 
   // register osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");


### PR DESCRIPTION
I don't understand why, but routing is broken in Qt library since this commit: https://github.com/Framstag/libosmscout/commit/f959c5a1289e68e9cb27ead589dceea512bd3e1c 
It just complains that `QmlRoutingProfileRef` is not registered metatype. This change is fixing that.