### PR TITLE
StyleEditor: make text area cursor visible

### DIFF
--- a/StyleEditor/qml_515/TextEditor.qml
+++ b/StyleEditor/qml_515/TextEditor.qml
@@ -201,6 +201,31 @@ Item {
                     color: "white"
                 }
 
+                // custom blinking cursor
+                cursorDelegate: Rectangle {
+                    id: cursor
+                    visible: textArea.cursorVisible
+                    color: textArea.color
+                    width: units.dp(2)
+
+                    SequentialAnimation {
+                        loops: Animation.Infinite
+                        running: true
+                        PropertyAction {
+                            target: cursor
+                            property: 'opacity'
+                            value: 1.0
+                        }
+                        PauseAnimation { duration: 500 }
+                        PropertyAction {
+                            target: cursor
+                            property: 'opacity'
+                            value: 0.0
+                        }
+                        PauseAnimation { duration: 500 }
+                    }
+                }
+
                 // fickable height ratio is not accurate
                 property int visibleLineCount: (pageArea.height / textArea.height)  * textArea.lineCount
                 property real rowHeight: textArea.height / textArea.lineCount

--- a/StyleEditor/qml_640/TextEditor.qml
+++ b/StyleEditor/qml_640/TextEditor.qml
@@ -201,6 +201,31 @@ Item {
                     color: "white"
                 }
 
+                // custom blinking cursor
+                cursorDelegate: Rectangle {
+                    id: cursor
+                    visible: textArea.cursorVisible
+                    color: textArea.color
+                    width: units.dp(2)
+
+                    SequentialAnimation {
+                        loops: Animation.Infinite
+                        running: true
+                        PropertyAction {
+                            target: cursor
+                            property: 'opacity'
+                            value: 1.0
+                        }
+                        PauseAnimation { duration: 500 }
+                        PropertyAction {
+                            target: cursor
+                            property: 'opacity'
+                            value: 0.0
+                        }
+                        PauseAnimation { duration: 500 }
+                    }
+                }
+
                 // fickable height ratio is not accurate
                 property int visibleLineCount: (pageArea.height / textArea.height)  * textArea.lineCount
                 property real rowHeight: textArea.height / textArea.lineCount


### PR DESCRIPTION
Build a blinking cursor with double pitch and fix the visibility.

The cursor could be not visible on the left side of the area. This fixes the issue by using a delegate. 