### PR TITLE
locale-aware byte size formatter

### DIFF
--- a/.github/workflows/build_and test_on_msys.yml
+++ b/.github/workflows/build_and test_on_msys.yml
@@ -38,6 +38,7 @@ jobs:
         run: cmake --build build
       - name: Run tests
         run:  "PATH=$PATH:$PWD/libosmscout:$PWD/libosmscout-import:$PWD/libosmscout-map:$PWD/libosmscout-test
+               LC_ALL=C
                ctest -j 4 --output-on-failure --exclude-regex PerformanceTest"
         working-directory: build
 
@@ -69,6 +70,7 @@ jobs:
       - name: Build project
         run: meson compile -C debug
       - name: Run tests
-        run: meson test -C debug --print-errorlogs
+        run: "LC_ALL=C
+              meson test -C debug --print-errorlogs"
         env:
           LANG: en_US.utf8

--- a/Tests/src/StringUtils.cpp
+++ b/Tests/src/StringUtils.cpp
@@ -308,8 +308,23 @@ TEST_CASE("Local aware number to string")
 {
   osmscout::Locale locale;
   locale.SetThousandsSeparator(" ");
+  locale.SetDecimalSeparator(".");
   REQUIRE(osmscout::NumberToString(1002030, locale) == "1 002 030");
   REQUIRE(osmscout::NumberToString(-1002030, locale) == "-1 002 030");
+
+  REQUIRE(osmscout::FloatToString(M_PI, locale, 2) == "3.14");
+  REQUIRE(osmscout::FloatToString(-1002030.123456, locale, 6) == "-1 002 030.123 456");
+  REQUIRE(osmscout::FloatToString(-1002030.125, locale, 2) == "-1 002 030.13");
+}
+
+TEST_CASE("Byte size to string")
+{
+  osmscout::Locale locale;
+  locale.SetThousandsSeparator("'");
+  locale.SetDecimalSeparator(",");
+  locale.SetUnitsSeparator(" ");
+  REQUIRE(osmscout::ByteSizeToString(1063256064.0, locale) == "1'014,0 MiB");
+  REQUIRE(osmscout::ByteSizeToString(6406241158.0, locale) == "6,0 GiB");
 }
 
 TEST_CASE("Trim string")

--- a/libosmscout-client-qt/include/osmscoutclientqt/ElevationChartWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/ElevationChartWidget.h
@@ -186,7 +186,7 @@ protected:
   int textPixelSize=14;
   int textPadding=4;
 
-  Locale locale=Locale::ByEnvironment();
+  Locale locale=Locale::ByEnvironmentSafe();
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
@@ -134,7 +134,7 @@ private:
 private:
   QThread     *thread;
   SettingsRef settings;
-  DistanceUnitSystem       units{Locale::ByEnvironment().GetDistanceUnits()}; // TODO: make possible to override
+  DistanceUnitSystem units{Locale::ByEnvironmentSafe().GetDistanceUnits()}; // TODO: make possible to override
   DBThreadRef dbThread;
   QTimer      timer;
   std::optional<Bearing> lastBearing;

--- a/libosmscout-client/src/osmscoutclient/MapManager.cpp
+++ b/libosmscout-client/src/osmscoutclient/MapManager.cpp
@@ -48,7 +48,7 @@ CancelableFuture<bool> MapManager::LookupDatabases()
       // https://en.cppreference.com/w/cpp/filesystem/is_directory
       // https://en.cppreference.com/w/cpp/filesystem/status
       if (!std::filesystem::exists(lookupDir) || !std::filesystem::is_directory(lookupDir)) {
-        osmscout::log.Warn() << "Lookup dir" << lookupDir.string() << "doesn't exist or isn't a directory";
+        osmscout::log.Warn() << "Lookup dir " << lookupDir.string() << " doesn't exist or isn't a directory";
         continue;
       }
 

--- a/libosmscout-map/src/osmscoutmap/MapParameter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapParameter.cpp
@@ -62,7 +62,7 @@ namespace osmscout {
     warnObjectCountLimit(0),
     warnCoordCountLimit(0),
     showAltLanguage(false),
-    locale{Locale::ByEnvironment()}
+    locale{Locale::ByEnvironmentSafe()}
   {
     // no code
   }

--- a/libosmscout/include/osmscout/util/Locale.h
+++ b/libosmscout/include/osmscout/util/Locale.h
@@ -24,6 +24,7 @@
 #include <osmscout/system/Compiler.h>
 
 #include <osmscout/util/Distance.h>
+#include <osmscout/log/Logger.h>
 
 #include <string>
 
@@ -102,7 +103,33 @@ namespace osmscout {
     }
 
   public:
-    static Locale ByEnvironment(std::locale locale = std::locale(""));
+
+    /** Creates Locale from provided std::locale
+     */
+    static Locale FromStdLocale(std::locale locale);
+
+    /** Creates Locale defined by current environment
+     *
+     * @throw std::runtime_error when locale defined by environment is undefined
+     */
+    static Locale ByEnvironment()
+    {
+      return FromStdLocale(std::locale(""));
+    }
+
+    /** Creates Locale defined by current environment,
+     * it is not throwing exception when environment locale is incorrect,
+     * it just return default Locale instead.
+     */
+    static Locale ByEnvironmentSafe()
+    {
+      try {
+        return ByEnvironment();
+      } catch (const std::runtime_error &e) {
+        log.Warn() << "Failed to get environment locale: " << e.what();
+        return Locale();
+      }
+    }
   };
 }
 

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -74,9 +74,19 @@ namespace osmscout {
    *
    * @param value
    * @param locale
-   * @return
+   * @return UTF-8 string
    */
   extern OSMSCOUT_API std::string NumberToString(long value, const Locale &locale);
+
+  /**
+   * Returns locale-aware string representation of number
+   *
+   * @param value
+   * @param locale
+   * @param precision
+   * @return UTF-8 string
+   */
+  extern OSMSCOUT_API std::string FloatToString(double value, const Locale &locale, uint32_t precision = 3);
 
   /**
    * \ingroup Util
@@ -403,9 +413,13 @@ namespace osmscout {
   /**
    * \ingroup Util
    *
+   * Prints byte size with short, human readable form by ISO/IEC 80000 standard.
+   * It means that KiB stands for 1024 bytes, MiB for 1024^2, GiB 1024^3...
+   *
+   * Returned string is locale aware, UTF-8 encoded
    */
-  extern OSMSCOUT_API std::string ByteSizeToString(FileOffset size);
-  extern OSMSCOUT_API std::string ByteSizeToString(double size);
+  extern OSMSCOUT_API std::string ByteSizeToString(FileOffset size, const Locale &locale = Locale::ByEnvironment());
+  extern OSMSCOUT_API std::string ByteSizeToString(double size, const Locale &locale = Locale::ByEnvironment());
 
   /**
    * \ingroup Util

--- a/libosmscout/include/osmscout/util/String.h
+++ b/libosmscout/include/osmscout/util/String.h
@@ -418,8 +418,8 @@ namespace osmscout {
    *
    * Returned string is locale aware, UTF-8 encoded
    */
-  extern OSMSCOUT_API std::string ByteSizeToString(FileOffset size, const Locale &locale = Locale::ByEnvironment());
-  extern OSMSCOUT_API std::string ByteSizeToString(double size, const Locale &locale = Locale::ByEnvironment());
+  extern OSMSCOUT_API std::string ByteSizeToString(FileOffset size, const Locale &locale = Locale::ByEnvironmentSafe());
+  extern OSMSCOUT_API std::string ByteSizeToString(double size, const Locale &locale = Locale::ByEnvironmentSafe());
 
   /**
    * \ingroup Util

--- a/libosmscout/src/osmscout/util/Locale.cpp
+++ b/libosmscout/src/osmscout/util/Locale.cpp
@@ -35,7 +35,7 @@ namespace osmscout {
   }
   }
 
-  Locale Locale::ByEnvironment(std::locale cppLocale)
+  Locale Locale::FromStdLocale(std::locale cppLocale)
   {
     Locale locale;
 

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -196,6 +196,7 @@ namespace osmscout {
   std::string NumberToString(long value, const Locale &locale)
   {
     std::stringstream ss;
+    ss.imbue(std::locale("C"));
     if (std::abs(value) < 1000 || locale.GetThousandsSeparator().empty()){
       ss << value;
     }else{
@@ -209,6 +210,27 @@ namespace osmscout {
         value = std::abs(value % mag);
         mag/=1000;
         ss << std::setw(3) << std::setfill('0') << (value/mag);
+      }
+    }
+    return ss.str();
+  }
+
+  extern OSMSCOUT_API std::string FloatToString(double value, const Locale &locale, uint32_t precision)
+  {
+    std::stringstream ss;
+    double order = std::pow(10, precision);
+    value = std::round(value * order) / order;
+    ss << NumberToString(static_cast<long>(value), locale);
+
+    if (precision > 0) {
+      ss << locale.GetDecimalSeparator();
+      double fractionNum = std::abs(value) - std::floor(std::abs(value));
+      std::string fraction = NumberToString(fractionNum * order, Locale());
+      for (size_t i = 0; i < fraction.size(); i++) {
+        if (i > 0 && i % 3 == 0 && i < fraction.size() - 1) {
+          ss << locale.GetThousandsSeparator();
+        }
+        ss << fraction[i];
       }
     }
     return ss.str();
@@ -329,36 +351,32 @@ namespace osmscout {
     return wordCount;
   }
 
-  std::string ByteSizeToString(FileOffset value)
+  std::string ByteSizeToString(FileOffset value, const Locale &locale)
   {
-    return ByteSizeToString((double)value);
+    return ByteSizeToString(static_cast<double>(value), locale);
   }
 
-  std::string ByteSizeToString(double value)
+  std::string ByteSizeToString(double value, const Locale &locale)
   {
     std::stringstream buffer;
 
-    buffer.setf(std::ios::fixed);
-    buffer << std::setprecision(1);
-
     if (value<1.0 && value>-1) {
-      buffer << "0 B";
+      buffer << "0" << locale.GetUnitsSeparator() << "B";
     }
-    else if (ceil(value)>=1024.0*1024*1024*1024) {
-      buffer << value/(1024.0*1024*1024*1024) << " TiB";
+    else if (ceil(value)>=std::pow(1024.0, 4.0)) {
+      buffer << FloatToString(value/std::pow(1024.0, 4.0), locale, 1) << locale.GetUnitsSeparator()  << "TiB";
     }
-    else if (ceil(value)>=1024.0*1024*1024) {
-      buffer << value/(1024.0*1024*1024) << " GiB";
+    else if (ceil(value)>=std::pow(1024.0, 3.0)) {
+      buffer << FloatToString(value/std::pow(1024.0, 3.0), locale, 1) << locale.GetUnitsSeparator() << "GiB";
     }
-    else if (ceil(value)>=1024.0*1024) {
-      buffer << value/(1024.0*1024) << " MiB";
+    else if (ceil(value)>=std::pow(1024.0, 2.0)) {
+      buffer << FloatToString(value/std::pow(1024.0, 2.0), locale, 1) << locale.GetUnitsSeparator() << "MiB";
     }
     else if (ceil(value)>=1024.0) {
-      buffer << value/1024.0 << " KiB";
+      buffer << FloatToString(value/1024.0, locale, 1) << locale.GetUnitsSeparator() << "KiB";
     }
     else {
-      buffer << std::setprecision(0);
-      buffer << value << " B";
+      buffer << FloatToString(value, locale, 0) << locale.GetUnitsSeparator() << "B";
     }
 
     return buffer.str();


### PR DESCRIPTION
Char-based number formatting (using std::stringstream) is broken for locales with non-ascii thousand separator (at least with gcc 8.3.0), for that reason, we should provide custom locale aware number-to-string conversion for float numbers and use it in ByteSizeToString utility.