### PR TITLE
ability to cleanup visual cache

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -168,6 +168,7 @@ public slots:
   virtual void Initialize() = 0;
 
   virtual void InvalidateVisualCache() = 0;
+  virtual void FlushVisualCaches(const std::chrono::milliseconds &idleMs) = 0;
   virtual void onStylesheetFilenameChanged();
   virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox) = 0;
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -298,6 +298,11 @@ private:
     }
   };
 
+  Slot<std::chrono::milliseconds> flushCachesSlot {
+    std::bind(&MapWidget::FlushCaches, this, std::placeholders::_1)
+  };
+
+
 private slots:
 
   virtual void onTap(const QPoint p);
@@ -534,6 +539,8 @@ public:
   {
     preventMouseStealing = b;
   }
+
+  void FlushCaches(const std::chrono::milliseconds &idleMs);
 
   /**
    * Helper for loading SVG graphics

--- a/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/PlaneMapRenderer.h
@@ -64,6 +64,8 @@ private:
                                                 // reverse order is possible
   QImage                        *finishedImage;
   size_t                        finishedEpoch{0};
+  std::chrono::steady_clock::time_point
+                                finishedLastUsage;
   osmscout::GeoCoord            finishedCoord;
   double                        finishedAngle;
   osmscout::Magnification       finishedMagnification;
@@ -83,6 +85,7 @@ signals:
 public slots:
   virtual void Initialize();
   virtual void InvalidateVisualCache();
+  virtual void FlushVisualCaches(const std::chrono::milliseconds &idleMs);
   virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox);
 
   void DrawMap();

--- a/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
@@ -37,7 +37,9 @@
 #include <osmscout/util/GeoBox.h>
 #include <osmscoutclientqt/ClientQtImportExport.h>
 
-//#define DEBUG_TILE_CACHE
+#include <chrono>
+
+// #define DEBUG_TILE_CACHE
 
 namespace osmscout {
 
@@ -69,7 +71,7 @@ QDebug& operator<<(QDebug &out, const TileCacheKey &key);
  */
 struct TileCacheVal
 {
-  QElapsedTimer lastAccess;
+  std::chrono::steady_clock::time_point lastAccess;
   QImage image;
   size_t epoch;
 };
@@ -97,7 +99,7 @@ signals:
 
 public:
   explicit TileCache(size_t cacheSize);
-  ~TileCache() override;
+  ~TileCache() override = default;
 
   /**
    * remove all pending requests
@@ -143,7 +145,7 @@ public:
   bool removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y);
   void put(uint32_t zoomLevel, uint32_t x, uint32_t y, const QImage &image, size_t epoch = 0);
 
-  void cleanupCache();
+  void cleanupCache(uint32_t maxRemove, const std::chrono::milliseconds &maximumLifetime);
 
   inline size_t getEpoch() const
   {
@@ -159,7 +161,6 @@ private:
   QHash<TileCacheKey, TileCacheVal> tiles;
   QHash<TileCacheKey, RequestState> requests;
   size_t                            cacheSize; // maximum count of elements in cache
-  uint32_t                          maximumLivetimeMs;
   size_t                            epoch{0};
 };
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/TiledMapOverlay.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TiledMapOverlay.h
@@ -85,6 +85,11 @@ private:
   bool                enabled;
   QColor              transparentColor;
 
+
+  Slot<std::chrono::milliseconds> flushCachesSlot {
+    std::bind(&TiledMapOverlay::FlushCaches, this, std::placeholders::_1)
+  };
+
 public slots:
   void tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y);
 
@@ -102,6 +107,8 @@ public:
 
   bool isEnabled();
   void setEnabled(bool b);
+
+  void FlushCaches(const std::chrono::milliseconds &idleMs);
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
@@ -92,6 +92,7 @@ signals:
 public slots:
   virtual void Initialize();
   virtual void InvalidateVisualCache();
+  virtual void FlushVisualCaches(const std::chrono::milliseconds &idleMs);
   virtual void onStylesheetFilenameChanged();
   virtual void onDatabaseLoaded(osmscout::GeoBox boundingBox);
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -56,6 +56,7 @@ MapWidget::MapWidget(QQuickItem* parent)
     dbThread->stylesheetFilenameChanged.Connect(stylesheetFilenameChangedSlot);
     dbThread->styleErrorsChanged.Connect(styleErrorsChangedSlot);
     dbThread->databaseLoadFinished.Connect(databaseLoadedSlot);
+    dbThread->flushCachesSignal.Connect(flushCachesSlot);
 
     tapRecognizer.setPhysicalDpi(dbThread->GetPhysicalDpi());
 
@@ -1065,5 +1066,10 @@ void MapWidget::SetRenderingType(QString strType)
 
     emit renderingTypeChanged(GetRenderingType());
   }
+}
+
+void MapWidget::FlushCaches(const std::chrono::milliseconds &idleMs)
+{
+  renderer->FlushVisualCaches(idleMs);
 }
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -100,6 +100,17 @@ void PlaneMapRenderer::InvalidateVisualCache()
   emit Redraw();
 }
 
+void PlaneMapRenderer::FlushVisualCaches(const std::chrono::milliseconds &idleMs)
+{
+  {
+    QMutexLocker finishedLocker(&finishedMutex);
+    if (std::chrono::steady_clock::now() - finishedLastUsage > idleMs) {
+      osmscout::log.Debug() << "Flush finished image";
+      finishedImage = nullptr;
+    }
+  }
+}
+
 /**
  * Render map defined by request to painter
  * @param painter
@@ -230,6 +241,7 @@ bool PlaneMapRenderer::RenderMap(QPainter& painter,
     targetRectangle.setSize(sourceRectangle.size());
   }
 
+  finishedLastUsage=std::chrono::steady_clock::now();
   painter.drawImage(targetRectangle,
                     *finishedImage,
                     sourceRectangle);

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -166,6 +166,15 @@ void TiledMapRenderer::InvalidateVisualCache()
   emit Redraw();
 }
 
+void TiledMapRenderer::FlushVisualCaches(const std::chrono::milliseconds &idleMs)
+{
+  {
+    QMutexLocker locker(&tileCacheMutex);
+    offlineTileCache.cleanupCache(std::numeric_limits<uint32_t>::max(), idleMs);
+    onlineTileCache.cleanupCache(std::numeric_limits<uint32_t>::max(), idleMs);
+  }
+}
+
 /**
  * Render map defined by request to painter
  * @param painter

--- a/libosmscout-client/include/osmscoutclient/DBThread.h
+++ b/libosmscout-client/include/osmscoutclient/DBThread.h
@@ -136,6 +136,8 @@ public:
     std::bind(&DBThread::FlushCaches, this, std::placeholders::_1)
   };
 
+  Signal<std::chrono::milliseconds> flushCachesSignal;
+
 private:
   MapManagerRef                      mapManager;
   std::string                        basemapLookupDirectory;

--- a/libosmscout-client/src/osmscoutclient/DBThread.cpp
+++ b/libosmscout-client/src/osmscoutclient/DBThread.cpp
@@ -481,6 +481,8 @@ const std::map<std::string,bool> DBThread::GetStyleFlags() const
 
 CancelableFuture<bool> DBThread::FlushCaches(const std::chrono::milliseconds &idleMs)
 {
+  flushCachesSignal.Emit(idleMs);
+
   return Async<bool>([this, idleMs](const Breaker& breaker) {
     if (breaker.IsAborted()) {
       return false;


### PR DESCRIPTION
Library has API for flushing old entries from caches (`DBThread::FlushCaches`). Until now, library was able to release just data caches. But huge amount of program memory may be occupied by visual caches (rendered map tiles...).

In some situations, it is needed to reduce process memory by releasing old cache entries.

By this commit, request for cache flush is exposed from `DBThread` to other components. `MapWidget` and `TiledMapOverlay` are connected to this signal and flushing old rendered tiles (or whole canvas in case of plane renderer).