### PR TITLE
do not (always) reset input handler when un-follow vehicle

### DIFF
--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -200,7 +200,7 @@ void MapWidget::setupInputHandler(InputHandler *newGesture)
     if (locked != inputHandler->isLockedToPosition()){
         emit lockToPositionChanged();
     }
-    //qDebug() << "Input handler changed (" << (newGesture->animationInProgress()? "animation": "stationary") << ")";
+    // qDebug() << "Input handler changed to" << inputHandler->metaObject()->className();
 }
 
 void MapWidget::redraw()
@@ -607,7 +607,9 @@ void MapWidget::setFollowVehicle(bool follow){
       setupInputHandler(new VehicleFollowHandler(*view, QSizeF(width(), height())));
     }
   }else{
-    setupInputHandler(new InputHandler(*view));
+    if (inputHandler->isFollowVehicle()) {
+      setupInputHandler(new InputHandler(*view));
+    }
   }
 }
 


### PR DESCRIPTION
In some cases there may be active different input handler (than VehicleFollowHandler) when following vehicle. In such case disabling vehicle following should not reset input handler and possible animation.