### PR TITLE
configurable tile scaling to power of two 

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -38,6 +38,7 @@
 #include <osmscoutclientqt/VoiceManager.h>
 #include <osmscoutclientqt/ElevationModule.h>
 #include <osmscoutclientqt/IconLookup.h>
+#include <osmscoutclientqt/TiledMapRenderer.h>
 
 #include <osmscoutclientqt/ClientQtImportExport.h>
 
@@ -65,6 +66,7 @@ private:
 
   size_t onlineTileCacheSize{100};
   size_t offlineTileCacheSize{200};
+  GLPowerOfTwoTexture glPowerOfTwoTexture{GLPowerOfTwoTexture::Upscaling};
 
   QString voiceLookupDirectory;
 
@@ -179,6 +181,11 @@ public:
     return *this;
   }
 
+  inline OSMScoutQtBuilder& WithTilePowerOfTwoScaling(GLPowerOfTwoTexture glPowerOfTwoTexture){
+    this->glPowerOfTwoTexture=glPowerOfTwoTexture;
+    return *this;
+  }
+
   inline OSMScoutQtBuilder& WithUserAgent(const QString &appName,
                                           const QString &appVersion){
     this->appName=appName;
@@ -240,19 +247,20 @@ class OSMSCOUT_CLIENT_QT_API OSMScoutQt : public QObject {
   friend class OSMScoutQtBuilder;
 
 private:
-  SettingsRef      settings;
-  MapManagerRef    mapManager;
-  DBThreadRef      dbThread;
-  QString          iconDirectory;
-  QString          cacheLocation;
-  size_t           onlineTileCacheSize;
-  size_t           offlineTileCacheSize;
-  QString          userAgent;
-  std::atomic_int  liveBackgroundThreads;
+  SettingsRef         settings;
+  MapManagerRef       mapManager;
+  DBThreadRef         dbThread;
+  QString             iconDirectory;
+  QString             cacheLocation;
+  size_t              onlineTileCacheSize;
+  size_t              offlineTileCacheSize;
+  GLPowerOfTwoTexture glPowerOfTwoTexture;
+  QString             userAgent;
+  std::atomic_int     liveBackgroundThreads;
 
-  std::mutex       mutex;
-  MapDownloaderRef mapDownloader; // created lazy, guarded by mutex
-  VoiceManagerRef  voiceManager; // created lazy, guarded by mutex
+  std::mutex          mutex;
+  MapDownloaderRef    mapDownloader; // created lazy, guarded by mutex
+  VoiceManagerRef     voiceManager; // created lazy, guarded by mutex
 
 private:
   OSMScoutQt(SettingsRef settings,
@@ -262,6 +270,7 @@ private:
              QString cacheLocation,
              size_t onlineTileCacheSize,
              size_t offlineTileCacheSize,
+             GLPowerOfTwoTexture glPowerOfTwoTexture,
              QString userAgent,
              QStringList customPoiTypes);
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
@@ -38,6 +38,22 @@
 
 namespace osmscout {
 
+/**
+ * \ingroup QtAPI
+ *
+ * Older/mobile OpenGL (without GL_ARB_texture_non_power_of_two) requires textures with size of power of two.
+ * To be able upload texture to GPU without rescaling in QOpenGLTextureCache::bindTexture,
+ * we may scale tiles to proper size.
+ *
+ * This enum control how to do it.
+ */
+enum class GLPowerOfTwoTexture {
+  NoScaling = 0, // GL_ARB_texture_non_power_of_two is supported, or we can justify the performance penalty of image rescaling
+  Upscaling = 1, // next "power of two" size is used
+  Downscaling = 2, // previous "power of two" size is used
+  Nearest = 3 // closest "power of two" size
+};
+
 class OSMSCOUT_CLIENT_QT_API TiledMapRenderer : public MapRenderer {
   Q_OBJECT
 
@@ -59,6 +75,8 @@ private:
   mutable QMutex                tileCacheMutex;
   TileCache                     onlineTileCache;
   TileCache                     offlineTileCache;
+
+  GLPowerOfTwoTexture           glPowerOfTwoTexture{GLPowerOfTwoTexture::Upscaling}; // guarded by lock
 
   OsmTileDownloader             *tileDownloader=nullptr;
 
@@ -118,7 +136,8 @@ public:
                    QString iconDirectory,
                    QString tileCacheDirectory,
                    size_t onlineTileCacheSize,
-                   size_t offlineTileCacheSize);
+                   size_t offlineTileCacheSize,
+                   GLPowerOfTwoTexture glPowerOfTwoTexture);
 
   virtual ~TiledMapRenderer();
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TiledMapRenderer.h
@@ -68,15 +68,15 @@ private:
   // for areas not covered by db.
   //
   // When offlineTileCache is invalidated, cache keeps unchanged,
-  // just its epoch is increased. When there is retrieved pixmap with
+  // just its epoch is increased. When there is retrieved image with
   // old epoch from cache, it is used, but rendering request is triggered.
   //
   // Offline tiles should be in ARGB format on db area interface.
-  mutable QMutex                tileCacheMutex;
+  mutable QMutex                tileCacheMutex; // MapRenderer::lock need to be acquired first, when both locks are hold together
   TileCache                     onlineTileCache;
   TileCache                     offlineTileCache;
 
-  GLPowerOfTwoTexture           glPowerOfTwoTexture{GLPowerOfTwoTexture::Upscaling}; // guarded by lock
+  std::atomic<GLPowerOfTwoTexture> glPowerOfTwoTexture{GLPowerOfTwoTexture::Upscaling};
 
   OsmTileDownloader             *tileDownloader=nullptr;
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -180,6 +180,7 @@ bool OSMScoutQtBuilder::Init()
                                   cacheLocation,
                                   onlineTileCacheSize,
                                   offlineTileCacheSize,
+                                  glPowerOfTwoTexture,
                                   userAgent,
                                   customPoiTypes);
 
@@ -294,6 +295,7 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
                        QString cacheLocation,
                        size_t onlineTileCacheSize,
                        size_t offlineTileCacheSize,
+                       GLPowerOfTwoTexture glPowerOfTwoTexture,
                        QString userAgent,
                        QStringList customPoiTypes):
         settings(settings),
@@ -302,6 +304,7 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
         cacheLocation(cacheLocation),
         onlineTileCacheSize(onlineTileCacheSize),
         offlineTileCacheSize(offlineTileCacheSize),
+        glPowerOfTwoTexture(glPowerOfTwoTexture),
         userAgent(userAgent),
         liveBackgroundThreads(0)
 {
@@ -452,7 +455,8 @@ MapRenderer* OSMScoutQt::MakeMapRenderer(RenderingType type)
                                      iconDirectory,
                                      cacheLocation,
                                      onlineTileCacheSize,
-                                     offlineTileCacheSize);
+                                     offlineTileCacheSize,
+                                     glPowerOfTwoTexture);
   }else{
     mapRenderer=new PlaneMapRenderer(thread,settings,dbThread,iconDirectory);
   }


### PR DESCRIPTION
Library user may decide howto scale tiles to power of two. It may be
 - upscaled
 - downscaled
 - use nearest "power of two"
 - keep unchanged (there is small performance penalty for scaling the tile before sending to GPU)

When GL_ARB_texture_non_power_of_two extension is available, scaling is disabled.