### PR TITLE
fixes huge dpi on hidpi screen

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapRenderer.h
@@ -33,7 +33,6 @@
 #include <QSettings>
 #include <QMutex>
 #include <QPainter>
-#include <QScreen>
 
 namespace osmscout {
 
@@ -98,7 +97,6 @@ protected:
 #endif
 
   double      mapDpi;
-  double      screenPixelRatio{1.0};
   bool        renderSea;
 
   QString     fontName;
@@ -178,8 +176,6 @@ public slots:
   virtual void onFontSizeChanged(double);
   virtual void onShowAltLanguageChanged(bool);
   virtual void onUnitsChanged(const QString&);
-
-  virtual void SetScreen(const QScreen*);
 
 protected:
   MapRenderer(QThread *thread,

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -188,7 +188,6 @@ signals:
   void styleErrorsChanged();
   void databaseLoaded(osmscout::GeoBox);
   void renderingTypeChanged(QString type);
-  void screenChanged(QScreen*);
 
   void objectPicked(const ObjectFileRef object);
 
@@ -320,8 +319,6 @@ private slots:
   void onMapDPIChange(double dpi);
 
   void onResize();
-
-  void onWindowChanged(QQuickWindow *window);
 
 private:
   void setupInputHandler(InputHandler *newGesture);

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -157,23 +157,6 @@ void MapRenderer::onUnitsChanged(const QString& units)
   emit Redraw();
 }
 
-void MapRenderer::SetScreen(const QScreen *screen)
-{
-  bool changed=false;
-  {
-    QMutexLocker locker(&lock);
-    if (this->screenPixelRatio != screen->devicePixelRatio()) {
-      this->screenPixelRatio = screen->devicePixelRatio();
-      log.Debug() << "Screen pixel ratio: " << this->screenPixelRatio;
-      changed = true;
-    }
-  }
-  if (changed) {
-    InvalidateVisualCache();
-    emit Redraw();
-  }
-}
-
 void MapRenderer::addOverlayObject(int id, const OverlayObjectRef& obj)
 {
   {

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -27,7 +27,6 @@
 #include <QtSvg/QSvgRenderer>
 #include <QtGlobal>
 #include <QQuickWindow>
-#include <QGuiApplication>
 
 namespace osmscout {
 
@@ -71,7 +70,6 @@ MapWidget::MapWidget(QQuickItem* parent)
 
     connect(this, &QQuickItem::widthChanged, this, &MapWidget::onResize);
     connect(this, &QQuickItem::heightChanged, this, &MapWidget::onResize);
-    connect(this, &QQuickItem::windowChanged, this, &MapWidget::onWindowChanged);
 
     connect(&iconAnimation, &IconAnimation::update, this, &MapWidget::redraw);
 
@@ -114,26 +112,6 @@ void MapWidget::setupRenderer()
 
     connect(renderer, &MapRenderer::Redraw,
             this, &MapWidget::redraw);
-
-    connect(this, &MapWidget::screenChanged,
-            renderer, &MapRenderer::SetScreen,
-            Qt::QueuedConnection);
-
-    QQuickWindow *window = this->window();
-    if (window) {
-      emit screenChanged(window->screen());
-    } else {
-      emit screenChanged(QGuiApplication::primaryScreen());
-    }
-}
-
-void MapWidget::onWindowChanged(QQuickWindow *window)
-{
-    if (window) {
-      emit screenChanged(window->screen());
-      connect(window, &QWindow::screenChanged,
-              this, &MapWidget::screenChanged);
-    }
 }
 
 void MapWidget::translateToTouch(QMouseEvent* event, Qt::TouchPointStates states)

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapRenderer.cpp
@@ -428,16 +428,13 @@ void TiledMapRenderer::onLoadJobFinished(QMap<QString,QMap<osmscout::TileKey,osm
             (double)loadXFrom + (double)width/2.0,
             (double)loadYFrom + (double)height/2.0);
 
-    // For HiDPI screens (screenPixelRatio > 1) tiles as up-scaled before displaying. When there is ratio 2.0, 100px on Qt canvas
-    // is displayed as 200px on the screen. To provide best results on HiDPI screen, we upscale tiles by this pixel ratio.
-    double finalDpi = mapDpi * this->screenPixelRatio;
-
-    uint32_t tileDimension = double(OSMTile::osmTileOriginalWidth()) * (finalDpi / OSMTile::tileDPI()); // pixels
+    uint32_t tileDimension = double(OSMTile::osmTileOriginalWidth()) * (mapDpi / OSMTile::tileDPI()); // pixels
 
     // older/mobile OpenGL (without GL_ARB_texture_non_power_of_two) requires textures with size of power of two
     // we should provide tiles with required size to avoid scaling in QOpenGLTextureCache::bindTexture
     tileDimension = qNextPowerOfTwo(tileDimension - 1);
-    finalDpi = (double(tileDimension) / double(OSMTile::osmTileOriginalWidth())) * OSMTile::tileDPI();
+
+    double finalDpi = (double(tileDimension) / double(OSMTile::osmTileOriginalWidth())) * OSMTile::tileDPI();
 
     QImage canvas(width * tileDimension,
                   height * tileDimension,


### PR DESCRIPTION
With hidpi the pixel size is already taken into account in the request dpi. So do not factorize again with the screen pixel ratio, and avoid OOM on device with limited resources.