### PR TITLE
take initial vehicle bearing into account during routing

### DIFF
--- a/Demos/qml/NavigationSimulation.qml
+++ b/Demos/qml/NavigationSimulation.qml
@@ -20,13 +20,6 @@ Window {
     width: 1024
     height: 768
 
-    function reroute(){
-        var startLoc = routingModel.locationEntryFromPosition(simulator.latitude, simulator.longitude);
-        var destinationLoc = routingModel.locationEntryFromPosition(simulator.endLat, simulator.endLon);
-        console.log("We leave route, reroute from " + Utils.locationStr(startLoc) + " -> " + Utils.locationStr(destinationLoc));
-        routingModel.setStartAndTarget(startLoc, destinationLoc);
-    }
-
     PositionSimulator {
         id: simulator
         track: PositionSimulationTrack
@@ -59,7 +52,10 @@ Window {
 
         onRerouteRequest: {
             if (routingModel.ready){
-                reroute();
+                var startLoc = routingModel.locationEntryFromPosition(fromLat, fromLon);
+                var destinationLoc = routingModel.locationEntryFromPosition(simulator.endLat, simulator.endLon);
+                console.log("We leave route, reroute from " + Utils.locationStr(startLoc) + " -> " + Utils.locationStr(destinationLoc) + ", bearing: " + bearingAngle);
+                routingModel.setStartAndTarget(startLoc, destinationLoc, "car", bearingAngle);
             }
         }
         onPositionEstimate: {

--- a/Demos/src/Navigation.cpp
+++ b/Demos/src/Navigation.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <cmath>
 #include <cstring>
+#include <optional>
 
 #include <osmscout/db/Database.h>
 
@@ -589,6 +590,7 @@ int main(int argc, char *argv[]){
     osmscout::RoutingResult result=router->CalculateRoute(*routingProfile,
                                                           start,
                                                           target,
+                                                          std::nullopt,
                                                           parameter);
 
     if (!result.Success()) {

--- a/Demos/src/Routing.cpp
+++ b/Demos/src/Routing.cpp
@@ -25,6 +25,7 @@
 #include <list>
 #include <sstream>
 #include <fstream>
+#include <optional>
 
 #include <osmscout/db/Database.h>
 
@@ -34,6 +35,7 @@
 #include <osmscout/routing/RouteDescriptionPostprocessor.h>
 
 #include <osmscout/cli/CmdLineParsing.h>
+#include <osmscout/util/Bearing.h>
 #include <osmscout/util/Geometry.h>
 #include <osmscout/util/Time.h>
 
@@ -69,6 +71,7 @@ struct Arguments
   osmscout::GeoCoord                start;
   std::vector<osmscout::GeoCoord>   via;
   osmscout::GeoCoord                target;
+  std::optional<osmscout::Bearing>  initialBearing;
   bool                              debug=false;
   bool                              dataDebug=false;
   bool                              routeDebug=false;
@@ -751,6 +754,11 @@ int main(int argc, char* argv[])
                       "penalty-max",
                       "Maximum junction penalty, time [s]. Default "s + std::to_string(duration_cast<seconds>(args.maxPenalty).count()));
 
+  argParser.AddOption(osmscout::CmdLineDoubleOption([&args](double value) {
+                        args.initialBearing=osmscout::Bearing::Degrees(value);
+                      }),
+                      "initial-bearing",
+                      "Initial vehicle bearing (degrees, North is 0, East is 90...).");
 
   argParser.AddOption(osmscout::CmdLineGeoCoordOption([&args](const osmscout::GeoCoord& value) {
                         args.via.push_back(value);
@@ -889,6 +897,7 @@ int main(int argc, char* argv[])
     result=router->CalculateRoute(*routingProfile,
                                   start,
                                   target,
+                                  args.initialBearing,
                                   parameter);
   }
 

--- a/Demos/src/RoutingAnimation.cpp
+++ b/Demos/src/RoutingAnimation.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <iostream>
 #include <list>
+#include <optional>
 
 #include <osmscout/projection/MercatorProjection.h>
 
@@ -653,6 +654,7 @@ int main(int argc, char* argv[])
   osmscout::RoutingResult result=router->CalculateRoute(routingProfile,
                                                         start,
                                                         target,
+                                                        std::nullopt,
                                                         parameter);
 
   if (!result.Success()) {

--- a/Tests/src/MultiDBRouting.cpp
+++ b/Tests/src/MultiDBRouting.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
   std::cout << "Calculate route..." << std::endl;
 
   osmscout::RoutingParameter parameter;
-  auto                       routingResult=router->CalculateRoute(startNode,targetNode,parameter);
+  auto                       routingResult=router->CalculateRoute(startNode,targetNode,std::nullopt,parameter);
 
   if (!routingResult.Success()){
     std::cerr << "Route failed" << std::endl;

--- a/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/LocationEntry.h
@@ -105,6 +105,7 @@ public:
   QString getTypeString() const;
   QString getObjectType() const;
   QString getLabel() const;
+  QString getDebugString() const;
   QString getAltName() const;
   QList<AdminRegionInfoRef> getAdminRegionList() const;
   QString getDatabase() const;

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
@@ -82,6 +82,10 @@ signals:
 
   void positionEstimateInTunnelChanged();
 
+  /** Requesting computation of the new route when wehicle leave current route.
+   *
+   * bearingAngle is in radians.
+   */
   void rerouteRequest(double fromLat, double fromLon,
                       const QString bearing,
                       double bearingAngle,

--- a/libosmscout-client-qt/include/osmscoutclientqt/Router.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/Router.h
@@ -162,11 +162,13 @@ private:
                            const LocationEntryRef &start,
                            const LocationEntryRef &target,
                            int requestId,
-                           const osmscout::BreakerRef &breaker);
+                           const osmscout::BreakerRef &breaker,
+                           const std::optional<osmscout::Bearing> &bearing);
 
   bool CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
                       const osmscout::RoutePosition& start,
                       const osmscout::RoutePosition& target,
+                      const std::optional<osmscout::Bearing> &bearing,
                       osmscout::RouteData& route,
                       int requestId,
                       const osmscout::BreakerRef &breaker);

--- a/libosmscout-client-qt/include/osmscoutclientqt/Router.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/Router.h
@@ -122,7 +122,8 @@ public slots:
                       LocationEntryRef target,
                       QmlRoutingProfileRef profile,
                       int requestId,
-                      osmscout::BreakerRef breaker);
+                      osmscout::BreakerRef breaker,
+                      std::optional<osmscout::Bearing> bearing);
 signals:
   void routeComputed(QtRouteData route,
                      int requestId);

--- a/libosmscout-client-qt/include/osmscoutclientqt/RoutingModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/RoutingModel.h
@@ -58,7 +58,8 @@ signals:
                     LocationEntryRef target,
                     QmlRoutingProfileRef profile,
                     int requestId,
-                    osmscout::BreakerRef breaker);
+                    osmscout::BreakerRef breaker,
+                    std::optional<osmscout::Bearing> bearing);
 
   void computingChanged();
 
@@ -67,13 +68,30 @@ signals:
   void routingProgress(int percent);
 
 public slots:
-  void setStartAndTarget(LocationEntry* start,
-                         LocationEntry* target,
-                         QString vehicleStr="car");
 
+  /** Compute new route.
+   *
+   * @param start
+   * @param target
+   * @param vehicleStr predefined vehicle string. It may be car|bicycle|foot
+   * @param vehicleBearing in radians, when negative, it is not taken into account
+   */
   void setStartAndTarget(LocationEntry* start,
                          LocationEntry* target,
-                         QmlRoutingProfile *routingProfile);
+                         QString vehicleStr="car",
+                         double vehicleBearing = -1);
+
+  /** Compute new route.
+   *
+   * @param start
+   * @param target
+   * @param routingProfile profile of the routing
+   * @param vehicleBearing in radians, when negative, it is not taken into account
+   */
+  void setStartAndTarget(LocationEntry* start,
+                         LocationEntry* target,
+                         QmlRoutingProfile *routingProfile,
+                         double vehicleBearing = -1);
 
   void clear();
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/LocationEntry.cpp
@@ -205,6 +205,18 @@ QString LocationEntry::getLabel() const
     return label;
 }
 
+QString LocationEntry::getDebugString() const
+{
+  switch (type) {
+    case LocationInfo::Type::typeObject:
+      return label + " (" + QString::fromStdString(coord.GetDisplayText()) + ")";
+    case LocationInfo::Type::typeCoordinate:
+      return QString::fromStdString(coord.GetDisplayText());
+    default:
+      return "none";
+  }
+}
+
 QString LocationEntry::getAltName() const
 {
   return altName;

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -190,12 +190,13 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
                                   int versionMajor,
                                   int versionMinor)
 {
+  // TODO: unify usage of osmscout namespace in signals and slots
   // register osmscout + standard types for usage in Qt signals/slots
   qRegisterMetaType<LocationEntryRef>("LocationEntryRef");
   qRegisterMetaType<osmscout::BreakerRef>("osmscout::BreakerRef");
   qRegisterMetaType<osmscout::Distance>("osmscout::Distance");
   qRegisterMetaType<osmscout::Bearing>("osmscout::Bearing");
-  qRegisterMetaType<std::shared_ptr<osmscout::Bearing>>("std::shared_ptr<osmscout::Bearing>");
+  qRegisterMetaType<std::shared_ptr<osmscout::Bearing>>("std::shared_ptr<osmscout::Bearing>"); // TODO: use optional bearing
   qRegisterMetaType<std::optional<osmscout::Bearing>>("std::optional<osmscout::Bearing>");
   qRegisterMetaType<osmscout::GeoBox>("osmscout::GeoBox");
   qRegisterMetaType<osmscout::GeoCoord>("osmscout::GeoCoord");

--- a/libosmscout-client-qt/src/osmscoutclientqt/Router.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/Router.cpp
@@ -79,6 +79,7 @@ osmscout::MultiDBRoutingServiceRef Router::MakeRoutingService(const std::list<DB
 bool Router::CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
                             const osmscout::RoutePosition& start,
                             const osmscout::RoutePosition& target,
+                            const std::optional<osmscout::Bearing> &bearing,
                             osmscout::RouteData& route,
                             int requestId,
                             const osmscout::BreakerRef &breaker)
@@ -96,6 +97,7 @@ bool Router::CalculateRoute(osmscout::MultiDBRoutingServiceRef &routingService,
 
   result=routingService->CalculateRoute(start,
                                         target,
+                                        bearing,
                                         parameter);
 
   if (!result.Success()){
@@ -181,7 +183,8 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
                                  const LocationEntryRef &start,
                                  const LocationEntryRef &target,
                                  int requestId,
-                                 const osmscout::BreakerRef &breaker)
+                                 const osmscout::BreakerRef &breaker,
+                                 const std::optional<osmscout::Bearing> &bearing)
 {
   std::optional<RoutePosition> startNodeOpt=LocationToRoutePosition(routingService, start);
   if (!startNodeOpt) {
@@ -207,6 +210,7 @@ void Router::ProcessRouteRequest(osmscout::MultiDBRoutingServiceRef &routingServ
   if (!CalculateRoute(routingService,
                       startNode,
                       targetNode,
+                      bearing,
                       routeData,
                       requestId,
                       breaker)) {
@@ -264,14 +268,14 @@ void Router::onRouteRequest(LocationEntryRef start,
     (bearing ? "bearing " + bearing->LongDisplayString() : "no bearing");
 
   dbThread->RunSynchronousJob(
-    [this,profile,requestId,start,target,breaker](const std::list<DBInstanceRef>& databases) {
+    [this,profile,requestId,start,target,breaker,bearing](const std::list<DBInstanceRef>& databases) {
       osmscout::MultiDBRoutingServiceRef routingService=MakeRoutingService(databases,profile);
       if (!routingService){
         osmscout::log.Warn() << "Can't open routing service";
         emit routeFailed("Can't open routing service",requestId);
         return;
       }
-      ProcessRouteRequest(routingService,start,target,requestId,breaker);
+      ProcessRouteRequest(routingService,start,target,requestId,breaker,bearing);
       routingService->Close();
     }
   );

--- a/libosmscout-client-qt/src/osmscoutclientqt/Router.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/Router.cpp
@@ -255,11 +255,13 @@ void Router::onRouteRequest(LocationEntryRef start,
                             LocationEntryRef target,
                             QmlRoutingProfileRef profile,
                             int requestId,
-                            osmscout::BreakerRef breaker)
+                            BreakerRef breaker,
+                            std::optional<osmscout::Bearing> bearing)
 {
-  osmscout::log.Debug() << "Routing from '" << start->getLabel().toStdString() <<
-    "' to '" << target->getLabel().toStdString() << "'" <<
-    " by '" << vehicleStr(profile->getVehicle()) << "'";
+  osmscout::log.Debug() << "Routing from '" << start->getDebugString().toStdString() <<
+    "' to '" << target->getDebugString().toStdString() << "'" <<
+    " by '" << vehicleStr(profile->getVehicle()) << "' " <<
+    (bearing ? "bearing " + bearing->LongDisplayString() : "no bearing");
 
   dbThread->RunSynchronousJob(
     [this,profile,requestId,start,target,breaker](const std::list<DBInstanceRef>& databases) {

--- a/libosmscout-client-qt/src/osmscoutclientqt/RoutingModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/RoutingModel.cpp
@@ -53,7 +53,8 @@ RoutingListModel::~RoutingListModel()
 
 void RoutingListModel::setStartAndTarget(LocationEntry* start,
                                          LocationEntry* target,
-                                         QString vehicleStr)
+                                         QString vehicleStr,
+                                         double vehicleBearing)
 {
   osmscout::Vehicle vehicle=osmscout::Vehicle::vehicleCar;
   if (vehicleStr=="bicycle"){
@@ -62,12 +63,13 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
     vehicle=osmscout::Vehicle::vehicleFoot;
   }
   QmlRoutingProfile profile(vehicle);
-  setStartAndTarget(start, target, &profile);
+  setStartAndTarget(start, target, &profile, vehicleBearing);
 }
 
 void RoutingListModel::setStartAndTarget(LocationEntry* start,
                                          LocationEntry* target,
-                                         QmlRoutingProfile *routingProfile)
+                                         QmlRoutingProfile *routingProfile,
+                                         double vehicleBearing)
 {
   cancel(); // cancel current computation
   clear(); // clear model
@@ -97,7 +99,8 @@ void RoutingListModel::setStartAndTarget(LocationEntry* start,
   QmlRoutingProfileRef profileRef=std::make_shared<QmlRoutingProfile>(*routingProfile);
   profileRef->setParent(Q_NULLPTR);
 
-  emit routeRequest(startRef,targetRef,profileRef,++requestId,breaker);
+  emit routeRequest(startRef,targetRef,profileRef,++requestId,breaker,
+                    (vehicleBearing < 0 ? std::nullopt : std::make_optional<Bearing>(Bearing::Radians(vehicleBearing))));
 }
 
 void RoutingListModel::onRouteComputed(QtRouteData route,

--- a/libosmscout/include/osmscout/routing/AbstractRoutingService.h
+++ b/libosmscout/include/osmscout/routing/AbstractRoutingService.h
@@ -41,11 +41,6 @@
 #include <osmscout/routing/MultiDBRoutingState.h>
 
 namespace osmscout {
-#ifdef OSMSCOUT_DEBUG_ROUTING
-constexpr bool debugRouting = true;
-#else
-constexpr bool debugRouting = false;
-#endif
 
   /**
    * Result of a routing calculation. This object is always returned.
@@ -221,6 +216,8 @@ constexpr bool debugRouting = false;
                             size_t inPathIndex,
                             size_t outPathIndex) = 0;
 
+    virtual double GetUTurnCost(const RoutingState& state, const DatabaseId databaseId) = 0;
+
     virtual double GetCosts(const RoutingState& state,
                             DatabaseId database,
                             const WayRef &way,
@@ -243,8 +240,8 @@ constexpr bool debugRouting = false;
 
     /**
      * Return the route node for the given db offset
-     * @param offset
-     *    Offset in given db
+     * @param id
+     *    Database and Offset in given db
      * @param node
      *    Node instance to write the result back
      * @return
@@ -380,6 +377,7 @@ constexpr bool debugRouting = false;
     RoutingResult CalculateRoute(RoutingState& state,
                                  const RoutePosition& start,
                                  const RoutePosition& target,
+                                 const std::optional<osmscout::Bearing> &bearing,
                                  const RoutingParameter& parameter);
 
     RouteDescriptionResult TransformRouteDataToRouteDescription(const RouteData& data);

--- a/libosmscout/include/osmscout/routing/AbstractRoutingService.h
+++ b/libosmscout/include/osmscout/routing/AbstractRoutingService.h
@@ -370,6 +370,13 @@ namespace osmscout {
                            Distance &currentMaxDistance,
                            const Distance &overallDistance,
                            const double &costLimit);
+
+    bool RestrictInitialUTurn(const RoutingState& state,
+                              const Bearing& vehicleBearing,
+                              const RoutePosition& start,
+                              RNodeRef startForwardNode,
+                              RNodeRef startBackwardNode);
+
   public:
     explicit AbstractRoutingService(const RouterParameter& parameter);
     ~AbstractRoutingService() override;

--- a/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
+++ b/libosmscout/include/osmscout/routing/MultiDBRoutingService.h
@@ -77,6 +77,8 @@ namespace osmscout {
                     const WayRef &way,
                     const Distance &wayLength) override;
 
+    double GetUTurnCost(const MultiDBRoutingState& state, const DatabaseId databaseId) override;
+
     double GetEstimateCosts(const MultiDBRoutingState& state,
                             DatabaseId database,
                             const Distance &targetDistance) override;
@@ -143,6 +145,7 @@ namespace osmscout {
 
     RoutingResult CalculateRoute(const RoutePosition &start,
                                  const RoutePosition &target,
+                                 const std::optional<osmscout::Bearing> &bearing,
                                  const RoutingParameter &parameter);
 
     RoutingResult CalculateRoute(const std::vector<osmscout::GeoCoord>& via,

--- a/libosmscout/include/osmscout/routing/RoutingService.h
+++ b/libosmscout/include/osmscout/routing/RoutingService.h
@@ -66,11 +66,11 @@ namespace osmscout {
   {
   private:
     ObjectFileRef object;
-    size_t        nodeIndex;
+    size_t        nodeIndex=0;
     DatabaseId    database;
 
   public:
-    RoutePosition();
+    RoutePosition() = default;
     RoutePosition(const ObjectFileRef& object,
                   size_t nodeIndex,
                   DatabaseId database);
@@ -223,6 +223,8 @@ namespace osmscout {
       DBId          id;                   //!< The file offset of the current route node
       RouteNodeRef  node;                 //!< The current route node
       DBId          prev;                 //!< The file offset of the previous route node
+      Id            exclude;              //!< excluded node to go, similar to route-node excludes,
+                                          //!< but used by routing service when initial bearing is restricted
       bool          prevRestricted=false; //!< previous node is restricted
       ObjectFileRef object;               //!< The object (way/area) visited from the current route node
 

--- a/libosmscout/include/osmscout/routing/SimpleRoutingService.h
+++ b/libosmscout/include/osmscout/routing/SimpleRoutingService.h
@@ -108,7 +108,7 @@ namespace osmscout {
    * - Transformation of the resulting route to a simple list of points
    * - Transformation of the resulting route to a routing description with is the base
    * for further transformations to a textual or visual description of the route
-   * - Returning the closest routeable node to  given geolocation
+   * - Returning the closest route-able node to given geolocation
    */
   class OSMSCOUT_API SimpleRoutingService: public AbstractRoutingService<RoutingProfile>
   {
@@ -152,6 +152,8 @@ namespace osmscout {
                     DatabaseId database,
                     const WayRef &way,
                     const Distance &wayLength) override;
+
+    double GetUTurnCost(const RoutingProfile& profile, const DatabaseId databaseId) override;
 
     double GetEstimateCosts(const RoutingProfile& profile,
                             DatabaseId database,

--- a/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
@@ -883,6 +883,93 @@ namespace osmscout {
     return true;
   }
 
+  template <class RoutingState>
+  bool AbstractRoutingService<RoutingState>::RestrictInitialUTurn(const RoutingState& state,
+                                                                  const Bearing& bearing,
+                                                                  const RoutePosition& start,
+                                                                  RNodeRef startForwardNode,
+                                                                  RNodeRef startBackwardNode)
+  {
+    if (startForwardNode && startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
+      // start is on the way between two route nodes, lets evaluate what route node is in opposite
+      // direction and add u-turn penalty to it and avoid return from node ahead
+      WayRef way;
+      if (!GetWayByOffset(DBFileOffset(start.GetDatabaseId(),
+                                       start.GetObjectFileRef().GetFileOffset()),
+                          way)) {
+        log.Error() << "Cannot get start way!";
+        return false;
+      }
+      if (CanUseForward(state,start.GetDatabaseId(),way) &&
+          CanUseBackward(state,start.GetDatabaseId(),way) &&
+          start.GetNodeIndex() > 0 &&
+          start.GetNodeIndex() < way->nodes.size() -1) {
+        auto pos = way->nodes[start.GetNodeIndex()].GetCoord();
+        auto forwardPos = way->nodes[start.GetNodeIndex()+1].GetCoord();
+        auto backwardPos = way->nodes[start.GetNodeIndex()-1].GetCoord();
+        auto forwardBearing = GetSphericalBearingInitial(pos, forwardPos);
+        auto backwardBearing = GetSphericalBearingInitial(pos, backwardPos);
+        auto forwardBearingDiff = (forwardBearing-bearing).AsDegrees();
+        forwardBearingDiff = forwardBearingDiff > 180 ? 360 - forwardBearingDiff : forwardBearingDiff;
+        auto backwardBearingDiff = (backwardBearing-bearing).AsDegrees();
+        backwardBearingDiff = backwardBearingDiff > 180 ? 360 - backwardBearingDiff : backwardBearingDiff;
+
+        auto penalizedRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startBackwardNode : startForwardNode;
+        if constexpr (debugRouting) {
+          std::cout << "Adding u-turn penalty to route node " << penalizedRNode->id;
+        }
+        auto aheadRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startForwardNode : startBackwardNode;
+        penalizedRNode->currentCost += GetUTurnCost(state, penalizedRNode->id.database);
+        penalizedRNode->overallCost = penalizedRNode->currentCost + penalizedRNode->estimateCost;
+
+        // avoid return from aheadRNode to penalizedRNode
+        aheadRNode->exclude = penalizedRNode->id.id;
+      }
+    }
+    if (startForwardNode && !startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
+      // start is directly on route-node, try to find what path is our source and add exclusion to it
+      double restrictedPathBearing = 20; // degrees
+      auto oppositeVehicleBearing = bearing - Bearing::Degrees(180);
+      for (const auto& path : startForwardNode->node->paths) {
+        auto object = startForwardNode->node->objects[path.objectIndex].object;
+        if (object.GetType() != refWay) {
+          continue;
+        }
+        WayRef way;
+        if (!GetWayByOffset(DBFileOffset(startForwardNode->id.database,
+                                         object.GetFileOffset()),
+                            way)) {
+          log.Error() << "Cannot get starting junction way!";
+          return false;
+        }
+
+        int fromNode=-1;
+        int toNode=-1;
+        for (size_t i= 0; i < way->nodes.size() && (fromNode<0 || toNode<0); i++) {
+          if (way->nodes[i].GetId() == startForwardNode->node->GetId()) {
+            fromNode = i;
+          }
+          if (way->nodes[i].GetId() == path.id) {
+            toNode = i;
+          }
+        }
+        assert(fromNode>=0);
+        assert(toNode>=0);
+        assert(fromNode!=toNode);
+        auto pathBearing = fromNode < toNode ?
+                           GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode+1].GetCoord()) :
+                           GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode-1].GetCoord());
+        auto bearingDiff = (pathBearing - oppositeVehicleBearing).AsDegrees();
+        bearingDiff = bearingDiff > 180 ? 360 - bearingDiff : bearingDiff;
+        if (bearingDiff < restrictedPathBearing) {
+          startForwardNode->exclude = path.id;
+          restrictedPathBearing = bearingDiff;
+        }
+      }
+    }
+    return true;
+  }
+
   /**
    * Calculate a route
    *
@@ -979,83 +1066,9 @@ namespace osmscout {
       return result;
     }
 
-    if (bearing) { // TODO: move to utility method
-      if (startForwardNode && startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
-        // start is on the way between two route nodes, lets evaluate what route node is in opposite
-        // direction and add u-turn penalty to it and avoid return from node ahead
-        WayRef     way;
-        if (!GetWayByOffset(DBFileOffset(start.GetDatabaseId(),
-                                         start.GetObjectFileRef().GetFileOffset()),
-                            way)) {
-          log.Error() << "Cannot get start way!";
-          return result;
-        }
-        if (CanUseForward(state,start.GetDatabaseId(),way) &&
-            CanUseBackward(state,start.GetDatabaseId(),way) &&
-            start.GetNodeIndex() > 0 &&
-            start.GetNodeIndex() < way->nodes.size() -1) {
-          auto pos = way->nodes[start.GetNodeIndex()].GetCoord();
-          auto forwardPos = way->nodes[start.GetNodeIndex()+1].GetCoord();
-          auto backwardPos = way->nodes[start.GetNodeIndex()-1].GetCoord();
-          auto forwardBearing = GetSphericalBearingInitial(pos, forwardPos);
-          auto backwardBearing = GetSphericalBearingInitial(pos, backwardPos);
-          auto forwardBearingDiff = (forwardBearing-*bearing).AsDegrees();
-          forwardBearingDiff = forwardBearingDiff > 180 ? 360 - forwardBearingDiff : forwardBearingDiff;
-          auto backwardBearingDiff = (backwardBearing-*bearing).AsDegrees();
-          backwardBearingDiff = backwardBearingDiff > 180 ? 360 - backwardBearingDiff : backwardBearingDiff;
-
-          auto penalizedRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startBackwardNode : startForwardNode;
-          if constexpr (debugRouting) {
-            std::cout << "Adding u-turn penalty to route node " << penalizedRNode->id;
-          }
-          auto aheadRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startForwardNode : startBackwardNode;
-          penalizedRNode->currentCost += GetUTurnCost(state, penalizedRNode->id.database);
-          penalizedRNode->overallCost = penalizedRNode->currentCost + penalizedRNode->estimateCost;
-
-          // avoid return from aheadRNode to penalizedRNode
-          aheadRNode->exclude = penalizedRNode->id.id;
-        }
-      }
-      if (startForwardNode && !startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
-        // start is directly on route-node, try to find what path is our source and add exclusion to it
-        double restrictedPathBearing = 45;
-        auto oppositeVehicleBearing= *bearing - Bearing::Degrees(180);
-        for (const auto& path : startForwardNode->node->paths) {
-          auto object = startForwardNode->node->objects[path.objectIndex].object;
-          if (object.GetType() != refWay) {
-            continue;
-          }
-          WayRef way;
-          if (!GetWayByOffset(DBFileOffset(startForwardNode->id.database,
-                                           object.GetFileOffset()),
-                              way)) {
-            log.Error() << "Cannot get starting junction way!";
-            return result;
-          }
-
-          int fromNode=-1;
-          int toNode=-1;
-          for (size_t i= 0; i < way->nodes.size() && (fromNode<0 || toNode<0); i++) {
-            if (way->nodes[i].GetId() == startForwardNode->node->GetId()) {
-              fromNode = i;
-            }
-            if (way->nodes[i].GetId() == path.id) {
-              toNode = i;
-            }
-          }
-          assert(fromNode>=0);
-          assert(toNode>=0);
-          assert(fromNode!=toNode);
-          auto pathBearing = fromNode < toNode ?
-                             GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode+1].GetCoord()) :
-                             GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode-1].GetCoord());
-          auto bearingDiff = (pathBearing - oppositeVehicleBearing).AsDegrees();
-          bearingDiff = bearingDiff > 180 ? 360 - bearingDiff : bearingDiff;
-          if (bearingDiff < restrictedPathBearing) {
-            startForwardNode->exclude = path.id;
-            restrictedPathBearing = bearingDiff;
-          }
-        }
+    if (bearing) {
+      if (!RestrictInitialUTurn(state, *bearing, start, startForwardNode, startBackwardNode)) {
+        return result;
       }
     }
 

--- a/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
@@ -648,7 +648,7 @@ namespace osmscout {
         }
         inPathIndex++;
       }
-      // in case of roundabout, node don't contains path back
+      // in case of roundabout, node don't contain path back
       inPathValid=inPathIndex < currentRouteNode->paths.size();
     }
 
@@ -661,6 +661,20 @@ namespace osmscout {
           std::cout << " (" << currentRouteNode->objects[path.objectIndex].object.GetTypeName() << " "
                     << currentRouteNode->objects[path.objectIndex].object.GetFileOffset() << ")";
           std::cout << " => back to the last node visited" << std::endl;
+        }
+        nodesIgnoredCount++;
+        i++;
+
+        continue;
+      }
+
+      if (path.id==current->exclude) {
+        if constexpr (debugRouting) {
+          std::cout << "  Skipping route";
+          std::cout << " to " << path.id;
+          std::cout << " (" << currentRouteNode->objects[path.objectIndex].object.GetTypeName() << " "
+                    << currentRouteNode->objects[path.objectIndex].object.GetFileOffset() << ")";
+          std::cout << " => special exclusion because of vehicle bearing" << std::endl;
         }
         nodesIgnoredCount++;
         i++;
@@ -878,6 +892,8 @@ namespace osmscout {
    *    Start of the route
    * @param target
    *    Target of teh route
+   * @param bearing
+   *    Initial vehicle bearing, route will start by the way in specified direction. When possible.
    * @param progress
    *    Optional callback for handling routing progress
    * @param route
@@ -889,6 +905,7 @@ namespace osmscout {
   RoutingResult AbstractRoutingService<RoutingState>::CalculateRoute(RoutingState& state,
                                                                      const RoutePosition& start,
                                                                      const RoutePosition& target,
+                                                                     const std::optional<osmscout::Bearing> &bearing,
                                                                      const RoutingParameter& parameter)
   {
     RoutingResult            result;
@@ -960,6 +977,86 @@ namespace osmscout {
     if (parameter.GetBreaker() &&
         parameter.GetBreaker()->IsAborted()) {
       return result;
+    }
+
+    if (bearing) { // TODO: move to utility method
+      if (startForwardNode && startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
+        // start is on the way between two route nodes, lets evaluate what route node is in opposite
+        // direction and add u-turn penalty to it and avoid return from node ahead
+        WayRef     way;
+        if (!GetWayByOffset(DBFileOffset(start.GetDatabaseId(),
+                                         start.GetObjectFileRef().GetFileOffset()),
+                            way)) {
+          log.Error() << "Cannot get start way!";
+          return result;
+        }
+        if (CanUseForward(state,start.GetDatabaseId(),way) &&
+            CanUseBackward(state,start.GetDatabaseId(),way) &&
+            start.GetNodeIndex() > 0 &&
+            start.GetNodeIndex() < way->nodes.size() -1) {
+          auto pos = way->nodes[start.GetNodeIndex()].GetCoord();
+          auto forwardPos = way->nodes[start.GetNodeIndex()+1].GetCoord();
+          auto backwardPos = way->nodes[start.GetNodeIndex()-1].GetCoord();
+          auto forwardBearing = GetSphericalBearingInitial(pos, forwardPos);
+          auto backwardBearing = GetSphericalBearingInitial(pos, backwardPos);
+          auto forwardBearingDiff = (forwardBearing-*bearing).AsDegrees();
+          forwardBearingDiff = forwardBearingDiff > 180 ? 360 - forwardBearingDiff : forwardBearingDiff;
+          auto backwardBearingDiff = (backwardBearing-*bearing).AsDegrees();
+          backwardBearingDiff = backwardBearingDiff > 180 ? 360 - backwardBearingDiff : backwardBearingDiff;
+
+          auto penalizedRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startBackwardNode : startForwardNode;
+          if constexpr (debugRouting) {
+            std::cout << "Adding u-turn penalty to route node " << penalizedRNode->id;
+          }
+          auto aheadRNode = ( forwardBearingDiff < backwardBearingDiff ) ? startForwardNode : startBackwardNode;
+          penalizedRNode->currentCost += GetUTurnCost(state, penalizedRNode->id.database);
+          penalizedRNode->overallCost = penalizedRNode->currentCost + penalizedRNode->estimateCost;
+
+          // avoid return from aheadRNode to penalizedRNode
+          aheadRNode->exclude = penalizedRNode->id.id;
+        }
+      }
+      if (startForwardNode && !startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
+        // start is directly on route-node, try to find what path is our source and add exclusion to it
+        double restrictedPathBearing = 45;
+        auto oppositeVehicleBearing= *bearing - Bearing::Degrees(180);
+        for (const auto& path : startForwardNode->node->paths) {
+          auto object = startForwardNode->node->objects[path.objectIndex].object;
+          if (object.GetType() != refWay) {
+            continue;
+          }
+          WayRef way;
+          if (!GetWayByOffset(DBFileOffset(startForwardNode->id.database,
+                                           object.GetFileOffset()),
+                              way)) {
+            log.Error() << "Cannot get starting junction way!";
+            return result;
+          }
+
+          int fromNode=-1;
+          int toNode=-1;
+          for (size_t i= 0; i < way->nodes.size() && (fromNode<0 || toNode<0); i++) {
+            if (way->nodes[i].GetId() == startForwardNode->node->GetId()) {
+              fromNode = i;
+            }
+            if (way->nodes[i].GetId() == path.id) {
+              toNode = i;
+            }
+          }
+          assert(fromNode>=0);
+          assert(toNode>=0);
+          assert(fromNode!=toNode);
+          auto pathBearing = fromNode < toNode ?
+                             GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode+1].GetCoord()) :
+                             GetSphericalBearingInitial(way->nodes[fromNode].GetCoord(), way->nodes[fromNode-1].GetCoord());
+          auto bearingDiff = (pathBearing - oppositeVehicleBearing).AsDegrees();
+          bearingDiff = bearingDiff > 180 ? 360 - bearingDiff : bearingDiff;
+          if (bearingDiff < restrictedPathBearing) {
+            startForwardNode->exclude = path.id;
+            restrictedPathBearing = bearingDiff;
+          }
+        }
+      }
     }
 
     if (startForwardNode) {

--- a/libosmscout/src/osmscout/routing/MultiDBRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/MultiDBRoutingService.cpp
@@ -198,6 +198,12 @@ namespace osmscout {
     return handles[database].profile->GetCosts(*way,wayLength);
   }
 
+  double MultiDBRoutingService::GetUTurnCost(const MultiDBRoutingState& /*state*/, const DatabaseId database)
+  {
+    assert(handles.size()>database);
+    return handles[database].profile->GetUTurnCost();
+  }
+
   double MultiDBRoutingService::GetEstimateCosts(const MultiDBRoutingState& /*state*/,
                                                  const DatabaseId database,
                                                  const Distance &targetDistance)
@@ -380,6 +386,7 @@ namespace osmscout {
 
   RoutingResult MultiDBRoutingService::CalculateRoute(const RoutePosition &start,
                                                       const RoutePosition &target,
+                                                      const std::optional<osmscout::Bearing> &bearing,
                                                       const RoutingParameter &parameter)
   {
     RoutingResult result;
@@ -395,6 +402,7 @@ namespace osmscout {
       return service->CalculateRoute(*handles[dbId].profile,
                                      start,
                                      target,
+                                     bearing,
                                      parameter);
     }
 
@@ -404,8 +412,6 @@ namespace osmscout {
       log.Error() << "Can't find start db " << start.GetDatabaseId();
       return result;
     }
-
-    // DatabaseRef database1=handles[start.GetDatabaseId()].db;
 
     if (target.GetDatabaseId()>=handles.size() ||
         !handles[target.GetDatabaseId()].database) {
@@ -417,6 +423,7 @@ namespace osmscout {
     return AbstractRoutingService<MultiDBRoutingState>::CalculateRoute(state,
                                                                        start,
                                                                        target,
+                                                                       bearing,
                                                                        parameter);
   }
 
@@ -459,6 +466,7 @@ namespace osmscout {
 
         partialResult=CalculateRoute(fromRoutePosition,
                                      toRoutePosition,
+                                     std::nullopt,
                                      parameter);
         if (!partialResult.Success()) {
           result.GetRoute().Clear();

--- a/libosmscout/src/osmscout/routing/RoutingProfile.cpp
+++ b/libosmscout/src/osmscout/routing/RoutingProfile.cpp
@@ -359,7 +359,12 @@ namespace osmscout {
     return false;
   }
 
-  ShortestPathRoutingProfile::ShortestPathRoutingProfile(const TypeConfigRef& typeConfig)
+  double AbstractRoutingProfile::GetUTurnCost() const
+  {
+    return 0;
+  }
+
+ShortestPathRoutingProfile::ShortestPathRoutingProfile(const TypeConfigRef& typeConfig)
   : AbstractRoutingProfile(typeConfig)
   {
     // no code

--- a/libosmscout/src/osmscout/routing/RoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/RoutingService.cpp
@@ -21,12 +21,6 @@
 
 namespace osmscout {
 
-  RoutePosition::RoutePosition()
-  : nodeIndex(0)
-  {
-    // no code
-  }
-
   RoutePosition::RoutePosition(const ObjectFileRef& object,
                                size_t nodeIndex,
                                DatabaseId database)

--- a/libosmscout/src/osmscout/routing/SimpleRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/SimpleRoutingService.cpp
@@ -120,6 +120,11 @@ namespace osmscout {
     return profile.GetCosts(*way,wayLength);
   }
 
+  double SimpleRoutingService::GetUTurnCost(const RoutingProfile& profile, const DatabaseId /*databaseId*/)
+  {
+    return profile.GetUTurnCost();
+  }
+
   double SimpleRoutingService::GetEstimateCosts(const RoutingProfile& profile,
                                                 const DatabaseId /*db*/,
                                                 const Distance &targetDistance)
@@ -422,6 +427,7 @@ namespace osmscout {
                                    RoutePosition(toObject,
                                                  toNodeIndex,/*db*/
                                                  0),
+                                   std::nullopt,
                                    parameter);
       if (!partialResult.Success()) {
         result.GetRoute().Clear();


### PR DESCRIPTION
It is pretty annoying when you decide to take different route than suggested by navigation and it stubbornly want to take u-turn and return to original path. U-turn is not allowed usually or pretty difficult and usually not something what you want to do. 

This change takes initial vehicle bearing into account and router compute route that continue in your direction.