### PR TITLE
drop iconv dependency, use just standard library conversions

### DIFF
--- a/cmake/Config.h.cmake
+++ b/cmake/Config.h.cmake
@@ -346,14 +346,6 @@
 #cmakedefine HAVE_LIB_ZLIB 1
 #endif
 
-/* iconv detected */
-#ifndef HAVE_ICONV
-#cmakedefine HAVE_ICONV 1
-#endif
-#ifndef ICONV_CONST
-#define ICONV_CONST @ICONV_CONST@
-#endif
-
 /* libagg detected */
 #ifndef HAVE_LIB_AGG
 #cmakedefine HAVE_LIB_AGG 1

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -172,30 +172,6 @@ set(HAVE_LIB_PROTOBUF $<TARGET_EXISTS:protobuf::libprotobuf>)
 find_package(ZLIB QUIET)
 set(HAVE_LIB_ZLIB $<TARGET_EXISTS:ZLIB::ZLIB>)
 
-find_package(Iconv QUIET)
-if(TARGET Iconv::Iconv)
-  set(HAVE_ICONV TRUE)
-
-  cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_INCLUDES ${ICONV_INCLUDE_DIR})
-  set(CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARIES})
-  if(MSVC)
-    set(CMAKE_REQUIRED_FLAGS /we4028 /fp:fast /wd4251 /Oi)
-  endif()
-  check_prototype_definition("iconv"
-          "size_t iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft)"
-          "-1"
-          "iconv.h"
-          ICONV_SECOND_ARGUMENT_IS_CONST)
-  cmake_pop_check_state()
-
-  if(${ICONV_SECOND_ARGUMENT_IS_CONST})
-    set(ICONV_CONST "const")
-  endif()
-else()
-  message(WARNING "No iconv support")
-endif()
-
 find_package(LibLZMA QUIET)
 
 find_package(PNG QUIET)

--- a/libosmscout-gpx/meson.build
+++ b/libosmscout-gpx/meson.build
@@ -17,7 +17,7 @@ osmscoutgpx = library('osmscout_gpx',
                       osmscoutgpxSrc,
                       include_directories: [osmscoutgpxIncDir, osmscoutIncDir],
                       cpp_args: cppArgs,
-                      dependencies: [mathDep, threadDep, xml2Dep, iconvDep, zlibDep],
+                      dependencies: [mathDep, threadDep, xml2Dep, zlibDep],
                       link_with: [osmscout],
                       version: libraryVersion,
                       install: true)

--- a/libosmscout/include/osmscout/private/meson.build
+++ b/libosmscout/include/osmscout/private/meson.build
@@ -10,10 +10,6 @@ coreCfg.set('HAVE_MMAP',mmapAvailable, description: 'mmap() is available')
 coreCfg.set('HAVE_POSIX_FADVISE',posixfadviceAvailable, description: 'posixfadvice() is available')
 coreCfg.set('HAVE_POSIX_MADVISE',posixmadviceAvailable, description: 'posixmadvice() is available')
 coreCfg.set('SIZEOF_WCHAR_T',sizeOfWChar, description: 'byte size of wchar_t')
-coreCfg.set('HAVE_ICONV',iconvAvailable, description: 'iconv library available')
-
-## TODO
-coreCfg.set('ICONV_CONST','', description: 'Signature of second parameter of the iconv() function')
 
 configure_file(output: 'Config.h',
                configuration: coreCfg)

--- a/libosmscout/meson.build
+++ b/libosmscout/meson.build
@@ -27,7 +27,7 @@ osmscout = library('osmscout',
                    osmscoutSrc,
                    include_directories: osmscoutIncDir,
                    cpp_args: cppArgs,
-                   dependencies: [mathDep, threadDep, openmpDep, iconvDep, marisaDep],
+                   dependencies: [mathDep, threadDep, openmpDep, marisaDep],
                    link_args: link_args,
                    version: libraryVersion,
                    install: true)

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,6 @@ endif
 # Check for headers
 fcntlAvailable = compiler.has_header('fcntl.h')
 statAvailable = compiler.has_header('sys/stat.h')
-iconvAvailable = compiler.has_header('iconv.h')
 codecvtAvailable = compiler.has_header('codecvt')
 jniAvailable = compiler.has_header('jni.h')
 
@@ -83,7 +82,6 @@ swigExe = find_program('swig', required: false)
 # Base
 mathDep = compiler.find_library('m', required : false)
 threadDep = dependency('threads')
-iconvDep = compiler.find_library('iconv', required: false)
 if compiler.get_id()=='clang' or compiler.get_id()=='msvc'
   openmpDep = dependency('', required: false)
 else


### PR DESCRIPTION
Iconv should not be needed with C++17, and standard library conversions are even faster by simple measurement (linux, gcc).