### PR TITLE
Set proper library soversion

### DIFF
--- a/cmake/ProjectConfig.cmake
+++ b/cmake/ProjectConfig.cmake
@@ -81,7 +81,7 @@ macro(osmscout_library_project)
 	set_target_properties(${_name} PROPERTIES
 		OUTPUT_NAME "${_output}"
 		VERSION ${OSMSCOUT_LIBRARY_VERSION}
-		SOVERSION ${OSMSCOUT_LIBRARY_VERSION}
+		SOVERSION ${PROJECT_VERSION_MAJOR}
 		FOLDER "${_folder}"
 	)
 	if(EXISTS ${_template})


### PR DESCRIPTION
Soversion should be equal major version because ldconfig expects a
certain pattern: libfoo.so -> libfoo.so.1 -> libfoo.so.1.1.1.  Since
version and soversion are equal build can't create proper soname link.