### PR TITLE
Use std::execution functionality with MSVC

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -365,13 +365,17 @@ if(PTHREAD_NAME_OK)
   set(OSMSCOUT_PTHREAD_NAME TRUE)
 endif()
 
-find_package(TBB QUIET)
-if (TBB_FOUND)
-  try_compile(TBB_HAS_SCHEDULER_INIT "${PROJECT_BINARY_DIR}"
-      "${PROJECT_SOURCE_DIR}/cmake/TestTBBSchedulerInit.cpp"
-      LINK_LIBRARIES TBB::tbb)
+if(MSVC)
+  set(HAVE_STD_EXECUTION 1)
+else()
+   find_package(TBB QUIET)
+   if (TBB_FOUND)
+   try_compile(TBB_HAS_SCHEDULER_INIT "${PROJECT_BINARY_DIR}"
+         "${PROJECT_SOURCE_DIR}/cmake/TestTBBSchedulerInit.cpp"
+         LINK_LIBRARIES TBB::tbb)
+   endif()
+   set(HAVE_STD_EXECUTION ${TBB_FOUND})
 endif()
-set(HAVE_STD_EXECUTION ${TBB_FOUND})
 
 find_program(HUGO_PATH hugo)
 

--- a/libosmscout-client/CMakeLists.txt
+++ b/libosmscout-client/CMakeLists.txt
@@ -44,7 +44,7 @@ osmscout_library_project(
 	SKIP_HEADER
 )
 
-if (HAVE_STD_EXECUTION)
+if (TBB_FOUND)
 	target_link_libraries(OSMScoutClient TBB::tbb)
 endif()
 

--- a/libosmscout-import/CMakeLists.txt
+++ b/libosmscout-import/CMakeLists.txt
@@ -170,7 +170,7 @@ if(MARISA_FOUND)
 	target_link_libraries(OSMScoutImport ${MARISA_LIBRARIES})
 endif()
 
-if (HAVE_STD_EXECUTION)
+if (TBB_FOUND)
 	target_link_libraries(OSMScoutImport TBB::tbb)
 endif()
 


### PR DESCRIPTION
Visual Studio also supports `std::execution` functionality, when C++17 is enabled it works out of the box.
No additional library like with gcc/clang is required.

This MR enables `std::execution` for MSVC by default.
I also modified the checks in `libosmscout-client` and `libosmscout-import` to only include the TBB lib where needed.