### PR TITLE
Lane suggestion rewrite

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -147,6 +147,9 @@ osmscout_test_project(NAME GeoCoordParse SOURCES src/GeoCoordParse.cpp)
 osmscout_test_project(NAME NumberSet SOURCES src/NumberSet.cpp)
 
 #---- ScanConversion
+osmscout_test_project(NAME RoutePostprocessor SOURCES src/RoutePostprocessor.cpp)
+
+#---- ScanConversion
 osmscout_test_project(NAME ScanConversion SOURCES src/ScanConversion.cpp)
 
 #---- ScreenMask

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -385,6 +385,16 @@ ReaderScannerPerformance = executable('ReaderScannerPerformance',
 
 test('Check reader scanner performance', ReaderScannerPerformance, args : [meson.current_source_dir() + '/data/testregion'])
 
+RoutePostprocessor = executable('RoutePostprocessor',
+                            'src/RoutePostprocessor.cpp',
+                            include_directories: [testIncDir, osmscoutIncDir],
+                            dependencies: [mathDep, openmpDep],
+                            link_with: [osmscout],
+                            install: true,
+                            install_dir: testInstallDir)
+
+test('Check route postprocessor', RoutePostprocessor)
+
 ScanConversion = executable('ScanConversion',
              'src/ScanConversion.cpp',
              include_directories: [testIncDir, osmscoutIncDir],

--- a/Tests/src/RoutePostprocessor.cpp
+++ b/Tests/src/RoutePostprocessor.cpp
@@ -1,0 +1,471 @@
+/*
+  RoutePostprocessor - a test program for libosmscout
+  Copyright (C) 2024  Lukas Karas
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include <cstdlib>
+#include <iostream>
+
+#include <osmscout/routing/RoutePostprocessor.h>
+
+#include <TestMain.h>
+
+using namespace std;
+using namespace osmscout;
+
+class MockDatabase {
+private:
+  TypeConfigRef typeConfig;
+  FileScanner wayScanner;
+
+public:
+  MockDatabase(TypeConfigRef typeConfig, const std::string &wayFile): typeConfig(typeConfig)
+  {
+    wayScanner.Open(wayFile, FileScanner::Mode::FastRandom, true);
+  }
+
+  ~MockDatabase()
+  {
+    wayScanner.Close();
+  };
+
+  osmscout::WayRef GetWay(const osmscout::DBFileOffset &offset)
+  {
+    assert(offset.database==0);
+    auto way=std::make_shared<Way>();
+    wayScanner.SetPos(offset.offset);
+    way->Read(*typeConfig, wayScanner);
+    return way;
+  }
+
+  TypeConfigRef GetTypeConfig() {
+    return typeConfig;
+  }
+};
+
+using MockDatabaseRef = std::shared_ptr<MockDatabase>;
+
+class MockDatabaseBuilder {
+private:
+  TypeConfigRef typeConfig=std::make_shared<TypeConfig>();
+  FileWriter writer;
+  TypeInfoRef type;
+  std::string wayFile="/tmp/test-ways.dat"; // TODO: make temporary, make sure that it is deleted
+  // needs to correspond to feature registration order
+  static constexpr size_t laneFeatureIndex=0;
+  static constexpr size_t accessFeatureIndex=1;
+
+public:
+  MockDatabaseBuilder()
+  {
+    osmscout::FeatureRef laneFeature = typeConfig->GetFeature(LanesFeature::NAME);
+    assert(laneFeature);
+    osmscout::FeatureRef accessFeature = typeConfig->GetFeature(AccessFeature::NAME);
+    assert(accessFeature);
+
+    type=std::make_shared<TypeInfo>("highway");
+    // type->SetInternal()
+    type->CanBeWay(true)
+      .CanRouteCar(true)
+      .AddFeature(laneFeature)
+      .AddFeature(accessFeature);
+
+    typeConfig->RegisterType(type);
+
+    writer.Open(wayFile);
+  }
+
+  ~MockDatabaseBuilder()
+  {
+    if (writer.IsOpen()) {
+      writer.Close();
+    }
+  }
+
+  ObjectFileRef AddWay(const std::vector<GeoCoord> &coords, std::function<void(AccessFeatureValue*, LanesFeatureValue*)> setupFeatures)
+  {
+    Way way;
+
+    FeatureValueBuffer featureValueBuffer;
+    featureValueBuffer.SetType(type);
+
+    setupFeatures(static_cast<AccessFeatureValue *>(featureValueBuffer.AllocateValue(accessFeatureIndex)),
+                  static_cast<LanesFeatureValue *>(featureValueBuffer.AllocateValue(laneFeatureIndex)));
+
+    way.SetFeatures(featureValueBuffer);
+
+    for (const GeoCoord &coord : coords) {
+      way.nodes.push_back(Point(0, coord));
+    }
+    ObjectFileRef wayRef(writer.GetPos(), RefType::refWay);
+    way.Write(*typeConfig, writer);
+    return wayRef;
+  }
+
+  MockDatabaseRef Build()
+  {
+    writer.Close();
+    return std::make_shared<MockDatabase>(typeConfig, wayFile);
+  }
+};
+
+class MockContext: public osmscout::PostprocessorContext
+{
+private:
+  MockDatabaseRef database;
+  LanesFeatureValueReader lanesReader;
+  AccessFeatureValueReader accessReader;
+
+public:
+  explicit MockContext(MockDatabaseRef database):
+    database(database),
+    lanesReader(*database->GetTypeConfig()),
+    accessReader(*database->GetTypeConfig())
+  {}
+
+  osmscout::AreaRef GetArea([[maybe_unused]] const osmscout::DBFileOffset &offset) const override
+  {
+    assert(false);
+    return osmscout::AreaRef();
+  }
+
+  osmscout::WayRef GetWay(const osmscout::DBFileOffset &offset) const override
+  {
+    return database->GetWay(offset);
+  }
+
+  osmscout::NodeRef GetNode([[maybe_unused]] const osmscout::DBFileOffset &offset) const override
+  {
+    assert(false);
+    return osmscout::NodeRef();
+  }
+
+  osmscout::Duration
+  GetTime([[maybe_unused]] osmscout::DatabaseId dbId, [[maybe_unused]] const osmscout::Area &area, [[maybe_unused]] const osmscout::Distance &deltaDistance) const override
+  {
+    assert(false);
+    return osmscout::Duration();
+  }
+
+  osmscout::Duration
+  GetTime([[maybe_unused]] osmscout::DatabaseId dbId, [[maybe_unused]] const osmscout::Way &way, [[maybe_unused]] const osmscout::Distance &deltaDistance) const override
+  {
+    assert(false);
+    return osmscout::Duration();
+  }
+
+  osmscout::RouteDescription::NameDescriptionRef
+  GetNameDescription([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::NameDescriptionRef();
+  }
+
+  osmscout::RouteDescription::NameDescriptionRef
+  GetNameDescription([[maybe_unused]] osmscout::DatabaseId dbId,
+                     [[maybe_unused]] const osmscout::ObjectFileRef &object) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::NameDescriptionRef();
+  }
+
+  osmscout::RouteDescription::NameDescriptionRef
+  GetNameDescription([[maybe_unused]] osmscout::DatabaseId dbId,
+                     [[maybe_unused]] const osmscout::Node &node) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::NameDescriptionRef();
+  }
+
+  osmscout::RouteDescription::NameDescriptionRef
+  GetNameDescription([[maybe_unused]] osmscout::DatabaseId dbId,
+                     [[maybe_unused]] const osmscout::Area &area) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::NameDescriptionRef();
+  }
+
+  osmscout::RouteDescription::NameDescriptionRef
+  GetNameDescription([[maybe_unused]] osmscout::DatabaseId dbId,
+                     [[maybe_unused]] const osmscout::Way &way) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::NameDescriptionRef();
+  }
+
+  bool IsMotorwayLink([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsMotorway([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsMiniRoundabout([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsClockwise([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsRoundabout([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsBridge([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  osmscout::NodeRef GetJunctionNode([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return osmscout::NodeRef();
+  }
+
+  osmscout::RouteDescription::DestinationDescriptionRef
+  GetDestination([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return osmscout::RouteDescription::DestinationDescriptionRef();
+  }
+
+  uint8_t GetMaxSpeed([[maybe_unused]] const osmscout::RouteDescription::Node &node) const override
+  {
+    assert(false);
+    return 0;
+  }
+
+  osmscout::RouteDescription::LaneDescription
+  GetLanes(const osmscout::DatabaseId &dbId, const osmscout::WayRef &way, bool forward) const override
+  {
+    assert(dbId==0);
+
+    AccessFeatureValue *accessValue=accessReader.GetValue(way->GetFeatureValueBuffer());
+    bool oneway=accessValue!=nullptr && accessValue->IsOneway();
+
+    uint8_t laneCount;
+    std::vector<LaneTurn> laneTurns;
+    LanesFeatureValue *lanesValue=lanesReader.GetValue(way->GetFeatureValueBuffer());
+    if (lanesValue!=nullptr) {
+      laneCount=std::max((uint8_t)1,forward ? lanesValue->GetForwardLanes() : lanesValue->GetBackwardLanes());
+      laneTurns=forward ? lanesValue->GetTurnForward() : lanesValue->GetTurnBackward();
+      while (laneTurns.size() < laneCount) {
+        laneTurns.push_back(LaneTurn::None);
+      }
+    } else {
+      // default lane count by object type
+      if (oneway) {
+        laneCount=way->GetType()->GetOnewayLanes();
+      } else {
+        laneCount=std::max(1,way->GetType()->GetLanes()/2);
+      }
+    }
+
+    return RouteDescription::LaneDescription(oneway, laneCount, laneTurns);
+  }
+
+  osmscout::RouteDescription::LaneDescriptionRef GetLanes(const osmscout::RouteDescription::Node &node) const override
+  {
+    RouteDescription::LaneDescriptionRef lanes;
+    if (node.GetPathObject().GetType()==refWay) {
+
+      WayRef way=GetWay(node.GetDBFileOffset());
+      bool forward = node.GetCurrentNodeIndex() < node.GetTargetNodeIndex();
+
+      lanes=std::make_shared<RouteDescription::LaneDescription>(GetLanes(node.GetDatabaseId(), way, forward));
+    }
+    return lanes;
+  }
+
+  osmscout::Id GetNodeId(const osmscout::RouteDescription::Node &node) const override
+  {
+    const ObjectFileRef& object=node.GetPathObject();
+    size_t nodeIndex=node.GetCurrentNodeIndex();
+    if (object.GetType()==refArea) {
+      AreaRef area=GetArea(node.GetDBFileOffset());
+
+      return area->rings.front().nodes[nodeIndex].GetId();
+    }
+
+    if (object.GetType()==refWay) {
+      WayRef way=GetWay(node.GetDBFileOffset());
+
+      return way->GetId(nodeIndex);
+    }
+
+    assert(false);
+    return 0;
+  }
+
+  size_t GetNodeIndex([[maybe_unused]] const osmscout::RouteDescription::Node &node,
+                      [[maybe_unused]] osmscout::Id nodeId) const override
+  {
+    assert(false);
+    return 0;
+  }
+
+  bool CanUseBackward(const osmscout::DatabaseId &dbId, osmscout::Id fromNodeId,
+                      const osmscout::ObjectFileRef &object) const override
+  {
+    if (object.GetType()==refWay) {
+      WayRef way=GetWay(DBFileOffset(dbId,object.GetFileOffset()));
+
+      size_t fromNodeIndex;
+
+      if (!way->GetNodeIndexByNodeId(fromNodeId,
+                                     fromNodeIndex)) {
+        assert(false);
+      }
+
+      if (fromNodeIndex>0) {
+        return false;
+      }
+
+      AccessFeatureValue *accessValue=accessReader.GetValue(way->GetFeatureValueBuffer());
+      if (!accessValue){
+        return true;
+      }
+      return accessValue->CanRouteCarBackward();
+    }
+
+    assert(false);
+    return false;
+  }
+
+  bool CanUseForward(const osmscout::DatabaseId &dbId, osmscout::Id fromNodeId,
+                     const osmscout::ObjectFileRef &object) const override
+  {
+    if (object.GetType()==refWay) {
+      WayRef way=GetWay(DBFileOffset(dbId,
+                                     object.GetFileOffset()));
+
+      size_t fromNodeIndex;
+
+      if (!way->GetNodeIndexByNodeId(fromNodeId,
+                                     fromNodeIndex)) {
+        assert(false);
+      }
+
+      if (fromNodeIndex==way->nodes.size()-1) {
+        return false;
+      }
+      AccessFeatureValue *accessValue=accessReader.GetValue(way->GetFeatureValueBuffer());
+      if (!accessValue){
+        return true;
+      }
+      return accessValue->CanRouteCarForward();
+    }
+    assert(false);
+    return false;
+  }
+
+  bool IsBackwardPath([[maybe_unused]] const osmscout::ObjectFileRef &object,
+                      [[maybe_unused]] size_t fromNodeIndex,
+                      [[maybe_unused]] size_t toNodeIndex) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsForwardPath([[maybe_unused]] const osmscout::ObjectFileRef &object,
+                     [[maybe_unused]] size_t fromNodeIndex,
+                     [[maybe_unused]] size_t toNodeIndex) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  bool IsNodeStartOrEndOfObject([[maybe_unused]] const osmscout::RouteDescription::Node &node,
+                                [[maybe_unused]] const osmscout::ObjectFileRef &object) const override
+  {
+    assert(false);
+    return false;
+  }
+
+  osmscout::GeoCoord GetCoordinates([[maybe_unused]] const osmscout::RouteDescription::Node &node,
+                                    [[maybe_unused]] size_t nodeIndex) const override
+  {
+    assert(false);
+    return osmscout::GeoCoord();
+  }
+
+  vector<osmscout::DatabaseRef> GetDatabases() const override
+  {
+    assert(false);
+    return vector<osmscout::DatabaseRef>();
+  }
+};
+
+TEST_CASE("Suggest right lane on simple junction")
+{
+  using namespace osmscout;
+
+  MockDatabaseBuilder databaseBuilder;
+  ObjectFileRef way1Ref=databaseBuilder.AddWay(
+    {GeoCoord(50.09294, 14.52899), GeoCoord(50.09282, 14.52976)},
+    [](AccessFeatureValue* access, LanesFeatureValue* lanes){
+      lanes->SetLanes(2, 0);
+      access->SetAccess(AccessFeatureValue::onewayForward | AccessFeatureValue::carForward);
+    });
+
+  ObjectFileRef way2Ref=databaseBuilder.AddWay(
+    {GeoCoord(50.09282, 14.52976), GeoCoord(50.09263, 14.53118)},
+    [](AccessFeatureValue* access, LanesFeatureValue* lanes){
+      lanes->SetLanes(1, 0);
+      access->SetAccess(AccessFeatureValue::onewayForward | AccessFeatureValue::carForward);
+    });
+
+  ObjectFileRef way3Ref=databaseBuilder.AddWay(
+    {GeoCoord(50.09282, 14.52976), GeoCoord(50.09261, 14.53093)},
+    [](AccessFeatureValue* access, LanesFeatureValue* lanes){
+      lanes->SetLanes(1, 0);
+      access->SetAccess(AccessFeatureValue::onewayForward | AccessFeatureValue::carForward);
+    });
+
+  RouteDescription description;
+
+  description.AddNode(0, 0, {way1Ref}, way1Ref, 1);
+  description.AddNode(0, 0, {way1Ref, way2Ref, way3Ref}, way3Ref, 1);
+  description.AddNode(0, 1, {way3Ref}, ObjectFileRef(), 0);
+
+  MockContext context(databaseBuilder.Build());
+
+  RoutePostprocessor::LanesPostprocessor lanesPostprocessor;
+  lanesPostprocessor.Process(context, description);
+
+  RoutePostprocessor::SuggestedLanesPostprocessor postprocessor;
+  postprocessor.Process(context, description);
+
+  // should suggest right lane
+  auto nodeIt = description.Nodes().begin();
+  auto suggestedLanes = std::dynamic_pointer_cast<RouteDescription::SuggestedLaneDescription>(nodeIt->GetDescription(RouteDescription::SUGGESTED_LANES_DESC));
+  REQUIRE(suggestedLanes->GetFrom()==1);
+  REQUIRE(suggestedLanes->GetTo()==1);
+}

--- a/libosmscout/include/osmscout/routing/RouteDescription.h
+++ b/libosmscout/include/osmscout/routing/RouteDescription.h
@@ -631,7 +631,7 @@ namespace osmscout {
     /**
      * \ingroup Routing
      *
-     * A suggested route lanes. It specifies range of lanes <from, to> that drive
+     * A suggested route lanes. It specifies range of lanes <from, to> that driver
      * should use. Lanes are counted from left (just route direction, not opposite direction),
      * left-most lane has index 0, both indexes are inclusive.
      */

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -374,6 +374,19 @@ namespace osmscout {
 
       bool Process(const RoutePostprocessor& postprocessor,
                    RouteDescription& description) override;
+
+    private:
+      RouteDescription::LaneDescriptionRef GetLaneDescription(const RouteDescription::Node &node) const;
+
+      /** Evaluate suggested lanes on nodes from "backBuffer", followed by "node".
+       * Node itself is junction, where count of lanes (on way from the node)
+       * is smaller than on the previous node (back of backBuffer).
+       *
+       * @param node
+       * @param backBuffer buffer of traveled nodes, recent node at back
+       */
+      void EvaluateLaneSuggestion(const RouteDescription::Node &node, const std::list<RouteDescription::Node*> &backBuffer) const;
+
     private:
       Distance distanceBefore;
     };

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -56,6 +56,9 @@ namespace osmscout {
     virtual WayRef GetWay(const DBFileOffset &offset) const = 0;
     virtual NodeRef GetNode(const DBFileOffset &offset) const = 0;
 
+    virtual const LanesFeatureValueReader& GetLaneReader(const DatabaseId &dbId) const = 0;
+    virtual const AccessFeatureValueReader& GetAccessReader(const DatabaseId &dbId) const = 0;
+
     virtual Duration GetTime(DatabaseId dbId,const Area& area,const Distance &deltaDistance) const = 0;
     virtual Duration GetTime(DatabaseId dbId,const Way& way,const Distance &deltaDistance) const = 0;
 
@@ -83,11 +86,11 @@ namespace osmscout {
 
     virtual uint8_t GetMaxSpeed(const RouteDescription::Node& node) const = 0;
 
-    virtual RouteDescription::LaneDescription GetLanes(const DatabaseId& dbId, const WayRef& way, bool forward) const = 0;
+    virtual RouteDescription::LaneDescription GetLanes(const DatabaseId& dbId, const WayRef& way, bool forward) const;
 
-    virtual RouteDescription::LaneDescriptionRef GetLanes(const RouteDescription::Node& node) const = 0;
+    virtual RouteDescription::LaneDescriptionRef GetLanes(const RouteDescription::Node& node) const;
 
-    virtual Id GetNodeId(const RouteDescription::Node& node) const = 0;
+    virtual Id GetNodeId(const RouteDescription::Node& node) const;
 
     virtual size_t GetNodeIndex(const RouteDescription::Node& node,
                                 Id nodeId) const = 0;
@@ -517,6 +520,9 @@ namespace osmscout {
     WayRef GetWay(const DBFileOffset &offset) const override;
     NodeRef GetNode(const DBFileOffset &offset) const override;
 
+    const LanesFeatureValueReader& GetLaneReader(const DatabaseId &dbId) const override;
+    const AccessFeatureValueReader& GetAccessReader(const DatabaseId &dbId) const override;
+
     Duration GetTime(DatabaseId dbId,const Area& area,const Distance &deltaDistance) const override;
     Duration GetTime(DatabaseId dbId,const Way& way,const Distance &deltaDistance) const override;
 
@@ -543,12 +549,6 @@ namespace osmscout {
     RouteDescription::DestinationDescriptionRef GetDestination(const RouteDescription::Node& node) const override;
 
     uint8_t GetMaxSpeed(const RouteDescription::Node& node) const override;
-
-    RouteDescription::LaneDescription GetLanes(const DatabaseId& dbId, const WayRef& way, bool forward) const override;
-
-    RouteDescription::LaneDescriptionRef GetLanes(const RouteDescription::Node& node) const override;
-
-    Id GetNodeId(const RouteDescription::Node& node) const override;
 
     size_t GetNodeIndex(const RouteDescription::Node& node,
                         Id nodeId) const override;

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -385,7 +385,9 @@ namespace osmscout {
        * @param node
        * @param backBuffer buffer of traveled nodes, recent node at back
        */
-      void EvaluateLaneSuggestion(const RouteDescription::Node &node, const std::list<RouteDescription::Node*> &backBuffer) const;
+      void EvaluateLaneSuggestion(const RoutePostprocessor& postprocessor,
+                                  const RouteDescription::Node &node,
+                                  const std::list<RouteDescription::Node*> &backBuffer) const;
 
     private:
       Distance distanceBefore;
@@ -465,6 +467,8 @@ namespace osmscout {
     RouteDescription::DestinationDescriptionRef GetDestination(const RouteDescription::Node& node) const;
 
     uint8_t GetMaxSpeed(const RouteDescription::Node& node) const;
+
+    RouteDescription::LaneDescription GetLanes(const DatabaseId& dbId, const WayRef& way, bool forward) const;
 
     RouteDescription::LaneDescriptionRef GetLanes(const RouteDescription::Node& node) const;
 

--- a/libosmscout/include/osmscout/util/Bearing.h
+++ b/libosmscout/include/osmscout/util/Bearing.h
@@ -116,6 +116,26 @@ namespace osmscout {
       return radians != o.radians;
     }
 
+    bool operator<(const Bearing& o) const
+    {
+      return radians<o.radians;
+    }
+
+    bool operator>(const Bearing& o) const
+    {
+      return radians>o.radians;
+    }
+
+    bool operator<=(const Bearing& o) const
+    {
+      return radians<=o.radians;
+    }
+
+    bool operator>=(const Bearing& o) const
+    {
+      return radians>=o.radians;
+    }
+
     inline static Bearing Radians(double radians)
     {
       return Bearing(radians);

--- a/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
+++ b/libosmscout/src/osmscout/routing/AbstractRoutingService.cpp
@@ -892,7 +892,7 @@ namespace osmscout {
   {
     if (startForwardNode && startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
       // start is on the way between two route nodes, lets evaluate what route node is in opposite
-      // direction and add u-turn penalty to it and avoid return from node ahead
+      // direction and add exclusion for the opposite node to avoid return from node ahead
       WayRef way;
       if (!GetWayByOffset(DBFileOffset(start.GetDatabaseId(),
                                        start.GetObjectFileRef().GetFileOffset()),
@@ -927,7 +927,7 @@ namespace osmscout {
       }
     }
     if (startForwardNode && !startBackwardNode && start.GetObjectFileRef().GetType()==refWay) {
-      // start is directly on route-node, try to find what path is our source and add exclusion to it
+      // start is directly on route-node, try to find what path is our source and add exclusion for it
       double restrictedPathBearing = 20; // degrees
       auto oppositeVehicleBearing = bearing - Bearing::Degrees(180);
       for (const auto& path : startForwardNode->node->paths) {


### PR DESCRIPTION
Suggested route lanes are based on turn geometry now (`DirectionDescription`).

But based on my experience and extensive report https://github.com/Karry/osmscout-sailfish/issues/326 , it provides misleading results on many junctions. So, it should analyze lanes and angles of all ways connected to the analyzed junction node...