### PR TITLE
just print warning when multipolyton ring has wrong type

### DIFF
--- a/libosmscout-import/include/osmscoutimport/GenRelAreaDat.h
+++ b/libosmscout-import/include/osmscoutimport/GenRelAreaDat.h
@@ -157,7 +157,7 @@ namespace osmscout {
         }
       }
 
-      inline std::string GetRelationRoleStr() const
+      static inline std::string GetRelationRoleStr(RelationRole relationRole)
       {
         switch (relationRole){
           case outer:
@@ -167,6 +167,11 @@ namespace osmscout {
           default:
             return "none";
         }
+      }
+
+      inline std::string GetRelationRoleStr() const
+      {
+        return GetRelationRoleStr(relationRole);
       }
 
       inline void SetId(OSMId id)

--- a/libosmscout-import/src/osmscoutimport/GenRelAreaDat.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenRelAreaDat.cpp
@@ -142,8 +142,7 @@ namespace osmscout {
       if (sub->relationRole!=MultipolygonPart::none){
         MultipolygonPart::RelationRole expectedRole = id % 2 == 0 ? MultipolygonPart::inner : MultipolygonPart::outer;
         if (sub->relationRole != expectedRole) {
-          progress.Error("Ring " + std::to_string(sub->id) + " has invalid role, continue");
-          continue;
+          progress.Warning("Ring " + std::to_string(sub->id) + " has invalid role " + sub->GetRelationRoleStr() + ", expecting " + MultipolygonPart::GetRelationRoleStr(expectedRole));
         }
       }
 


### PR DESCRIPTION
When multipolygon contains more than one level of nested rings, second nested rigns should be outer. But is not so big problem when even these rings are with inner type (two nested inner rings). So, instead of skipping such rings with invalid type, just log warning and continue.

When ring is skipped, ring grouping fail and whole multipolygon is omitted from import. It is too strict.

Fixing https://github.com/Framstag/libosmscout/issues/1508