### PR TITLE
fix milliseconds in TimestampToISO8601TimeString

### DIFF
--- a/Tests/src/SunriseSunsetTest.cpp
+++ b/Tests/src/SunriseSunsetTest.cpp
@@ -64,40 +64,40 @@ bool SunriseSunsetTest(const osmscout::Timestamp &day,
 }
 
 TEST_CASE("Compute Prague sunrise and sunset at winter solstice") {
-  std::string winterSolstice="2021-12-21T12:00:00.0Z";
+  std::string winterSolstice="2021-12-21T12:00:00.000Z";
   osmscout::GeoCoord pragueLoc(50.083, 14.422);
-  REQUIRE(SunriseSunsetString(winterSolstice, pragueLoc, +1) == "2021-12-21T07:59:58.0Z - 2021-12-21T16:03:24.0Z");
+  REQUIRE(SunriseSunsetString(winterSolstice, pragueLoc, +1) == "2021-12-21T07:59:58.000Z - 2021-12-21T16:03:24.000Z");
 }
 
 TEST_CASE("Polar night at Tromso at winter solstice") {
-  std::string winterSolstice="2021-12-21T12:00:00.0Z";
+  std::string winterSolstice="2021-12-21T12:00:00.000Z";
   osmscout::GeoCoord tromsoLoc(69.6523, 18.9753);
   REQUIRE(SunriseSunsetString(winterSolstice, tromsoLoc, +1) == "nullopt");
 }
 
 TEST_CASE("Compute sunrise and sunset for some date and locations") {
-  REQUIRE(SunriseSunsetTest(Ts("2013-01-20T12:00:00.0Z"), osmscout::GeoCoord(34.0522, -118.2437), -8,
-                            Ts("2013-01-20T06:57:00.0Z"), Ts("2013-01-20T17:11:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-01-20T12:00:00.0Z"), osmscout::GeoCoord(48.8567, 2.351), +1,
-                            Ts("2013-01-20T08:35:00.0Z"), Ts("2013-01-20T17:28:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2012-12-25T12:00:00.0Z"), osmscout::GeoCoord(-33.86, 151.2111), +11,
-                            Ts("2012-12-25T05:43:00.0Z"), Ts("2012-12-25T20:07:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-05-01T12:00:00.0Z"), osmscout::GeoCoord(35.6938, 139.7036), +9,
-                            Ts("2013-05-01T04:49:00.0Z"), Ts("2013-05-01T18:27:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-06-05T12:00:00.0Z"), osmscout::GeoCoord(53.3441, -6.2675), +1,
-                            Ts("2013-06-05T05:01:00.0Z"), Ts("2013-06-05T21:46:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-06-22T12:00:00.0Z"), osmscout::GeoCoord(41.8781, -87.6298), -5,
-                            Ts("2013-06-22T05:16:00.0Z"), Ts("2013-06-22T20:29:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2015-08-27T12:00:00.0Z"), osmscout::GeoCoord(21.3069, -157.8583), -10,
-                            Ts("2015-08-27T06:13:00.0Z"), Ts("2015-08-27T18:53:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-05-01T12:00:00.0Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
-                            Ts("2013-05-01T07:29:00.0Z"), Ts("2013-05-01T18:12:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-10-19T12:00:00.0Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
-                            Ts("2013-10-19T06:07:00.0Z"), Ts("2013-10-19T19:11:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-01-26T12:00:00.0Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
-                            Ts("2013-01-26T06:07:00.0Z"), Ts("2013-01-26T20:04:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-10-20T12:00:00.0Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
-                            Ts("2013-10-20T06:05:00.0Z"), Ts("2013-10-20T19:11:00.0Z")));
-  REQUIRE(SunriseSunsetTest(Ts("2013-10-31T12:00:00.0Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
-                            Ts("2013-10-31T05:53:00.0Z"), Ts("2013-10-31T19:21:00.0Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-01-20T12:00:00.000Z"), osmscout::GeoCoord(34.0522, -118.2437), -8,
+                            Ts("2013-01-20T06:57:00.000Z"), Ts("2013-01-20T17:11:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-01-20T12:00:00.000Z"), osmscout::GeoCoord(48.8567, 2.351), +1,
+                            Ts("2013-01-20T08:35:00.000Z"), Ts("2013-01-20T17:28:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2012-12-25T12:00:00.000Z"), osmscout::GeoCoord(-33.86, 151.2111), +11,
+                            Ts("2012-12-25T05:43:00.000Z"), Ts("2012-12-25T20:07:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-05-01T12:00:00.000Z"), osmscout::GeoCoord(35.6938, 139.7036), +9,
+                            Ts("2013-05-01T04:49:00.000Z"), Ts("2013-05-01T18:27:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-06-05T12:00:00.000Z"), osmscout::GeoCoord(53.3441, -6.2675), +1,
+                            Ts("2013-06-05T05:01:00.000Z"), Ts("2013-06-05T21:46:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-06-22T12:00:00.000Z"), osmscout::GeoCoord(41.8781, -87.6298), -5,
+                            Ts("2013-06-22T05:16:00.000Z"), Ts("2013-06-22T20:29:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2015-08-27T12:00:00.000Z"), osmscout::GeoCoord(21.3069, -157.8583), -10,
+                            Ts("2015-08-27T06:13:00.000Z"), Ts("2015-08-27T18:53:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-05-01T12:00:00.000Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
+                            Ts("2013-05-01T07:29:00.000Z"), Ts("2013-05-01T18:12:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-10-19T12:00:00.000Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
+                            Ts("2013-10-19T06:07:00.000Z"), Ts("2013-10-19T19:11:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-01-26T12:00:00.000Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
+                            Ts("2013-01-26T06:07:00.000Z"), Ts("2013-01-26T20:04:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-10-20T12:00:00.000Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
+                            Ts("2013-10-20T06:05:00.000Z"), Ts("2013-10-20T19:11:00.000Z")));
+  REQUIRE(SunriseSunsetTest(Ts("2013-10-31T12:00:00.000Z"), osmscout::GeoCoord(-34.6092, -58.3732), -3,
+                            Ts("2013-10-31T05:53:00.000Z"), Ts("2013-10-31T19:21:00.000Z")));
 }

--- a/Tests/src/TimeParse.cpp
+++ b/Tests/src/TimeParse.cpp
@@ -4,8 +4,16 @@
 
 TEST_CASE("Parse ISO8601 time string") {
   osmscout::Timestamp ts;
-  std::string testString="2017-03-12T14:31:56.0Z";
+  std::string testString="2017-03-12T14:31:56.000Z";
   REQUIRE(osmscout::ParseISO8601TimeString(testString, ts));
   REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()).count()==1489329116000);
+  REQUIRE(osmscout::TimestampToISO8601TimeString(ts)==testString);
+}
+
+TEST_CASE("Parse ISO8601 time string with millisecond precision") {
+  osmscout::Timestamp ts;
+  std::string testString="2017-03-12T14:31:56.012Z";
+  REQUIRE(osmscout::ParseISO8601TimeString(testString, ts));
+  REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()).count()==1489329116012);
   REQUIRE(osmscout::TimestampToISO8601TimeString(ts)==testString);
 }

--- a/libosmscout/src/osmscout/util/String.cpp
+++ b/libosmscout/src/osmscout/util/String.cpp
@@ -718,9 +718,9 @@ namespace osmscout {
     stream << buff.data();
 
     // add milliseconds
-    auto millisFromEpoch = timestamp.time_since_epoch().count();
+    auto millisFromEpoch = duration_cast<milliseconds>(timestamp.time_since_epoch()).count();
     stream << ".";
-    stream << (millisFromEpoch - ((millisFromEpoch / 1000) * 1000));
+    stream << std::setfill('0') << std::setw(3) << (millisFromEpoch - ((millisFromEpoch / 1000) * 1000));
     stream << "Z";
     return stream.str();
   }


### PR DESCRIPTION
System clock is using nanosecond precision,
to get number of millisecond from epoch start,
it is necessary to use duration_cast to milliseconds.