### PR TITLE
do not throw away node serial number during deduplication

### DIFF
--- a/libosmscout-import/src/osmscoutimport/SortWayDat.cpp
+++ b/libosmscout-import/src/osmscoutimport/SortWayDat.cpp
@@ -227,6 +227,7 @@ namespace osmscout {
             reduced=true;
           }
           else if (way.GetSerial(n-1)==0) {
+            nodeBuffer.back()=way.nodes[n]; // do not throw away node[n].serial value
             way.nodes[n-1]=way.nodes[n];
             duplicateCount++;
             reduced=true;


### PR DESCRIPTION
During investigation of weird routing issue https://github.com/Karry/osmscout-sailfish/issues/326 I just notice that two ways are not connected in routing graph. The reason is that one way ( https://www.openstreetmap.org/way/25157980#map=17/47.19971/7.58580 ) have two nodes too close together and import tool de-duplicate them. But serial number of the deleted node is lost in this process, so ways sharing this node are not connected anymore...