### PR TITLE
introduce the new movement pivotBy, using linear progression

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/InputHandler.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/InputHandler.h
@@ -276,6 +276,7 @@ public:
     virtual bool move(const QVector2D &vector); // move vector in pixels
     virtual bool rotateTo(double angle);
     virtual bool rotateBy(double angleChange);
+    virtual bool pivotBy(double angleChange);
     virtual bool touch(const QTouchEvent &event);
     virtual bool currentPosition(bool locationValid, osmscout::GeoCoord currentPosition);
     virtual bool vehiclePosition(const VehiclePosition &vehiclePosition, bool autoRotateMap);
@@ -306,8 +307,9 @@ private:
     MapView startMapView;
     QVector2D _move;
     osmscout::Magnification targetMagnification;
-    double targetAngle;
-    int animationDuration;
+    double targetAngle = 0.0;
+    int animationDuration = 0;
+    bool linearProgression = false;
 
     const int MOVE_ANIMATION_DURATION = 1000; // ms
     const int ZOOM_ANIMATION_DURATION = 500; // ms
@@ -335,6 +337,7 @@ public:
     bool move(const QVector2D &vector) override; // move vector in pixels
     bool rotateTo(double angle) override;
     bool rotateBy(double angleChange) override;
+    bool pivotBy(double angleChange) override;
     bool touch(const QTouchEvent &event) override;
 };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -216,6 +216,7 @@ public slots:
   void rotateTo(double angle);
   void rotateLeft();
   void rotateRight();
+  void pivotBy(double angleChange);
 
   void toggleDaylight();
   void reloadStyle();

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -518,6 +518,15 @@ void MapWidget::rotateRight()
     }
 }
 
+void MapWidget::pivotBy(double angleChange)
+{
+  vehicle.lastGesture.restart();
+  if (!inputHandler->pivotBy(angleChange)){
+    setupInputHandler(new MoveHandler(*view));
+    inputHandler->pivotBy(angleChange);
+  }
+}
+
 void MapWidget::toggleDaylight()
 {
     DBThreadRef dbThread=OSMScoutQt::GetInstance().GetDBThread();


### PR DESCRIPTION
The new movement rotates the view by angle and with linear progression.

A linear progression allows for improve visual rendering of a compass-guided rotation.