### PR TITLE
fix GetJunctionNode

### DIFF
--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -2199,7 +2199,7 @@ namespace osmscout {
     TypeInfoSet junctionTypeSet=it->second;
     for (const auto &obj : node.GetObjects()) {
       if (obj.IsNode()) {
-        NodeRef n = GetNode(node.GetDBFileOffset());
+        NodeRef n = GetNode(DBFileOffset(node.GetDatabaseId(), obj.GetFileOffset()));
         if (junctionTypeSet.IsSet(n->GetType())) {
           return n;
         }


### PR DESCRIPTION
Thank you @janbar for the notice. I was able to reproduce the crash with 
```
./Demos/Routing \
  france-ile-de-france \
  48.5633000 2.2417000 \
  48.4562833 2.0553333
```
