### PR TITLE
Stop copying QImage and save memory and cpu time

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TileCache.h
@@ -73,7 +73,7 @@ struct TileCacheVal
 {
   using clock=std::chrono::steady_clock;
   clock::time_point lastAccess;
-  QImage image;
+  std::shared_ptr<QImage> image;
   size_t epoch;
 };
 
@@ -144,7 +144,7 @@ public:
    * @return true if there was such request
    */
   bool removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y);
-  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, const QImage &image, size_t epoch = 0);
+  void put(uint32_t zoomLevel, uint32_t x, uint32_t y, std::shared_ptr<QImage> image, size_t epoch = 0);
 
   void cleanupCache(uint32_t maxRemove, const std::chrono::milliseconds &maximumLifetime);
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/TileCache.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TileCache.cpp
@@ -167,7 +167,7 @@ TileCacheVal TileCache::get(uint32_t zoomLevel, uint32_t x, uint32_t y)
     TileCacheKey key = {zoomLevel, x, y};
     if (!tiles.contains(key)){
         qWarning() << this << "No tile in cache for key " << key;
-        return {TileCacheVal::clock::now(), QImage(), epoch}; // throw std::underflow_error ?
+        return {TileCacheVal::clock::now(), std::make_shared<QImage>(), epoch}; // throw std::underflow_error ?
     }
     TileCacheVal val = tiles.value(key);
     val.lastAccess = TileCacheVal::clock::now();
@@ -186,7 +186,7 @@ bool TileCache::removeRequest(uint32_t zoomLevel, uint32_t x, uint32_t y)
     return requests.remove(key) > 0;
 }
 
-void TileCache::put(uint32_t zoomLevel, uint32_t x, uint32_t y, const QImage &image, size_t epoch)
+void TileCache::put(uint32_t zoomLevel, uint32_t x, uint32_t y, std::shared_ptr<QImage> image, size_t epoch)
 {
     removeRequest(zoomLevel, x, y);
     TileCacheKey key = {zoomLevel, x, y};

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledMapOverlay.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledMapOverlay.cpp
@@ -101,7 +101,7 @@ void TileLoaderThread::tileDownloaded(uint32_t zoomLevel, uint32_t x, uint32_t y
 {
   {
     QMutexLocker locker(&tileCacheMutex);
-    onlineTileCache.put(zoomLevel, x, y, image);
+    onlineTileCache.put(zoomLevel, x, y, std::make_shared<QImage>(image));
   }
 
   emit downloaded(zoomLevel, x, y);

--- a/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TiledRenderingHelper.cpp
@@ -212,13 +212,13 @@ bool TiledRenderingHelper::lookupAndDrawTile(TileCache& tileCache, QPainter& pai
     //qDebug() << "  - lookup tile " << lookupXTile << " " << lookupYTile << " zoom " << lookupTileZoom << " " << " viewport " << lookupTileViewport;
     if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
       TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
-      if (!val.image.isNull()){
-        double imageWidth = val.image.width();
-        double imageHeight = val.image.height();
+      if (!val.image->isNull()){
+        double imageWidth = val.image->width();
+        double imageHeight = val.image->height();
         QRectF imageViewport(imageWidth * lookupTileViewport.x(), imageHeight * lookupTileViewport.y(),
                              imageWidth * lookupTileViewport.width(), imageHeight * lookupTileViewport.height() );
 
-        painter.drawImage(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), val.image, imageViewport);
+        painter.drawImage(QRectF(x, y, renderTileWidth+overlap, renderTileHeight+overlap), *val.image, imageViewport);
       }
       lookupTileFound = true;
       if (lookupTileZoom == zoomLevel && val.epoch == tileCache.getEpoch()) {
@@ -290,12 +290,12 @@ void TiledRenderingHelper::lookupAndDrawBottomTileRecursive(TileCache& tileCache
       bool found = false;
       if (tileCache.contains(lookupTileZoom, lookupXTile, lookupYTile)){
         TileCacheVal val = tileCache.get(lookupTileZoom, lookupXTile, lookupYTile);
-        if (!val.image.isNull()){
-          double imageWidth = val.image.width();
-          double imageHeight = val.image.height();
+        if (!val.image->isNull()){
+          double imageWidth = val.image->width();
+          double imageHeight = val.image->height();
           painter.drawImage(
               QRectF(x + tx * (renderTileWidth/tileCnt), y + ty * (renderTileHeight/tileCnt), renderTileWidth/tileCnt + overlap, renderTileHeight/tileCnt + overlap),
-              val.image,
+              *val.image,
               QRectF(0.0, 0.0, imageWidth, imageHeight));
           found = true;
         }


### PR DESCRIPTION
Uses smart pointers and avoid copy all back buffers when setting/getting from cache.