### PR TITLE
lookup parent admin region while building location index

### DIFF
--- a/libosmscout-import/include/osmscoutimport/GenLocationIndex.h
+++ b/libosmscout-import/include/osmscoutimport/GenLocationIndex.h
@@ -297,6 +297,26 @@ namespace osmscout {
 
     ImportErrorReporterRef errorReporter;
 
+    struct AddressData
+    {
+      ObjectFileRef object;
+      GeoCoord coord;
+      std::string name;
+      std::string location;
+      std::string address;
+      std::string postalCode;
+    };
+
+    struct AreaAddressData: public AddressData
+    {
+      std::vector<Point> nodes;
+      GeoBox boundingBox;
+    };
+
+    struct NodeAddressData: public AddressData
+    {
+    };
+
   private:
     void Write(FileWriter& writer,
                const ObjectFileRef& object) const;
@@ -377,26 +397,34 @@ namespace osmscout {
                                  const std::string& postalCode,
                                  const locidx::RegionIndex& regionIndex);
 
+    void AddGenericAddressToRegion(Progress& progress,
+                                   locidx::Region& region,
+                                   const AddressData &address,
+                                   bool allowDuplicates,
+                                   bool& added,
+                                   bool& locationResolved);
+
     void AddAddressToRegion(Progress& progress,
                             locidx::Region& region,
-                            const ObjectFileRef& object,
-                            const std::string& location,
-                            const std::string& address,
-                            const std::string &postalCode,
+                            const NodeAddressData& nodeAddress,
                             bool allowDuplicates,
                             bool& added,
                             bool& locationResolved);
 
-    void AddAddressAreaToRegion(Progress& progress,
-                                locidx::Region& region,
-                                const FileOffset& fileOffset,
-                                const std::string& location,
-                                const std::string& address,
-                                const std::string &postalCode,
-                                const std::vector<Point>& nodes,
-                                const GeoBox& boundingBox,
-                                bool& added,
-                                bool& locationResolved);
+    void AddAddressToRegion(Progress& progress,
+                            locidx::Region& region,
+                            const AreaAddressData& areaAddress,
+                            bool allowDuplicates,
+                            bool& added,
+                            bool& locationResolved);
+
+    template <class Address>
+    void AddAddressToRegion(Progress& progress,
+                            const locidx::RegionIndex& regionIndex,
+                            const locidx::RegionRef& rootRegion,
+                            const Address& address,
+                            bool allowDuplicates,
+                            bool& added);
 
     bool IndexAddressAreas(const TypeConfig& typeConfig,
                            const ImportParameter& parameter,
@@ -432,17 +460,10 @@ namespace osmscout {
      * @return a valid iterator to the location else locations.end()
      */
     std::map<std::string,locidx::RegionLocation>::iterator FindLocation(Progress& progress,
-                                                                const locidx::Region& region,
-                                                                locidx::PostalArea& postalArea,
-                                                                const std::string &locationName) const;
+                                                                        const locidx::Region& region,
+                                                                        locidx::PostalArea& postalArea,
+                                                                        const std::string &locationName) const;
 
-    void AddAddressNodeToRegion(Progress& progress,
-                                locidx::Region& region,
-                                const FileOffset& fileOffset,
-                                const std::string& location,
-                                const std::string& address,
-                                const std::string& postalCode,
-                                bool& added);
 
     bool IndexAddressNodes(const TypeConfig& typeConfig,
                            const ImportParameter& parameter,

--- a/libosmscout-import/include/osmscoutimport/GenLocationIndex.h
+++ b/libosmscout-import/include/osmscoutimport/GenLocationIndex.h
@@ -276,6 +276,9 @@ namespace osmscout {
 
       RegionRef GetRegionForNode(const RegionRef& rootRegion,
                                  const GeoCoord& coord) const;
+
+      std::vector<RegionRef> GetRegionsForNode(const RegionRef& rootRegion,
+                                               const GeoCoord& coord) const;
     };
 
   }
@@ -381,7 +384,8 @@ namespace osmscout {
                             const std::string& address,
                             const std::string &postalCode,
                             bool allowDuplicates,
-                            bool& added);
+                            bool& added,
+                            bool& locationResolved);
 
     void AddAddressAreaToRegion(Progress& progress,
                                 locidx::Region& region,
@@ -391,7 +395,8 @@ namespace osmscout {
                                 const std::string &postalCode,
                                 const std::vector<Point>& nodes,
                                 const GeoBox& boundingBox,
-                                bool& added);
+                                bool& added,
+                                bool& locationResolved);
 
     bool IndexAddressAreas(const TypeConfig& typeConfig,
                            const ImportParameter& parameter,

--- a/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
@@ -675,6 +675,34 @@ namespace osmscout {
       return rootRegion;
     }
 
+    std::vector<RegionRef> RegionIndex::GetRegionsForNode(const RegionRef& rootRegion,
+                                                          const GeoCoord& coord) const
+    {
+      std::vector<RegionRef> result;
+
+      uint32_t minX=(uint32_t)((coord.GetLon()+180.0)/cellWidth);
+      uint32_t minY=(uint32_t)((coord.GetLat()+90.0)/cellHeight);
+
+      const auto indexCell=index.find(Pixel(minX,minY));
+
+      if (indexCell!=index.end()) {
+        for (const auto& region : indexCell->second) {
+          for (const auto& area : region->areas) {
+            if (IsCoordInArea(coord,area)) {
+              result.push_back(region);
+              break;
+            }
+          }
+        }
+      }
+
+      if (result.empty()) {
+        result.push_back(rootRegion);
+      }
+
+      return result;
+    }
+
     std::string RegionLocation::GetName() const
     {
       std::string name;
@@ -1719,7 +1747,8 @@ namespace osmscout {
                                                   const std::string& address,
                                                   const std::string &postalCode,
                                                   bool allowDuplicates,
-                                                  bool& added)
+                                                  bool& added,
+                                                  bool& locationResolved)
   {
     std::map<std::string,locidx::RegionLocation>::iterator loc;
     auto                                           postalAreaEntry=region.postalAreas.end();
@@ -1760,10 +1789,11 @@ namespace osmscout {
     }
 
     if (!locFound) {
-      errorReporter->ReportLocationDebug(object,
-                                         std::string("Street '")+location +"' of address '"+address+"' cannot be resolved in region '"+region.name+"'");
+      locationResolved=false;
       return;
     }
+
+    locationResolved=true;
 
     // If there is a non-default postal area but the location is in the default postal area => make a copy
     if (foundInDefaultArea &&
@@ -1803,7 +1833,8 @@ namespace osmscout {
                                                       const std::string &postalCode,
                                                       const std::vector<Point>& nodes,
                                                       const GeoBox& boundingBox,
-                                                      bool& added)
+                                                      bool& added,
+                                                      bool& locationResolved)
   {
     for (const auto& childRegion : region.regions) {
       // Fast check, if the object is in the bounds of the area
@@ -1818,7 +1849,8 @@ namespace osmscout {
                                    postalCode,
                                    nodes,
                                    boundingBox,
-                                   added);
+                                   added,
+                                   locationResolved);
             return;
           }
         }
@@ -1832,7 +1864,8 @@ namespace osmscout {
                        address,
                        postalCode,
                        false,
-                       added);
+                       added,
+                       locationResolved);
   }
 
   bool LocationIndexGenerator::IndexAddressAreas(const TypeConfig& typeConfig,
@@ -1896,21 +1929,36 @@ namespace osmscout {
           continue;
         }
 
-        locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                              boundingBox.GetCenter());
-
         if (isAddress) {
           bool added=false;
+          bool locationResolved=false;
 
-          AddAddressAreaToRegion(progress,
-                                 *region,
-                                 fileOffset,
-                                 location,
-                                 address,
-                                 postalCode,
-                                 nodes,
-                                 boundingBox,
-                                 added);
+          std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
+                                                                               boundingBox.GetCenter());
+          for (const auto& region : regions) {
+            if (region->level>=0 && region->level<6) {
+              break;
+            }
+            AddAddressAreaToRegion(progress,
+                                   *region,
+                                   fileOffset,
+                                   location,
+                                   address,
+                                   postalCode,
+                                   nodes,
+                                   boundingBox,
+                                   added,
+                                   locationResolved);
+            if (locationResolved) {
+              break;
+            }
+          }
+
+          if (!locationResolved) {
+            assert(!regions.empty());
+            errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refArea),
+                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+regions.front()->name+"'");
+          }
 
           if (added) {
             addressFound++;
@@ -1920,6 +1968,8 @@ namespace osmscout {
         if (isPOI) {
           bool added=false;
 
+          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
+                                                                boundingBox.GetCenter());
           region->AddPOIArea(fileOffset,
                              name,
                              nodes,
@@ -1982,6 +2032,7 @@ namespace osmscout {
       }
     }
 
+    bool locationResolved=false;
     AddAddressToRegion(progress,
                        region,
                        ObjectFileRef(fileOffset,refWay),
@@ -1989,7 +2040,8 @@ namespace osmscout {
                        address,
                        "",
                        false,
-                       added);
+                       added,
+                       locationResolved);
 
     for (const auto& area : region.areas) {
       if (IsAreaCompletelyInArea(nodes,area)) {
@@ -2150,6 +2202,7 @@ namespace osmscout {
                                                       const std::string &postalCode,
                                                       bool& added)
   {
+    bool locationResolved=false;
     AddAddressToRegion(progress,
                        region,
                        ObjectFileRef(fileOffset,refNode),
@@ -2157,7 +2210,8 @@ namespace osmscout {
                        address,
                        postalCode,
                        true,
-                       added);
+                       added,
+                       locationResolved);
   }
 
   bool LocationIndexGenerator::IndexAddressNodes(const TypeConfig& typeConfig,
@@ -2219,23 +2273,36 @@ namespace osmscout {
           continue;
         }
 
-        locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                              coord);
-
-        if (!region) {
-          continue;
-        }
-
         if (isAddress) {
           bool added=false;
+          bool locationResolved=false;
 
-          AddAddressNodeToRegion(progress,
-                                 *region,
-                                 fileOffset,
-                                 location,
-                                 address,
-                                 postalCode,
-                                 added);
+          std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
+                                                                               coord);
+          for (const auto& region : regions) {
+            if (region->level>=0 && region->level<6) {
+              break;
+            }
+            AddAddressToRegion(progress,
+                               *region,
+                               ObjectFileRef(fileOffset,refNode),
+                               location,
+                               address,
+                               postalCode,
+                               true,
+                               added,
+                               locationResolved);
+            if (locationResolved) {
+              break;
+            }
+          }
+
+          if (!locationResolved) {
+            assert(!regions.empty());
+            errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refNode),
+                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+regions.front()->name+"'");
+          }
+
           if (added) {
             addressFound++;
           }
@@ -2244,9 +2311,13 @@ namespace osmscout {
         if (isPOI) {
           bool added=false;
 
-          region->AddPOINode(fileOffset,
-                             name,
-                             added);
+          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
+                                                                coord);
+          if (region) {
+            region->AddPOINode(fileOffset,
+                               name,
+                               added);
+          }
           if (added) {
             poiFound++;
           }

--- a/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
@@ -1933,31 +1933,48 @@ namespace osmscout {
           bool added=false;
           bool locationResolved=false;
 
-          std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
-                                                                               boundingBox.GetCenter());
-          for (const auto& region : regions) {
-            if (region->level>=0 && region->level<6) {
-              break;
-            }
-            AddAddressAreaToRegion(progress,
-                                   *region,
-                                   fileOffset,
-                                   location,
-                                   address,
-                                   postalCode,
-                                   nodes,
-                                   boundingBox,
-                                   added,
-                                   locationResolved);
-            if (locationResolved) {
-              break;
+          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
+                                                                boundingBox.GetCenter());
+          AddAddressAreaToRegion(progress,
+                                 *region,
+                                 fileOffset,
+                                 location,
+                                 address,
+                                 postalCode,
+                                 nodes,
+                                 boundingBox,
+                                 added,
+                                 locationResolved);
+
+          if (!locationResolved) {
+            std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
+                                                                                 boundingBox.GetCenter());
+            for (const auto& parentRegion : regions) {
+              if (parentRegion==region) {
+                continue;
+              }
+              if (parentRegion->level>=0 && parentRegion->level<6) {
+                break;
+              }
+              AddAddressAreaToRegion(progress,
+                                     *parentRegion,
+                                     fileOffset,
+                                     location,
+                                     address,
+                                     postalCode,
+                                     nodes,
+                                     boundingBox,
+                                     added,
+                                     locationResolved);
+              if (locationResolved) {
+                break;
+              }
             }
           }
 
           if (!locationResolved) {
-            assert(!regions.empty());
             errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refArea),
-                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+regions.front()->name+"'");
+                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+region->name+"'");
           }
 
           if (added) {
@@ -2277,30 +2294,46 @@ namespace osmscout {
           bool added=false;
           bool locationResolved=false;
 
-          std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
-                                                                               coord);
-          for (const auto& region : regions) {
-            if (region->level>=0 && region->level<6) {
-              break;
-            }
-            AddAddressToRegion(progress,
-                               *region,
-                               ObjectFileRef(fileOffset,refNode),
-                               location,
-                               address,
-                               postalCode,
-                               true,
-                               added,
-                               locationResolved);
-            if (locationResolved) {
-              break;
+          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
+                                                                coord);
+          AddAddressToRegion(progress,
+                             *region,
+                             ObjectFileRef(fileOffset,refNode),
+                             location,
+                             address,
+                             postalCode,
+                             true,
+                             added,
+                             locationResolved);
+
+          if (!locationResolved) {
+            std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
+                                                                                 coord);
+            for (const auto& parentRegion : regions) {
+              if (parentRegion==region) {
+                continue;
+              }
+              if (parentRegion->level>=0 && parentRegion->level<6) {
+                break;
+              }
+              AddAddressToRegion(progress,
+                                 *parentRegion,
+                                 ObjectFileRef(fileOffset,refNode),
+                                 location,
+                                 address,
+                                 postalCode,
+                                 true,
+                                 added,
+                                 locationResolved);
+              if (locationResolved) {
+                break;
+              }
             }
           }
 
           if (!locationResolved) {
-            assert(!regions.empty());
             errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refNode),
-                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+regions.front()->name+"'");
+                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+region->name+"'");
           }
 
           if (added) {

--- a/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
+++ b/libosmscout-import/src/osmscoutimport/GenLocationIndex.cpp
@@ -1740,15 +1740,12 @@ namespace osmscout {
     }
   }
 
-  void LocationIndexGenerator::AddAddressToRegion(Progress& progress,
-                                                  locidx::Region& region,
-                                                  const ObjectFileRef& object,
-                                                  const std::string& location,
-                                                  const std::string& address,
-                                                  const std::string &postalCode,
-                                                  bool allowDuplicates,
-                                                  bool& added,
-                                                  bool& locationResolved)
+  void LocationIndexGenerator::AddGenericAddressToRegion(Progress& progress,
+                                                         locidx::Region& region,
+                                                         const AddressData &address,
+                                                         bool allowDuplicates,
+                                                         bool& added,
+                                                         bool& locationResolved)
   {
     std::map<std::string,locidx::RegionLocation>::iterator loc;
     auto                                           postalAreaEntry=region.postalAreas.end();
@@ -1757,14 +1754,14 @@ namespace osmscout {
 
 
     // Is postal code available: Search for the postal area for the given postal code
-    if (!postalCode.empty()) {
-      postalAreaEntry=region.postalAreas.find(postalCode);
+    if (!address.postalCode.empty()) {
+      postalAreaEntry=region.postalAreas.find(address.postalCode);
 
       // If the postal areas does not exist yet, create one
       if (postalAreaEntry==region.postalAreas.end()) {
-        locidx::PostalArea postalArea(postalCode);
+        locidx::PostalArea postalArea(address.postalCode);
 
-        postalAreaEntry=region.postalAreas.emplace(postalCode,postalArea).first;
+        postalAreaEntry=region.postalAreas.emplace(address.postalCode,postalArea).first;
       }
     }
 
@@ -1773,7 +1770,7 @@ namespace osmscout {
       loc=FindLocation(progress,
                        region,
                        postalAreaEntry->second,
-                       location);
+                       address.location);
 
       locFound=loc!=postalAreaEntry->second.locations.end();
     }
@@ -1783,7 +1780,7 @@ namespace osmscout {
       loc=FindLocation(progress,
                        region,
                        region.defaultPostalArea->second,
-                       location);
+                       address.location);
       locFound=loc!=region.defaultPostalArea->second.locations.end();
       foundInDefaultArea=true;
     }
@@ -1811,61 +1808,112 @@ namespace osmscout {
     if (!allowDuplicates) {
       // Check for duplicates
       for (const auto& regionAddress : loc->second.addresses) {
-        if (regionAddress.name==address) {
+        if (regionAddress.name==address.address) {
           return;
         }
       }
     }
 
-    locidx::RegionAddress regionAddress(address,
-                                        object);
+    locidx::RegionAddress regionAddress(address.address,
+                                        address.object);
 
     loc->second.addresses.push_back(regionAddress);
 
     added=true;
   }
 
-  void LocationIndexGenerator::AddAddressAreaToRegion(Progress& progress,
-                                                      locidx::Region& region,
-                                                      const FileOffset& fileOffset,
-                                                      const std::string& location,
-                                                      const std::string& address,
-                                                      const std::string &postalCode,
-                                                      const std::vector<Point>& nodes,
-                                                      const GeoBox& boundingBox,
-                                                      bool& added,
-                                                      bool& locationResolved)
+  void LocationIndexGenerator::AddAddressToRegion(Progress& progress,
+                                                  locidx::Region& region,
+                                                  const NodeAddressData& nodeAddress,
+                                                  bool allowDuplicates,
+                                                  bool& added,
+                                                  bool& locationResolved)
   {
+    assert(nodeAddress.object.type==refNode);
+    AddGenericAddressToRegion(progress,
+                              region,
+                              nodeAddress,
+                              allowDuplicates,
+                              added,
+                              locationResolved);
+  }
+
+  void LocationIndexGenerator::AddAddressToRegion(Progress& progress,
+                                                  locidx::Region& region,
+                                                  const AreaAddressData& areaAddress,
+                                                  [[maybe_unused]] bool allowDuplicates,
+                                                  bool& added,
+                                                  bool& locationResolved)
+  {
+    assert(areaAddress.object.type==refArea);
     for (const auto& childRegion : region.regions) {
       // Fast check, if the object is in the bounds of the area
-      if (childRegion->CouldContain(boundingBox)) {
+      if (childRegion->CouldContain(areaAddress.boundingBox)) {
         for (const auto& childArea : childRegion->areas) {
-          if (IsAreaCompletelyInArea(nodes,childArea)) {
-            AddAddressAreaToRegion(progress,
-                                   *childRegion,
-                                   fileOffset,
-                                   location,
-                                   address,
-                                   postalCode,
-                                   nodes,
-                                   boundingBox,
-                                   added,
-                                   locationResolved);
+          if (IsAreaCompletelyInArea(areaAddress.nodes,childArea)) {
+            AddAddressToRegion(progress,
+                               *childRegion,
+                               areaAddress,
+                               allowDuplicates,
+                               added,
+                               locationResolved);
             return;
           }
         }
       }
     }
 
+    AddGenericAddressToRegion(progress,
+                              region,
+                              areaAddress,
+                              allowDuplicates,
+                              added,
+                              locationResolved);
+  }
+
+  template <typename Address>
+  void LocationIndexGenerator::AddAddressToRegion(Progress& progress,
+                                                  const locidx::RegionIndex& regionIndex,
+                                                  const locidx::RegionRef& rootRegion,
+                                                  const Address &address,
+                                                  bool allowDuplicates,
+                                                  bool& added)
+  {
+    bool locationResolved=false;
+
+    locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion, address.coord);
     AddAddressToRegion(progress,
-                       region,
-                       ObjectFileRef(fileOffset,refArea),
-                       location,
+                       *region,
                        address,
-                       postalCode,
-                       false,
+                       allowDuplicates,
                        added,
                        locationResolved);
+
+    if (!locationResolved) {
+      std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion, address.coord);
+      for (const auto& parentRegion : regions) {
+        if (parentRegion==region) {
+          continue;
+        }
+        if (parentRegion->level>=0 && parentRegion->level<6) {
+          break;
+        }
+        AddAddressToRegion(progress,
+                           *parentRegion,
+                           address,
+                           allowDuplicates,
+                           added,
+                           locationResolved);
+        if (locationResolved) {
+          break;
+        }
+      }
+    }
+
+    if (!locationResolved) {
+      errorReporter->ReportLocationDebug(address.object,
+                                         std::string("Street '")+address.location+"' of address '"+address.address+"' cannot be resolved in region '"+region->name+"'");
+    }
   }
 
   bool LocationIndexGenerator::IndexAddressAreas(const TypeConfig& typeConfig,
@@ -1880,10 +1928,9 @@ namespace osmscout {
       size_t             addressFound=0;
       size_t             poiFound=0;
       size_t             postalCodeFound=0;
-      FileOffset         fileOffset;
       TypeId             typeId;
       TypeInfoRef        type;
-      std::vector<Point> nodes;
+      AreaAddressData    areaAddress;
 
       scanner.Open(AppendFileToDir(parameter.GetDestinationDirectory(),
                                    AreaAreaIndexGenerator::AREAADDRESS_DAT),
@@ -1894,34 +1941,30 @@ namespace osmscout {
 
       for (uint32_t a=1; a<=areaCount; a++) {
         uint32_t           tmpType;
-        std::string        name;
-        std::string        postalCode;
-        std::string        location;
-        std::string        address;
 
         progress.SetProgress(a,areaCount);
 
-        fileOffset=scanner.ReadFileOffset();
+        areaAddress.object=ObjectFileRef(scanner.ReadFileOffset(), refArea);
         tmpType=scanner.ReadUInt32Number();
 
-        name=scanner.ReadString();
-        postalCode=scanner.ReadString();
-        location=scanner.ReadString();
-        address=scanner.ReadString();
+        areaAddress.name=scanner.ReadString();
+        areaAddress.postalCode=scanner.ReadString();
+        areaAddress.location=scanner.ReadString();
+        areaAddress.address=scanner.ReadString();
 
-        GeoBox boundingBox;
         std::vector<SegmentGeoBox> segments;
-        scanner.Read(nodes,segments,boundingBox,false);
+        scanner.Read(areaAddress.nodes,segments,areaAddress.boundingBox,false);
+        areaAddress.coord=areaAddress.boundingBox.GetCenter();
 
         typeId=(TypeId)tmpType;
         type=typeConfig.GetAreaTypeInfo(typeId);
 
-        bool isAddress=!location.empty() &&
-                       !address.empty();
-        bool isPOI=!name.empty() &&
+        bool isAddress=!areaAddress.location.empty() &&
+                       !areaAddress.address.empty();
+        bool isPOI=!areaAddress.name.empty() &&
                    type->GetIndexAsPOI();
 
-        if (!postalCode.empty()) {
+        if (!areaAddress.postalCode.empty()) {
           postalCodeFound++;
         }
 
@@ -1931,51 +1974,12 @@ namespace osmscout {
 
         if (isAddress) {
           bool added=false;
-          bool locationResolved=false;
-
-          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                                boundingBox.GetCenter());
-          AddAddressAreaToRegion(progress,
-                                 *region,
-                                 fileOffset,
-                                 location,
-                                 address,
-                                 postalCode,
-                                 nodes,
-                                 boundingBox,
-                                 added,
-                                 locationResolved);
-
-          if (!locationResolved) {
-            std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
-                                                                                 boundingBox.GetCenter());
-            for (const auto& parentRegion : regions) {
-              if (parentRegion==region) {
-                continue;
-              }
-              if (parentRegion->level>=0 && parentRegion->level<6) {
-                break;
-              }
-              AddAddressAreaToRegion(progress,
-                                     *parentRegion,
-                                     fileOffset,
-                                     location,
-                                     address,
-                                     postalCode,
-                                     nodes,
-                                     boundingBox,
-                                     added,
-                                     locationResolved);
-              if (locationResolved) {
-                break;
-              }
-            }
-          }
-
-          if (!locationResolved) {
-            errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refArea),
-                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+region->name+"'");
-          }
+          AddAddressToRegion(progress,
+                             regionIndex,
+                             rootRegion,
+                             areaAddress,
+                             false,
+                             added);
 
           if (added) {
             addressFound++;
@@ -1986,11 +1990,11 @@ namespace osmscout {
           bool added=false;
 
           locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                                boundingBox.GetCenter());
-          region->AddPOIArea(fileOffset,
-                             name,
-                             nodes,
-                             boundingBox,
+                                                                areaAddress.coord);
+          region->AddPOIArea(areaAddress.object.GetFileOffset(),
+                             areaAddress.name,
+                             areaAddress.nodes,
+                             areaAddress.boundingBox,
                              added);
 
           if (added) {
@@ -2050,15 +2054,16 @@ namespace osmscout {
     }
 
     bool locationResolved=false;
-    AddAddressToRegion(progress,
-                       region,
-                       ObjectFileRef(fileOffset,refWay),
-                       location,
-                       address,
-                       "",
-                       false,
-                       added,
-                       locationResolved);
+    AddressData wayAddress;
+    wayAddress.object=ObjectFileRef(fileOffset,refWay);
+    wayAddress.location=location;
+    wayAddress.address=address;
+    AddGenericAddressToRegion(progress,
+                              region,
+                              wayAddress,
+                              false,
+                              added,
+                              locationResolved);
 
     for (const auto& area : region.areas) {
       if (IsAreaCompletelyInArea(nodes,area)) {
@@ -2211,26 +2216,6 @@ namespace osmscout {
     return locations.end();
   }
 
-  void LocationIndexGenerator::AddAddressNodeToRegion(Progress& progress,
-                                                      locidx::Region& region,
-                                                      const FileOffset& fileOffset,
-                                                      const std::string& location,
-                                                      const std::string& address,
-                                                      const std::string &postalCode,
-                                                      bool& added)
-  {
-    bool locationResolved=false;
-    AddAddressToRegion(progress,
-                       region,
-                       ObjectFileRef(fileOffset,refNode),
-                       location,
-                       address,
-                       postalCode,
-                       true,
-                       added,
-                       locationResolved);
-  }
-
   bool LocationIndexGenerator::IndexAddressNodes(const TypeConfig& typeConfig,
                                                  const ImportParameter& parameter,
                                                  Progress& progress,
@@ -2240,13 +2225,13 @@ namespace osmscout {
     FileScanner scanner;
 
     try {
-      size_t      addressFound=0;
-      size_t      poiFound=0;
-      size_t      postalCodeFound=0;
-      FileOffset  fileOffset;
-      TypeId      typeId;
-      TypeInfoRef type;
-      GeoCoord    coord;
+      size_t          addressFound=0;
+      size_t          poiFound=0;
+      size_t          postalCodeFound=0;
+      NodeAddressData nodeAddress;
+
+      TypeId          typeId;
+      TypeInfoRef     type;
 
       scanner.Open(AppendFileToDir(parameter.GetDestinationDirectory(),
                                    SortNodeDataGenerator::NODEADDRESS_DAT),
@@ -2257,32 +2242,28 @@ namespace osmscout {
 
       for (uint32_t n=1; n<=nodeCount; n++) {
         uint32_t    tmpType;
-        std::string name;
-        std::string postalCode;
-        std::string location;
-        std::string address;
 
         progress.SetProgress(n,nodeCount);
 
-        fileOffset=scanner.ReadFileOffset();
+        nodeAddress.object=ObjectFileRef(scanner.ReadFileOffset(),refNode);
         tmpType=scanner.ReadUInt32Number();
 
-        name=scanner.ReadString();
-        postalCode=scanner.ReadString();
-        location=scanner.ReadString();
-        address=scanner.ReadString();
+        nodeAddress.name=scanner.ReadString();
+        nodeAddress.postalCode=scanner.ReadString();
+        nodeAddress.location=scanner.ReadString();
+        nodeAddress.address=scanner.ReadString();
 
-        coord=scanner.ReadCoord();
+        nodeAddress.coord=scanner.ReadCoord();
 
         typeId=(TypeId)tmpType;
         type=typeConfig.GetNodeTypeInfo(typeId);
 
-        bool isAddress=!location.empty() &&
-                       !address.empty();
-        bool isPOI=!name.empty() &&
+        bool isAddress=!nodeAddress.location.empty() &&
+                       !nodeAddress.address.empty();
+        bool isPOI=!nodeAddress.name.empty() &&
                    type->GetIndexAsPOI();
 
-        if (!postalCode.empty()) {
+        if (!nodeAddress.postalCode.empty()) {
           postalCodeFound++;
         }
 
@@ -2292,49 +2273,13 @@ namespace osmscout {
 
         if (isAddress) {
           bool added=false;
-          bool locationResolved=false;
 
-          locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                                coord);
           AddAddressToRegion(progress,
-                             *region,
-                             ObjectFileRef(fileOffset,refNode),
-                             location,
-                             address,
-                             postalCode,
+                             regionIndex,
+                             rootRegion,
+                             nodeAddress,
                              true,
-                             added,
-                             locationResolved);
-
-          if (!locationResolved) {
-            std::vector<locidx::RegionRef> regions=regionIndex.GetRegionsForNode(rootRegion,
-                                                                                 coord);
-            for (const auto& parentRegion : regions) {
-              if (parentRegion==region) {
-                continue;
-              }
-              if (parentRegion->level>=0 && parentRegion->level<6) {
-                break;
-              }
-              AddAddressToRegion(progress,
-                                 *parentRegion,
-                                 ObjectFileRef(fileOffset,refNode),
-                                 location,
-                                 address,
-                                 postalCode,
-                                 true,
-                                 added,
-                                 locationResolved);
-              if (locationResolved) {
-                break;
-              }
-            }
-          }
-
-          if (!locationResolved) {
-            errorReporter->ReportLocationDebug(ObjectFileRef(fileOffset,refNode),
-                                               std::string("Street '")+location+"' of address '"+address+"' cannot be resolved in region '"+region->name+"'");
-          }
+                             added);
 
           if (added) {
             addressFound++;
@@ -2345,10 +2290,10 @@ namespace osmscout {
           bool added=false;
 
           locidx::RegionRef region=regionIndex.GetRegionForNode(rootRegion,
-                                                                coord);
+                                                                nodeAddress.coord);
           if (region) {
-            region->AddPOINode(fileOffset,
-                               name,
+            region->AddPOINode(nodeAddress.object.GetFileOffset(),
+                               nodeAddress.name,
                                added);
           }
           if (added) {


### PR DESCRIPTION
# Issue

In OpenStreetMap database, there is node [#419849333](https://www.openstreetmap.org/node/419849333) with these tags:
```
addr:conscriptionnumber 	45
addr:country 	CZ
addr:housenumber 	45
addr:place 	Číčovice
addr:postcode 	25268
ref:ruian:addr 	6406416
```

It is imported in latest Czech offline database, see:
```
./DumpData/DumpData -n 419849333 ../Maps/czech-republic-26-20260501-1046/

Node {
  OSM id: 419849333

  Id {
    Kind: Node
    Id: 48329145
  }

  Geometry {
    Coordinate: 50.15414 N 14.24125 E
  }

  General {
    Type: address
  }

  Location {
    Address: 45
  }

  lat: 50.15414
  lon: 14.24125
}
```

But the address lookup code do not see it, you can check by:

```
./Demos/LocationLookup --debug ../Maps/czech-republic-26-20260501-1046/ "Číčovice 45"
```

there is entry in `import.log` about this node:
```
cat ../Maps/czech-republic-26-20260501-1046/import.log | grep 48329145
     Node 48329145 - Street 'Číčovice' of address '45' cannot be resolved in region 'Velké Číčovice'
```

For small villages without named street, there is added "virtual" street / place if I remember correctly. It should match to it and be added to the index...

# Claude Code analysis (Opus 4.6 model)

Now I see the full picture. Here's the flow:

  1. Line 2222: The region is determined by geographic coordinates (GetRegionForNode) → this puts node 48329145 into "Velké Číčovice"
  2. Line 2232: AddAddressNodeToRegion is called with that region
  3. In AddAddressToRegion (line 1715), it calls FindLocation to find the location name "Číčovice" within "Velké Číčovice"
  4. FindLocation (line 2103) checks:
    - Existing locations in the postal area → not found
    - Whether location name matches region name ("Číčovice" vs "Velké Číčovice") → no match
    - Region aliases → no match
  5. Returns end() → "cannot be resolved" error

  The bug: when FindLocation fails in the node's geographic region, the code doesn't try parent regions. The virtual location "Číčovice" was created in "Malé Číčovice" (because that region has an alias "Číčovice"), but it doesn't exist in the sibling "Velké Číčovice".

● The hierarchy is:
  Číčovice (admin level 8)
  ├── Velké Číčovice (admin level 10) ← node is geographically here
  └── Malé Číčovice (admin level 10) ← has alias "Číčovice", virtual location created here

The parent region "Číčovice" (admin level 8) has the same name as the addr:place. So a fix could be: when FindLocation fails in the leaf region, try walking up to parent regions.

# Fix

Instead of looking in a single (smallest) region, we now iterate through all enclosing regions from smallest to largest (using the existing spatial index sorting), stopping at admin_level < 6 as a safety bound. The first region where the location name resolves wins.