### PR TITLE
Adjust the pixel ratio of tiles for a better visual rendering

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
@@ -65,10 +65,16 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
     }
   }
 
+  // enable subpixel rendering so that magnification up to 2x remains
+  // as smooth as possible
+  static constexpr double pitchFactor = 1.5;
+  // the magnification level is adjusted taking into account the pixel
+  // ratio of the request and the fixed dpi of the OSM tile
   projection.Set(request.coord,
                  0,
-                 request.magnification,
-                 request.dpi,
+                 Magnification(request.magnification.GetMagnification()
+                               * pitchFactor * request.dpi / OSMTile::tileDPI()),
+                 OSMTile::tileDPI() / pitchFactor,
                  width,
                  height);
 


### PR DESCRIPTION
- To make it as similar as possible to plane rendering
- To fix the huge aliasing defect when a magnification is applied

I attached a set of screenshots to show the enhancement for ours eyes, and it doesn't require more cpu time !

Offline tiles: The left is without this commit, the center has the commit, and the right is plane rendering.

![Capture d’écran du 2024-10-04 14-54-26](https://github.com/user-attachments/assets/72473ed6-e531-4e3e-bad5-94ff6dac3250)

![Capture d’écran du 2024-10-04 14-45-51](https://github.com/user-attachments/assets/dd431b56-1c2c-4152-9c21-b92cad1f51d9)

Note that the antiliasing isn't enable on tiled views, because the shot has done during animation. By forcing the hints to enable antiliasing, the unpatched view (left) shows blurred contours (lines, areas, icons etc...).

---
Online tiles: Finally, I tested too with online tiles: the same benefits, the rendering is much better as before, even zooming a level:

![Capture d’écran du 2024-10-04 16-15-06](https://github.com/user-attachments/assets/9e67d44f-00ad-4dba-af35-551fa798e1af)
A view when I zoom the level:
![Capture d’écran du 2024-10-04 16-31-03](https://github.com/user-attachments/assets/ffbc3b53-802d-4497-a44d-41c8631cc0b9)

