### PR TITLE
better area optimization with "simple" constraint

### DIFF
--- a/libosmscout/src/osmscout/util/Transformation.cpp
+++ b/libosmscout/src/osmscout/util/Transformation.cpp
@@ -587,17 +587,35 @@ namespace osmscout {
       size_t i=0;
       size_t j;
       bool updated=true;
-      // following while is just performance optimisation,
+      // following while is just performance optimization,
       // we don't start searching intersections from start again
       while (updated) {
         if (FindIntersection(optimised,i,j)) {
           isSimple=false;
           modified=true;
-          if (isArea && j-i > i+(optimised.size()-j)){
-            optimised.erase(optimised.begin()+j+1, optimised.end());
-            optimised.erase(optimised.begin(), optimised.begin()+i);
-            optimised.push_back(optimised.front());
-            i=0;
+
+          if (isArea) {
+            // try to cut off the smaller portion of the area
+            GeoBox middleBox;
+            GeoBox startBox;
+            GeoBox endBox;
+
+            GetSegmentBoundingBox(optimised, i, j + 1, middleBox);
+            GetSegmentBoundingBox(optimised, 0, i + 1, startBox);
+            GetSegmentBoundingBox(optimised, j, optimised.size(), endBox);
+
+            GeoBox unionBox=startBox;
+            unionBox.Include(endBox);
+
+            if (middleBox.GetSize() > unionBox.GetSize()){
+              optimised.erase(optimised.begin()+j+1, optimised.end());
+              optimised.erase(optimised.begin(), optimised.begin()+i);
+              optimised.push_back(optimised.front());
+              i=0;
+            }
+            else {
+              optimised.erase(optimised.begin()+i+1, optimised.begin()+j+1);
+            }
           }
           else {
             optimised.erase(optimised.begin()+i+1, optimised.begin()+j+1);


### PR DESCRIPTION
When area/way is optimized (reduced geometry complexity), there may be requirement that resulted geometry is simple (no intersecting lines). This constraint is ensured by searching for intersection and when there is some, portion of the simplified geometry is removed.
In case of areas, such portion may be in the middle or its begin and end. Geometric size should take into account, not number of notes.

___

I just noticed weird artifact in the wood in Italy. When this multi-polygon https://www.openstreetmap.org/relation/2196994 is not "simple" after optimization (level 10):

<img src="https://github.com/user-attachments/assets/0623a30f-8d73-420f-bf4b-c9f35c5b5c2d" width=400 />

and it is updated to this:

<img src="https://github.com/user-attachments/assets/699a9e7f-29b0-4baf-b85d-af97d1eddbc8" width=400 />

after this change, result is:

<img src="https://github.com/user-attachments/assets/f35fff55-4acd-40d2-bdb9-c79a5c99beb4" width=400 />

It is not ideal, it may create weird results too, but I believe that it will be better overall and still fast.