### PR TITLE
import generic shop as POI

### DIFF
--- a/stylesheets/map.ost
+++ b/stylesheets/map.ost
@@ -1297,13 +1297,13 @@ TYPES
   TYPE shop_building
     = AREA (EXISTS "shop" AND EXISTS "building" AND !("building" IN ["no","false","0"]))
       {Name, NameAlt, OpeningHours, Phone, Website}
-      ADDRESS
+      ADDRESS POI
       GROUP shop, building, routingPOI
 
   TYPE shop
     = NODE AREA (EXISTS "shop")
       {Name, NameAlt, OpeningHours, Phone, Website}
-      ADDRESS
+      ADDRESS POI
       GROUP shop, routingPOI
 
   //


### PR DESCRIPTION
Import generic shop (without specific type) as POI. The main difference is the inclusion in the location index, so user may search shops like Hornbach (shop=doityourself) by combination of the name and region.
Like "Hornbach Čestlice".