### PR TITLE
final fix for screen touch/pointer event with qt6

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -41,6 +41,9 @@ MapWidget::MapWidget(QQuickItem* parent)
     setOpaquePainting(true);
     setAcceptedMouseButtons(Qt::LeftButton);
     setAcceptHoverEvents(true);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    setAcceptTouchEvents(true);
+#endif
 
     renderer = OSMScoutQt::GetInstance().MakeMapRenderer(renderingType);
     auto settings=OSMScoutQt::GetInstance().GetSettings();
@@ -101,24 +104,21 @@ void MapWidget::translateToTouch(QMouseEvent* event, Qt::TouchPointStates states
 {
     assert(event);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // translate the mouse event for desktop device without touch pointer
+    QTouchEvent touchEvnt(QEvent::TouchBegin, event->pointingDevice(), Qt::NoModifier, event->points());
+#else
     QTouchEvent::TouchPoint touchPoint;
     touchPoint.setPressure(1);
     touchPoint.setPos(event->pos());
     touchPoint.setState(states);
     QList<QTouchEvent::TouchPoint> points;
     points << touchPoint;
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QTouchEvent touchEvnt(QEvent::TouchBegin, 0, Qt::NoModifier, 0, points);
-#else
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QTouchEvent touchEvnt(QEvent::TouchBegin, 0, Qt::NoModifier, Qt::TouchPointStates(), points);
-#endif
 #else
-    // TODO: rework
-    // 6.7.2: CTOR QEventPoint fails to initialize the position, so pass directly event points
-    // 6.7.2: Without passing a valid pointer to device, it will crash later on released event by
-    //        calling QQuickWindowPrivate::clearGrabbers >> QPointerEvent::setExclusiveGrabber
-    QTouchEvent touchEvnt(QEvent::TouchBegin, event->pointingDevice(), Qt::NoModifier, event->points());
+    QTouchEvent touchEvnt(QEvent::TouchBegin, 0, Qt::NoModifier, 0, points);
+#endif
 #endif
 
     //qDebug() << "translate mouse event to touch event: "<< touchEvnt;


### PR DESCRIPTION
On platform without mouse pointer, touch events should be accepted and processed without translations.

It closes the workaround introduced in the commit 256b2a43dc3507adc66987e2ec2c019df359bf03.
Qt5 is not affected by this fix, even if it would work with Qt >= 5.10. So I don't change the previous behavior for qt5, as it works as expected with the mouse event translation.
With qt6, it is no longer possible to translate properly a mouse event to touch event, and we have to handle touch events without any translations.

Tested with qt5 & qt6 on Desktop (Linux), and mobile devices (Android 12 & 14). 