### PR TITLE
ScreenBox resize fix

### DIFF
--- a/Tests/src/ScreenBox.cpp
+++ b/Tests/src/ScreenBox.cpp
@@ -101,3 +101,15 @@ TEST_CASE("Resize empty rectangle by zero")
 
   REQUIRE(expectedResizedBox==resizedBox);
 }
+
+TEST_CASE("Resize square to zero")
+{
+  osmscout::ScreenBox box(osmscout::Vertex2D(-1, -1),
+                          osmscout::Vertex2D(1, 1));
+  osmscout::ScreenBox resizedBox=box.Resize(-1);
+
+  osmscout::ScreenBox expectedResizedBox(osmscout::Vertex2D(0, 0),
+                                         osmscout::Vertex2D(0, 0));
+
+  REQUIRE(expectedResizedBox==resizedBox);
+}

--- a/Tests/src/ScreenBox.cpp
+++ b/Tests/src/ScreenBox.cpp
@@ -77,3 +77,27 @@ TEST_CASE("Resize >0")
 
   REQUIRE(expectedResizedBox==resizedBox);
 }
+
+TEST_CASE("Resize ==0")
+{
+  osmscout::ScreenBox box(osmscout::Vertex2D(-1, -1),
+                          osmscout::Vertex2D(1, 1));
+  osmscout::ScreenBox resizedBox=box.Resize(0);
+
+  osmscout::ScreenBox expectedResizedBox(osmscout::Vertex2D(-1, -1),
+                                         osmscout::Vertex2D(1, 1));
+
+  REQUIRE(expectedResizedBox==resizedBox);
+}
+
+TEST_CASE("Resize empty rectangle by zero")
+{
+  osmscout::ScreenBox box(osmscout::Vertex2D(-1, -1),
+                          osmscout::Vertex2D(-1, 1));
+  osmscout::ScreenBox resizedBox=box.Resize(0);
+
+  osmscout::ScreenBox expectedResizedBox(osmscout::Vertex2D(-1, -1),
+                                         osmscout::Vertex2D(-1, 1));
+
+  REQUIRE(expectedResizedBox==resizedBox);
+}

--- a/Tests/src/ScreenBox.cpp
+++ b/Tests/src/ScreenBox.cpp
@@ -112,4 +112,10 @@ TEST_CASE("Resize square to zero")
                                          osmscout::Vertex2D(0, 0));
 
   REQUIRE(expectedResizedBox==resizedBox);
+  REQUIRE(resizedBox.IsEmpty());
+
+  resizedBox=resizedBox.Resize(-1);
+
+  REQUIRE(expectedResizedBox==resizedBox);
+  REQUIRE(resizedBox.IsEmpty());
 }

--- a/libosmscout/include/osmscout/util/ScreenBox.h
+++ b/libosmscout/include/osmscout/util/ScreenBox.h
@@ -123,7 +123,7 @@ namespace osmscout {
      * Resize the rectangle in all dimension using the given amount.
      * If pixel is >=0 the resulting area will be bigger, else smaller.
      *
-     * It is checked that pixel>=width/2 and pixel >=height/2
+     * It is checked that offset>=width/-2 and offset>=height/-2
      *
      * The size delta will be 2*pixel in width and in height!
      *

--- a/libosmscout/include/osmscout/util/ScreenBox.h
+++ b/libosmscout/include/osmscout/util/ScreenBox.h
@@ -53,6 +53,11 @@ namespace osmscout {
     ScreenBox(const ScreenBox& other) = default;
 
     /**
+     * Move-Constructor
+     */
+    ScreenBox(ScreenBox&& other) = default;
+
+    /**
      * Initialize the GeoBox based on the given coordinates. The two Coordinates
      * together span a rectangular (in coordinates, not on the sphere) area.
      */
@@ -63,6 +68,11 @@ namespace osmscout {
      * Assign the value of other
      */
     ScreenBox& operator=(const ScreenBox& other) = default;
+
+    /**
+     * Move assignment operator
+     */
+    ScreenBox& operator=(ScreenBox&& other) = default;
 
     /**
      * Compare two values
@@ -106,6 +116,26 @@ namespace osmscout {
     }
 
     /**
+     * Returns the size of the screen box (width*height).
+     *
+     * @return GetWidth()*GetHeight()
+     */
+    [[nodiscard]] double GetSize() const
+    {
+      return GetWidth()*GetHeight();
+    }
+
+    /**
+     * Check if size of the screen box is zero
+     *
+     * @return GetSize()==0.0
+     */
+    [[nodiscard]] bool IsEmpty() const
+    {
+      return GetSize()==0.0;
+    }
+
+    /**
      * Returns the center coordinates of the box
      * @return the center coordinates
      */
@@ -121,11 +151,12 @@ namespace osmscout {
 
     /**
      * Resize the rectangle in all dimension using the given amount.
-     * If pixel is >=0 the resulting area will be bigger, else smaller.
+     * If offset is >=0 the resulting area will be bigger, else smaller.
      *
-     * It is checked that offset>=width/-2 and offset>=height/-2
+     * If the reduction (negative offset) is bigger than width/2 or height/2,
+     * resulted screen box will have zero size (will be empty).
      *
-     * The size delta will be 2*pixel in width and in height!
+     * The size delta will be 2*offset in width and in height!
      *
      * @param offset the amount to change the coordinates.
      * @return the resulting ScreenBox

--- a/libosmscout/src/osmscout/util/ScreenBox.cpp
+++ b/libosmscout/src/osmscout/util/ScreenBox.cpp
@@ -65,14 +65,24 @@ namespace osmscout {
 
   ScreenBox ScreenBox::Resize(double offset) const
   {
-    // If the offset is negative its absolute value must not be >= than width/2 or height/2
-    assert(offset >= GetWidth()/-2);
-    assert(offset >= GetHeight()/-2);
+    double minX, minY, maxX, maxY;
 
-    return {Vertex2D(minCoord.GetX()-offset,
-                     minCoord.GetY()-offset),
-            Vertex2D(maxCoord.GetX()+offset,
-                     maxCoord.GetY()+offset)};
+    if (offset < GetWidth()/-2) {
+      maxX=minX=(maxCoord.GetX()+minCoord.GetX()) / 2;
+    } else {
+      minX=minCoord.GetX()-offset;
+      maxX=maxCoord.GetX()+offset;
+    }
+
+    if(offset < GetHeight()/-2){
+      maxY=minY=(maxCoord.GetY()+minCoord.GetY()) / 2;
+    } else {
+      minY=minCoord.GetY()-offset;
+      maxY=maxCoord.GetY()+offset;
+    }
+
+    return {Vertex2D(minX,minY),
+            Vertex2D(maxX,maxY)};
   }
 
   ScreenBox ScreenBox::Merge(const ScreenBox& other) const

--- a/libosmscout/src/osmscout/util/ScreenBox.cpp
+++ b/libosmscout/src/osmscout/util/ScreenBox.cpp
@@ -65,9 +65,9 @@ namespace osmscout {
 
   ScreenBox ScreenBox::Resize(double offset) const
   {
-    // If the offset is negative its absolute value must not be > than width or height
-    assert(offset>-GetWidth());
-    assert(offset>-GetHeight());
+    // If the offset is negative its absolute value must not be >= than width/2 or height/2
+    assert(offset >= GetWidth()/-2);
+    assert(offset >= GetHeight()/-2);
 
     return {Vertex2D(minCoord.GetX()-offset,
                      minCoord.GetY()-offset),


### PR DESCRIPTION
As reported by @ToFuCH at https://github.com/Karry/osmscout-sailfish/issues/325 , rendering Bern (Switzerland) map on zoom level 13 is causing crash. 

Problem is that some area (not important which one) has zero height during rendering and renderer tries to resize it with zero offset. This operation should be correct, but it hits assert
```
assert(offset>-GetHeight());
```

Correct assert should be:
```
assert(offset >= GetHeight()/-2);
```