### PR TITLE
update windows github actions to windows-2025 image

### DIFF
--- a/.github/workflows/build_and test_on_msys.yml
+++ b/.github/workflows/build_and test_on_msys.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_gcc_cmake:
     name: gcc and cmake
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: msys2 {0}
@@ -46,7 +46,7 @@ jobs:
 
   build_gcc_meson:
     name: gcc and meson
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
support for windows-2019 was removed,
see https://github.com/actions/runner-images/issues/12045