### PR TITLE
StyleEditor: fix visible binding after scrolling

### DIFF
--- a/StyleEditor/qml_515/TextEditor.qml
+++ b/StyleEditor/qml_515/TextEditor.qml
@@ -208,6 +208,18 @@ Item {
                     color: textArea.color
                     width: units.dp(2)
 
+                    // scrolling area will break the binding
+                    // so rebind the property and force redraw
+                    Connections {
+                        target: textArea
+                        onCursorPositionChanged: {
+                            visible = textArea.cursorVisible
+                        }
+                        onActiveFocusChanged: {
+                            visible = textArea.cursorVisible
+                        }
+                    }
+
                     SequentialAnimation {
                         loops: Animation.Infinite
                         running: true

--- a/StyleEditor/qml_640/TextEditor.qml
+++ b/StyleEditor/qml_640/TextEditor.qml
@@ -208,6 +208,18 @@ Item {
                     color: textArea.color
                     width: units.dp(2)
 
+                    // scrolling area will break the binding
+                    // so rebind the property and force redraw
+                    Connections {
+                        target: textArea
+                        onCursorPositionChanged: {
+                            visible = textArea.cursorVisible
+                        }
+                        onActiveFocusChanged: {
+                            visible = textArea.cursorVisible
+                        }
+                    }
+
                     SequentialAnimation {
                         loops: Animation.Infinite
                         running: true


### PR DESCRIPTION
An other workaround for TextArea to fix the binding of the cursor visibility after scrolling the area. The goal is to rebind the property when the cursor position is changed, i.e when clicking new position on scrolled area.