### PR TITLE
invalidate visual cache properly on database reload

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -119,6 +119,7 @@ signals:
   void showAltLanguageSignal(bool);
   void unitsSignal(QString);
   void stylesheetFilenameChanged();
+  void databaseLoadFinished(const osmscout::GeoBox &geoBox);
 
 private:
   // slots
@@ -159,12 +160,14 @@ private:
   };
 
   Slot<> stylesheetFilenameChangedSlot{ std::bind(&MapRenderer::stylesheetFilenameChanged, this) };
+  Slot<GeoBox> databaseLoadFinishedSlot{ std::bind(&MapRenderer::databaseLoadFinished, this, std::placeholders::_1) };
 
 public slots:
   virtual void Initialize() = 0;
 
   virtual void InvalidateVisualCache() = 0;
   virtual void onStylesheetFilenameChanged();
+  virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox) = 0;
 
   virtual void onMapDPIChange(double dpi);
   virtual void onRenderSeaChanged(bool);

--- a/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
@@ -83,6 +83,8 @@ signals:
 public slots:
   virtual void Initialize();
   virtual void InvalidateVisualCache();
+  virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox);
+
   void DrawMap();
   void HandleTileStatusChanged(QString dbPath,const osmscout::TileRef tile);
   void onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>>);

--- a/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
@@ -82,24 +82,22 @@ private:
   Slot<OnlineTileProvider> onlineTileProviderSlot{ std::bind(&TiledMapRenderer::onlineTileProviderSignal, this, std::placeholders::_1) };
   Slot<bool> onlineTileEnabledSlot{ std::bind(&TiledMapRenderer::onlineTilesEnabledSignal, this, std::placeholders::_1) };
   Slot<bool> offlineMapChangedSlot{ std::bind(&TiledMapRenderer::offlineMapChangedSignal, this, std::placeholders::_1) };
-  Slot<GeoBox> databaseLoadFinishedSlot{ std::bind(&TiledMapRenderer::databaseLoadFinished, this, std::placeholders::_1) };
 
 signals:
   void onlineTileProviderSignal(OnlineTileProvider provider);
   void onlineTilesEnabledSignal(bool);
   void offlineMapChangedSignal(bool);
-  void databaseLoadFinished(const GeoBox &geoBox);
 
 public slots:
   virtual void Initialize();
   virtual void InvalidateVisualCache();
   virtual void onStylesheetFilenameChanged();
+  virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox);
 
   void onlineTileRequest(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile);
   void offlineTileRequest(uint32_t zoomLevel, uint32_t xtile, uint32_t ytile);
   void tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, QByteArray downloadedData);
   void tileDownloadFailed(uint32_t zoomLevel, uint32_t x, uint32_t y, bool zoomLevelOutOfRange);
-  void onDatabaseLoaded(osmscout::GeoBox boundingBox);
   void onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osmscout::TileRef>>);
 
   void onlineTileProviderChanged(const OnlineTileProvider &);

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -51,6 +51,7 @@ MapRenderer::MapRenderer(QThread *thread,
   settings->showAltLanguageChanged.Connect(showAltLanguageSlot);
   settings->unitsChanged.Connect(unitsSlot);
   dbThread->stylesheetFilenameChanged.Connect(stylesheetFilenameChangedSlot);
+  dbThread->databaseLoadFinished.Connect(databaseLoadFinishedSlot);
 
   connect(this, &MapRenderer::mapDpiChangeSignal,
           this, &MapRenderer::onMapDPIChange,
@@ -75,6 +76,9 @@ MapRenderer::MapRenderer(QThread *thread,
           this, &MapRenderer::Initialize);
   connect(this, &MapRenderer::stylesheetFilenameChanged,
           this, &MapRenderer::onStylesheetFilenameChanged,
+          Qt::QueuedConnection);
+  connect(this, &MapRenderer::databaseLoadFinished,
+          this, &MapRenderer::onDatabaseLoaded,
           Qt::QueuedConnection);
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -85,7 +85,7 @@ PlaneMapRenderer::~PlaneMapRenderer()
     delete loadJob;
 }
 
-void PlaneMapRenderer::onDatabaseLoaded(osmscout::GeoBox boundingBox)
+void PlaneMapRenderer::onDatabaseLoaded([[maybe_unused]] osmscout::GeoBox boundingBox)
 {
   InvalidateVisualCache();
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -85,12 +85,17 @@ PlaneMapRenderer::~PlaneMapRenderer()
     delete loadJob;
 }
 
+void PlaneMapRenderer::onDatabaseLoaded(osmscout::GeoBox boundingBox)
+{
+  InvalidateVisualCache();
+}
+
 void PlaneMapRenderer::InvalidateVisualCache()
 {
   {
     QMutexLocker finishedLocker(&finishedMutex);
     osmscout::log.Debug() << "Invalidate finished image";
-    epoch++;;
+    epoch++;
   }
   emit Redraw();
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -56,7 +56,6 @@ TiledMapRenderer::TiledMapRenderer(QThread *thread,
   settings->onlineTileProviderChanged.Connect(onlineTileProviderSlot);
   settings->onlineTilesEnabledChanged.Connect(onlineTileEnabledSlot);
   settings->offlineMapChanged.Connect(offlineMapChangedSlot);
-  dbThread->databaseLoadFinished.Connect(databaseLoadFinishedSlot);
 
   connect(this, &TiledMapRenderer::onlineTileProviderSignal,
           this, &TiledMapRenderer::onlineTileProviderChanged,
@@ -68,9 +67,6 @@ TiledMapRenderer::TiledMapRenderer(QThread *thread,
           this, &TiledMapRenderer::onOfflineMapChanged,
           Qt::QueuedConnection);
 
-  connect(this, &TiledMapRenderer::databaseLoadFinished,
-          this, &TiledMapRenderer::onDatabaseLoaded,
-          Qt::QueuedConnection);
   //
   // Make sure that we always decouple caller and receiver even if they are running in the same thread
   // else we might get into a dead lock
@@ -217,7 +213,7 @@ void TiledMapRenderer::onDatabaseLoaded(osmscout::GeoBox boundingBox)
   {
     QMutexLocker locker(&tileCacheMutex);
     onlineTileCache.invalidate(boundingBox);
-    offlineTileCache.invalidate(boundingBox);
+    offlineTileCache.incEpoch();
   }
 
   emit Redraw();

--- a/libosmscout-client/include/osmscoutclient/DBThread.h
+++ b/libosmscout-client/include/osmscoutclient/DBThread.h
@@ -105,50 +105,34 @@ public:
 
   // slots
   Slot<> toggleDaylight{
-    [this](){
-      ToggleDaylight();
-    }
+    std::bind(&DBThread::ToggleDaylight, this)
   };
 
   Slot<std::string, bool> setStyleFlag{
-    [this](const std::string &key, bool value) {
-      SetStyleFlag(key, value);
-    }
+    std::bind(&DBThread::SetStyleFlag, this, std::placeholders::_1, std::placeholders::_2)
   };
 
   Slot<std::string> reloadStyle{
-    [this](const std::string &suffix) {
-      ReloadStyle(suffix);
-    }
+    std::bind(&DBThread::ReloadStyle, this, std::placeholders::_1)
   };
 
   Slot<std::string, std::unordered_map<std::string,bool>, std::string> loadStyle {
-    [this](const std::string &stylesheetFilename,
-           const std::unordered_map<std::string,bool> &stylesheetFlags,
-           const std::string &suffix) {
-      LoadStyle(stylesheetFilename, stylesheetFlags, suffix);
-    }
+    std::bind(&DBThread::LoadStyle, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
   };
 
   Slot<> initialize{
-    [this](){
-      Initialize();
-    }
+    std::bind(&DBThread::Initialize, this)
   };
 
   Slot<std::vector<std::filesystem::path>> databaseListChangedSlot {
-    [this](const std::vector<std::filesystem::path> &paths) {
-      OnDatabaseListChanged(paths);
-    }
+    std::bind(&DBThread::OnDatabaseListChanged, this, std::placeholders::_1)
   };
 
   /**
    * Flush all caches for db that was not used in recent idleMs
    */
   Slot<std::chrono::milliseconds> flushCaches {
-    [this](const std::chrono::milliseconds &idleMs) {
-      FlushCaches(idleMs);
-    }
+    std::bind(&DBThread::FlushCaches, this, std::placeholders::_1)
   };
 
 private:


### PR DESCRIPTION
another bug introduced recently by moving classes to client library - database reload emited stylesheet change signal in the past, but I removed it... So, visual cache in renderers needs to be invalidated even on database load signal...