### PR TITLE
close previous db-load job, an other one

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -413,6 +413,7 @@ void PlaneMapRenderer::DrawMap()
 
     if (loadJob->IsFinished()){
       // this slot is may be called from DBLoadJob, we can't delete it now
+      loadJob->Close();
       loadJob->deleteLater();
       loadJob=nullptr;
     }

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -488,6 +488,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     }
 
     // this slot is called from DBLoadJob, we can't delete it now
+    loadJob->Close();
     loadJob->deleteLater();
     loadJob=nullptr;
 


### PR DESCRIPTION
See commit 5b62a91.

And not rely on job destructor, it seems that Qt may postpone object deletion after deleteLater() invocation for very long time. In such situation data are still loading and job is holding database read-lock.

@Karry, an other one is fixed here. I catched it on mobile device (Android). I guess the issue appear too on device slower than desktop used to develop or test.
