### PR TITLE
Location search improvements

### DIFF
--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -378,7 +378,7 @@ int main(int argc, char* argv[])
                         args.repeat=value;
                       }),
                       "repeat",
-                      "Cout of repeat for performance test");
+                      "Count of repeat for performance test");
 
   argParser.AddOption(osmscout::CmdLineFlag([&args](const bool& value) {
                         args.transliterate=value;

--- a/Demos/src/LocationLookup.cpp
+++ b/Demos/src/LocationLookup.cpp
@@ -435,7 +435,7 @@ int main(int argc, char* argv[])
   }
 
   osmscout::DatabaseParameter databaseParameter;
-  osmscout::DatabaseRef       database(new osmscout::Database(databaseParameter));
+  osmscout::DatabaseRef       database=std::make_shared<osmscout::Database>(databaseParameter);
 
   if (!database->Open(args.databaseDirectory)) {
     std::cerr << "Cannot open db" << std::endl;

--- a/libosmscout/src/osmscout/location/LocationService.cpp
+++ b/libosmscout/src/osmscout/location/LocationService.cpp
@@ -1379,9 +1379,19 @@ namespace osmscout {
       locationIgnoreTokenSet.insert(UTF8StringToUpper(token));
     }
 
+    // Locations are streets in town usually. But for small villages without named streets,
+    // village name (region) is added as virtual location to our location index.
+    // Address points are linked by "addr:place" tag to the place (region).
+    //
+    // So, to be able lookup address points just by phrase "Village 123",
+    // we add region name to location search patterns.
+    // We would force users to use pattern "Village Village 123" otherwise.
+    std::list<std::string> extendedLocationTokens=locationTokens;
+    extendedLocationTokens.push_back(regionMatch.name);
+
     // Build Location search patterns
 
-    std::list<TokenStringRef> locationSearchPatterns=GenerateSearchPatterns(locationTokens,
+    std::list<TokenStringRef> locationSearchPatterns=GenerateSearchPatterns(extendedLocationTokens,
                                                                             locationIgnoreTokenSet,
                                                                             locationIndex->GetLocationMaxWords());
 

--- a/libosmscout/src/osmscout/location/LocationService.cpp
+++ b/libosmscout/src/osmscout/location/LocationService.cpp
@@ -1088,7 +1088,7 @@ namespace osmscout {
    * @param tokenString
    *    Token to remove
    * @param tokens
-   *    List to rmeove token parameter from
+   *    List to remove token parameter from
    * @return
    *    New list
    */


### PR DESCRIPTION
Locations are streets in town usually. But for small villages without named streets,
village name (region) is added as virtual location to our location index.
Address points are linked by "addr:place" tag to the place (region).

So, to be able lookup address points just by phrase "Village 123",
we should add region name to location search patterns.
We would force users to use pattern "Village Village 123" otherwise.

This is fix for https://github.com/Framstag/libosmscout/issues/1533