### PR TITLE
fix crash when deleting the renderer and flushing its cache in differ…

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -95,6 +95,7 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_PROPERTY(bool interactiveIcons READ hasInteractiveIcons WRITE setInteractiveIcons)
 
 private:
+  mutable QMutex   rendererMutex;
   MapRenderer      *renderer{nullptr};
 
   MapView          *view{nullptr};

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -1054,6 +1054,7 @@ void MapWidget::SetRenderingType(QString strType)
     type=RenderingType::TiledRendering;
   }
   if (type!=renderingType){
+    QMutexLocker locker(&rendererMutex);
     renderingType=type;
 
     std::map<int,OverlayObjectRef> overlayWays = renderer->getOverlayObjects();
@@ -1070,6 +1071,7 @@ void MapWidget::SetRenderingType(QString strType)
 
 void MapWidget::FlushCaches(const std::chrono::milliseconds &idleMs)
 {
+  QMutexLocker locker(&rendererMutex);
   renderer->FlushVisualCaches(idleMs);
 }
 }


### PR DESCRIPTION
Fixes a race condition when changing the type of renderer.

```
    T1 DELETE renderer 0x79058fe0abe0
    T1 ~TiledMapRenderer
    T2 Memory advise: RUNNING_CRITICAL
    T2 Flushing caches: rss=162 MB
    T2 FLUSH renderer 0x79058fe0abe0
    T1 QMutex: destroying locked mutex
    T1 ~MapRenderer
    T1 NEW renderer 0x79058fdfef90
    
    Fatal signal 4 (SIGILL), code 2 (ILL_ILLOPN), fault addr 0x79040eabfdc0 in tid 25849 (ub.janbar.osmin), pid 25849 (ub.janbar.osmin)
    00 pc 00000000002badc0  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libQt5Gui_x86_64.so (QPlatformPixmap::~QPlatformPixmap()+0) (BuildId: dbd5f77478b04c04ebdd16f851d52f7321b3495b)
    01 pc 00000000002b7564  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libQt5Gui_x86_64.so (QPixmap::~QPixmap()+26) (BuildId: dbd5f77478b04c04ebdd16f851d52f7321b3495b)
    02 pc 0000000000cd3d78  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libosmin_x86_64.so (osmscout::TileCacheVal::~TileCacheVal()+24) (BuildId: 546df76d199e5c2903ed9c84359a6eb34fa9f169)
    03 pc 000000000126eb81  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libosmin_x86_64.so (osmscout::TileCache::cleanupCache(unsigned int, std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000l> > const&)+689) (BuildId: 546df76d199e5c2903ed9c84359a6eb34fa9f169)
    04 pc 0000000001268e56  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libosmin_x86_64.so (osmscout::TiledMapRenderer::FlushVisualCaches(std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000l> > const&)+86) (BuildId: 546df76d199e5c2903ed9c84359a6eb34fa9f169)
    05 pc 0000000000f74723  /data/app/~~UXDU60fFv0KYfTjtEp57GA==/io.github.janbar.osmin-2DDICge9spMz9eJjSByUwg==/lib/x86_64/libosmin_x86_64.so (osmscout::MapWidget::FlushCaches(std::__ndk1::chrono::duration<long long, std::__ndk1::ratio<1l, 1000l> > const&)+115) (BuildId: 546df76d199e5c2903ed9c84359a6eb34fa9f169)

```