### PR TITLE
Fix crash during style parsing

### DIFF
--- a/libosmscout-map/parser/OSS/Parser.frame
+++ b/libosmscout-map/parser/OSS/Parser.frame
@@ -141,7 +141,7 @@ void Parser::SynErr(int n)
 
 void Parser::SemErr(const char* msg)
 {
-  if (!state) {
+  if (!state && errors->hasErrors) {
     return;
   }
 

--- a/libosmscout-map/src/osmscoutmap/oss/Parser.cpp
+++ b/libosmscout-map/src/osmscoutmap/oss/Parser.cpp
@@ -61,7 +61,7 @@ void Parser::SynErr(int n)
 
 void Parser::SemErr(const char* msg)
 {
-  if (!state) {
+  if (!state && errors->hasErrors) {
     return;
   }
 


### PR DESCRIPTION
During the refactoring of the StyleEditor, I found these issues in the parsing stage.
This fixes a "bypass" of symbol errors during parsing. At least the first error shouldn't be bypassed, else later it will try to deref nullptr after some dynamic cast, and finally crash with segfault.   