### PR TITLE
try to clean up partial download on resume

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/FileDownloader.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/FileDownloader.h
@@ -46,6 +46,7 @@ static constexpr std::chrono::seconds DownloadReadTimeout{60}; ///< Download rea
 static constexpr std::chrono::seconds BackOffInitial{1}; ///< Initial back-off time
 static constexpr std::chrono::seconds BackOffMax{300}; ///< Maximum back-off time
 static constexpr int MaxDownloadRetries{-1}; ///< Maximal number of download retries before cancelling download
+static constexpr char const *TemporaryFileSuffix{".download"}; ///< suffix of file being downloaded
 }
 
 /// \brief Downloads a file specified by URL

--- a/libosmscout-client-qt/src/osmscoutclientqt/FileDownloader.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/FileDownloader.cpp
@@ -62,7 +62,7 @@ FileDownloader::FileDownloader(QNetworkAccessManager *manager,
     return;
   }
 
-  file.setFileName(path + ".download");
+  file.setFileName(path + FileDownloaderConfig::TemporaryFileSuffix);
   if (!file.open(QIODevice::WriteOnly)) {
     isOk = false;
     qWarning() << "Cannot open file:" << file.fileName();


### PR DESCRIPTION
Trying to resume an aborted partial download. The flow is simple as to delete the invalid map directory, but not recursively for security reason. Therefore now the function deleteDatabase handle partial downloads too.

The original issue has been reported by https://github.com/janbar/osmin/issues/63.
