### PR TITLE
Lane turn UI

### DIFF
--- a/Demos/qml/NavigationSimulation.qml
+++ b/Demos/qml/NavigationSimulation.qml
@@ -459,6 +459,7 @@ Window {
             id: laneTurnsComponent
 
             laneTurns: navigationModel.laneTurns
+            laneTurn: navigationModel.laneTurn
             visible: navigationModel.laneSuggested
             suggestedLaneFrom: navigationModel.suggestedLaneFrom
             suggestedLaneTo: navigationModel.suggestedLaneTo

--- a/OSMScout2/pics/laneturn/through_left-left.svg
+++ b/OSMScout2/pics/laneturn/through_left-left.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5"
+   height="10"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="through_left-left.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2069"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="133.50176"
+     inkscape:cx="3.8538818"
+     inkscape:cy="3.5317886"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <g
+     transform="matrix(0,-2.4081601,2.1748875,0,3.6024926,3.3877599)"
+     id="g8">
+    <path
+       style="color:#000000;fill:#000000;stroke:none;stroke-width:0"
+       d="m -0.71991525,-0.7940678 0.33177966,0.18940678 0.0330509,-0.96949148 -0.93305091,0.3775423 0.28940685,0.21186444 L -1.5,-0.2 h -1 v 0.4 l 1.2408772,-0.011021 c 0.1567725,-0.31877075 0.34911383,-0.6632679 0.53920755,-0.98304684 z"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <g
+       transform="translate(0.01211499,-0.00956066)"
+       id="g8-3">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.08"
+         d="M 0,0.6 1.2,0 0,-0.6 v 0.4 h -1.1076271 l 0.38771185,-0.5940678 0.33177966,0.18940678 0.0330509,-0.96949148 -0.93305091,0.3775423 0.28940685,0.21186444 L -1.5,-0.2 h -1 V 0.2 H 0 Z"
+         id="path6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/OSMScout2/pics/laneturn/through_left-through.svg
+++ b/OSMScout2/pics/laneturn/through_left-through.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5"
+   height="10"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="through_left-through.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2069"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="133.50176"
+     inkscape:cx="3.8538818"
+     inkscape:cy="3.5317886"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <g
+     transform="matrix(0,-2.4081601,2.1748875,0,3.6024926,3.3877599)"
+     id="g8">
+    <path
+       style="color:#000000;fill:#000000;stroke:#000000;stroke-width:0.0655436;stroke-dasharray:none;stroke-opacity:1"
+       d="m -0.00497669,0.58897904 1.19999999,-0.6 -1.19999999,-0.6 v 0.4 c -1.25047671,-0.00756 -1.18487661,0 -2.50000001,0 v 0.4 h 2.50000001 z"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <g
+       transform="translate(0.0071383,-0.02058162)"
+       id="g8-3">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.08"
+         d="M 0,0.6 1.2,0 0,-0.6 v 0.4 h -1.1076271 l 0.38771185,-0.5940678 0.33177966,0.18940678 0.0330509,-0.96949148 -0.93305091,0.3775423 0.28940685,0.21186444 L -1.5,-0.2 h -1 V 0.2 H 0 Z"
+         id="path6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/OSMScout2/pics/laneturn/through_right-right.svg
+++ b/OSMScout2/pics/laneturn/through_right-right.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5"
+   height="10"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="through_right-right.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2069"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="133.50176"
+     inkscape:cx="3.8688629"
+     inkscape:cy="3.5392792"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <g
+     transform="matrix(0,-2.4081601,2.1748875,0,3.6024926,3.3877599)"
+     id="g8">
+    <path
+       style="color:#000000;fill:#000000;stroke:none;stroke-width:0"
+       d="m -0.71991525,-0.19465989 0.33177966,-0.18940678 0.0330509,0.96949148 L -1.2881356,0.20788251 -0.99872875,-0.00398193 -1.5,-0.78872769 h -1 V -1.1887277 l 1.2408772,0.011021 c 0.1567725,0.31877076 0.34911383,0.66326791 0.53920755,0.98304681 z"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <g
+       transform="matrix(1,0,0,-1,0.01211499,-0.97916703)"
+       id="g8-3">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.08"
+         d="M 0,0.6 1.2,0 0,-0.6 v 0.4 h -1.1076271 l 0.38771185,-0.5940678 0.33177966,0.18940678 0.0330509,-0.96949148 -0.93305091,0.3775423 0.28940685,0.21186444 L -1.5,-0.2 h -1 V 0.2 H 0 Z"
+         id="path6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/OSMScout2/pics/laneturn/through_right-through.svg
+++ b/OSMScout2/pics/laneturn/through_right-through.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5"
+   height="10"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="through_right-through.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2069"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="133.50176"
+     inkscape:cx="3.8688629"
+     inkscape:cy="3.5168076"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <g
+     transform="matrix(0,-2.4081601,2.1748875,0,3.6024926,3.3877599)"
+     id="g8">
+    <path
+       style="color:#000000;fill:#000000;stroke:#000000;stroke-width:0.0655436;stroke-dasharray:none;stroke-opacity:1"
+       d="m -0.00497669,-1.5997487 1.19999999,0.60000005 -1.19999999,0.6 v -0.4 c -1.25047671,0.00756 -1.18487661,0 -2.50000001,0 V -1.1997487 h 2.50000001 z"
+       id="path6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <g
+       transform="matrix(1,0,0,-1,0.0071383,-0.99018799)"
+       id="g8-3">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.08"
+         d="M 0,0.6 1.2,0 0,-0.6 v 0.4 h -1.1076271 l 0.38771185,-0.5940678 0.33177966,0.18940678 0.0330509,-0.96949148 -0.93305091,0.3775423 0.28940685,0.21186444 L -1.5,-0.2 h -1 V 0.2 H 0 Z"
+         id="path6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/OSMScout2/qml/custom/LaneTurnIcon.qml
+++ b/OSMScout2/qml/custom/LaneTurnIcon.qml
@@ -4,9 +4,10 @@ Image{
     id: laneTurnIcon
 
     property string turnType: 'unknown'
+    property bool suggested: false
+    property string suggestedTurn: 'unknown'
     property string unknownTypeIcon: 'empty'
     property int roundaboutExit: -1
-    property bool outline: false
 
     /*
      * This is mapping libosmscout route step types and step icons.
@@ -16,31 +17,61 @@ Image{
         'left': 'left',
         'slight_left': 'left',
         'merge_to_left': 'left',
+
         'through;left': 'through_left',
         'through;slight_left': 'through_left',
         'through;sharp_left': 'through_left',
+
+        'through;left-through': 'through_left-through',
+        'through;slight_left-through': 'through_left-through',
+        'through;sharp_left-through': 'through_left-through',
+
+        'through;left-left': 'through_left-left',
+        'through;slight_left-slight_left': 'through_left-left',
+        'through;sharp_left-sharp_left': 'through_left-left',
+
         'through': 'through',
+
         'through;right': 'through_right',
         'through;slight_right': 'through_right',
         'through;sharp_right': 'through_right',
+
+        'through;right-through': 'through_right-through',
+        'through;slight_right-through': 'through_right-through',
+        'through;sharp_right-through': 'through_right-through',
+
+        'through;right-right': 'through_right-right',
+        'through;slight_right-slight_right': 'through_right-right',
+        'through;sharp_right-sharp_right': 'through_right-right',
+
         'right': 'right',
         'slight_right': 'right',
         'merge_to_right': 'right'
     }
 
     function iconUrl(icon){
-        return '../../pics/laneturn/' + icon + (outline ? '_outline' : '') + '.svg';
+        return '../../pics/laneturn/' + icon + (suggested ? '' : '_outline') + '.svg';
     }
 
     function typeIcon(type){
-      if (typeof iconMapping[type] === 'undefined'){
-          console.log("Can't find icon for type " + type);
+      console.log("turn icon " + turnType + " " + (suggested ? ("suggested: " + suggestedTurn) : "not-suggested"))
+      var icon = iconMapping[turnType];
+      if (typeof icon === 'undefined'){
+          console.log("Can't find icon for type " + turnType);
           return iconUrl(unknownTypeIcon);
       }
-      return iconUrl(iconMapping[type]);
+      if (suggested) {
+          console.log("mapping: " + turnType + '-' + suggestedTurn)
+          var suggestedTurnIcon = iconMapping[turnType + '-' + suggestedTurn];
+          if (typeof suggestedTurnIcon !== 'undefined'){
+              icon = suggestedTurnIcon;
+          }
+      }
+
+      return iconUrl(icon);
     }
 
-    source: typeIcon(turnType)
+    source: typeIcon()
 
     fillMode: Image.PreserveAspectFit
     horizontalAlignment: Image.AlignHCenter

--- a/OSMScout2/qml/custom/LaneTurns.qml
+++ b/OSMScout2/qml/custom/LaneTurns.qml
@@ -8,6 +8,7 @@ Rectangle{
     height: 60
 
     property var laneTurns: ["", "through", "through;right", "right"]
+    property var laneTurn: "through"
     property var suggestedLaneFrom: 1
     property var suggestedLaneTo: 2
     property var maxWidth: height * 4
@@ -70,14 +71,15 @@ Rectangle{
         parentObj.width = 0;
         for (var i in laneTurns){
             var turn = laneTurns[i];
-            console.log("turn " + i + ": " + turn + " <" + suggestedLaneFrom + ", " + suggestedLaneTo + ">");
+            console.log("turn " + i + ": " + turn + " <" + suggestedLaneFrom + ", " + suggestedLaneTo + ">: " + laneTurn);
             var icon = iconComponent.createObject(parentObj,
                                               {
                                                   id: "turnIcon" + i,
                                                   turnType: turn,
+                                                  suggestedTurn: laneTurn,
                                                   height: parentObj.height,
                                                   width: iconWidth,
-                                                  outline: ( i < suggestedLaneFrom || i > suggestedLaneTo)
+                                                  suggested: ( i >= suggestedLaneFrom && i <= suggestedLaneTo)
                                               });
             if (icon == null) {
                 // Error Handling

--- a/OSMScout2/res.qrc
+++ b/OSMScout2/res.qrc
@@ -66,6 +66,10 @@
         <file>pics/laneturn/through_right_outline.svg</file>
         <file>pics/laneturn/through_right.svg</file>
         <file>pics/laneturn/through.svg</file>
+        <file>pics/laneturn/through_left-left.svg</file>
+        <file>pics/laneturn/through_left-through.svg</file>
+        <file>pics/laneturn/through_right-right.svg</file>
+        <file>pics/laneturn/through_right-through.svg</file>
 
         <file>resources/online-tile-providers.json</file>
         <file>resources/map-providers.json</file>

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModel.h
@@ -64,6 +64,7 @@ class OSMSCOUT_CLIENT_QT_API NavigationModel : public QAbstractListModel
   Q_PROPERTY(bool laneSuggested READ isLaneSuggested NOTIFY laneUpdate)
   Q_PROPERTY(int suggestedLaneFrom READ getSuggestedLaneFrom NOTIFY laneUpdate)
   Q_PROPERTY(int suggestedLaneTo READ getSuggestedLaneTo NOTIFY laneUpdate)
+  Q_PROPERTY(QString laneTurn READ getLaneTurn NOTIFY laneUpdate)
   Q_PROPERTY(QStringList laneTurns READ getLaneTurns NOTIFY laneUpdate)
 
 signals:
@@ -216,6 +217,11 @@ public:
   int getSuggestedLaneTo() const
   {
     return lane.suggestedTo;
+  }
+
+  QString getLaneTurn() const
+  {
+    return QString::fromStdString(LaneTurnString(lane.turn));
   }
 
   QStringList getLaneTurns() const

--- a/libosmscout/include/osmscout/navigation/LaneAgent.h
+++ b/libosmscout/include/osmscout/navigation/LaneAgent.h
@@ -34,12 +34,14 @@ public:
    */
   struct OSMSCOUT_API Lane
   {
-    bool oneway{false};
-    int count{1};
-    bool suggested{false};
-    int suggestedFrom{0};
-    int suggestedTo{0};
-    std::vector<LaneTurn> turns;
+    bool oneway{false}; /// when route is oneway
+    int count{1}; /// number of route lanes
+    std::vector<LaneTurn> turns; /// individual turns for lanes
+
+    bool suggested{false}; /// when suggested lanes and turn is valid
+    int suggestedFrom{0}; /// suggested lanes (from), inclusive
+    int suggestedTo{0}; /// suggested lanes (to), inclusive
+    LaneTurn turn{LaneTurn::None}; /// turn that we should take
 
     Lane() = default;
 

--- a/libosmscout/src/osmscout/navigation/LaneAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/LaneAgent.cpp
@@ -39,8 +39,10 @@ LaneAgent::Lane::Lane(const RouteDescription::LaneDescriptionRef laneDsc,
     suggested = true;
     suggestedFrom = suggestedLaneDsc->GetFrom();
     suggestedTo = suggestedLaneDsc->GetTo();
+    turn = suggestedLaneDsc->GetTurn();
   } else {
     suggestedTo = count-1;
+    turn = LaneTurn::None;
   }
 }
 
@@ -51,7 +53,8 @@ bool LaneAgent::Lane::operator!=(const LaneAgent::Lane &o) const
          suggested!=o.suggested ||
          suggestedFrom!=o.suggestedFrom ||
          suggestedTo!=o.suggestedTo ||
-         turns!=o.turns;
+         turns!=o.turns ||
+         turn!=o.turn;
 }
 
 std::list<NavigationMessageRef> LaneAgent::Process(const NavigationMessageRef& message)


### PR DESCRIPTION
Propagate suggested turn (evaluated by lane agent) to the UI and show corresponding icon:

![image](https://github.com/user-attachments/assets/b43b39d9-9b88-4efa-98c7-a79a47e61126)

so, driver is informed not just about the fact that she/he can use some lanes, but also that should continue straight...