### PR TITLE
fix translations of routing instructions

### DIFF
--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -13,6 +13,376 @@
     </message>
 </context>
 <context>
+    <name>RouteDescriptionBuilder</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
+        <source>Turn</source>
+        <translation>Zahněte</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
+        <source>Turn sharp left</source>
+        <translation>Zahněte ostře vlevo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
+        <source>Turn left</source>
+        <translation>Zahněte vlevo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
+        <source>Turn slightly left</source>
+        <translation>Zahněte mírně vlevo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
+        <source>Straight on</source>
+        <translation>Pokračuje rovně</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="89"/>
+        <source>Turn slightly right</source>
+        <translation>Zahněte mírně vpravo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="91"/>
+        <source>Turn right</source>
+        <translation>Zahněte vpravo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="93"/>
+        <source>Turn sharp right</source>
+        <translation>Zahněte ostře vpravo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="103"/>
+        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="107"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="109"/>
+        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="111"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="113"/>
+        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračuje rovně&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="115"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="117"/>
+        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="119"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt; na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
+        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="135"/>
+        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="137"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="139"/>
+        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Pokračujte rovně&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="141"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="143"/>
+        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="145"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="159"/>
+        <source>unnamed road</source>
+        <extracomment>unknown road name</extracomment>
+        <translation>nepojmenovaná cesta</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="163"/>
+        <source>(%1)</source>
+        <extracomment>road just with ref number</extracomment>
+        <translation>(%1)</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="167"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="260"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="298"/>
+        <source>&quot;%1&quot;</source>
+        <extracomment>road just with name, without ref</extracomment>
+        <translation>&quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
+        <source>&quot;%1&quot; (%2)</source>
+        <extracomment>road with name (%1) and ref (%2)</extracomment>
+        <translation>&quot;%1&quot; (%2)</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="182"/>
+        <source>On unnamed exit</source>
+        <extracomment>unnamed motorway exit</extracomment>
+        <translation>Na nepojmenovaném exitu</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="186"/>
+        <source>On exit %1</source>
+        <extracomment>motorway exit just with ref</extracomment>
+        <translation>Na exitu %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="190"/>
+        <source>On exit &quot;%1&quot;</source>
+        <extracomment>motorway exit with name, without ref</extracomment>
+        <translation>Na exitu &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="193"/>
+        <source>On exit %1 &quot;%2&quot;</source>
+        <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
+        <translation>Na exitu %1 &quot;%2&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
+        <translation>&lt;strong&gt;Vjeďte&lt;/strong&gt; na %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="270"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="282"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="287"/>
+        <source>Start</source>
+        <translation>Vyjeďte</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
+        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
+        <translation>&lt;strong&gt;Pokračujte&lt;/strong&gt; po %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="276"/>
+        <source>Continue</source>
+        <translation>Pokračujte</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt; po %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="302"/>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt; na %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="304"/>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="306"/>
+        <source>Target reached</source>
+        <translation>Dosaženo cíle</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="361"/>
+        <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="364"/>
+        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="366"/>
+        <source>Enter roundabout</source>
+        <translation>Vjeďte na kruhový objezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="379"/>
+        <source>Take the first exit</source>
+        <translation>Použijte první výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="382"/>
+        <source>Take the second exit</source>
+        <translation>Použijte druhý výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="385"/>
+        <source>Take the third exit</source>
+        <translation>Použijte třetí výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
+        <source>Take the %1th exit</source>
+        <translation>Použijte %1. výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="395"/>
+        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu na ulici %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="399"/>
+        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
+        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="411"/>
+        <source>Enter motorway</source>
+        <translation>Vjeďte na dálnici</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="423"/>
+        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="427"/>
+        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="432"/>
+        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
+        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="435"/>
+        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="461"/>
+        <source>Change motorway</source>
+        <translation>Změna dálnice</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="476"/>
+        <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt; z %1 na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="481"/>
+        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation>%1 &lt;strong&gt;změna dálnice&lt;/strong&gt; z %2 na %3</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="488"/>
+        <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="491"/>
+        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation>%1 &lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="523"/>
+        <source>Leave motorway</source>
+        <translation>Sjeďte z dálnice</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="539"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1 na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="544"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2 na %3</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="551"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="555"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="562"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
+        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="565"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="599"/>
+        <source>Way changes name</source>
+        <translation>Změna silnice</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="602"/>
+        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1 na %2</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="606"/>
+        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
+        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1</translation>
+    </message>
+</context>
+<context>
     <name>RoutingStep</name>
     <message>
         <location filename="../qml/custom/RoutingStep.qml" line="46"/>
@@ -32,376 +402,6 @@
         <location filename="../qml/custom/Utils.js" line="50"/>
         <source>km</source>
         <translation>km</translation>
-    </message>
-</context>
-<context>
-    <name>osmscout::RouteDescriptionBuilder</name>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="80"/>
-        <source>Turn sharp left</source>
-        <translation>Zahněte ostře vlevo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="82"/>
-        <source>Turn left</source>
-        <translation>Zahněte vlevo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="84"/>
-        <source>Turn slightly left</source>
-        <translation>Zahněte mírně vlevo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="86"/>
-        <source>Straight on</source>
-        <translation>Pokračuje rovně</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="88"/>
-        <source>Turn slightly right</source>
-        <translation>Zahněte mírně vpravo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="90"/>
-        <source>Turn right</source>
-        <translation>Zahněte vpravo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="92"/>
-        <source>Turn sharp right</source>
-        <translation>Zahněte ostře vpravo</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="76"/>
-        <source>Turn</source>
-        <translation>Zahněte</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="102"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="106"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="108"/>
-        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="110"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="112"/>
-        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Pokračuje rovně&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="114"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="116"/>
-        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="118"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt; na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="128"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="132"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="134"/>
-        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="136"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="138"/>
-        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Pokračujte rovně&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="140"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="142"/>
-        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="144"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="158"/>
-        <source>unnamed road</source>
-        <extracomment>unknown road name</extracomment>
-        <translation>nepojmenovaná cesta</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="162"/>
-        <source>(%1)</source>
-        <extracomment>road just with ref number</extracomment>
-        <translation>(%1)</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="166"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="259"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="297"/>
-        <source>&quot;%1&quot;</source>
-        <extracomment>road just with name, without ref</extracomment>
-        <translation>&quot;%1&quot;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="169"/>
-        <source>&quot;%1&quot; (%2)</source>
-        <extracomment>road with name (%1) and ref (%2)</extracomment>
-        <translation>&quot;%1&quot; (%2)</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="181"/>
-        <source>On unnamed exit</source>
-        <extracomment>unnamed motorway exit</extracomment>
-        <translation>Na nepojmenovaném exitu</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="185"/>
-        <source>On exit %1</source>
-        <extracomment>motorway exit just with ref</extracomment>
-        <translation>Na exitu %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="189"/>
-        <source>On exit &quot;%1&quot;</source>
-        <extracomment>motorway exit with name, without ref</extracomment>
-        <translation>Na exitu &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="192"/>
-        <source>On exit %1 &quot;%2&quot;</source>
-        <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
-        <translation>Na exitu %1 &quot;%2&quot;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="268"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
-        <translation>&lt;strong&gt;Vjeďte&lt;/strong&gt; na %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
-        <source>Start</source>
-        <translation>Vyjeďte</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="274"/>
-        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
-        <translation>&lt;strong&gt;Pokračujte&lt;/strong&gt; po %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
-        <source>Continue</source>
-        <translation>Pokračujte</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="280"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
-        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt; po %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="285"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="301"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
-        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt; na %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="303"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="305"/>
-        <source>Target reached</source>
-        <translation>Dosaženo cíle</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="360"/>
-        <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="363"/>
-        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="365"/>
-        <source>Enter roundabout</source>
-        <translation>Vjeďte na kruhový objezd</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="394"/>
-        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
-        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu na ulici %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="398"/>
-        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
-        <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="410"/>
-        <source>Enter motorway</source>
-        <translation>Vjeďte na dálnici</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="422"/>
-        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="426"/>
-        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
-        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="431"/>
-        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="434"/>
-        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="460"/>
-        <source>Change motorway</source>
-        <translation>Změna dálnice</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="475"/>
-        <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
-        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt; z %1 na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="480"/>
-        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation>%1 &lt;strong&gt;změna dálnice&lt;/strong&gt; z %2 na %3</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="487"/>
-        <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="490"/>
-        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation>%1 &lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="522"/>
-        <source>Leave motorway</source>
-        <translation>Sjeďte z dálnice</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="538"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
-        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1 na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="543"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2 na %3</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="550"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
-        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="554"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="561"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="564"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt;</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="598"/>
-        <source>Way changes name</source>
-        <translation>Změna silnice</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="601"/>
-        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
-        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1 na %2</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="605"/>
-        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
-        <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="378"/>
-        <source>Take the first exit</source>
-        <translation>Použijte první výjezd</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="381"/>
-        <source>Take the second exit</source>
-        <translation>Použijte druhý výjezd</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="384"/>
-        <source>Take the third exit</source>
-        <translation>Použijte třetí výjezd</translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="387"/>
-        <source>Take the %1th exit</source>
-        <translation>Použijte %1. výjezd</translation>
     </message>
 </context>
 </TS>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -2,6 +2,376 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en">
 <context>
+    <name>RouteDescriptionBuilder</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
+        <source>Turn</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
+        <source>Turn sharp left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
+        <source>Turn left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
+        <source>Turn slightly left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
+        <source>Straight on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="89"/>
+        <source>Turn slightly right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="91"/>
+        <source>Turn right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="93"/>
+        <source>Turn sharp right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="103"/>
+        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="107"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="109"/>
+        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="111"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="113"/>
+        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="115"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="117"/>
+        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="119"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
+        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="135"/>
+        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="137"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="139"/>
+        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="141"/>
+        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="143"/>
+        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="145"/>
+        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="159"/>
+        <source>unnamed road</source>
+        <extracomment>unknown road name</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="163"/>
+        <source>(%1)</source>
+        <extracomment>road just with ref number</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="167"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="260"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="298"/>
+        <source>&quot;%1&quot;</source>
+        <extracomment>road just with name, without ref</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
+        <source>&quot;%1&quot; (%2)</source>
+        <extracomment>road with name (%1) and ref (%2)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="182"/>
+        <source>On unnamed exit</source>
+        <extracomment>unnamed motorway exit</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="186"/>
+        <source>On exit %1</source>
+        <extracomment>motorway exit just with ref</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="190"/>
+        <source>On exit &quot;%1&quot;</source>
+        <extracomment>motorway exit with name, without ref</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="193"/>
+        <source>On exit %1 &quot;%2&quot;</source>
+        <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="270"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="282"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="287"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
+        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="276"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
+        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="302"/>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="304"/>
+        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="306"/>
+        <source>Target reached</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="361"/>
+        <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="364"/>
+        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="366"/>
+        <source>Enter roundabout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="379"/>
+        <source>Take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="382"/>
+        <source>Take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="385"/>
+        <source>Take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
+        <source>Take the %1th exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="395"/>
+        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="399"/>
+        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="411"/>
+        <source>Enter motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="423"/>
+        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="427"/>
+        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="432"/>
+        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="435"/>
+        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="461"/>
+        <source>Change motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="476"/>
+        <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="481"/>
+        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="488"/>
+        <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="491"/>
+        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="523"/>
+        <source>Leave motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="539"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="544"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="551"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="555"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="562"/>
+        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="565"/>
+        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
+        <extracomment>%1 is motorway exit description</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="599"/>
+        <source>Way changes name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="602"/>
+        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="606"/>
+        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RoutingStep</name>
     <message>
         <location filename="../qml/custom/RoutingStep.qml" line="46"/>
@@ -20,376 +390,6 @@
         <location filename="../qml/custom/Utils.js" line="48"/>
         <location filename="../qml/custom/Utils.js" line="50"/>
         <source>km</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>osmscout::RouteDescriptionBuilder</name>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="76"/>
-        <source>Turn</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="80"/>
-        <source>Turn sharp left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="82"/>
-        <source>Turn left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="84"/>
-        <source>Turn slightly left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="86"/>
-        <source>Straight on</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="88"/>
-        <source>Turn slightly right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="90"/>
-        <source>Turn right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="92"/>
-        <source>Turn sharp right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="102"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="106"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="108"/>
-        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="110"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="112"/>
-        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="114"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="116"/>
-        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="118"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="128"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="132"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="134"/>
-        <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="136"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="138"/>
-        <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="140"/>
-        <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="142"/>
-        <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="144"/>
-        <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="158"/>
-        <source>unnamed road</source>
-        <extracomment>unknown road name</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="162"/>
-        <source>(%1)</source>
-        <extracomment>road just with ref number</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="166"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="259"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="297"/>
-        <source>&quot;%1&quot;</source>
-        <extracomment>road just with name, without ref</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="169"/>
-        <source>&quot;%1&quot; (%2)</source>
-        <extracomment>road with name (%1) and ref (%2)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="181"/>
-        <source>On unnamed exit</source>
-        <extracomment>unnamed motorway exit</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="185"/>
-        <source>On exit %1</source>
-        <extracomment>motorway exit just with ref</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="189"/>
-        <source>On exit &quot;%1&quot;</source>
-        <extracomment>motorway exit with name, without ref</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="192"/>
-        <source>On exit %1 &quot;%2&quot;</source>
-        <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="268"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
-        <source>Start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="274"/>
-        <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
-        <source>Continue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="280"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="285"/>
-        <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="301"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="303"/>
-        <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="305"/>
-        <source>Target reached</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="360"/>
-        <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="363"/>
-        <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="365"/>
-        <source>Enter roundabout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="378"/>
-        <source>Take the first exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="381"/>
-        <source>Take the second exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="384"/>
-        <source>Take the third exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="387"/>
-        <source>Take the %1th exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="394"/>
-        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="398"/>
-        <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="410"/>
-        <source>Enter motorway</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="422"/>
-        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="426"/>
-        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="431"/>
-        <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="434"/>
-        <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="460"/>
-        <source>Change motorway</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="475"/>
-        <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="480"/>
-        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="487"/>
-        <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="490"/>
-        <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="522"/>
-        <source>Leave motorway</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="538"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="543"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="550"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="554"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="561"/>
-        <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="564"/>
-        <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
-        <extracomment>%1 is motorway exit description</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="598"/>
-        <source>Way changes name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="601"/>
-        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="605"/>
-        <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp
@@ -33,6 +33,11 @@
 
 namespace osmscout {
 
+/*
+ * TRANSLATOR osmscout::RouteDescriptionBuilder
+ * please keep above comment here, to make Qt lupdate tool happy without full namespace specification
+ */
+
 RouteDescriptionBuilder::RouteDescriptionBuilder::Callback::Callback(QList<RouteStep> &routeSteps,
                                                                      const Distance &stopAfter,
                                                                      bool skipInformative):


### PR DESCRIPTION
Qt's lupdate tool require full namespace definition for tr function to detect translation strings properly.