### PR TITLE
qt6: fix default arg for overriden member rowCount

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
@@ -88,7 +88,7 @@ public:
     LocationInfoModel();
     ~LocationInfoModel() override;
 
-    Q_INVOKABLE int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const override
+    Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
         return model.size();
     };

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationInfoModel.h
@@ -90,6 +90,7 @@ public:
 
     Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
+        Q_UNUSED(parent);
         return model.size();
     };
     

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
@@ -94,6 +94,7 @@ public:
 
   Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
+      Q_UNUSED(parent);
       return model.size();
   };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapObjectInfoModel.h
@@ -92,7 +92,7 @@ public:
   MapObjectInfoModel();
   ~MapObjectInfoModel() override;
 
-  Q_INVOKABLE int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const override
+  Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
       return model.size();
   };

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapStyleModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapStyleModel.h
@@ -58,7 +58,7 @@ public:
   QString getStyle() const;
   void setStyle(const QString &style);
 
-  Q_INVOKABLE int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const override
+  Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
       return stylesheets.size();
   };

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapStyleModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapStyleModel.h
@@ -60,6 +60,7 @@ public:
 
   Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
+      Q_UNUSED(parent);
       return stylesheets.size();
   };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/OnlineTileProviderModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OnlineTileProviderModel.h
@@ -101,6 +101,7 @@ public:
 
   Q_INVOKABLE virtual int inline rowCount(const QModelIndex &parent = QModelIndex()) const
   {
+    Q_UNUSED(parent);
     return onlineProviders.size();
   };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/OnlineTileProviderModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OnlineTileProviderModel.h
@@ -99,7 +99,7 @@ public:
     IdRole = Qt::UserRole+1,
   };
 
-  Q_INVOKABLE virtual int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const
+  Q_INVOKABLE virtual int inline rowCount(const QModelIndex &parent = QModelIndex()) const
   {
     return onlineProviders.size();
   };

--- a/libosmscout-client-qt/include/osmscoutclientqt/OpeningHoursModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OpeningHoursModel.h
@@ -65,7 +65,7 @@ public:
   OpeningHoursModel& operator=(const OpeningHoursModel&) = delete;
   OpeningHoursModel& operator=(OpeningHoursModel&&) = delete;
 
-  Q_INVOKABLE int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const override
+  Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
     return model.size();
   };

--- a/libosmscout-client-qt/include/osmscoutclientqt/OpeningHoursModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OpeningHoursModel.h
@@ -67,6 +67,7 @@ public:
 
   Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
+    Q_UNUSED(parent);
     return model.size();
   };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
@@ -61,7 +61,7 @@ public:
   StyleFlagsModel();
   ~StyleFlagsModel() override;
 
-  Q_INVOKABLE int inline rowCount(const QModelIndex &/*parent = QModelIndex()*/) const override
+  Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
       return mapFlags.size();
   };

--- a/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/StyleFlagsModel.h
@@ -63,6 +63,7 @@ public:
 
   Q_INVOKABLE int inline rowCount(const QModelIndex &parent = QModelIndex()) const override
   {
+      Q_UNUSED(parent);
       return mapFlags.size();
   };
 


### PR DESCRIPTION
Running with qt 6.6.0, the following issue occur calling rowCount() from qml side:

`qrc:/controls2/Routing.qml:84: Error: Insufficient arguments`
