### PR TITLE
try to fix crash starting routing on highway

### DIFF
--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -1776,6 +1776,9 @@ namespace osmscout {
     int allowedLaneFrom = 0;
     int allowedLaneTo = prevLanes->GetLaneCount()-1; // inclusive
     std::vector<LaneTurn> laneTurns = prevLanes->GetLaneTurns();
+    if (laneTurns.empty()) {
+      return;
+    }
 
     // remove allowed lanes used for left exits
     for (const auto &exit: junctionLeftExits) {
@@ -2634,7 +2637,7 @@ namespace osmscout {
     RouteDescription::Node *previousNode = nullptr;
     for (auto &node : description.Nodes()) {
         if (--nodeCount == 0) {
-            
+
             if (previousNode) {
                 RouteDescription::ViaDescriptionRef desc=std::make_shared<RouteDescription::ViaDescription>(sectionCount, sectionLengths[sectionCount - 1]);
                 previousNode->AddDescription(RouteDescription::NODE_VIA_DESC, desc);
@@ -2642,18 +2645,18 @@ namespace osmscout {
 
             previousNode = &node;
             nodeCount = sectionLengths[sectionCount++];
-            
+
             if (sectionCount >= nbSections) {
                 break;
             }
         }
     }
-      
+
     if (previousNode) {
         RouteDescription::ViaDescriptionRef desc=std::make_shared<RouteDescription::ViaDescription>(nbSections, sectionLengths[nbSections - 1]);
         previousNode->AddDescription(RouteDescription::NODE_VIA_DESC, desc);
     }
-      
+
     return true;
   }
 }


### PR DESCRIPTION
laneTurns = an empty vector
allowedLaneFrom = 0
allowedLaneTo = 0

```
* thread #33, name = 'Router', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x0) frame #0: 0x00005555558eb30e osmin`osmscout::RoutePostprocessor::SuggestedLanesPostprocessor::EvaluateLaneSuggestion(osmscout::PostprocessorContext const&, osmscout::RouteDescription::Node const&, std::__cxx11::list<osmscout::RouteDescription::Node*, std::allocator<osmscout::RouteDescription::Node*>> const&) const at RoutePostprocessor.cpp:1842:44 1839
   1840	    // detect what all allowed turns have common
   1841	    // keep in mind that laneTurns may have removed directions used by exits, it is benefitial here
-> 1842	    uint32_t suggestedTurnBits = TurnToBits(laneTurns[allowedLaneFrom]);
   1843	    for (int i = allowedLaneFrom + 1; i <= allowedLaneTo; i++) {
   1844	      suggestedTurnBits &= TurnToBits(laneTurns[i]);
   1845	    }
```