### PR TITLE
fix reading uninitialized cacheEntry.value

### DIFF
--- a/libosmscout/src/osmscout/db/AreaAreaIndex.cpp
+++ b/libosmscout/src/osmscout/db/AreaAreaIndex.cpp
@@ -74,7 +74,7 @@ namespace osmscout {
 #endif
 
       if (!indexCache.GetEntry(offset,cacheRef)) {
-        IndexCache::CacheEntry cacheEntry(offset);
+        IndexCache::CacheEntry cacheEntry(offset, IndexCell());
 
         cacheRef=indexCache.SetEntry(cacheEntry);
 


### PR DESCRIPTION
during release build on ubuntu 24.04, I get this warning:
```
In file included from /work/libosmscout/libosmscout/include/osmscout/io/NumericIndex.h:26,
                 from /work/libosmscout/libosmscout/include/osmscout/io/DataFile.h:32,
                 from /work/libosmscout/libosmscout/include/osmscout/db/AreaAreaIndex.h:31,
                 from /work/libosmscout/libosmscout/src/osmscout/db/AreaAreaIndex.cpp:20:
In member function ‘osmscout::Cache<K, V, IK>::CacheRef osmscout::Cache<K, V, IK>::SetEntry(const CacheEntry&) [with K = long unsigned int; V = osmscout::AreaAreaIndex::IndexCell; IK = long unsigned int]’,
    inlined from ‘bool osmscout::AreaAreaIndex::GetIndexCell(uint32_t, osmscout::FileOffset, IndexCell&, osmscout::FileOffset&) const’ at /work/libosmscout/libosmscout/src/osmscout/db/AreaAreaIndex.cpp:79:37:
/work/libosmscout/libosmscout/include/osmscout/util/Cache.h:224:9: warning: ‘cacheEntry.osmscout::Cache<long unsigned int, osmscout::AreaAreaIndex::IndexCell>::CacheEntry::value’ may be used uninitialized [-Wmaybe-uninitialized]
  224 |         order.front().value=entry.value;
      |         ^~~~~
/work/libosmscout/libosmscout/src/osmscout/db/AreaAreaIndex.cpp: In member function ‘bool osmscout::AreaAreaIndex::GetIndexCell(uint32_t, osmscout::FileOffset, IndexCell&, osmscout::FileOffset&) const’:
/work/libosmscout/libosmscout/src/osmscout/db/AreaAreaIndex.cpp:77:32: note: ‘cacheEntry’ declared here
   77 |         IndexCache::CacheEntry cacheEntry(offset);
      |                                ^~~~~~~~~~
```