### PR TITLE
Use logger settings instead hard coded values to configure the tracing level

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -332,8 +332,8 @@ void PlaneMapRenderer::DrawMap()
     drawParameter.SetPatternMode(osmscout::MapParameter::PatternMode::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
-    drawParameter.SetDebugData(false);
-    drawParameter.SetDebugPerformance(true);
+    drawParameter.SetDebugData(osmscout::log.IsDebug());
+    drawParameter.SetDebugPerformance(osmscout::log.IsWarn());
     // We want to get notified, if we have more than 1000 objects from a certain type (=> move type rendering to a higher zoom level?)
     drawParameter.SetWarningObjectCountLimit(1000);
     // We want to get notified, if we have more than 20000 coords from a certain type (=> move type rendering to a higher zoom level?)

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -436,8 +436,8 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     drawParameter.SetPatternMode(osmscout::MapParameter::PatternMode::Scalable);
     drawParameter.SetIconPaths(paths);
     drawParameter.SetPatternPaths(paths);
-    drawParameter.SetDebugData(false);
-    drawParameter.SetDebugPerformance(true);
+    drawParameter.SetDebugData(osmscout::log.IsDebug());
+    drawParameter.SetDebugPerformance(osmscout::log.IsWarn());
 
     // optimize process can reduce number of nodes before rendering
     // it helps for slow renderer backend, but it cost some cpu


### PR DESCRIPTION
This allows you to enable/disable render logging traces by simply configuring the logger.

i.e invoking ```osmscout::log.Warn(true|false)``` will enable/disable debug performance. By default log.Debug is Off and log.Warn is On. Therefore this commit won't change the current behavior.