### PR TITLE
close previous db-load job

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -474,7 +474,8 @@ void PlaneMapRenderer::TriggerMapRendering(const MapViewStruct& request, size_t 
   {
     QMutexLocker locker(&lock);
     if (loadJob!=nullptr){
-      // TODO: check if job contains same tiles...
+      // TODO: check if job contains the same tiles...
+      loadJob->Close();
       loadJob->deleteLater();
       loadJob=nullptr;
     }


### PR DESCRIPTION
And not rely on job destructor, it seems that Qt may postpone object deletion after deleteLater() invocation for very long time. In such situation data are still loading and job is holding database read-lock.