### PR TITLE
use black text in StyleEditor epxlicitly

### DIFF
--- a/StyleEditor/qml_515/AboutDialog.qml
+++ b/StyleEditor/qml_515/AboutDialog.qml
@@ -21,6 +21,7 @@ DialogBase {
 
             text: "<b>StyleEditor</b>"
             font.pixelSize: units.fs("large")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -29,6 +30,7 @@ DialogBase {
 
             text: "Style sheet editor for the libosmscout library<br/>See http://libosmscout.sf.net"
             font.pixelSize: units.fs("medium")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -37,6 +39,7 @@ DialogBase {
 
             text: "All geographic data:<br/>© OpenStreetMap contributors<br/>See www.openstreetmap.org/copyright"
             font.pixelSize: units.fs("medium")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
     }

--- a/StyleEditor/qml_515/SearchGeocodeDialog.qml
+++ b/StyleEditor/qml_515/SearchGeocodeDialog.qml
@@ -34,6 +34,7 @@ DialogBase {
             Text {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 text: "Latitude:"
             }
 
@@ -53,6 +54,7 @@ DialogBase {
             Text {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 text: "Longitude:"
             }
 

--- a/StyleEditor/qml_515/SearchLocationDialog.qml
+++ b/StyleEditor/qml_515/SearchLocationDialog.qml
@@ -20,6 +20,7 @@ DialogBase {
         Text {
             Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
             font.pixelSize: units.fs("large")
+            color: foregroundColor
             text: "Location:"
         }
 

--- a/StyleEditor/qml_515/TextEditor.qml
+++ b/StyleEditor/qml_515/TextEditor.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Universal 2.2
 import DocumentHandler 1.0
 
 import "custom"
 
 Item {
     id: textEditor
-    property color baseColor: "#f2f2f2"
-    property color backgroundColor: "white"
+    property color backgroundColor: Universal.background
+    property color foregroundColor: Universal.foreground
     property alias source: document.source
     property MapControl map
 
@@ -138,7 +139,7 @@ Item {
         // line numbers
         Rectangle {
             id: lineColumn
-            color: baseColor
+            color: "#f2f2f2"
             anchors.left: parent.left
             width: units.gu(6)
             height: parent.height
@@ -195,8 +196,9 @@ Item {
                 rightPadding: units.gu(2)
                 topPadding: 0
                 bottomPadding: 0
+                color: "black"
                 background: Rectangle {
-                    color: backgroundColor
+                    color: "white"
                 }
 
                 // fickable height ratio is not accurate
@@ -281,7 +283,7 @@ Item {
         id: header
         width: parent.width
         height: units.gu(5)
-        color: baseColor
+        color: backgroundColor
 
         Row {
             id: fileRow
@@ -292,10 +294,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 width: saveButton.width
                 height: saveButton.height
-                //color: "transparent"
-                //border.width: units.dp(2)
-                //border.color: saveButton.enabled ? "red" : "transparent"
-                color: saveButton.enabled ? "#ffd" : "transparent"
+                color: "transparent"
                 ToolButton {
                     id: saveButton
                     height: units.gu(5)
@@ -384,12 +383,13 @@ Item {
                 width: searchText.width + units.gu(1)
                 height: units.gu(3.5)
                 border.width: searchText.focus ? units.dp(2) : units.dp(1)
-                border.color: "black"
-                color: searchText.focus ? "#ffd" : "white"
+                border.color: foregroundColor
+                color: backgroundColor
                 TextInput {
                     id: searchText
                     anchors.centerIn: parent
                     width: units.gu(15)
+                    color: foregroundColor
                     font.pixelSize: units.fs("small")
                     maximumLength: 255
                     clip: true
@@ -439,7 +439,7 @@ Item {
         width: parent.width
         height: units.gu(4)
         anchors.bottom: parent.bottom
-        color: baseColor
+        color: backgroundColor
 
         Text {
             id: statusText

--- a/StyleEditor/qml_515/custom/DialogBase.qml
+++ b/StyleEditor/qml_515/custom/DialogBase.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Universal 2.2
 
 Dialog {
     id: dialog
@@ -29,6 +30,9 @@ Dialog {
       \qmlproperty string text
      */
     property string text
+
+    property color foregroundColor: Universal.foreground
+    property color backgroundColor: Universal.background
 
     property real minimumWidth: units.gu(40)
     property real minimumHeight: Math.max(160, units.gu(20))
@@ -71,6 +75,7 @@ Dialog {
                 horizontalAlignment: Text.AlignHCenter
                 text: dialog.text
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 wrapMode: Text.Wrap
             }
 

--- a/StyleEditor/qml_515/custom/LineEdit.qml
+++ b/StyleEditor/qml_515/custom/LineEdit.qml
@@ -1,10 +1,13 @@
 import QtQuick 2.12
+import QtQuick.Controls.Universal 2.2
 
 Item {
     id: lineEdit
 
-    property color defaultBackgroundColor: "white"
+    readonly property color defaultForegroundColor: Universal.foreground
+    readonly property color defaultBackgroundColor: Universal.background
 
+    property color foregroundColor: defaultForegroundColor
     property color backgroundColor: defaultBackgroundColor
     property color focusColor: "lightgrey"
     property color selectedFocusColor: "lightblue"
@@ -33,6 +36,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: units.fs("large")
+        color: foregroundColor
         clip: true
 
         onFocusChanged: {

--- a/StyleEditor/qml_515/custom/LocationEdit.qml
+++ b/StyleEditor/qml_515/custom/LocationEdit.qml
@@ -59,9 +59,11 @@ LineEdit {
         console.log("Change")
         if (location == null) {
             locationEdit.backgroundColor = locationEdit.defaultBackgroundColor
+            locationEdit.foregroundColor = locationEdit.defaultForegroundColor
         }
         else {
             locationEdit.backgroundColor = "#ddffdd"
+            locationEdit.foregroundColor = "black"
         }
     }
 

--- a/StyleEditor/qml_640/AboutDialog.qml
+++ b/StyleEditor/qml_640/AboutDialog.qml
@@ -21,6 +21,7 @@ DialogBase {
 
             text: "<b>StyleEditor</b>"
             font.pixelSize: units.fs("large")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -29,6 +30,7 @@ DialogBase {
 
             text: "Style sheet editor for the libosmscout library<br/>See http://libosmscout.sf.net"
             font.pixelSize: units.fs("medium")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -37,6 +39,7 @@ DialogBase {
 
             text: "All geographic data:<br/>© OpenStreetMap contributors<br/>See www.openstreetmap.org/copyright"
             font.pixelSize: units.fs("medium")
+            color: foregroundColor
             horizontalAlignment: Text.AlignHCenter
         }
     }

--- a/StyleEditor/qml_640/SearchGeocodeDialog.qml
+++ b/StyleEditor/qml_640/SearchGeocodeDialog.qml
@@ -34,6 +34,7 @@ DialogBase {
             Text {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 text: "Latitude:"
             }
 
@@ -53,6 +54,7 @@ DialogBase {
             Text {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 text: "Longitude:"
             }
 

--- a/StyleEditor/qml_640/SearchLocationDialog.qml
+++ b/StyleEditor/qml_640/SearchLocationDialog.qml
@@ -20,6 +20,7 @@ DialogBase {
         Text {
             Layout.alignment: Qt.AlignLeft | Qt.AlignBaseline
             font.pixelSize: units.fs("large")
+            color: foregroundColor
             text: "Location:"
         }
 

--- a/StyleEditor/qml_640/TextEditor.qml
+++ b/StyleEditor/qml_640/TextEditor.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Universal 2.2
 import DocumentHandler 1.0
 
 import "custom"
 
 Item {
     id: textEditor
-    property color baseColor: "#f2f2f2"
-    property color backgroundColor: "white"
+    property color backgroundColor: Universal.background
+    property color foregroundColor: Universal.foreground
     property alias source: document.source
     property MapControl map
 
@@ -138,7 +139,7 @@ Item {
         // line numbers
         Rectangle {
             id: lineColumn
-            color: baseColor
+            color: "#f2f2f2"
             anchors.left: parent.left
             width: units.gu(6)
             height: parent.height
@@ -195,8 +196,9 @@ Item {
                 rightPadding: units.gu(2)
                 topPadding: 0
                 bottomPadding: 0
+                color: "black"
                 background: Rectangle {
-                    color: backgroundColor
+                    color: "white"
                 }
 
                 // fickable height ratio is not accurate
@@ -281,7 +283,7 @@ Item {
         id: header
         width: parent.width
         height: units.gu(5)
-        color: baseColor
+        color: backgroundColor
 
         Row {
             id: fileRow
@@ -292,10 +294,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 width: saveButton.width
                 height: saveButton.height
-                //color: "transparent"
-                //border.width: units.dp(2)
-                //border.color: saveButton.enabled ? "red" : "transparent"
-                color: saveButton.enabled ? "#ffd" : "transparent"
+                color: "transparent"
                 ToolButton {
                     id: saveButton
                     height: units.gu(5)
@@ -384,12 +383,13 @@ Item {
                 width: searchText.width + units.gu(1)
                 height: units.gu(3.5)
                 border.width: searchText.focus ? units.dp(2) : units.dp(1)
-                border.color: "black"
-                color: searchText.focus ? "#ffd" : "white"
+                border.color: foregroundColor
+                color: backgroundColor
                 TextInput {
                     id: searchText
                     anchors.centerIn: parent
                     width: units.gu(15)
+                    color: foregroundColor
                     font.pixelSize: units.fs("small")
                     maximumLength: 255
                     clip: true
@@ -439,7 +439,7 @@ Item {
         width: parent.width
         height: units.gu(4)
         anchors.bottom: parent.bottom
-        color: baseColor
+        color: backgroundColor
 
         Text {
             id: statusText

--- a/StyleEditor/qml_640/custom/DialogBase.qml
+++ b/StyleEditor/qml_640/custom/DialogBase.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Universal 2.2
 
 Dialog {
     id: dialog
@@ -29,6 +30,9 @@ Dialog {
       \qmlproperty string text
      */
     property string text
+
+    property color foregroundColor: Universal.foreground
+    property color backgroundColor: Universal.background
 
     property real minimumWidth: units.gu(40)
     property real minimumHeight: Math.max(160, units.gu(20))
@@ -71,6 +75,7 @@ Dialog {
                 horizontalAlignment: Text.AlignHCenter
                 text: dialog.text
                 font.pixelSize: units.fs("large")
+                color: foregroundColor
                 wrapMode: Text.Wrap
             }
 

--- a/StyleEditor/qml_640/custom/LineEdit.qml
+++ b/StyleEditor/qml_640/custom/LineEdit.qml
@@ -1,10 +1,13 @@
 import QtQuick 2.12
+import QtQuick.Controls.Universal 2.2
 
 Item {
     id: lineEdit
 
-    property color defaultBackgroundColor: "white"
+    readonly property color defaultForegroundColor: Universal.foreground
+    readonly property color defaultBackgroundColor: Universal.background
 
+    property color foregroundColor: defaultForegroundColor
     property color backgroundColor: defaultBackgroundColor
     property color focusColor: "lightgrey"
     property color selectedFocusColor: "lightblue"
@@ -33,6 +36,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: units.fs("large")
+        color: foregroundColor
         clip: true
 
         onFocusChanged: {

--- a/StyleEditor/qml_640/custom/LocationEdit.qml
+++ b/StyleEditor/qml_640/custom/LocationEdit.qml
@@ -59,9 +59,11 @@ LineEdit {
         console.log("Change")
         if (location == null) {
             locationEdit.backgroundColor = locationEdit.defaultBackgroundColor
+            locationEdit.foregroundColor = locationEdit.defaultForegroundColor
         }
         else {
             locationEdit.backgroundColor = "#ddffdd"
+            locationEdit.foregroundColor = "black"
         }
     }
 


### PR DESCRIPTION
As we are using while text background, text is unreadable with dark system palette (using bright texts).
So, using black color explicitly makes it readable.