### PR TITLE
render plane map without alpha channel

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -338,7 +338,7 @@ void PlaneMapRenderer::DrawMap()
 
       currentImage=new QImage(QSize(currentWidth,
                                     currentHeight),
-                              QImage::Format_RGBA8888_Premultiplied);
+                              QImage::Format_RGB888);
     }
 
     osmscout::MapParameter       drawParameter;


### PR DESCRIPTION
it is not needed, it will save some memory
and RGB888 format should not be converted
in `QOpenGLTextureCache::bindTexture`