### PR TITLE
HiDPI support in tile map renderer

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -33,6 +33,7 @@
 #include <QSettings>
 #include <QMutex>
 #include <QPainter>
+#include <QScreen>
 
 namespace osmscout {
 
@@ -97,6 +98,7 @@ protected:
 #endif
 
   double      mapDpi;
+  double      screenPixelRatio{1.0};
   bool        renderSea;
 
   QString     fontName;
@@ -175,6 +177,8 @@ public slots:
   virtual void onFontSizeChanged(double);
   virtual void onShowAltLanguageChanged(bool);
   virtual void onUnitsChanged(const QString&);
+
+  virtual void SetScreen(const QScreen*);
 
 protected:
   MapRenderer(QThread *thread,

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -188,6 +188,7 @@ signals:
   void styleErrorsChanged();
   void databaseLoaded(osmscout::GeoBox);
   void renderingTypeChanged(QString type);
+  void screenChanged(QScreen*);
 
 public slots:
   void changeView(const MapView &view);
@@ -309,6 +310,8 @@ private slots:
 
   void onResize();
 
+  void onWindowChanged(QQuickWindow *window);
+
 private:
   void setupInputHandler(InputHandler *newGesture);
 
@@ -319,6 +322,8 @@ private:
    * @return approximated magnification by object dimension
    */
   osmscout::Magnification magnificationByDimension(const Distance &dimension);
+
+  void setupRenderer();
 
 public:
   MapWidget(QQuickItem* parent = nullptr);

--- a/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
@@ -70,7 +70,7 @@ QDebug& operator<<(QDebug &out, const TileCacheKey &key);
 struct TileCacheVal
 {
   QElapsedTimer lastAccess;
-  QPixmap image;
+  QImage image;
   size_t epoch;
 };
 
@@ -141,7 +141,7 @@ public:
    * @return true if there was such request
    */
   bool removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y);
-  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, size_t epoch = 0);
+  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, const QImage &image, size_t epoch = 0);
 
   void cleanupCache();
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -157,6 +157,23 @@ void MapRenderer::onUnitsChanged(const QString& units)
   emit Redraw();
 }
 
+void MapRenderer::SetScreen(const QScreen *screen)
+{
+  bool changed=false;
+  {
+    QMutexLocker locker(&lock);
+    if (this->screenPixelRatio != screen->devicePixelRatio()) {
+      this->screenPixelRatio = screen->devicePixelRatio();
+      log.Debug() << "Screen pixel ratio: " << this->screenPixelRatio;
+      changed = true;
+    }
+  }
+  if (changed) {
+    InvalidateVisualCache();
+    emit Redraw();
+  }
+}
+
 void MapRenderer::addOverlayObject(int id, const OverlayObjectRef& obj)
 {
   {

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -97,8 +97,8 @@ bool OSMScoutQtBuilder::Init()
    *   130 - PC (24" FullHD)
    *   100 - Qt default (reported by SailfishOS < 2.0.1)
    */
-  QScreen *srn=QGuiApplication::screens().at(0);
-  double physicalDpi = (double)srn->physicalDotsPerInch();
+  QScreen *srn=QGuiApplication::primaryScreen();
+  double physicalDpi = srn ? (double)srn->physicalDotsPerInch() : 100;
 
   QLocale locale;
   QString defaultUnits;

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -326,7 +326,7 @@ void PlaneMapRenderer::DrawMap()
 
       currentImage=new QImage(QSize(currentWidth,
                                     currentHeight),
-                              QImage::Format_RGB32);
+                              QImage::Format_RGBA8888_Premultiplied);
     }
 
     osmscout::MapParameter       drawParameter;

--- a/libosmscout-client-qt/src/osmscoutclientqt/TileCache.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TileCache.cpp
@@ -174,7 +174,7 @@ TileCacheVal TileCache::get(uint32_t zoomLevel, uint32_t x, uint32_t y)
     TileCacheKey key = {zoomLevel, x, y};
     if (!tiles.contains(key)){
         qWarning() << this << "No tile in cache for key " << key;
-        return {QElapsedTimer(), QPixmap(), epoch}; // throw std::underflow_error ?
+        return {QElapsedTimer(), QImage(), epoch}; // throw std::underflow_error ?
     }
     TileCacheVal val = tiles.value(key);
     val.lastAccess.start();
@@ -193,14 +193,13 @@ bool TileCache::removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y)
     return requests.remove(key) > 0;
 }
 
-void TileCache::put(uint32_t zoomLevel, uint32_t x, uint32_t y, QImage image, size_t epoch)
+void TileCache::put(uint32_t zoomLevel, uint32_t x, uint32_t y, const QImage &image, size_t epoch)
 {
-    QPixmap pixmap = QPixmap::fromImage(image);
     removeRequest(zoomLevel, x, y);
     TileCacheKey key = {zoomLevel, x, y};
     QElapsedTimer now;
     now.start();
-    TileCacheVal val = {now, pixmap, epoch};
+    TileCacheVal val = {now, image, epoch};
 
 #ifdef DEBUG_TILE_CACHE
     qDebug() << this << "inserting tile" << key;

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -28,6 +28,7 @@
 
 #include <QGuiApplication>
 #include <QScreen>
+#include <QtCore>
 
 namespace osmscout {
 TiledMapRenderer::TiledMapRenderer(QThread *thread,
@@ -425,11 +426,11 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
      */
     double finalDpi = mapDpi * 2 * this->screenPixelRatio;
 
-    uint32_t tileDimension = (double)OSMTile::osmTileOriginalWidth() * (finalDpi / OSMTile::tileDPI()); // pixels
+    uint32_t tileDimension = double(OSMTile::osmTileOriginalWidth()) * (finalDpi / OSMTile::tileDPI()); // pixels
 
     QImage canvas(width * tileDimension,
                   height * tileDimension,
-                  QImage::Format_ARGB32_Premultiplied); // TODO: verify best format with profiler (callgrind)
+                  QImage::Format_RGBA8888_Premultiplied);
 
     QColor transparent = QColor::fromRgbF(1, 1, 1, 0.0);
     canvas.fill(transparent);

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -419,14 +419,16 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
             (double)loadXFrom + (double)width/2.0,
             (double)loadYFrom + (double)height/2.0);
 
-    /** tiles are up-scaled almost two times, when zoom level is near its next integer value (for example 16.99)
-     * to avoid blured result, we render tiles two times bigger than its minimum visual size.
-     * Another possible upscale (screenPixelRatio) is for HiDPI screens - when there is ratio 2.0, 100px on Qt canvas
-     * is displayed as 200px on the screen. To provide best results on HiDPI screen, we upscale tiles by this pixel ratio.
-     */
-    double finalDpi = mapDpi * 2 * this->screenPixelRatio;
+    // For HiDPI screens (screenPixelRatio > 1) tiles as up-scaled before displaying. When there is ratio 2.0, 100px on Qt canvas
+    // is displayed as 200px on the screen. To provide best results on HiDPI screen, we upscale tiles by this pixel ratio.
+    double finalDpi = mapDpi * this->screenPixelRatio;
 
     uint32_t tileDimension = double(OSMTile::osmTileOriginalWidth()) * (finalDpi / OSMTile::tileDPI()); // pixels
+
+    // older/mobile OpenGL (without GL_ARB_texture_non_power_of_two) requires textures with size of power of two
+    // we should provide tiles with required size to avoid scaling in QOpenGLTextureCache::bindTexture
+    tileDimension = qNextPowerOfTwo(tileDimension - 1);
+    finalDpi = (double(tileDimension) / double(OSMTile::osmTileOriginalWidth())) * OSMTile::tileDPI();
 
     QImage canvas(width * tileDimension,
                   height * tileDimension,

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -418,10 +418,17 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
             (double)loadXFrom + (double)width/2.0,
             (double)loadYFrom + (double)height/2.0);
 
-    double osmTileDimension = (double)OSMTile::osmTileOriginalWidth() * (mapDpi / OSMTile::tileDPI() ); // pixels
+    /** tiles are up-scaled almost two times, when zoom level is near its next integer value (for example 16.99)
+     * to avoid blured result, we render tiles two times bigger than its minimum visual size.
+     * Another possible upscale (screenPixelRatio) is for HiDPI screens - when there is ratio 2.0, 100px on Qt canvas
+     * is displayed as 200px on the screen. To provide best results on HiDPI screen, we upscale tiles by this pixel ratio.
+     */
+    double finalDpi = mapDpi * 2 * this->screenPixelRatio;
 
-    QImage canvas((double)width * osmTileDimension,
-                  (double)height * osmTileDimension,
+    uint32_t tileDimension = (double)OSMTile::osmTileOriginalWidth() * (finalDpi / OSMTile::tileDPI()); // pixels
+
+    QImage canvas(width * tileDimension,
+                  height * tileDimension,
                   QImage::Format_ARGB32_Premultiplied); // TODO: verify best format with profiler (callgrind)
 
     QColor transparent = QColor::fromRgbF(1, 1, 1, 0.0);
@@ -468,7 +475,7 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
     osmscout::MercatorProjection projection;
     osmscout::Magnification magnification(loadZ);
 
-    projection.Set(tileVisualCenter, /* angle */ 0, magnification, mapDpi,
+    projection.Set(tileVisualCenter, /* angle */ 0, magnification, finalDpi,
                    canvas.width(), canvas.height());
     projection.SetLinearInterpolationUsage(loadZ.Get() >= 10);
 
@@ -519,9 +526,9 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
                 for (uint32_t x = loadXFrom; x <= loadXTo; ++x){
 
                     QImage tile = canvas.copy(
-                            (double)(x - loadXFrom) * osmTileDimension,
-                            (double)(y - loadYFrom) * osmTileDimension,
-                            osmTileDimension, osmTileDimension
+                            (x - loadXFrom) * tileDimension,
+                            (y - loadYFrom) * tileDimension,
+                            tileDimension, tileDimension
                             );
 
                     offlineTileCache.put(loadZ.Get(), x, y, tile, loadEpoch);

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
@@ -218,8 +218,7 @@ bool TiledRenderingHelper::lookupAndDrawTile(TileCache& tileCache, QPainter& pai
         QRectF imageViewport(imageWidth * lookupTileViewport.x(), imageHeight * lookupTileViewport.y(),
                              imageWidth * lookupTileViewport.width(), imageHeight * lookupTileViewport.height() );
 
-        // TODO: support map rotation
-        painter.drawPixmap(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
+        painter.drawImage(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
       }
       lookupTileFound = true;
       if (lookupTileZoom == zoomLevel && val.epoch == tileCache.getEpoch()) {
@@ -294,7 +293,7 @@ void TiledRenderingHelper::lookupAndDrawBottomTileRecursive(TileCache& tileCache
         if (!val.image.isNull()){
           double imageWidth = val.image.width();
           double imageHeight = val.image.height();
-          painter.drawPixmap(
+          painter.drawImage(
               QRectF(x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt + overlap, renderTileHeight/tileCnt + overlap),
               val.image,
               QRectF(0.0, 0.0, imageWidth, imageHeight));

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
@@ -65,16 +65,10 @@ bool TiledRenderingHelper::RenderTiles(QPainter &painter,
     }
   }
 
-  // enable subpixel rendering so that magnification up to 2x remains
-  // as smooth as possible
-  static constexpr double pitchFactor = 1.5;
-  // the magnification level is adjusted taking into account the pixel
-  // ratio of the request and the fixed dpi of the OSM tile
   projection.Set(request.coord,
                  0,
-                 Magnification(request.magnification.GetMagnification()
-                               * pitchFactor * request.dpi / OSMTile::tileDPI()),
-                 OSMTile::tileDPI() / pitchFactor,
+                 request.magnification,
+                 request.dpi,
                  width,
                  height);
 


### PR DESCRIPTION
Hi, here is support for HiDPI screens in tiled map renderer. May I ask you @janbar for the review please? 

It is fun on Wayland, when you can have different scale (pixel ratio) for each monitor. Then map is refreshed when window is moved from one monitor to another...