### PR TITLE
register size_t as qt metatype

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
@@ -77,7 +77,6 @@ private:
   size_t                        epoch{0};
 
 signals:
-  //void TileStatusChanged(const osmscout::TileRef& tile);
   void TriggerMapRenderingSignal(const MapViewStruct& request, size_t requestEpoch);
   void TriggerInitialRendering();
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -211,6 +211,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<QtRouteData>("QtRouteData");
   qRegisterMetaType<uint32_t>("uint32_t");
   qRegisterMetaType<uint64_t>("uint64_t");
+  qRegisterMetaType<size_t>("size_t");
   qRegisterMetaType<AdminRegionInfoRef>("AdminRegionInfoRef");
   qRegisterMetaType<QList<AdminRegionInfoRef>>("QList<AdminRegionInfoRef>");
   qRegisterMetaType<std::unordered_map<std::string,bool>>("std::unordered_map<std::string,bool>");


### PR DESCRIPTION
Plane map renderer stopped working after recent Qt changes. I am not sure about the true reason :-/ The fact that Qt metatypes are checked at runtime is not helping. It just prints a warning:
```
QObject::connect: Cannot queue arguments of type 'size_t'
(Make sure 'size_t' is registered using qRegisterMetaType().)
```