### PR TITLE
Group multi-node junctions in SuggestedLanesPostprocessor

### DIFF
--- a/Tests/src/LaneEvaluationCompare.cpp
+++ b/Tests/src/LaneEvaluationCompare.cpp
@@ -26,7 +26,8 @@ struct SuggestionDiff
   std::optional<NodeLaneInfo> lanes;
   std::optional<NodeSuggestedLaneInfo> oldSuggestion;
   std::optional<NodeSuggestedLaneInfo> newSuggestion;
-  std::vector<RouteNodeInfo> routeNodes;
+  std::vector<RouteNodeInfo> oldRouteNodes;
+  std::vector<RouteNodeInfo> newRouteNodes;
   size_t junctionLocalIndex = 0;
 };
 
@@ -77,7 +78,8 @@ static std::vector<SuggestionDiff> CompareRouteInfos(const RouteInfo &oldRoute,
       size_t windowEnd = std::min(i + kNodeWindowRadius + 1, maxNodes);
       diff.junctionLocalIndex = i - windowStart;
       for (size_t j = windowStart; j < windowEnd; j++) {
-        diff.routeNodes.push_back(newRoute.nodes[j]);
+        diff.oldRouteNodes.push_back(oldRoute.nodes[j]);
+        diff.newRouteNodes.push_back(newRoute.nodes[j]);
       }
 
       diffs.push_back(std::move(diff));
@@ -96,10 +98,11 @@ static std::vector<SuggestionDiff> CompareRouteInfos(const RouteInfo &oldRoute,
 
 static void RenderLegend(cairo_t *cairo,
                          const SuggestionDiff &diff,
+                         const std::vector<RouteNodeInfo> &routeNodes,
                          const std::optional<NodeSuggestedLaneInfo> &suggestion,
                          const std::string &label)
 {
-  const auto &node = diff.routeNodes[diff.junctionLocalIndex];
+  const auto &node = routeNodes[diff.junctionLocalIndex];
 
   std::vector<std::string> lines;
   lines.push_back(label);
@@ -166,10 +169,11 @@ static void RenderLegend(cairo_t *cairo,
 static void RenderLaneOverlay(cairo_t *cairo,
                               const MercatorProjection &projection,
                               const SuggestionDiff &diff,
+                              const std::vector<RouteNodeInfo> &routeNodes,
                               const std::optional<NodeSuggestedLaneInfo> &suggestion,
                               const std::string &label)
 {
-  if (diff.routeNodes.size() < 2) {
+  if (routeNodes.size() < 2) {
     return;
   }
 
@@ -179,8 +183,8 @@ static void RenderLaneOverlay(cairo_t *cairo,
   };
 
   std::vector<PixelNode> pixelNodes;
-  pixelNodes.reserve(diff.routeNodes.size());
-  for (const auto &rn : diff.routeNodes) {
+  pixelNodes.reserve(routeNodes.size());
+  for (const auto &rn : routeNodes) {
     PixelNode pn;
     pn.valid = projection.GeoToPixel(rn.coord, pn.pixel);
     pixelNodes.push_back(pn);
@@ -193,7 +197,7 @@ static void RenderLaneOverlay(cairo_t *cairo,
       continue;
     }
 
-    const auto &segNode = diff.routeNodes[seg];
+    const auto &segNode = routeNodes[seg];
     int segLaneCount = segNode.lanes.has_value() ? segNode.lanes->laneCount : 0;
     if (segLaneCount <= 0) {
       continue;
@@ -214,6 +218,8 @@ static void RenderLaneOverlay(cairo_t *cairo,
     bool adjacentToJunction = seg == diff.junctionLocalIndex ||
                               (diff.junctionLocalIndex > 0 && seg == diff.junctionLocalIndex - 1);
 
+    const auto &segSuggestion = segNode.suggestedLanes;
+
     for (int lane = 0; lane < segLaneCount; lane++) {
       double offset = -totalWidth / 2.0 + lane * laneSpacing;
 
@@ -222,8 +228,8 @@ static void RenderLaneOverlay(cairo_t *cairo,
       double x1 = pixelNodes[seg + 1].pixel.GetX() + perpX * offset;
       double y1 = pixelNodes[seg + 1].pixel.GetY() + perpY * offset;
 
-      bool isSuggested = adjacentToJunction && suggestion.has_value() &&
-                         lane >= suggestion->from && lane <= suggestion->to;
+      bool isSuggested = adjacentToJunction && segSuggestion.has_value() &&
+                         lane >= segSuggestion->from && lane <= segSuggestion->to;
 
       if (isSuggested) {
         cairo_set_source_rgba(cairo, 0.0, 0.8, 0.0, 0.8);
@@ -264,7 +270,7 @@ static void RenderLaneOverlay(cairo_t *cairo,
     cairo_fill(cairo);
   }
 
-  RenderLegend(cairo, diff, suggestion, label);
+  RenderLegend(cairo, diff, routeNodes, suggestion, label);
 }
 
 static bool RenderJunctionImage(const std::string &databaseDir,
@@ -335,10 +341,11 @@ static bool RenderJunctionImage(const std::string &databaseDir,
   painter.DrawMap(projection, drawParameter, dataVec, cairo);
 
   const auto &suggestion = useOldSuggestion ? diff.oldSuggestion : diff.newSuggestion;
+  const auto &routeNodes = useOldSuggestion ? diff.oldRouteNodes : diff.newRouteNodes;
   std::string label = useOldSuggestion ? "OLD: " : "NEW: ";
   label += FormatSuggestion(suggestion);
 
-  RenderLaneOverlay(cairo, projection, diff, suggestion, label);
+  RenderLaneOverlay(cairo, projection, diff, routeNodes, suggestion, label);
 
   if (cairo_surface_write_to_png(surface, outputPath.c_str()) != CAIRO_STATUS_SUCCESS) {
     log.Error() << "Cannot write PNG: " << outputPath;

--- a/Tests/src/LaneEvaluationCompare.cpp
+++ b/Tests/src/LaneEvaluationCompare.cpp
@@ -123,7 +123,7 @@ static void RenderLegend(cairo_t *cairo,
     if (!node.lanes->laneTurns.empty()) {
       lanesStr += " turns=[";
       for (size_t i = 0; i < node.lanes->laneTurns.size(); i++) {
-        if (i > 0) lanesStr += ",";
+        if (i > 0) lanesStr += " | ";
         lanesStr += node.lanes->laneTurns[i];
       }
       lanesStr += "]";

--- a/Tests/src/RoutePostprocessorTest.cpp
+++ b/Tests/src/RoutePostprocessorTest.cpp
@@ -272,7 +272,7 @@ public:
   osmscout::Duration
   GetTime([[maybe_unused]] osmscout::DatabaseId dbId, [[maybe_unused]] const osmscout::Way &way, [[maybe_unused]] const osmscout::Distance &deltaDistance) const override
   {
-    assert(false);
+    // DistanceAndTimePostprocessor using this method, but we don't need valid time for testing
     return osmscout::Duration();
   }
 
@@ -486,6 +486,7 @@ public:
 
 void Postprocess(RouteDescription &description, MockContext &context)
 {
+  RoutePostprocessor::DistanceAndTimePostprocessor().Process(context, description);
   RoutePostprocessor::LanesPostprocessor().Process(context, description);
   RoutePostprocessor::SuggestedLanesPostprocessor().Process(context, description);
 
@@ -1077,10 +1078,9 @@ TEST_CASE("Describe complex city junction: Průmyslová, Černokostecká")
     auto nodeIt = description.Nodes().begin();
     auto suggestedLanes = nodeIt->GetDescription<RouteDescription::SuggestedLaneDescription>();
     REQUIRE(suggestedLanes);
-    // TODO: improve lane evaluation on similar junctions
-    // REQUIRE(suggestedLanes->GetFrom() == 0);
-    // REQUIRE(suggestedLanes->GetTo() == 1);
-    // REQUIRE(suggestedLanes->GetTurn() == LaneTurn::Left);
+    REQUIRE(suggestedLanes->GetFrom() == 0);
+    REQUIRE(suggestedLanes->GetTo() == 1);
+    REQUIRE(suggestedLanes->GetTurn() == LaneTurn::Left);
   }
 }
 

--- a/Tests/src/RoutePostprocessorTest.cpp
+++ b/Tests/src/RoutePostprocessorTest.cpp
@@ -1077,10 +1077,9 @@ TEST_CASE("Describe complex city junction: Průmyslová, Černokostecká")
     auto nodeIt = description.Nodes().begin();
     auto suggestedLanes = nodeIt->GetDescription<RouteDescription::SuggestedLaneDescription>();
     REQUIRE(suggestedLanes);
-    // TODO: improve lane evaluation on similar junctions
-    // REQUIRE(suggestedLanes->GetFrom() == 0);
-    // REQUIRE(suggestedLanes->GetTo() == 1);
-    // REQUIRE(suggestedLanes->GetTurn() == LaneTurn::Left);
+    REQUIRE(suggestedLanes->GetFrom() == 0);
+    REQUIRE(suggestedLanes->GetTo() == 1);
+    REQUIRE(suggestedLanes->GetTurn() == LaneTurn::Left);
   }
 }
 

--- a/Tests/src/RoutePostprocessorTest.cpp
+++ b/Tests/src/RoutePostprocessorTest.cpp
@@ -272,6 +272,7 @@ public:
   osmscout::Duration
   GetTime([[maybe_unused]] osmscout::DatabaseId dbId, [[maybe_unused]] const osmscout::Way &way, [[maybe_unused]] const osmscout::Distance &deltaDistance) const override
   {
+    // DistanceAndTimePostprocessor using this method, but we don't need valid time for testing
     return osmscout::Duration();
   }
 

--- a/Tests/src/RoutePostprocessorTest.cpp
+++ b/Tests/src/RoutePostprocessorTest.cpp
@@ -272,7 +272,6 @@ public:
   osmscout::Duration
   GetTime([[maybe_unused]] osmscout::DatabaseId dbId, [[maybe_unused]] const osmscout::Way &way, [[maybe_unused]] const osmscout::Distance &deltaDistance) const override
   {
-    assert(false);
     return osmscout::Duration();
   }
 
@@ -486,6 +485,7 @@ public:
 
 void Postprocess(RouteDescription &description, MockContext &context)
 {
+  RoutePostprocessor::DistanceAndTimePostprocessor().Process(context, description);
   RoutePostprocessor::LanesPostprocessor().Process(context, description);
   RoutePostprocessor::SuggestedLanesPostprocessor().Process(context, description);
 

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -459,15 +459,19 @@ namespace osmscout {
     private:
       RouteDescription::LaneDescriptionRef GetLaneDescription(const RouteDescription::Node &node) const;
 
-      /** Evaluate suggested lanes on nodes from "backBuffer", followed by "node".
-       * Node itself is junction, where count of lanes (on way from the node)
-       * is smaller than on the previous node (back of backBuffer).
+      /** Evaluate suggested lanes on nodes from "backBuffer", followed by junction node(s).
+       * Junction nodes are crossings where the route transitions from the incoming lane
+       * configuration (back of backBuffer) to a different one. Multiple consecutive junction
+       * nodes that are close together and connected by segments with the same lane configuration
+       * are grouped into a single logical junction — their exits are aggregated.
        *
-       * @param node
-       * @param backBuffer buffer of traveled nodes, recent node at back
+       * @param junctionNodes one or more consecutive junction nodes forming a logical junction
+       * @param lastNode the node after the last junction node (provides outgoing way info)
+       * @param backBuffer buffer of traveled nodes before the junction, recent node at back
        */
       void EvaluateLaneSuggestion(const PostprocessorContext& context,
-                                  const RouteDescription::Node &node,
+                                  const std::vector<const RouteDescription::Node*> &junctionNodes,
+                                  const RouteDescription::Node &lastNode,
                                   const std::list<RouteDescription::Node*> &backBuffer) const;
 
     private:

--- a/libosmscout/include/osmscout/routing/RoutePostprocessor.h
+++ b/libosmscout/include/osmscout/routing/RoutePostprocessor.h
@@ -459,15 +459,19 @@ namespace osmscout {
     private:
       RouteDescription::LaneDescriptionRef GetLaneDescription(const RouteDescription::Node &node) const;
 
-      /** Evaluate suggested lanes on nodes from "backBuffer", followed by "node".
-       * Node itself is junction, where count of lanes (on way from the node)
-       * is smaller than on the previous node (back of backBuffer).
+      /** Evaluate suggested lanes on nodes from "backBuffer", followed by junction node(s).
+       * Junction nodes are crossings where the route transitions from the incoming lane
+       * configuration (back of backBuffer) to a different one. Multiple consecutive junction
+       * nodes that are close together and connected by segments with the same lane configuration
+       * are grouped into a single logical junction — their exits are aggregated.
        *
-       * @param node
-       * @param backBuffer buffer of traveled nodes, recent node at back
+       * @param junctionNodes one or more consecutive junction nodes forming a logical junction
+       * @param lastNode the node after the last junction node (provides outgoing way info)
+       * @param backBuffer buffer of traveled nodes before the junction, recent node at back
        */
       void EvaluateLaneSuggestion(const PostprocessorContext& context,
-                                  const RouteDescription::Node &node,
+                                  const std::vector<RouteDescription::Node*> &junctionNodes,
+                                  const RouteDescription::Node &lastNode,
                                   const std::list<RouteDescription::Node*> &backBuffer) const;
 
     private:

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -2101,15 +2101,6 @@ namespace osmscout {
   bool RoutePostprocessor::SuggestedLanesPostprocessor::Process(const PostprocessorContext& postprocessor,
                                                                 RouteDescription& description)
   {
-    // Helper to get a node's geographic coordinate from its path way object
-    auto getNodeCoord = [&postprocessor](const RouteDescription::Node &n) -> GeoCoord {
-      if (n.GetPathObject().Valid() && n.GetPathObject().GetType() == refWay) {
-        WayRef w = postprocessor.GetWay(n.GetDBFileOffset());
-        return w->nodes[n.GetCurrentNodeIndex()].GetCoord();
-      }
-      return n.GetLocation();
-    };
-
     // buffer of traveled nodes, recent node at back
     std::list<RouteDescription::Node*> backBuffer;
     for (auto& node : description.Nodes()) {
@@ -2151,8 +2142,8 @@ namespace osmscout {
               break;
             }
             // Must be close to the most recently grouped junction node
-            Distance dist = GetSphericalDistance(getNodeCoord(*candidate),
-                                                getNodeCoord(*junctionNodes.back()));
+            Distance dist = GetSphericalDistance(candidate->GetLocation(),
+                                                junctionNodes.back()->GetLocation());
             if (dist > Meters(50)) {
               break;
             }

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -29,8 +29,9 @@
 #include <algorithm>
 #include <cassert>
 #include <iostream>
-#include <string_view>
 #include <numeric>
+#include <set>
+#include <string_view>
 
 namespace osmscout {
 
@@ -1851,73 +1852,141 @@ namespace osmscout {
   } // end of anonymous namespace
 
   void RoutePostprocessor::SuggestedLanesPostprocessor::EvaluateLaneSuggestion(const PostprocessorContext& postprocessor,
-                                                                               const RouteDescription::Node &node,
+                                                                               const std::vector<const RouteDescription::Node*> &junctionNodes,
+                                                                               const RouteDescription::Node &lastNode,
                                                                                const std::list<RouteDescription::Node*> &backBuffer) const
   {
-    if (node.GetPathObject().GetType()!=refWay) {
+    assert(!junctionNodes.empty());
+    const RouteDescription::Node &firstJunctionNode = *junctionNodes.front();
+    const RouteDescription::Node &lastJunctionNode = *junctionNodes.back();
+
+    if (firstJunctionNode.GetPathObject().GetType()!=refWay) {
       return; // areas not considered now
     }
 
     assert(!backBuffer.empty());
     const RouteDescription::Node &prevNode=*backBuffer.back();
-    DatabaseId dbId = node.GetDatabaseId();
+    DatabaseId dbId = firstJunctionNode.GetDatabaseId();
     if (prevNode.GetDatabaseId() != dbId) {
       return; // we consider nodes just from the same database for simplicity
     }
 
-    auto lanes = GetLaneDescription(node);
+    auto lanes = GetLaneDescription(lastNode);
+    if (!lanes) {
+      lanes = GetLaneDescription(lastJunctionNode);
+    }
     assert(lanes);
     auto prevLanes = GetLaneDescription(prevNode);
     assert(prevLanes);
 
-    // read lanes on the ALL junction ways, use heuristics what lanes we can use to move forward
-    Id nodeId = postprocessor.GetNodeId(node);
+    // Collect node IDs internal to the junction group (to exclude from exits)
+    std::set<Id> internalNodeIds;
+    for (const auto* jNode : junctionNodes) {
+      internalNodeIds.insert(postprocessor.GetNodeId(*jNode));
+    }
+
+    // Collect internal way file offsets (connecting segments between grouped nodes) to exclude.
+    // These are the path objects of all junction nodes except the last — the last node's
+    // pathObject is the outgoing way leaving the junction, not an internal connector.
+    // The incoming way and outgoing way are excluded separately via prevNodeId/nextNodeId checks.
+    std::set<FileOffset> internalWayOffsets;
+    for (size_t idx = 0; idx + 1 < junctionNodes.size(); ++idx) {
+      const auto* jNode = junctionNodes[idx];
+      if (jNode->GetPathObject().Valid() && jNode->GetPathObject().GetType() == refWay) {
+        internalWayOffsets.insert(jNode->GetPathObject().GetFileOffset());
+      }
+    }
 
     WayRef prevWay = postprocessor.GetWay(prevNode.GetDBFileOffset());
     Id prevNodeId = prevWay->GetId(prevNode.GetCurrentNodeIndex());
-    // bearing from current node to previous
+    // bearing from first junction node to previous node
     Bearing prevNodeBearing = GetSphericalBearingInitial(prevWay->nodes[prevNode.GetTargetNodeIndex()].GetCoord(),
                                                          prevWay->nodes[prevNode.GetCurrentNodeIndex()].GetCoord());
 
-    WayRef way = postprocessor.GetWay(node.GetDBFileOffset());
-    Id nextNodeId = way->GetId(node.GetTargetNodeIndex());
-    Bearing nextNodeBearing = GetSphericalBearingInitial(way->nodes[node.GetCurrentNodeIndex()].GetCoord(),
-                                                         way->nodes[node.GetTargetNodeIndex()].GetCoord());
+    // Outgoing way: from the last junction node
+    WayRef outWay;
+    Id nextNodeId;
+    Bearing nextNodeBearing;
+    if (lastJunctionNode.GetPathObject().Valid() && lastJunctionNode.GetPathObject().GetType() == refWay) {
+      outWay = postprocessor.GetWay(lastJunctionNode.GetDBFileOffset());
+      nextNodeId = outWay->GetId(lastJunctionNode.GetTargetNodeIndex());
+      nextNodeBearing = GetSphericalBearingInitial(outWay->nodes[lastJunctionNode.GetCurrentNodeIndex()].GetCoord(),
+                                                    outWay->nodes[lastJunctionNode.GetTargetNodeIndex()].GetCoord());
+    } else {
+      return; // no valid outgoing way
+    }
+
+    // Collect exits from ALL junction nodes
+    size_t totalObjects = 0;
+    for (const auto* jNode : junctionNodes) {
+      totalObjects += jNode->GetObjects().size();
+    }
 
     std::vector<JunctionExit> junctionExits; // excluding incoming and outgoing way
     std::vector<JunctionExit> junctionLeftExits;
     std::vector<JunctionExit> junctionRightExits;
-    junctionExits.reserve(node.GetObjects().size());
-    junctionLeftExits.reserve(node.GetObjects().size());
-    junctionRightExits.reserve(node.GetObjects().size());
+    junctionExits.reserve(totalObjects);
+    junctionLeftExits.reserve(totalObjects);
+    junctionRightExits.reserve(totalObjects);
 
-    for (const auto &o: node.GetObjects()){
-      if (!o.IsWay()) {
-        continue; // areas not considered now
-      }
+    // Track exit node IDs we've already added to avoid duplicates from overlapping object lists
+    std::set<Id> addedExitNodeIds;
 
-      way=postprocessor.GetWay(DBFileOffset(node.GetDatabaseId(), o.GetFileOffset()));
-      for (size_t i = 0; i < way->nodes.size(); i++) {
-        if (way->nodes[i].GetId() == nodeId) {
-          if (i < way->nodes.size()-1 && postprocessor.CanUseForward(dbId, nodeId, o)) {
-            Id junctionNodeId = way->nodes[i+1].GetId();
-            if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId) {
-              auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i + 1].GetCoord());
-              auto wayLanes = postprocessor.GetLanes(node.GetDatabaseId(), way, true);
-              junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+    for (const auto* jNode : junctionNodes) {
+      Id jNodeId = postprocessor.GetNodeId(*jNode);
+
+      for (const auto &o: jNode->GetObjects()) {
+        if (!o.IsWay()) {
+          continue; // areas not considered now
+        }
+
+        // Skip internal junction connector ways
+        if (internalWayOffsets.count(o.GetFileOffset()) > 0) {
+          continue;
+        }
+
+        WayRef way = postprocessor.GetWay(DBFileOffset(dbId, o.GetFileOffset()));
+        for (size_t i = 0; i < way->nodes.size(); i++) {
+          if (way->nodes[i].GetId() == jNodeId) {
+            if (i < way->nodes.size()-1 && postprocessor.CanUseForward(dbId, jNodeId, o)) {
+              Id junctionNodeId = way->nodes[i+1].GetId();
+              if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId
+                  && internalNodeIds.count(junctionNodeId) == 0
+                  && addedExitNodeIds.count(junctionNodeId) == 0) {
+                auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i + 1].GetCoord());
+                auto wayLanes = postprocessor.GetLanes(dbId, way, true);
+                junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+                addedExitNodeIds.insert(junctionNodeId);
+              }
             }
-          }
-          if (i > 0 && postprocessor.CanUseBackward(dbId, nodeId, o)) {
-            Id junctionNodeId = way->nodes[i-1].GetId();
-            if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId) {
-              auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i - 1].GetCoord());
-              auto wayLanes = postprocessor.GetLanes(node.GetDatabaseId(), way, false);
-              junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+            if (i > 0 && postprocessor.CanUseBackward(dbId, jNodeId, o)) {
+              Id junctionNodeId = way->nodes[i-1].GetId();
+              if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId
+                  && internalNodeIds.count(junctionNodeId) == 0
+                  && addedExitNodeIds.count(junctionNodeId) == 0) {
+                auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i - 1].GetCoord());
+                auto wayLanes = postprocessor.GetLanes(dbId, way, false);
+                junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+                addedExitNodeIds.insert(junctionNodeId);
+              }
             }
+            break;
           }
-          break;
         }
       }
+    }
+
+    // Filter exits whose bearing is too close to the incoming direction (opposite carriageway / U-turn).
+    // An exit within ~30° of prevNodeBearing is going back toward where we came from.
+    if (junctionNodes.size() > 1) {
+      junctionExits.erase(
+        std::remove_if(junctionExits.begin(), junctionExits.end(),
+          [&prevNodeBearing](const JunctionExit &exit) {
+            Bearing diff = exit.bearing - prevNodeBearing;
+            // diff near 0° means exit goes same direction as "junction→prev", i.e., back where we came from
+            return diff < Bearing::Degrees(30) || diff > Bearing::Degrees(330);
+          }),
+        junctionExits.end());
     }
 
     Bearing prevNodeRelativeToNextBearing = prevNodeBearing - nextNodeBearing;
@@ -2032,7 +2101,14 @@ namespace osmscout {
   bool RoutePostprocessor::SuggestedLanesPostprocessor::Process(const PostprocessorContext& postprocessor,
                                                                 RouteDescription& description)
   {
-    using namespace std::string_view_literals;
+    // Helper to get a node's geographic coordinate from its path way object
+    auto getNodeCoord = [&postprocessor](const RouteDescription::Node &n) -> GeoCoord {
+      if (n.GetPathObject().Valid() && n.GetPathObject().GetType() == refWay) {
+        WayRef w = postprocessor.GetWay(n.GetDBFileOffset());
+        return w->nodes[n.GetCurrentNodeIndex()].GetCoord();
+      }
+      return n.GetLocation();
+    };
 
     // buffer of traveled nodes, recent node at back
     std::list<RouteDescription::Node*> backBuffer;
@@ -2055,9 +2131,58 @@ namespace osmscout {
         if (prevLanes->GetLaneCount() > lanes->GetLaneCount() // lane count was decreased
             || prevLanes->GetLaneTurns() != lanes->GetLaneTurns()) { // lane turns changed
 
-          EvaluateLaneSuggestion(postprocessor, node, backBuffer);
+          // Group junction nodes: scan backwards through backBuffer for preceding junction nodes
+          // that are close together and have the same lane config. This handles complex intersections
+          // modeled as multiple OSM nodes connected by short internal segments.
+          std::vector<const RouteDescription::Node*> junctionNodes;
+          junctionNodes.push_back(&node);
+
+          size_t backwardCount = 0;
+          for (auto bufIt = backBuffer.rbegin(); bufIt != backBuffer.rend(); ++bufIt) {
+            // Keep at least one node in backBuffer as the prevNode for evaluation
+            if (backwardCount + 1 >= backBuffer.size()) {
+              break;
+            }
+
+            const RouteDescription::Node* candidate = *bufIt;
+
+            // Must be a real junction (multiple ways crossing)
+            if (candidate->GetObjects().size() <= 1) {
+              break;
+            }
+            // Must be close to the most recently grouped junction node
+            Distance dist = GetSphericalDistance(getNodeCoord(*candidate),
+                                                getNodeCoord(*junctionNodes.back()));
+            if (dist > Meters(50)) {
+              break;
+            }
+            // The segment from this node should have the same lane config as the approach
+            auto candidateLanes = GetLaneDescription(*candidate);
+            if (!candidateLanes ||
+                candidateLanes->GetLaneCount() != prevLanes->GetLaneCount() ||
+                candidateLanes->GetLaneTurns() != prevLanes->GetLaneTurns()) {
+              break;
+            }
+
+            junctionNodes.push_back(candidate);
+            backwardCount++;
+          }
+
+          // Reverse so junctionNodes is in route order (earliest first)
+          std::reverse(junctionNodes.begin(), junctionNodes.end());
+
+          // Remove backward-grouped nodes from backBuffer
+          for (size_t i = 0; i < backwardCount && !backBuffer.empty(); ++i) {
+            backBuffer.pop_back();
+          }
+
+          if (!backBuffer.empty()) {
+            EvaluateLaneSuggestion(postprocessor, junctionNodes, node, backBuffer);
+          }
 
           backBuffer.clear();
+          backBuffer.push_back(&node);
+          continue;
         }
       }
 

--- a/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
+++ b/libosmscout/src/osmscout/routing/RoutePostprocessor.cpp
@@ -29,8 +29,9 @@
 #include <algorithm>
 #include <cassert>
 #include <iostream>
-#include <string_view>
 #include <numeric>
+#include <set>
+#include <string_view>
 
 namespace osmscout {
 
@@ -1759,8 +1760,8 @@ namespace osmscout {
             turn == LaneTurn::Through_SlightLeft ||
             turn == LaneTurn::Through_SharpLeft) {
           // do not consume lane when it allows to use with two directions, just remove left direction
-          laneTurns[allowedLaneTo] = LaneTurn::Through;
-          continue;
+          laneTurns[allowedLaneFrom] = LaneTurn::Through;
+          break;
         }
         if ((laneCntMatch || exitVariant == turn) && allowedLaneFrom < allowedLaneTo) {
           allowedLaneFrom++;
@@ -1795,7 +1796,7 @@ namespace osmscout {
           turn==LaneTurn::Through_SharpRight) {
         // do not consume lane when it allows to use with two directions, just remove right direction
         laneTurns[allowedLaneTo]=LaneTurn::Through;
-        continue;
+        break;
       }
       if ((laneCntMatch || exitVariant==turn) && allowedLaneFrom < allowedLaneTo) {
         allowedLaneTo--;
@@ -1851,73 +1852,133 @@ namespace osmscout {
   } // end of anonymous namespace
 
   void RoutePostprocessor::SuggestedLanesPostprocessor::EvaluateLaneSuggestion(const PostprocessorContext& postprocessor,
-                                                                               const RouteDescription::Node &node,
+                                                                               const std::vector<RouteDescription::Node*> &junctionNodes,
+                                                                               const RouteDescription::Node &lastNode,
                                                                                const std::list<RouteDescription::Node*> &backBuffer) const
   {
-    if (node.GetPathObject().GetType()!=refWay) {
+    assert(!junctionNodes.empty());
+    const RouteDescription::Node &firstJunctionNode = *junctionNodes.front();
+    const RouteDescription::Node &lastJunctionNode = *junctionNodes.back();
+
+    if (firstJunctionNode.GetPathObject().GetType()!=refWay) {
       return; // areas not considered now
     }
 
     assert(!backBuffer.empty());
     const RouteDescription::Node &prevNode=*backBuffer.back();
-    DatabaseId dbId = node.GetDatabaseId();
+    DatabaseId dbId = firstJunctionNode.GetDatabaseId();
     if (prevNode.GetDatabaseId() != dbId) {
       return; // we consider nodes just from the same database for simplicity
     }
 
-    auto lanes = GetLaneDescription(node);
+    auto lanes = GetLaneDescription(lastNode);
+    if (!lanes) {
+      lanes = GetLaneDescription(lastJunctionNode);
+    }
     assert(lanes);
-    auto prevLanes = GetLaneDescription(prevNode);
+    // When backward grouping pulled approach nodes out of backBuffer, use their lane
+    // config (from firstJunctionNode) instead of the now-exposed backBuffer.back().
+    // The grouped nodes were verified to have the approach config during grouping.
+    RouteDescription::LaneDescriptionRef prevLanes;
+    if (junctionNodes.size() > 1) {
+      prevLanes = GetLaneDescription(firstJunctionNode);
+    }
+    if (!prevLanes) {
+      prevLanes = GetLaneDescription(prevNode);
+    }
     assert(prevLanes);
 
-    // read lanes on the ALL junction ways, use heuristics what lanes we can use to move forward
-    Id nodeId = postprocessor.GetNodeId(node);
+    // Collect node IDs internal to the junction group (to exclude from exits)
+    std::set<Id> internalNodeIds;
+    for (const auto* jNode : junctionNodes) {
+      internalNodeIds.insert(postprocessor.GetNodeId(*jNode));
+    }
 
     WayRef prevWay = postprocessor.GetWay(prevNode.GetDBFileOffset());
     Id prevNodeId = prevWay->GetId(prevNode.GetCurrentNodeIndex());
-    // bearing from current node to previous
+    // bearing from first junction node to previous node
     Bearing prevNodeBearing = GetSphericalBearingInitial(prevWay->nodes[prevNode.GetTargetNodeIndex()].GetCoord(),
                                                          prevWay->nodes[prevNode.GetCurrentNodeIndex()].GetCoord());
 
-    WayRef way = postprocessor.GetWay(node.GetDBFileOffset());
-    Id nextNodeId = way->GetId(node.GetTargetNodeIndex());
-    Bearing nextNodeBearing = GetSphericalBearingInitial(way->nodes[node.GetCurrentNodeIndex()].GetCoord(),
-                                                         way->nodes[node.GetTargetNodeIndex()].GetCoord());
+    // Outgoing way: from the last junction node
+    WayRef outWay;
+    Id nextNodeId;
+    Bearing nextNodeBearing;
+    if (lastJunctionNode.GetPathObject().Valid() && lastJunctionNode.GetPathObject().GetType() == refWay) {
+      outWay = postprocessor.GetWay(lastJunctionNode.GetDBFileOffset());
+      nextNodeId = outWay->GetId(lastJunctionNode.GetTargetNodeIndex());
+      nextNodeBearing = GetSphericalBearingInitial(outWay->nodes[lastJunctionNode.GetCurrentNodeIndex()].GetCoord(),
+                                                    outWay->nodes[lastJunctionNode.GetTargetNodeIndex()].GetCoord());
+    } else {
+      return; // no valid outgoing way
+    }
+
+    // Collect exits from ALL junction nodes
+    size_t totalObjects = 0;
+    for (const auto* jNode : junctionNodes) {
+      totalObjects += jNode->GetObjects().size();
+    }
 
     std::vector<JunctionExit> junctionExits; // excluding incoming and outgoing way
     std::vector<JunctionExit> junctionLeftExits;
     std::vector<JunctionExit> junctionRightExits;
-    junctionExits.reserve(node.GetObjects().size());
-    junctionLeftExits.reserve(node.GetObjects().size());
-    junctionRightExits.reserve(node.GetObjects().size());
+    junctionExits.reserve(totalObjects);
+    junctionLeftExits.reserve(totalObjects);
+    junctionRightExits.reserve(totalObjects);
 
-    for (const auto &o: node.GetObjects()){
-      if (!o.IsWay()) {
-        continue; // areas not considered now
-      }
+    // Track exit node IDs we've already added to avoid duplicates from overlapping object lists
+    std::set<Id> addedExitNodeIds;
 
-      way=postprocessor.GetWay(DBFileOffset(node.GetDatabaseId(), o.GetFileOffset()));
-      for (size_t i = 0; i < way->nodes.size(); i++) {
-        if (way->nodes[i].GetId() == nodeId) {
-          if (i < way->nodes.size()-1 && postprocessor.CanUseForward(dbId, nodeId, o)) {
-            Id junctionNodeId = way->nodes[i+1].GetId();
-            if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId) {
-              auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i + 1].GetCoord());
-              auto wayLanes = postprocessor.GetLanes(node.GetDatabaseId(), way, true);
-              junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+    for (const auto* jNode : junctionNodes) {
+      Id jNodeId = postprocessor.GetNodeId(*jNode);
+
+      for (const auto &o: jNode->GetObjects()) {
+        if (!o.IsWay()) {
+          continue; // areas not considered now
+        }
+
+        WayRef way = postprocessor.GetWay(DBFileOffset(dbId, o.GetFileOffset()));
+        for (size_t i = 0; i < way->nodes.size(); i++) {
+          if (way->nodes[i].GetId() == jNodeId) {
+            if (i < way->nodes.size()-1 && postprocessor.CanUseForward(dbId, jNodeId, o)) {
+              Id junctionNodeId = way->nodes[i+1].GetId();
+              if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId
+                  && internalNodeIds.count(junctionNodeId) == 0
+                  && addedExitNodeIds.count(junctionNodeId) == 0) {
+                auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i + 1].GetCoord());
+                auto wayLanes = postprocessor.GetLanes(dbId, way, true);
+                junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+                addedExitNodeIds.insert(junctionNodeId);
+              }
             }
-          }
-          if (i > 0 && postprocessor.CanUseBackward(dbId, nodeId, o)) {
-            Id junctionNodeId = way->nodes[i-1].GetId();
-            if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId) {
-              auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i - 1].GetCoord());
-              auto wayLanes = postprocessor.GetLanes(node.GetDatabaseId(), way, false);
-              junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+            if (i > 0 && postprocessor.CanUseBackward(dbId, jNodeId, o)) {
+              Id junctionNodeId = way->nodes[i-1].GetId();
+              if (junctionNodeId!=prevNodeId && junctionNodeId!=nextNodeId
+                  && internalNodeIds.count(junctionNodeId) == 0
+                  && addedExitNodeIds.count(junctionNodeId) == 0) {
+                auto bearing = GetSphericalBearingInitial(way->nodes[i].GetCoord(), way->nodes[i - 1].GetCoord());
+                auto wayLanes = postprocessor.GetLanes(dbId, way, false);
+                junctionExits.push_back({junctionNodeId, bearing, Bearing(), wayLanes});
+                addedExitNodeIds.insert(junctionNodeId);
+              }
             }
+            break;
           }
-          break;
         }
       }
+    }
+
+    // Filter exits whose bearing is too close to the incoming direction (opposite carriageway / U-turn).
+    // An exit within ~30° of prevNodeBearing is going back toward where we came from.
+    if (junctionNodes.size() > 1) {
+      junctionExits.erase(
+        std::remove_if(junctionExits.begin(), junctionExits.end(),
+          [&prevNodeBearing](const JunctionExit &exit) {
+            Bearing diff = exit.bearing - prevNodeBearing;
+            // diff near 0° means exit goes same direction as "junction→prev", i.e., back where we came from
+            return diff < Bearing::Degrees(30) || diff > Bearing::Degrees(330);
+          }),
+        junctionExits.end());
     }
 
     Bearing prevNodeRelativeToNextBearing = prevNodeBearing - nextNodeBearing;
@@ -1947,6 +2008,7 @@ namespace osmscout {
     while (prevLanes->GetLaneCount() > laneTurns.size()) {
       laneTurns.push_back(LaneTurn::None);
     }
+    std::vector<LaneTurn> originalLaneTurns = laneTurns;
 
     // when number of outgoing lanes match to incoming one, we may decide easily what lane belong to what exit...
     bool laneCntMatch = laneTurns.size() ==
@@ -1980,6 +2042,66 @@ namespace osmscout {
     // setup suggested lane description to incoming route segment
     assert(allowedLaneTo >= allowedLaneFrom);
 
+    Bearing relativeBearing = nextNodeBearing - (prevNodeBearing + Bearing::Radians(M_PI)); // relative to straight direction
+
+    // For turn-change triggers (same lane count, different turns), refine the suggestion
+    // using lane turn annotations. This handles cases like [left, through, through;right]
+    // changing to [left, through, through] where exits may over-consume compound lanes
+    // and leave incompatible edge lanes.
+    if (prevLanes->GetLaneCount() == lanes->GetLaneCount()) {
+      constexpr uint32_t throughBit = 0b00001000;
+      constexpr uint32_t leftBits   = 0b00000111;
+      constexpr uint32_t rightBits  = 0b01110000;
+
+      // Restore consumed compound lanes (through+right / through+left).
+      // These serve multiple directions and shouldn't be fully consumed.
+      while (allowedLaneTo < int(originalLaneTurns.size()) - 1) {
+        uint32_t origBits = TurnToBits(originalLaneTurns[allowedLaneTo + 1]);
+        if ((origBits & throughBit) && (origBits & (leftBits | rightBits))) {
+          allowedLaneTo++;
+        } else {
+          break;
+        }
+      }
+      while (allowedLaneFrom > 0) {
+        uint32_t origBits = TurnToBits(originalLaneTurns[allowedLaneFrom - 1]);
+        if ((origBits & throughBit) && (origBits & (leftBits | rightBits))) {
+          allowedLaneFrom--;
+        } else {
+          break;
+        }
+      }
+
+      // Narrow edges whose turn is incompatible with the route direction.
+      // For through routes, only narrow from the left — slight road curves
+      // can make through lanes appear as slight_right in annotations.
+      bool routeIsRight = relativeBearing > Bearing::Degrees(40) && relativeBearing < Bearing::Degrees(180);
+      bool routeIsLeft  = relativeBearing > Bearing::Degrees(180) && relativeBearing < Bearing::Degrees(320);
+
+      uint32_t routeDirectionBits = throughBit;
+      if (routeIsRight) { routeDirectionBits = rightBits; }
+      else if (routeIsLeft) { routeDirectionBits = leftBits; }
+
+      while (allowedLaneFrom < allowedLaneTo && allowedLaneFrom < int(originalLaneTurns.size())) {
+        uint32_t turnBits = TurnToBits(originalLaneTurns[allowedLaneFrom]);
+        if (turnBits != 0 && (turnBits & routeDirectionBits) == 0) {
+          allowedLaneFrom++;
+        } else {
+          break;
+        }
+      }
+      if (routeIsLeft || routeIsRight) {
+        while (allowedLaneTo > allowedLaneFrom && allowedLaneTo < int(originalLaneTurns.size())) {
+          uint32_t turnBits = TurnToBits(originalLaneTurns[allowedLaneTo]);
+          if (turnBits != 0 && (turnBits & routeDirectionBits) == 0) {
+            allowedLaneTo--;
+          } else {
+            break;
+          }
+        }
+      }
+    }
+
     // detect what all allowed turns have common
     // keep in mind that laneTurns may have removed directions used by exits, it is benefitial here
     uint32_t suggestedTurnBits;
@@ -1995,8 +2117,6 @@ namespace osmscout {
         suggestedTurnBits &= TurnToBits(LaneTurn::Unknown);
       }
     }
-    // evaluate suggested direction from lane turns
-    Bearing relativeBearing = nextNodeBearing - (prevNodeBearing + Bearing::Radians(M_PI)); // relative to straight direction
     LaneTurn suggestedTurn = BitsToTurn(suggestedTurnBits);
     if (suggestedTurn == LaneTurn::Through_SlightRight || suggestedTurn == LaneTurn::Through_Right || suggestedTurn == LaneTurn::Through_SharpRight) {
       if (relativeBearing > Bearing::Degrees(30) && relativeBearing < Bearing::Degrees(180)) {
@@ -2022,6 +2142,15 @@ namespace osmscout {
       }
       nodePtr->AddDescription(suggested);
     }
+    // Also write suggestion to grouped junction nodes that have the same lane config
+    // as the approach. These nodes were removed from backBuffer during grouping but
+    // still represent approach segments that need the suggestion.
+    for (auto* jNode : junctionNodes) {
+      auto nodeLanes = GetLaneDescription(*jNode);
+      if (nodeLanes && *prevLanes == *nodeLanes) {
+        jNode->AddDescription(suggested);
+      }
+    }
   }
 
   RouteDescription::LaneDescriptionRef RoutePostprocessor::SuggestedLanesPostprocessor::GetLaneDescription(const RouteDescription::Node &node) const
@@ -2032,8 +2161,6 @@ namespace osmscout {
   bool RoutePostprocessor::SuggestedLanesPostprocessor::Process(const PostprocessorContext& postprocessor,
                                                                 RouteDescription& description)
   {
-    using namespace std::string_view_literals;
-
     // buffer of traveled nodes, recent node at back
     std::list<RouteDescription::Node*> backBuffer;
     for (auto& node : description.Nodes()) {
@@ -2055,9 +2182,58 @@ namespace osmscout {
         if (prevLanes->GetLaneCount() > lanes->GetLaneCount() // lane count was decreased
             || prevLanes->GetLaneTurns() != lanes->GetLaneTurns()) { // lane turns changed
 
-          EvaluateLaneSuggestion(postprocessor, node, backBuffer);
+          // Group junction nodes: scan backwards through backBuffer for preceding junction nodes
+          // that are close together and have the same lane config. This handles complex intersections
+          // modeled as multiple OSM nodes connected by short internal segments.
+          std::vector<RouteDescription::Node*> junctionNodes;
+          junctionNodes.push_back(&node);
+
+          size_t backwardCount = 0;
+          for (auto bufIt = backBuffer.rbegin(); bufIt != backBuffer.rend(); ++bufIt) {
+            // Keep at least one node in backBuffer as the prevNode for evaluation
+            if (backwardCount + 1 >= backBuffer.size()) {
+              break;
+            }
+
+            RouteDescription::Node* candidate = *bufIt;
+
+            // Must be a real junction (multiple ways crossing)
+            if (candidate->GetObjects().size() <= 1) {
+              break;
+            }
+            // Must be close to the trigger node (first junction node)
+            Distance dist = GetSphericalDistance(candidate->GetLocation(),
+                                                junctionNodes.front()->GetLocation());
+            if (dist > Meters(35)) {
+              break;
+            }
+            // The segment from this node should have the same lane config as the approach
+            auto candidateLanes = GetLaneDescription(*candidate);
+            if (!candidateLanes ||
+                candidateLanes->GetLaneCount() != prevLanes->GetLaneCount() ||
+                candidateLanes->GetLaneTurns() != prevLanes->GetLaneTurns()) {
+              break;
+            }
+
+            junctionNodes.push_back(candidate);
+            backwardCount++;
+          }
+
+          // Reverse so junctionNodes is in route order (earliest first)
+          std::reverse(junctionNodes.begin(), junctionNodes.end());
+
+          // Remove backward-grouped nodes from backBuffer
+          for (size_t i = 0; i < backwardCount && !backBuffer.empty(); ++i) {
+            backBuffer.pop_back();
+          }
+
+          if (!backBuffer.empty()) {
+            EvaluateLaneSuggestion(postprocessor, junctionNodes, node, backBuffer);
+          }
 
           backBuffer.clear();
+          backBuffer.push_back(&node);
+          continue;
         }
       }
 


### PR DESCRIPTION
Vibe-coded improvement of "suggested lane" heuristics... I am going to test with real word junctions and carefully review it first. 

---

Complex OSM intersections are modeled as multiple nodes connected by short internal segments that maintain the same lane configuration. The lane suggestion algorithm previously processed each node independently, seeing only a subset of exits and producing wrong lane recommendations.

Scan backwards through the route buffer to detect consecutive junction nodes that are close together (<50m) and share the same lane config, then aggregate their exits into a single evaluation. Filter exits pointing back toward the incoming direction to suppress opposite carriageway false positives in grouped junctions.

Fixes the Průmyslová/Černokostecká test case.