### PR TITLE
give precedence to labels from ordinary map databases

### DIFF
--- a/Demos/include/DrawMap.h
+++ b/Demos/include/DrawMap.h
@@ -372,6 +372,7 @@ public:
       assert(styleConfig);
 
       dbData.styleConfig = styleConfig;
+      dbData.basemap = database->IsBasemap();
 
       mapService->LookupTiles(projection,tiles);
       mapService->LoadMissingTileData(searchParameter,*styleConfig,tiles);

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -349,6 +349,7 @@ void DBRenderJob::Run(const DBInstanceRef& basemapDatabase,
 
     MapData data;
     data.styleConfig=db->GetStyleConfig();
+    data.basemap=db->GetDatabase()->IsBasemap();
     db->GetMapService()->AddTileDataToMapData(tileList, data);
 
     if (last) {

--- a/libosmscout-map-agg/include/osmscoutmapagg/MapPainterAgg.h
+++ b/libosmscout-map-agg/include/osmscoutmapagg/MapPainterAgg.h
@@ -173,6 +173,7 @@ namespace osmscout {
      */
     virtual void RegisterRegularLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const std::vector<LabelData> &labels,
                                       const Vertex2D &position,
@@ -183,6 +184,7 @@ namespace osmscout {
      */
     virtual void RegisterContourLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const PathLabelData &label,
                                       const LabelPath &labelPath) override;

--- a/libosmscout-map-agg/src/osmscoutmapagg/MapPainterAgg.cpp
+++ b/libosmscout-map-agg/src/osmscoutmapagg/MapPainterAgg.cpp
@@ -406,6 +406,7 @@ namespace osmscout {
 
   void MapPainterAgg::RegisterRegularLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const std::vector<LabelData> &labels,
                                            const Vertex2D &position,
@@ -413,6 +414,7 @@ namespace osmscout {
   {
     labelLayouter.RegisterLabel(projection,
                                 parameter,
+                                basemap,
                                 ref,
                                 position,
                                 labels,
@@ -424,12 +426,14 @@ namespace osmscout {
    */
   void MapPainterAgg::RegisterContourLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const PathLabelData &label,
                                            const LabelPath &labelPath)
   {
     labelLayouter.RegisterContourLabel(projection,
                                        parameter,
+                                       basemap,
                                        ref,
                                        label,
                                        labelPath);

--- a/libosmscout-map-cairo/include/osmscoutmapcairo/MapPainterCairo.h
+++ b/libosmscout-map-cairo/include/osmscoutmapcairo/MapPainterCairo.h
@@ -160,6 +160,7 @@ namespace osmscout {
      */
     void RegisterRegularLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const std::vector<LabelData>& labels,
                               const Vertex2D& position,
@@ -170,6 +171,7 @@ namespace osmscout {
      */
     void RegisterContourLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const PathLabelData& label,
                               const LabelPath& labelPath) override;

--- a/libosmscout-map-cairo/src/osmscoutmapcairo/MapPainterCairo.cpp
+++ b/libosmscout-map-cairo/src/osmscoutmapcairo/MapPainterCairo.cpp
@@ -1100,6 +1100,7 @@ namespace osmscout {
 
   void MapPainterCairo::RegisterRegularLabel(const Projection &projection,
                                              const MapParameter &parameter,
+                                             bool basemap,
                                              const ObjectFileRef& ref,
                                              const std::vector<LabelData> &labels,
                                              const Vertex2D &position,
@@ -1107,6 +1108,7 @@ namespace osmscout {
   {
     labelLayouter.RegisterLabel(projection,
                                 parameter,
+                                basemap,
                                 ref,
                                 position,
                                 labels,
@@ -1118,12 +1120,14 @@ namespace osmscout {
    */
   void MapPainterCairo::RegisterContourLabel(const Projection &projection,
                                              const MapParameter &parameter,
+                                             bool basemap,
                                              const ObjectFileRef& ref,
                                              const PathLabelData &label,
                                              const LabelPath &labelPath)
   {
     labelLayouter.RegisterContourLabel(projection,
                                        parameter,
+                                       basemap,
                                        ref,
                                        label,
                                        labelPath);

--- a/libosmscout-map-directx/include/osmscoutmapdirectx/MapPainterDirectX.h
+++ b/libosmscout-map-directx/include/osmscoutmapdirectx/MapPainterDirectX.h
@@ -163,6 +163,7 @@ namespace osmscout {
 	*/
   void RegisterRegularLabel(const Projection &projection,
                             const MapParameter &parameter,
+                            bool basemap,
                             const ObjectFileRef& ref,
                             const std::vector<LabelData> &labels,
                             const Vertex2D &position,
@@ -173,6 +174,7 @@ namespace osmscout {
 	*/
   void RegisterContourLabel(const Projection &projection,
                             const MapParameter &parameter,
+                            bool basemap,
                             const ObjectFileRef& ref,
                             const PathLabelData &label,
                             const LabelPath &labelPath) override;

--- a/libosmscout-map-directx/src/osmscoutmapdirectx/MapPainterDirectX.cpp
+++ b/libosmscout-map-directx/src/osmscoutmapdirectx/MapPainterDirectX.cpp
@@ -675,12 +675,13 @@ namespace osmscout
 
   void MapPainterDirectX::RegisterRegularLabel(const Projection &projection,
 	  const MapParameter &parameter,
-      const ObjectFileRef& ref,
+	  bool basemap,
+    const ObjectFileRef& ref,
 	  const std::vector<LabelData> &labels,
 	  const Vertex2D &position,
 	  double objectWidth)
   {
-    m_LabelLayouter.RegisterLabel(projection, parameter, ref, position, labels, objectWidth);
+    m_LabelLayouter.RegisterLabel(projection, parameter, basemap, ref, position, labels, objectWidth);
   }
 
   /**
@@ -688,11 +689,12 @@ namespace osmscout
   */
   void MapPainterDirectX::RegisterContourLabel(const Projection &projection,
 	  const MapParameter &parameter,
-      const ObjectFileRef& ref,
+	  bool basemap,
+    const ObjectFileRef& ref,
 	  const PathLabelData &label,
 	  const LabelPath &labelPath)
   {
-    m_LabelLayouter.RegisterContourLabel(projection, parameter, ref, label, labelPath);
+    m_LabelLayouter.RegisterContourLabel(projection, parameter, basemap, ref, label, labelPath);
   }
 
   void MapPainterDirectX::DrawLabels(const Projection& projection,

--- a/libosmscout-map-gdi/include/osmscoutmapgdi/MapPainterGDI.h
+++ b/libosmscout-map-gdi/include/osmscoutmapgdi/MapPainterGDI.h
@@ -108,6 +108,7 @@ namespace osmscout {
      */
     void RegisterRegularLabel(const Projection &projection,
                               const MapParameter &parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const std::vector<LabelData> &labels,
                               const Vertex2D &position,
@@ -118,6 +119,7 @@ namespace osmscout {
      */
     void RegisterContourLabel(const Projection &projection,
                               const MapParameter &parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const PathLabelData &label,
                               const LabelPath &labelPath) override;

--- a/libosmscout-map-gdi/src/osmscoutmapgdi/MapPainterGDI.cpp
+++ b/libosmscout-map-gdi/src/osmscoutmapgdi/MapPainterGDI.cpp
@@ -609,19 +609,21 @@ namespace osmscout {
 
   void MapPainterGDI::RegisterRegularLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const std::vector<LabelData> &labels,
                                            const Vertex2D &position,
                                            double objectWidth) {
-    m_labelLayouter.RegisterLabel(projection, parameter, ref, position, labels, objectWidth);
+    m_labelLayouter.RegisterLabel(projection, parameter, basemap, ref, position, labels, objectWidth);
   }
 
   void MapPainterGDI::RegisterContourLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const PathLabelData &label,
                                            const LabelPath &labelPath) {
-    m_labelLayouter.RegisterContourLabel(projection, parameter, ref, label, labelPath);
+    m_labelLayouter.RegisterContourLabel(projection, parameter, basemap, ref, label, labelPath);
   }
 
   void MapPainterGDI::DrawLabels(const Projection &projection,

--- a/libosmscout-map-iosx/include/osmscoutmapiosx/MapPainterIOS.h
+++ b/libosmscout-map-iosx/include/osmscoutmapiosx/MapPainterIOS.h
@@ -223,6 +223,7 @@ namespace osmscout {
 
         virtual void RegisterRegularLabel(const Projection &projection,
                                           const MapParameter &parameter,
+                                          bool basemap,
                                           const ObjectFileRef& ref,
                                           const std::vector<LabelData> &labels,
                                           const Vertex2D &position,
@@ -230,6 +231,7 @@ namespace osmscout {
 
         virtual void RegisterContourLabel(const Projection &projection,
                                           const MapParameter &parameter,
+                                          bool basemap,
                                           const ObjectFileRef& ref,
                                           const PathLabelData &label,
                                           const LabelPath &labelPath) override;

--- a/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
+++ b/libosmscout-map-iosx/src/osmscout/MapPainterIOS.mm
@@ -560,19 +560,21 @@ namespace osmscout {
 
     void MapPainterIOS::RegisterRegularLabel(const Projection &projection,
                                              const MapParameter &parameter,
+                                             bool basemap,
                                              const ObjectFileRef& ref,
                                              const std::vector<LabelData> &labels,
                                              const Vertex2D &position,
                                              double objectWidth){
-        labelLayouter.RegisterLabel(projection, parameter, ref, position, labels, objectWidth);
+        labelLayouter.RegisterLabel(projection, parameter, basemap, ref, position, labels, objectWidth);
     }
 
     void MapPainterIOS::RegisterContourLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const PathLabelData &label,
                                       const LabelPath &labelPath){
-        labelLayouter.RegisterContourLabel(projection, parameter, ref, label, labelPath);
+        labelLayouter.RegisterContourLabel(projection, parameter, basemap, ref, label, labelPath);
     }
 
     void MapPainterIOS::DrawLabels(const Projection& projection,

--- a/libosmscout-map-qt/include/osmscoutmapqt/MapPainterQt.h
+++ b/libosmscout-map-qt/include/osmscoutmapqt/MapPainterQt.h
@@ -78,13 +78,6 @@ namespace osmscout {
 
     QtLabelLayouter            labelLayouter;
 
-    /**
-     * non-owning pointer to layouter
-     * when it is not null, all labels are registered to it
-     * and DrawLabels method is no-op
-     */
-    QtLabelLayouter            *delegateLabelLayouter{nullptr};
-
     std::map<std::string,QImage,std::less<>> images;        //! map of QImage for icons, key is name of the icon
                                                 //! - it should be independent on the specific style configuration
     std::vector<QImage>          patternImages; //! vector of QImage for fill patterns, index is patter id
@@ -183,6 +176,7 @@ namespace osmscout {
      */
     void RegisterRegularLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const std::vector<LabelData>& labels,
                               const Vertex2D& position,
@@ -193,6 +187,7 @@ namespace osmscout {
      */
     void RegisterContourLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const PathLabelData& label,
                               const LabelPath& labelPath) override;

--- a/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
+++ b/libosmscout-map-qt/src/osmscoutmapqt/MapPainterQt.cpp
@@ -853,14 +853,6 @@ namespace osmscout {
     labelLayouter.SetLayoutOverlap(projection.ConvertWidthToPixel(parameter.GetLabelLayouterOverlap()));
   }
 
-  MapPainterQt::QtLabelLayouter& MapPainterQt::GetLayouter()
-  {
-    if (delegateLabelLayouter){
-      return *delegateLabelLayouter;
-    }
-    return labelLayouter;
-  }
-
   void MapPainterQt::DrawRectangle(int x, int y,
                                    int width, int height,
                                    const Color &color)
@@ -876,13 +868,15 @@ namespace osmscout {
 
   void MapPainterQt::RegisterRegularLabel(const Projection &projection,
                                           const MapParameter &parameter,
+                                          bool basemap,
                                           const ObjectFileRef& ref,
                                           const std::vector<LabelData> &labels,
                                           const Vertex2D &position,
                                           double objectWidth)
   {
-    GetLayouter().RegisterLabel(projection,
+    labelLayouter.RegisterLabel(projection,
                                 parameter,
+                                basemap,
                                 ref,
                                 position,
                                 labels,
@@ -891,12 +885,14 @@ namespace osmscout {
 
   void MapPainterQt::RegisterContourLabel(const Projection &projection,
                                           const MapParameter &parameter,
+                                          bool basemap,
                                           const ObjectFileRef& ref,
                                           const PathLabelData &label,
                                           const LabelPath &labelPath)
   {
-    GetLayouter().RegisterContourLabel(projection,
+    labelLayouter.RegisterContourLabel(projection,
                                        parameter,
+                                       basemap,
                                        ref,
                                        label,
                                        labelPath);
@@ -906,10 +902,6 @@ namespace osmscout {
                                 const MapParameter& parameter,
                                 const std::vector<MapData>& /*data*/)
   {
-    if (delegateLabelLayouter !=nullptr){
-      return;
-    }
-
     labelLayouter.Layout(projection, parameter);
 
     labelLayouter.DrawLabels(projection,

--- a/libosmscout-map-svg/include/osmscoutmapsvg/MapPainterSVG.h
+++ b/libosmscout-map-svg/include/osmscoutmapsvg/MapPainterSVG.h
@@ -171,6 +171,7 @@ namespace osmscout {
      */
     virtual void RegisterRegularLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const std::vector<LabelData> &labels,
                                       const Vertex2D &position,
@@ -181,6 +182,7 @@ namespace osmscout {
      */
     virtual void RegisterContourLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const PathLabelData &label,
                                       const LabelPath &labelPath) override;

--- a/libosmscout-map-svg/src/osmscoutmapsvg/MapPainterSVG.cpp
+++ b/libosmscout-map-svg/src/osmscoutmapsvg/MapPainterSVG.cpp
@@ -716,6 +716,7 @@ namespace osmscout {
 
   void MapPainterSVG::RegisterRegularLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const std::vector<LabelData> &labels,
                                            const Vertex2D &position,
@@ -723,6 +724,7 @@ namespace osmscout {
   {
     labelLayouter.RegisterLabel(projection,
                                 parameter,
+                                basemap,
                                 ref,
                                 position,
                                 labels,
@@ -734,12 +736,14 @@ namespace osmscout {
    */
   void MapPainterSVG::RegisterContourLabel(const Projection &projection,
                                            const MapParameter &parameter,
+                                           bool basemap,
                                            const ObjectFileRef& ref,
                                            const PathLabelData &label,
                                            const LabelPath &labelPath)
   {
     labelLayouter.RegisterContourLabel(projection,
                                        parameter,
+                                       basemap,
                                        ref,
                                        label,
                                        labelPath);

--- a/libosmscout-map/include/osmscoutmap/LabelLayouter.h
+++ b/libosmscout-map/include/osmscoutmap/LabelLayouter.h
@@ -45,7 +45,7 @@ constexpr bool debugLabelLayouter = false;
   class PathLabelData
   {
   public:
-    size_t            priority{0}; //!< Priority of the entry
+    size_t            priority{0}; //!< Priority of the entry (from stylesheet)
     std::string       text;        //!< The label text (type==Text|PathText)
     double            height;
     PathTextStyleRef  style;
@@ -64,7 +64,7 @@ constexpr bool debugLabelLayouter = false;
     };
   public:
     Type              type{Type::Text};
-    size_t            priority{0}; //!< Priority of the entry
+    size_t            priority{0}; //!< Priority of the entry (from stylesheet)
     size_t            position{0}; //!< Relative position of the label
 
     double            alpha{1.0};   //!< Alpha value of the label; 0.0 = fully transparent, 1.0 = solid
@@ -142,6 +142,48 @@ constexpr bool debugLabelLayouter = false;
     std::vector<Glyph<NativeGlyph>> ToGlyphs() const;
   };
 
+  struct LabelPriority
+  {
+    /** LabelPriority is used to determine the order of labels and to decide which label to show when there is a collision.
+     *
+     * - `priority` is defined by the stylesheet
+     * - `basemap` flag is here to give precedence to labels from ordinary map databases before world overview (basemap)
+     * - `ref` is used for providing stable output for two labels with the same priority (and basemap flag)
+     */
+    size_t                priority{std::numeric_limits<size_t>::max()}; //!< Priority from the stylesheet
+    bool                  basemap{false}; //!< true when label is for object from basemap database
+    ObjectFileRef         ref;
+
+    LabelPriority() = default;
+
+    LabelPriority(size_t priority, bool basemap, const ObjectFileRef& ref):
+      priority(priority), basemap(basemap), ref(ref)
+    {}
+
+    bool operator<(const LabelPriority& other) const
+    {
+      return std::tie(priority, basemap, ref) < std::tie(other.priority, other.basemap, other.ref);
+    }
+
+    bool operator<=(const LabelPriority& other) const
+    {
+      return std::tie(priority, basemap, ref) <= std::tie(other.priority, other.basemap, other.ref);
+    }
+
+    bool operator!=(const LabelPriority& other) const
+    {
+      return std::tie(priority, basemap, ref) != std::tie(other.priority, other.basemap, other.ref);
+    }
+
+    friend std::ostream& operator<<(std::ostream& stream, const LabelPriority &prio);
+  };
+
+  inline std::ostream& operator<<(std::ostream& stream, const LabelPriority &prio)
+  {
+    stream << "LabelPriority(" << prio.priority << ", " << prio.basemap << ", " << prio.ref.GetName() << ")";
+    return stream;
+  }
+
   template<class NativeGlyph, class NativeLabel>
   class LabelInstance
   {
@@ -156,9 +198,8 @@ constexpr bool debugLabelLayouter = false;
     };
 
   public:
-    ObjectFileRef         ref;
-    size_t                priority{std::numeric_limits<size_t>::max()}; //!< Priority of the entry (minimum of priority label elements)
-    // TODO: move priority from label to element
+    LabelPriority priority; //!< Priority of the entry (minimum of priority label elements)
+
     std::vector<Element>  elements;
   };
 
@@ -167,25 +208,20 @@ constexpr bool debugLabelLayouter = false;
   {
   public:
 #ifdef OSMSCOUT_DEBUG_LABEL_LAYOUTER
-    std::string                     text;     //!< The original label (if debug))
-    double                          offset;   //!< The offset of the label in relation the the way start (if debug))
+    std::string                     text;     //!< The original label (if debug)
+    double                          offset;   //!< The offset of the label in relation the way start (if debug)
     Vertex2D                        start;    //!< Screen coordinates of the start of the path
 #endif
-    ObjectFileRef                   ref;
-    size_t                          priority; //!< Priority of the label
+    LabelPriority                   priority; //!< Priority of the label
     std::vector<Glyph<NativeGlyph>> glyphs;   //!< Vector of glyphs of the label text (see text)
-    osmscout::PathTextStyleRef      style;    //!< Style for drawing the text of the label
+    PathTextStyleRef                style;    //!< Style for drawing the text of the label
   };
 
   template <class NativeGlyph, class NativeLabel>
   static bool LabelInstanceSorter(const LabelInstance<NativeGlyph, NativeLabel> &a,
                                   const LabelInstance<NativeGlyph, NativeLabel> &b)
   {
-    if (a.priority != b.priority) {
-      return a.priority < b.priority;
-    }
-
-    return a.ref < b.ref;
+    return a.priority < b.priority;
   }
 
   template <class NativeGlyph>
@@ -195,10 +231,6 @@ constexpr bool debugLabelLayouter = false;
 
     if (a.priority != b.priority) {
       return a.priority < b.priority;
-    }
-
-    if (a.ref != b.ref) {
-      return a.ref < b.ref;
     }
 
     return a.glyphs[0].trPosition.GetX() < b.glyphs[0].trPosition.GetX();
@@ -430,7 +462,7 @@ constexpr bool debugLabelLayouter = false;
         }
 
         if (!visibleElements.empty()) {
-          LabelInstanceType instanceCopy{currentLabel.ref,currentLabel.priority, visibleElements};
+          LabelInstanceType instanceCopy{currentLabel.priority, visibleElements};
           labelInstances.push_back(instanceCopy);
 
           // mark all labels at once (elements of single label may have no padding)
@@ -658,7 +690,9 @@ constexpr bool debugLabelLayouter = false;
       element.labelData=data;
 
       if (data.type==LabelData::Type::Icon || data.type==LabelData::Type::Symbol){
-        instance.priority = std::min(data.priority, instance.priority);
+        instance.priority = std::min(
+          LabelPriority(data.priority, instance.priority.basemap, instance.priority.ref),
+          instance.priority);
         element.x = point.GetX() - data.iconWidth / 2;
         if (offset<0){
           element.y = point.GetY() - data.iconHeight / 2;
@@ -670,7 +704,9 @@ constexpr bool debugLabelLayouter = false;
         }
       }
       else {
-        instance.priority = std::min(data.priority, instance.priority);
+        instance.priority = std::min(
+          LabelPriority(data.priority, instance.priority.basemap, instance.priority.ref),
+          instance.priority);
         // TODO: should we take style into account?
         // Qt allows to split text layout and style setup
         element.label = textLayouter->Layout(projection, parameter,
@@ -694,6 +730,7 @@ constexpr bool debugLabelLayouter = false;
 
     void RegisterLabel(const Projection& projection,
                        const MapParameter& parameter,
+                       bool basemap,
                        const ObjectFileRef& ref,
                        const Vertex2D& point,
                        const LabelData& data,
@@ -702,6 +739,7 @@ constexpr bool debugLabelLayouter = false;
       LabelInstanceType instance;
 
       instance.ref=ref;
+      instance.basemap=basemap;
 
       double offset=-1;
       ProcessLabel(projection,
@@ -717,6 +755,7 @@ constexpr bool debugLabelLayouter = false;
 
     void RegisterLabel(const Projection& projection,
                        const MapParameter& parameter,
+                       bool basemap,
                        const ObjectFileRef& ref,
                        const Vertex2D& point,
                        const std::vector<LabelData>& data,
@@ -724,7 +763,7 @@ constexpr bool debugLabelLayouter = false;
     {
       LabelInstanceType instance;
 
-      instance.ref=ref;
+      instance.priority=LabelPriority(std::numeric_limits<size_t>::max(), basemap, ref);
 
       double offset=-1;
       for (const auto& d : data) {
@@ -742,6 +781,7 @@ constexpr bool debugLabelLayouter = false;
 
     void RegisterContourLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const PathLabelData &labelData,
                               const LabelPath &labelPath)
@@ -784,8 +824,7 @@ constexpr bool debugLabelLayouter = false;
 
         ContourLabelType cLabel;
 
-        cLabel.ref = ref;
-        cLabel.priority = labelData.priority;
+        cLabel.priority = LabelPriority(labelData.priority, basemap, ref);
         cLabel.style = labelData.style;
 
         if constexpr (debugLabelLayouter) {

--- a/libosmscout-map/include/osmscoutmap/MapData.h
+++ b/libosmscout-map/include/osmscoutmap/MapData.h
@@ -48,6 +48,7 @@ namespace osmscout {
   {
   public:
     StyleConfigRef        styleConfig;  //!< Style configuration for rendering (specific for database)
+    bool                  basemap{false};
 
     std::vector<NodeRef>  nodes;        //!< Nodes as retrieved from db
     std::vector<AreaRef>  areas;        //!< Areas as retrieved from db

--- a/libosmscout-map/include/osmscoutmap/MapPainter.h
+++ b/libosmscout-map/include/osmscoutmap/MapPainter.h
@@ -111,6 +111,7 @@ namespace osmscout {
       const TypeConfig             *typeConfigPtr;     //!< pointer to type config, used just for cache purposes, not owned
 
       StyleConfigRef               styleConfig;
+      bool                         basemap{false};
 
       /**
        * Attribute readers
@@ -128,7 +129,9 @@ namespace osmscout {
       //@}
 
     public:
-      explicit DatabaseCacheEntry(const TypeConfig &typeConfig, const StyleConfigRef &styleConfig);
+      explicit DatabaseCacheEntry(const TypeConfig &typeConfig,
+                                  const StyleConfigRef &styleConfig,
+                                  bool basemap);
     };
 
     /**
@@ -303,6 +306,7 @@ namespace osmscout {
     void PrepareNode(const StyleConfig& styleConfig,
                      const Projection& projection,
                      const MapParameter& parameter,
+                     bool basemap,
                      const NodeRef& node);
 
     void PrepareNodes(size_t dbIndex,
@@ -366,6 +370,7 @@ namespace osmscout {
     void LayoutPointLabels(const StyleConfig& styleConfig,
                            const Projection& projection,
                            const MapParameter& parameter,
+                           bool basemap,
                            const ObjectFileRef& ref,
                            const FeatureValueBuffer& buffer,
                            const IconStyleRef& iconStyle,
@@ -601,6 +606,7 @@ namespace osmscout {
      */
     virtual void RegisterRegularLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const std::vector<LabelData> &labels,
                                       const Vertex2D &position,
@@ -611,6 +617,7 @@ namespace osmscout {
      */
     virtual void RegisterContourLabel(const Projection &projection,
                                       const MapParameter &parameter,
+                                      bool basemap,
                                       const ObjectFileRef& ref,
                                       const PathLabelData &label,
                                       const LabelPath &labelPath) = 0;

--- a/libosmscout-map/include/osmscoutmap/MapPainterNoOp.h
+++ b/libosmscout-map/include/osmscoutmap/MapPainterNoOp.h
@@ -50,6 +50,7 @@ namespace osmscout {
 
     void RegisterRegularLabel(const Projection& projection,
                               const MapParameter& parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const std::vector<LabelData> &labels,
                               const Vertex2D& position,
@@ -57,6 +58,7 @@ namespace osmscout {
 
     void RegisterContourLabel(const Projection &projection,
                               const MapParameter &parameter,
+                              bool basemap,
                               const ObjectFileRef& ref,
                               const PathLabelData &label,
                               const LabelPath &labelPath) override;

--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -152,9 +152,12 @@ constexpr bool debugGroundTiles = false;
     return a.position<b.position;
   }
 
-  MapPainter::DatabaseCacheEntry::DatabaseCacheEntry(const TypeConfig &typeConfig, const StyleConfigRef &styleConfig):
+  MapPainter::DatabaseCacheEntry::DatabaseCacheEntry(const TypeConfig &typeConfig,
+                                                     const StyleConfigRef &styleConfig,
+                                                     bool basemap):
     typeConfigPtr(&typeConfig),
     styleConfig(styleConfig),
+    basemap(basemap),
     nameReader(typeConfig),
     nameAltReader(typeConfig),
     refReader(typeConfig),
@@ -339,6 +342,7 @@ constexpr bool debugGroundTiles = false;
 
       RegisterRegularLabel(projection,
                            parameter,
+                           false,
                            ObjectFileRef(),
                            labelData,
                            pixel,
@@ -367,6 +371,7 @@ constexpr bool debugGroundTiles = false;
   void MapPainter::LayoutPointLabels(const StyleConfig& styleConfig,
                                      const Projection& projection,
                                      const MapParameter& parameter,
+                                     bool basemap,
                                      const ObjectFileRef& ref,
                                      const FeatureValueBuffer& buffer,
                                      const IconStyleRef& iconStyle,
@@ -472,6 +477,7 @@ constexpr bool debugGroundTiles = false;
 
     RegisterRegularLabel(projection,
                          parameter,
+                         basemap,
                          ref,
                          labelLayoutData,
                          screenPos,
@@ -513,10 +519,13 @@ constexpr bool debugGroundTiles = false;
   {
     assert(dbIndex<databaseCache.size());
     const auto &styleConfig=*databaseCache[dbIndex].styleConfig;
+    bool basemap=databaseCache[dbIndex].basemap;
+
     for (const auto& node : data.nodes) {
       PrepareNode(styleConfig,
                   projection,
                   parameter,
+                  basemap,
                   node);
     }
 
@@ -524,6 +533,7 @@ constexpr bool debugGroundTiles = false;
       PrepareNode(styleConfig,
                   projection,
                   parameter,
+                  basemap,
                   node);
     }
   }
@@ -534,6 +544,7 @@ constexpr bool debugGroundTiles = false;
   {
     assert(areaData.dbIndex<databaseCache.size());
     const auto &styleConfig=*databaseCache[areaData.dbIndex].styleConfig;
+    bool basemap=databaseCache[areaData.dbIndex].basemap;
     IconStyleRef iconStyle=styleConfig.GetAreaIconStyle(areaData.type,
                                                         *areaData.buffer,
                                                         projection);
@@ -565,6 +576,7 @@ constexpr bool debugGroundTiles = false;
     LayoutPointLabels(styleConfig,
                       projection,
                       parameter,
+                      basemap,
                       areaData.ref,
                       *areaData.buffer,
                       iconStyle,
@@ -579,6 +591,7 @@ constexpr bool debugGroundTiles = false;
   {
     assert(areaData.dbIndex<databaseCache.size());
     const auto &styleConfig=*databaseCache[areaData.dbIndex].styleConfig;
+    bool basemap=databaseCache[areaData.dbIndex].basemap;
     PathTextStyleRef borderTextStyle=styleConfig.GetAreaBorderTextStyle(areaData.type,
                                                                         *areaData.buffer,
                                                                         projection);
@@ -627,6 +640,7 @@ constexpr bool debugGroundTiles = false;
 
     RegisterContourLabel(projection,
                          parameter,
+                         basemap,
                          areaData.ref,
                          labelData,
                          labelPath);
@@ -683,6 +697,7 @@ constexpr bool debugGroundTiles = false;
   void MapPainter::PrepareNode(const StyleConfig& styleConfig,
                                const Projection& projection,
                                const MapParameter& parameter,
+                               bool basemap,
                                const NodeRef& node)
   {
     IconStyleRef iconStyle=styleConfig.GetNodeIconStyle(node->GetFeatureValueBuffer(),
@@ -700,6 +715,7 @@ constexpr bool debugGroundTiles = false;
     LayoutPointLabels(styleConfig,
                       projection,
                       parameter,
+                      basemap,
                       node->GetObjectFileRef(),
                       node->GetFeatureValueBuffer(),
                       iconStyle,
@@ -924,6 +940,8 @@ constexpr bool debugGroundTiles = false;
                                        const std::string_view &textLabel)
   {
     assert(pathTextStyle);
+    assert(data.dbIndex<databaseCache.size());
+    bool basemap=databaseCache[data.dbIndex].basemap;
 
     double           lineOffset=0.0;
     CoordBufferRange range=data.coordRange;
@@ -960,6 +978,7 @@ constexpr bool debugGroundTiles = false;
 
     RegisterContourLabel(projection,
                          parameter,
+                         basemap,
                          ObjectFileRef(data.ref,RefType::refWay),
                          labelData,
                          labelPath);
@@ -2035,9 +2054,9 @@ constexpr bool debugGroundTiles = false;
       assert(data[i].styleConfig);
       auto typeConfig = data[i].styleConfig->GetTypeConfig();
       if (databaseCache.size() <= i) {
-        databaseCache.emplace_back(DatabaseCacheEntry{*typeConfig, data[i].styleConfig});
+        databaseCache.emplace_back(DatabaseCacheEntry{*typeConfig, data[i].styleConfig, data[i].basemap});
       } else if (databaseCache[i].typeConfigPtr != typeConfig.get()) {
-        databaseCache[i] = DatabaseCacheEntry{*typeConfig, data[i].styleConfig};
+        databaseCache[i] = DatabaseCacheEntry{*typeConfig, data[i].styleConfig, data[i].basemap};
         styleSheetShanged=true;
       } else if (databaseCache[i].styleConfig != data[i].styleConfig){
         styleSheetShanged=true;
@@ -2379,6 +2398,7 @@ constexpr bool debugGroundTiles = false;
         vect.push_back(labelBox);
         RegisterRegularLabel(projection,
                              parameter,
+                             false,
                              ObjectFileRef(),
                              vect,
                              pixel,
@@ -3135,6 +3155,7 @@ constexpr bool debugGroundTiles = false;
               vect.push_back(labelBox);
               RegisterRegularLabel(projection,
                                    parameter,
+                                   false,
                                    ObjectFileRef(),
                                    vect,
                                    screenPos,

--- a/libosmscout-map/src/osmscoutmap/MapPainterNoOp.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainterNoOp.cpp
@@ -49,6 +49,7 @@ namespace osmscout {
 
   void MapPainterNoOp::RegisterRegularLabel(const Projection& /*projection*/,
                                             const MapParameter& /*parameter*/,
+                                            bool /*basemap*/,
                                             const ObjectFileRef& /*ref*/,
                                             const std::vector<LabelData> &/*labels*/,
                                             const Vertex2D& /*position*/,
@@ -60,6 +61,7 @@ namespace osmscout {
 
   void MapPainterNoOp::RegisterContourLabel(const Projection & /*projection*/,
                                             const MapParameter & /*parameter*/,
+                                            bool /*basemap*/,
                                             const ObjectFileRef& /*ref*/,
                                             const PathLabelData & /*label*/,
                                             const LabelPath & /*labelPath*/)


### PR DESCRIPTION
before world overview (basemap). As basemap database suppose to be distributed as application resource
without regular updates, it may become obsolete.
Another issue is that basemap database may prefer
English names by default, despite local names in ordinary databases.

For these reasons, it make sense to precedence labels fro ordinary database when they have the same priority (like citi name label).