### PR TITLE
Let import GPX version 1.0

### DIFF
--- a/libosmscout-gpx/src/osmscoutgpx/Import.cpp
+++ b/libosmscout-gpx/src/osmscoutgpx/Import.cpp
@@ -276,6 +276,7 @@ public:
       return NameSpace::Unknown;
     }
     static std::unordered_map<std::string,NameSpace> nameSpaceMap{
+      {"http://www.topografix.com/GPX/1/0", NameSpace::Gpx},
       {"http://www.topografix.com/GPX/1/1", NameSpace::Gpx},
       {"http://www.garmin.com/xmlschemas/GpxExtensions/v3", NameSpace::GarminExtensions},
     };


### PR DESCRIPTION
Allows to import file with format 1.0. The attributes used here still compatible with validated version 1.1. 