### PR TITLE
Piper TTS for navigation instructions

### DIFF
--- a/.github/workflows/build_and test_on_ubuntu_24_04.yml
+++ b/.github/workflows/build_and test_on_ubuntu_24_04.yml
@@ -40,6 +40,17 @@ jobs:
               qttools5-dev qtmultimedia5-dev
               libglm-dev libglew-dev libglut-dev
               libmarisa-dev"
+      - name: Install libpiper
+        run: |
+          git clone https://github.com/OHF-Voice/piper1-gpl.git
+          cd piper1-gpl/libpiper
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebug -DCMAKE_INSTALL_PREFIX=/opt/piper  ..
+          make -j $(nproc)
+          sudo make install
+          echo /opt/piper/lib | sudo tee /etc/ld.so.conf.d/piper.conf
+          sudo ldconfig
       - name: Configure build project
         run: meson setup --buildtype debugoptimized --unity on debug
         env:
@@ -74,6 +85,17 @@ jobs:
                qttools5-dev qtmultimedia5-dev
                libglm-dev libglew-dev libglut-dev
                libmarisa-dev"
+      - name: Install libpiper
+        run: |
+          git clone https://github.com/OHF-Voice/piper1-gpl.git
+          cd piper1-gpl/libpiper
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebug -DCMAKE_INSTALL_PREFIX=/opt/piper  ..
+          make -j $(nproc)
+          sudo make install
+          echo /opt/piper/lib | sudo tee /etc/ld.so.conf.d/piper.conf
+          sudo ldconfig
       - name: Configure build project
         run:  meson setup --buildtype debugoptimized --unity on debug
       - name: Build project
@@ -104,6 +126,17 @@ jobs:
                libglm-dev libglew-dev libglut-dev libglfw3-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libxxf86vm-dev
                xvfb
                libmarisa-dev"
+      - name: Install libpiper
+        run: |
+          git clone https://github.com/OHF-Voice/piper1-gpl.git
+          cd piper1-gpl/libpiper
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebug -DCMAKE_INSTALL_PREFIX=/opt/piper  ..
+          make -j $(nproc)
+          sudo make install
+          echo /opt/piper/lib | sudo tee /etc/ld.so.conf.d/piper.conf
+          sudo ldconfig
       - name: Configure build project
         run: cmake -B build -DCMAKE_UNITY_BUILD=ON -DOSMSCOUT_BUILD_CLIENT_JAVA=OFF -Wno-dev -G "Ninja"
       - name: Build project
@@ -126,6 +159,17 @@ jobs:
         run:  sudo apt-get install software-properties-common
       - name: Install gcc compiler and Co
         run:  sudo apt-get -y install gcc g++ libtbb-dev ccache libtool pkg-config python3-pip
+      - name: Install libpiper
+        run: |
+          git clone https://github.com/OHF-Voice/piper1-gpl.git
+          cd piper1-gpl/libpiper
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebug -DCMAKE_INSTALL_PREFIX=/opt/piper  ..
+          make -j $(nproc)
+          sudo make install
+          echo /opt/piper/lib | sudo tee /etc/ld.so.conf.d/piper.conf
+          sudo ldconfig
       - name: Install current meson and ninja
         run: "pip3 install --only-binary :all: --break-system-packages meson ninja"
       - name: Install libosmscout dependencies
@@ -161,6 +205,17 @@ jobs:
                libpng-dev
                qmake6 libqt6svg6-dev libqt6core5compat6-dev qt6-declarative-dev qt6-positioning-dev qt6-tools-dev-tools
                qt6-l10n-tools qt6-tools-dev qt6-multimedia-dev"
+      - name: Install libpiper
+        run: |
+          git clone https://github.com/OHF-Voice/piper1-gpl.git
+          cd piper1-gpl/libpiper
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebug -DCMAKE_INSTALL_PREFIX=/opt/piper  ..
+          make -j $(nproc)
+          sudo make install
+          echo /opt/piper/lib | sudo tee /etc/ld.so.conf.d/piper.conf
+          sudo ldconfig
       - name: Configure build project
         run: cmake -B build -DCMAKE_UNITY_BUILD=ON -DOSMSCOUT_BUILD_CLIENT_JAVA=OFF -Wno-dev -G "Ninja"
       - name: Build project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,6 +664,12 @@ if (HAVE_HTTPLIB)
 else ()
   message(STATUS "- httplib:                       FALSE")
 endif ()
+if (HAVE_LIB_PIPER)
+  message(STATUS "- piper:                         TRUE")
+else ()
+  message(STATUS "- piper:                         FALSE")
+endif ()
+
 message(STATUS "")
 
 message(STATUS "Qt5 libraries (${Qt5_FOUND}):")

--- a/Demos/include/QtDemoApp.h
+++ b/Demos/include/QtDemoApp.h
@@ -52,6 +52,7 @@ public:
     QString iconDirectory="icons";
     QString translationDir;
     QString basemapDir;
+    QString espeakDataDir;
   };
 
 public:

--- a/Demos/qml/NavigationSimulation.qml
+++ b/Demos/qml/NavigationSimulation.qml
@@ -244,6 +244,9 @@ Window {
                 id: voiceComboBox
                 editable: true
 
+                Layout.preferredWidth: 300
+                Layout.fillWidth: true
+
                 property bool initialized: false
 
                 function getData(row, role){

--- a/Demos/src/QtDemoApp.cpp
+++ b/Demos/src/QtDemoApp.cpp
@@ -173,6 +173,7 @@ int QtDemoApp::Run(const Arguments &args, const QUrl &qmlFileUrl)
       .AddOnlineTileProviders(":/resources/online-tile-providers.json")
       .AddMapProviders(":/resources/map-providers.json")
       .AddVoiceProviders(":/resources/voice-providers.json")
+      .WithNavigationTranslationDir(translationDir)
       .WithUserAgent(QApplication::applicationName(), QApplication::applicationVersion());
 
   if (!builder.Init()){

--- a/Demos/src/QtDemoApp.cpp
+++ b/Demos/src/QtDemoApp.cpp
@@ -82,6 +82,13 @@ void QtDemoApp::Arguments::AddOptions(osmscout::CmdLineParser &argParser)
                       "translations",
                       "Directory with translation files (*.qm)",
                       false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([this](const std::string& value) {
+                        espeakDataDir=QString::fromStdString(value);
+                      }),
+                      "espeak-data",
+                      "Directory with espeak-ng data (used by Piper text-to-speech)",
+                      false);
 }
 
 bool QtDemoApp::Arguments::Parse(int argc, char* argv[], int &exitCode)
@@ -174,6 +181,7 @@ int QtDemoApp::Run(const Arguments &args, const QUrl &qmlFileUrl)
       .AddMapProviders(":/resources/map-providers.json")
       .AddVoiceProviders(":/resources/voice-providers.json")
       .WithNavigationTranslationDir(translationDir)
+      .WithEspeakDataDir(args.espeakDataDir)
       .WithUserAgent(QApplication::applicationName(), QApplication::applicationVersion());
 
   if (!builder.Init()){

--- a/OSMScout2/CMakeLists.txt
+++ b/OSMScout2/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TRANSLATION_TS_FILES
 set(TRANSLATION_SOURCE_FILES
 	${SOURCE_FILES}
 	../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp
+	../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
 	)
 
 # See http://doc.qt.io/qt-5/cmake-manual.html

--- a/OSMScout2/CMakeLists.txt
+++ b/OSMScout2/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TRANSLATION_TS_FILES
 set(TRANSLATION_SOURCE_FILES
 	${SOURCE_FILES}
 	../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp
+  ../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
 	)
 
 # See http://doc.qt.io/qt-5/cmake-manual.html

--- a/OSMScout2/qml/VoiceDownloadDialog.qml
+++ b/OSMScout2/qml/VoiceDownloadDialog.qml
@@ -17,7 +17,6 @@ MapDialog {
     label: "Voice Downloader"
     fullscreen: parent.width<500 || parent.height<600
 
-
     AvailableVoicesModel {
         id: availableVoices
     }
@@ -34,8 +33,9 @@ MapDialog {
             width: parent.width
             Layout.minimumWidth: Math.min(voiceDownloadDialog.width * 0.8, 500)
 
-            text: "Voice samples were created as part of <a href=\"https://community.kde.org/Marble/VoiceOfMarble\">VoiceOfMarble</a> project. " +
-                  "Licensed under terms of <a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC BY-SA 3.0</a> license."
+            text: "Voice samples were created as part of <a href=\"https://community.kde.org/Marble/VoiceOfMarble\">VoiceOfMarble</a> project.<br />" +
+                  "Licensed under terms of <a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC BY-SA 3.0</a> license.<br />" +
+                  "Piper models are (mostly) copied from <a href=\"https://huggingface.co/rhasspy/piper-voices\">HuggingFace, piper-voices</a>."
             onLinkActivated: Qt.openUrlExternally(link)
 
             font.pixelSize: Theme.textFontSize
@@ -69,6 +69,11 @@ MapDialog {
                 }
             }
 
+            TableViewColumn {
+                role: "type"
+                title: "Type"
+                width: 80
+            }
             TableViewColumn {
                 role: "lang"
                 title: "Language"

--- a/OSMScout2/resources/voice-providers.json
+++ b/OSMScout2/resources/voice-providers.json
@@ -1,7 +1,7 @@
 [
   {
     "uri": "https://osmscout.karry.cz/voices",
-    "listUri": "https://osmscout.karry.cz/voices/list.json?locale=%1",
+    "listUri": "https://osmscout.karry.cz/voices/list-v2.json?locale=%1",
     "name": "karry.cz"
   }
 ]

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -229,6 +229,7 @@ int main(int argc, char* argv[])
     .AddOnlineTileProviders(":/resources/online-tile-providers.json")
     .AddMapProviders(":/resources/map-providers.json")
     .AddVoiceProviders(":/resources/voice-providers.json")
+    .WithNavigationTranslationDir(translationDir)
     .WithUserAgent("OSMScout2DemoApp", "v?");
 
   if (!builder.Init()){

--- a/OSMScout2/src/OSMScout.cpp
+++ b/OSMScout2/src/OSMScout.cpp
@@ -86,6 +86,7 @@ struct Arguments {
   QString iconDirectory="icons";
   QString translationDir;
   QString basemapDirectory;
+  QString espeakDataDir;
 };
 
 int main(int argc, char* argv[])
@@ -157,6 +158,13 @@ int main(int argc, char* argv[])
                     "baseMap",
                     "Directory with basemap",
                     false);
+
+  argParser.AddOption(osmscout::CmdLineStringOption([&args](const std::string& value) {
+                        args.espeakDataDir=QString::fromStdString(value);
+                      }),
+                      "espeak-data",
+                      "Directory with espeak-ng data (used by Piper text-to-speech)",
+                      false);
 
   argParser.AddPositional(osmscout::CmdLineStringOption([&args](const std::string& value) {
                             args.databaseDirectory=QString::fromStdString(value);
@@ -230,6 +238,7 @@ int main(int argc, char* argv[])
     .AddMapProviders(":/resources/map-providers.json")
     .AddVoiceProviders(":/resources/voice-providers.json")
     .WithNavigationTranslationDir(translationDir)
+    .WithEspeakDataDir(args.espeakDataDir)
     .WithUserAgent("OSMScout2DemoApp", "v?");
 
   if (!builder.Init()){

--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -392,145 +392,145 @@
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="91"/>
         <source>GPS signal found</source>
-        <translation type="unfinished"></translation>
+        <translation>Nalezen GPS signál</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="93"/>
         <source>GPS signal lost</source>
-        <translation type="unfinished"></translation>
+        <translation>Ztracen GPS signál</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="96"/>
         <source>You have reached your destination</source>
-        <translation type="unfinished"></translation>
+        <translation>Dorazili jste do cíle</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="99"/>
         <source>Turn sharply left</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře doleva</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="101"/>
         <source>Turn left</source>
-        <translation type="unfinished">Zahněte vlevo</translation>
+        <translation>Zahněte doleva</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="103"/>
         <source>Continue straight ahead</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokračujte rovně</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="105"/>
         <source>Turn right</source>
-        <translation type="unfinished">Zahněte vpravo</translation>
+        <translation>Zahněte doprava</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="107"/>
         <source>Turn sharply right</source>
-        <translation type="unfinished"></translation>
+        <translation>Zahněte ostře doprava</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="110"/>
         <source>Leave the motorway</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z dálnice</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="112"/>
         <source>Leave the motorway on the left</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z dálenice vlevo</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="114"/>
         <source>Leave the motorway on the right</source>
-        <translation type="unfinished"></translation>
+        <translation>Sjeďte z dálnice vpravo</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="120"/>
         <source>Take the first exit</source>
-        <translation type="unfinished">Použijte první výjezd</translation>
+        <translation>Použijte první výjezd</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="121"/>
         <source>At the roundabout, take the first exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte prvním výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="124"/>
         <source>Take the second exit</source>
-        <translation type="unfinished">Použijte druhý výjezd</translation>
+        <translation>Vyjeďte druhým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="125"/>
         <source>At the roundabout, take the second exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte druhým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="128"/>
         <source>Take the third exit</source>
-        <translation type="unfinished">Použijte třetí výjezd</translation>
+        <translation>Vyjeďte třetím výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="129"/>
         <source>At the roundabout, take the third exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte třetím výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="132"/>
         <source>Take the fourth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyjeďte čtvrtým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="133"/>
         <source>At the roundabout, take the fourth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte čtvrtým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="136"/>
         <source>Take the fifth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyjeďte pátým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="137"/>
         <source>At the roundabout, take the fifth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte pátým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="140"/>
         <source>Take the sixth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyjeďte šestým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="141"/>
         <source>At the roundabout, take the sixth exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Na kruhovém objezdu, vyjeďte šestým výjezdem</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="177"/>
         <source>meters</source>
-        <translation type="unfinished">metrů</translation>
+        <translation>metrů</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="178"/>
         <source>yards</source>
-        <translation type="unfinished"></translation>
+        <translation>yardů</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="181"/>
         <source>After %1 %2</source>
         <extracomment>e.g. &quot;After 300 meters/yards&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Za %1 %2</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="226"/>
         <source>%1, %2</source>
         <extracomment>combine distance and maneuver, e.g. &quot;After 300 meters, turn left&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1, %2</translation>
     </message>
     <message>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="237"/>
         <source>%1, then %2</source>
         <extracomment>%1 is the following maneuver, e.g. &quot;Turn left, then turn right&quot;.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1, poté %2</translation>
     </message>
 </context>
 <context>

--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -388,6 +388,152 @@
     </message>
 </context>
 <context>
+    <name>TTSMessageGeneratorQt</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="91"/>
+        <source>GPS signal found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="93"/>
+        <source>GPS signal lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="96"/>
+        <source>You have reached your destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="99"/>
+        <source>Turn sharply left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="101"/>
+        <source>Turn left</source>
+        <translation type="unfinished">Zahněte vlevo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="103"/>
+        <source>Continue straight ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="105"/>
+        <source>Turn right</source>
+        <translation type="unfinished">Zahněte vpravo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="107"/>
+        <source>Turn sharply right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="110"/>
+        <source>Leave the motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="112"/>
+        <source>Leave the motorway on the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="114"/>
+        <source>Leave the motorway on the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="120"/>
+        <source>Take the first exit</source>
+        <translation type="unfinished">Použijte první výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="121"/>
+        <source>At the roundabout, take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="124"/>
+        <source>Take the second exit</source>
+        <translation type="unfinished">Použijte druhý výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="125"/>
+        <source>At the roundabout, take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="128"/>
+        <source>Take the third exit</source>
+        <translation type="unfinished">Použijte třetí výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="129"/>
+        <source>At the roundabout, take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="132"/>
+        <source>Take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="133"/>
+        <source>At the roundabout, take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="136"/>
+        <source>Take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="137"/>
+        <source>At the roundabout, take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="140"/>
+        <source>Take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="141"/>
+        <source>At the roundabout, take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="177"/>
+        <source>meters</source>
+        <translation type="unfinished">metrů</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="178"/>
+        <source>yards</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="181"/>
+        <source>After %1 %2</source>
+        <extracomment>e.g. &quot;After 300 meters/yards&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="226"/>
+        <source>%1, %2</source>
+        <extracomment>combine distance and maneuver, e.g. &quot;After 300 meters, turn left&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="237"/>
+        <source>%1, then %2</source>
+        <extracomment>%1 is the following maneuver, e.g. &quot;Turn left, then turn right&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Utils</name>
     <message>
         <location filename="../qml/custom/Utils.js" line="45"/>

--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -15,369 +15,366 @@
 <context>
     <name>RouteDescriptionBuilder</name>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
         <source>Turn</source>
-        <translation>Zahněte</translation>
+        <translation type="vanished">Zahněte</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="75"/>
         <source>Turn sharp left</source>
         <translation>Zahněte ostře vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
         <source>Turn left</source>
         <translation>Zahněte vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="79"/>
         <source>Turn slightly left</source>
         <translation>Zahněte mírně vlevo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
         <source>Straight on</source>
         <translation>Pokračuje rovně</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="89"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
         <source>Turn slightly right</source>
         <translation>Zahněte mírně vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="91"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
         <source>Turn right</source>
         <translation>Zahněte vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="93"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
         <source>Turn sharp right</source>
         <translation>Zahněte ostře vpravo</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="103"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
+        <translation type="vanished">Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="107"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="98"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="109"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="100"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="111"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="102"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="113"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="104"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Pokračuje rovně&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="115"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="106"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="117"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="108"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="119"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="110"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt; na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
         <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation>Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
+        <translation type="vanished">Na křižovatce %1&lt;strong&gt;Zahněte&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="121"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="135"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="123"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="137"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="125"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vlevo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="139"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="127"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Pokračujte rovně&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="141"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte mírně vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="143"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="131"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="145"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Zahněte ostře vpravo&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="159"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="147"/>
         <source>unnamed road</source>
         <extracomment>unknown road name</extracomment>
         <translation>nepojmenovaná cesta</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="163"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="151"/>
         <source>(%1)</source>
         <extracomment>road just with ref number</extracomment>
         <translation>(%1)</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="167"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="260"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="298"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="155"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="248"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
         <source>&quot;%1&quot;</source>
         <extracomment>road just with name, without ref</extracomment>
         <translation>&quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="158"/>
         <source>&quot;%1&quot; (%2)</source>
         <extracomment>road with name (%1) and ref (%2)</extracomment>
         <translation>&quot;%1&quot; (%2)</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="182"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
         <source>On unnamed exit</source>
         <extracomment>unnamed motorway exit</extracomment>
         <translation>Na nepojmenovaném exitu</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="186"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="174"/>
         <source>On exit %1</source>
         <extracomment>motorway exit just with ref</extracomment>
         <translation>Na exitu %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="190"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="178"/>
         <source>On exit &quot;%1&quot;</source>
         <extracomment>motorway exit with name, without ref</extracomment>
         <translation>Na exitu &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="193"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="181"/>
         <source>On exit %1 &quot;%2&quot;</source>
         <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
         <translation>Na exitu %1 &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="257"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
         <translation>&lt;strong&gt;Vjeďte&lt;/strong&gt; na %1</translation>
     </message>
     <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="258"/>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="270"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="282"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="287"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
         <source>Start</source>
         <translation>Vyjeďte</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="263"/>
         <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
         <translation>&lt;strong&gt;Pokračujte&lt;/strong&gt; po %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="276"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="264"/>
         <source>Continue</source>
         <translation>Pokračujte</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
         <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt; po %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="274"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Vyjeďte&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="302"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="290"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
         <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt; na %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="304"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="292"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Dosaženo cíle&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="306"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="294"/>
         <source>Target reached</source>
         <translation>Dosaženo cíle</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="361"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="350"/>
         <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="364"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="353"/>
         <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Vjeďte na kruhový objezd&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="366"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="355"/>
         <source>Enter roundabout</source>
         <translation>Vjeďte na kruhový objezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="379"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="368"/>
         <source>Take the first exit</source>
         <translation>Použijte první výjezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="382"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="371"/>
         <source>Take the second exit</source>
         <translation>Použijte druhý výjezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="385"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="374"/>
         <source>Take the third exit</source>
         <translation>Použijte třetí výjezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="377"/>
         <source>Take the %1th exit</source>
         <translation>Použijte %1. výjezd</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="395"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="384"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
         <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu na ulici %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="399"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
         <translation>&lt;strong&gt;Sjeďte z kruhového objezdu&lt;/strong&gt; na %1. výjezdu</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="411"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="400"/>
         <source>Enter motorway</source>
         <translation>Vjeďte na dálnici</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="423"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="412"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
         <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="427"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="416"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
         <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="432"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="421"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation>Na křižovatce %1&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="435"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="424"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Vjeďte na dálnici&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="461"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="448"/>
         <source>Change motorway</source>
         <translation>Změna dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="476"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="463"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
         <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="481"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="468"/>
         <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation>%1 &lt;strong&gt;změna dálnice&lt;/strong&gt; z %2 na %3</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="488"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="475"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="491"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="478"/>
         <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation>%1 &lt;strong&gt;Změna dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="523"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="510"/>
         <source>Leave motorway</source>
         <translation>Sjeďte z dálnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="539"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="526"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
         <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="544"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="531"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2 na %3</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="551"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="538"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
         <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt; %1</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="555"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="542"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt; %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="562"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="549"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
         <translation>&lt;strong&gt;Sjeďte z dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="565"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="552"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation>%1 &lt;strong&gt;sjeďte z dálnice&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="599"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="586"/>
         <source>Way changes name</source>
         <translation>Změna silnice</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="602"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="589"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
         <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1 na %2</translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="606"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="593"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
         <translation>&lt;strong&gt;Změna silnice&lt;/strong&gt; z %1</translation>
     </message>

--- a/OSMScout2/translations/cs.ts
+++ b/OSMScout2/translations/cs.ts
@@ -388,6 +388,152 @@
     </message>
 </context>
 <context>
+    <name>TTSMessageGeneratorQt</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="91"/>
+        <source>GPS signal found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="93"/>
+        <source>GPS signal lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="96"/>
+        <source>You have reached your destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="99"/>
+        <source>Turn sharply left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="101"/>
+        <source>Turn left</source>
+        <translation type="unfinished">Zahněte vlevo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="103"/>
+        <source>Continue straight ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="105"/>
+        <source>Turn right</source>
+        <translation type="unfinished">Zahněte vpravo</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="107"/>
+        <source>Turn sharply right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="110"/>
+        <source>Leave the motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="112"/>
+        <source>Leave the motorway on the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="114"/>
+        <source>Leave the motorway on the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="120"/>
+        <source>Take the first exit</source>
+        <translation type="unfinished">Použijte první výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="121"/>
+        <source>At the roundabout, take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="124"/>
+        <source>Take the second exit</source>
+        <translation type="unfinished">Použijte druhý výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="125"/>
+        <source>At the roundabout, take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="128"/>
+        <source>Take the third exit</source>
+        <translation type="unfinished">Použijte třetí výjezd</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="129"/>
+        <source>At the roundabout, take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="132"/>
+        <source>Take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="133"/>
+        <source>At the roundabout, take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="136"/>
+        <source>Take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="137"/>
+        <source>At the roundabout, take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="140"/>
+        <source>Take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="141"/>
+        <source>At the roundabout, take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="177"/>
+        <source>meters</source>
+        <translation type="unfinished">metrů</translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="178"/>
+        <source>yards</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="181"/>
+        <source>After %1 %2</source>
+        <extracomment>e.g. &quot;After 300 meters/yards&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="226"/>
+        <source>%1, %2</source>
+        <extracomment>combine distance and maneuver, e.g. &quot;After 300 meters, turn left&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="237"/>
+        <source>, then %1</source>
+        <extracomment>%1 is the following maneuver, e.g. &quot;Turn left, then turn right&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Utils</name>
     <message>
         <location filename="../qml/custom/Utils.js" line="45"/>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -4,369 +4,354 @@
 <context>
     <name>RouteDescriptionBuilder</name>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
-        <source>Turn</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="75"/>
         <source>Turn sharp left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="77"/>
         <source>Turn left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="79"/>
         <source>Turn slightly left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="81"/>
         <source>Straight on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="89"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="83"/>
         <source>Turn slightly right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="91"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="85"/>
         <source>Turn right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="93"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="87"/>
         <source>Turn sharp right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="103"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt; into %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="107"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="98"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="109"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="100"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="111"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="102"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="113"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="104"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="115"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="106"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="117"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="108"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="119"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="110"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt; into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
-        <source>At crossing %1&lt;strong&gt;Turn&lt;/strong&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="121"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="135"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="123"/>
         <source>At crossing %1&lt;strong&gt;Turn left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="137"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="125"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly left&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="139"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="127"/>
         <source>At crossing %1&lt;strong&gt;Straight on&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="141"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="129"/>
         <source>At crossing %1&lt;strong&gt;Turn slightly right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="143"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="131"/>
         <source>At crossing %1&lt;strong&gt;Turn right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="145"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="133"/>
         <source>At crossing %1&lt;strong&gt;Turn sharp right&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="159"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="147"/>
         <source>unnamed road</source>
         <extracomment>unknown road name</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="163"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="151"/>
         <source>(%1)</source>
         <extracomment>road just with ref number</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="167"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="260"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="298"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="155"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="248"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
         <source>&quot;%1&quot;</source>
         <extracomment>road just with name, without ref</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="158"/>
         <source>&quot;%1&quot; (%2)</source>
         <extracomment>road with name (%1) and ref (%2)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="182"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="170"/>
         <source>On unnamed exit</source>
         <extracomment>unnamed motorway exit</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="186"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="174"/>
         <source>On exit %1</source>
         <extracomment>motorway exit just with ref</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="190"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="178"/>
         <source>On exit &quot;%1&quot;</source>
         <extracomment>motorway exit with name, without ref</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="193"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="181"/>
         <source>On exit %1 &quot;%2&quot;</source>
         <extracomment>motorway exit with ref (%1) and name (%2)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="257"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="258"/>
         <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="270"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="282"/>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="287"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="275"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="263"/>
         <source>&lt;strong&gt;Continue&lt;/strong&gt; along %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="276"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="264"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="281"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="269"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt; along %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="286"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="274"/>
         <source>&lt;strong&gt;Start&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="302"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="290"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt; at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="304"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="292"/>
         <source>&lt;strong&gt;Target reached&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="306"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="294"/>
         <source>Target reached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="361"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="350"/>
         <source>At crossing %1&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="364"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="353"/>
         <source>&lt;strong&gt;Enter roundabout&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="366"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="355"/>
         <source>Enter roundabout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="379"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="368"/>
         <source>Take the first exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="382"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="371"/>
         <source>Take the second exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="385"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="374"/>
         <source>Take the third exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="377"/>
         <source>Take the %1th exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="395"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="384"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit into street %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="399"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="388"/>
         <source>&lt;strong&gt;Leave roundabout&lt;/strong&gt; on %1. exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="411"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="400"/>
         <source>Enter motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="423"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="412"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="427"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="416"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="432"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="421"/>
         <source>At crossing %1&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="435"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="424"/>
         <source>&lt;strong&gt;Enter motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="461"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="448"/>
         <source>Change motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="476"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="463"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt; from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="481"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="468"/>
         <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt; from %2 to %3</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="488"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="475"/>
         <source>&lt;strong&gt;Change motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="491"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="478"/>
         <source>%1 &lt;strong&gt;Change motorway&lt;/strong&gt;</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="523"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="510"/>
         <source>Leave motorway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="539"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="526"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1 into %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="544"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="531"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2 into %3</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="551"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="538"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="555"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="542"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt; %2</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="562"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="549"/>
         <source>&lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="565"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="552"/>
         <source>%1 &lt;strong&gt;Leave motorway&lt;/strong&gt;</source>
         <extracomment>%1 is motorway exit description</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="599"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="586"/>
         <source>Way changes name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="602"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="589"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="606"/>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/RouteDescriptionBuilder.cpp" line="593"/>
         <source>&lt;strong&gt;Way changes name&lt;/strong&gt; to %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -365,6 +365,152 @@
     </message>
 </context>
 <context>
+    <name>TTSMessageGeneratorQt</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="91"/>
+        <source>GPS signal found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="93"/>
+        <source>GPS signal lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="96"/>
+        <source>You have reached your destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="99"/>
+        <source>Turn sharply left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="101"/>
+        <source>Turn left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="103"/>
+        <source>Continue straight ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="105"/>
+        <source>Turn right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="107"/>
+        <source>Turn sharply right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="110"/>
+        <source>Leave the motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="112"/>
+        <source>Leave the motorway on the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="114"/>
+        <source>Leave the motorway on the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="120"/>
+        <source>Take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="121"/>
+        <source>At the roundabout, take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="124"/>
+        <source>Take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="125"/>
+        <source>At the roundabout, take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="128"/>
+        <source>Take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="129"/>
+        <source>At the roundabout, take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="132"/>
+        <source>Take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="133"/>
+        <source>At the roundabout, take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="136"/>
+        <source>Take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="137"/>
+        <source>At the roundabout, take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="140"/>
+        <source>Take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="141"/>
+        <source>At the roundabout, take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="177"/>
+        <source>meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="178"/>
+        <source>yards</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="181"/>
+        <source>After %1 %2</source>
+        <extracomment>e.g. &quot;After 300 meters/yards&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="226"/>
+        <source>%1, %2</source>
+        <extracomment>combine distance and maneuver, e.g. &quot;After 300 meters, turn left&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="237"/>
+        <source>%1, then %2</source>
+        <extracomment>%1 is the following maneuver, e.g. &quot;Turn left, then turn right&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Utils</name>
     <message>
         <location filename="../qml/custom/Utils.js" line="45"/>

--- a/OSMScout2/translations/en.ts
+++ b/OSMScout2/translations/en.ts
@@ -365,6 +365,152 @@
     </message>
 </context>
 <context>
+    <name>TTSMessageGeneratorQt</name>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="91"/>
+        <source>GPS signal found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="93"/>
+        <source>GPS signal lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="96"/>
+        <source>You have reached your destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="99"/>
+        <source>Turn sharply left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="101"/>
+        <source>Turn left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="103"/>
+        <source>Continue straight ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="105"/>
+        <source>Turn right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="107"/>
+        <source>Turn sharply right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="110"/>
+        <source>Leave the motorway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="112"/>
+        <source>Leave the motorway on the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="114"/>
+        <source>Leave the motorway on the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="120"/>
+        <source>Take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="121"/>
+        <source>At the roundabout, take the first exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="124"/>
+        <source>Take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="125"/>
+        <source>At the roundabout, take the second exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="128"/>
+        <source>Take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="129"/>
+        <source>At the roundabout, take the third exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="132"/>
+        <source>Take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="133"/>
+        <source>At the roundabout, take the fourth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="136"/>
+        <source>Take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="137"/>
+        <source>At the roundabout, take the fifth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="140"/>
+        <source>Take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="141"/>
+        <source>At the roundabout, take the sixth exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="177"/>
+        <source>meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="178"/>
+        <source>yards</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="181"/>
+        <source>After %1 %2</source>
+        <extracomment>e.g. &quot;After 300 meters/yards&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="226"/>
+        <source>%1, %2</source>
+        <extracomment>combine distance and maneuver, e.g. &quot;After 300 meters, turn left&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp" line="237"/>
+        <source>, then %1</source>
+        <extracomment>%1 is the following maneuver, e.g. &quot;Turn left, then turn right&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Utils</name>
     <message>
         <location filename="../qml/custom/Utils.js" line="45"/>

--- a/Tests/src/HeaderCheckTest.cpp
+++ b/Tests/src/HeaderCheckTest.cpp
@@ -169,6 +169,7 @@ static const std::set<std::string> allowedDependencies{
     "osmscoutclientqt => osmscout.location",
     "osmscoutclientqt => osmscout.routing",
     "osmscoutclientqt => osmscout.navigation",
+    "osmscoutclientqt => osmscout.io",
     "osmscoutclientqt => osmscout",
     "osmscoutclientqt => osmscoutmap",
     "osmscoutclientqt => osmscoutmapqt",

--- a/cmake/Config.h.cmake
+++ b/cmake/Config.h.cmake
@@ -371,6 +371,7 @@
 #cmakedefine OSMSCOUT_MAP_SVG_HAVE_LIB_PANGO 1
 #endif
 
+
 #ifndef OSMSCOUT_PTHREAD_NAME
 /* Threads are pthreads and non-posix setname is available */
 #cmakedefine OSMSCOUT_PTHREAD_NAME

--- a/cmake/FindPiper.cmake
+++ b/cmake/FindPiper.cmake
@@ -1,0 +1,54 @@
+# - Try to find Piper TTS (libpiper)
+#
+# Upstream libpiper ships neither a CMake package config nor a pkg-config file,
+# so this module locates the header and library manually. A pkg-config lookup is
+# still attempted first as a fallback for future versions / custom builds.
+#
+# The following hints are honoured (in addition to the standard system paths):
+#   PIPER_ROOT (CMake variable)
+#   /opt/piper
+#
+# Once done, this will define:
+#   Piper_FOUND         - system has libpiper
+#   Piper_INCLUDE_DIRS  - the libpiper include directories
+#   Piper_LIBRARIES     - link these to use libpiper
+#
+# and the imported target:
+#   Piper::Piper
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_PIPER QUIET piper libpiper)
+endif()
+
+find_path(Piper_INCLUDE_DIRS
+    NAMES piper.h
+    HINTS ${PC_PIPER_INCLUDEDIR}
+          ${PC_PIPER_INCLUDE_DIRS}
+          ${PIPER_ROOT}
+          /opt/piper
+    PATH_SUFFIXES include piper
+)
+
+find_library(Piper_LIBRARIES
+    NAMES piper libpiper
+    HINTS ${PC_PIPER_LIBDIR}
+          ${PC_PIPER_LIBRARY_DIRS}
+          ${PIPER_ROOT}
+          /opt/piper
+    PATH_SUFFIXES lib lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Piper
+    REQUIRED_VARS Piper_LIBRARIES Piper_INCLUDE_DIRS)
+
+if(Piper_FOUND AND NOT TARGET Piper::Piper)
+  add_library(Piper::Piper UNKNOWN IMPORTED)
+  set_target_properties(Piper::Piper PROPERTIES
+      IMPORTED_LOCATION "${Piper_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Piper_INCLUDE_DIRS}")
+endif()
+
+mark_as_advanced(Piper_INCLUDE_DIRS Piper_LIBRARIES)
+

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -358,6 +358,13 @@ find_package(Doxygen QUIET)
 set(Matlab_FIND_COMPONENTS MX_LIBRARY)
 find_package(MATLAB QUIET)
 
+option(OSMSCOUT_BUILD_WITH_PIPER "Enable Piper TTS (libpiper) support if available" ON)
+if(OSMSCOUT_BUILD_WITH_PIPER)
+  find_package(Piper QUIET)
+endif()
+target_exists(Piper::Piper HAVE_LIB_PIPER)
+set(OSMSCOUT_HAVE_LIB_PIPER ${HAVE_LIB_PIPER})
+
 find_package(Gperftools QUIET)
 set(HAVE_LIB_GPERFTOOLS ${GPERFTOOLS_FOUND})
 if(GPERFTOOLS_FOUND)

--- a/libosmscout-client-java/src/OSMScoutClient.cpp
+++ b/libosmscout-client-java/src/OSMScoutClient.cpp
@@ -1472,7 +1472,7 @@ public:
         std::make_shared<osmscout::ArrivalEstimateAgent>(),
         std::make_shared<osmscout::SpeedAgent>(),
         std::make_shared<osmscout::LaneAgent>(),
-        std::make_shared<osmscout::VoiceInstructionAgent>(osmscout::DistanceUnitSystem::Metrics),
+        std::make_shared<osmscout::VoiceInstructionAgent>(osmscout::DistanceUnitSystem::Metrics, std::make_shared<osmscout::NoOpTTSMessageGenerator>()),
         std::make_shared<osmscout::RouteInstructionAgent<JavaRouteInstruction, JavaRouteInstructionBuilder>>()
       }
   {
@@ -1647,6 +1647,7 @@ private:
 
     auto startTime = std::chrono::system_clock::now();
     ProcessEngineMessage(std::make_shared<osmscout::InitializeMessage>(startTime));
+    ProcessEngineMessage(std::make_shared<osmscout::VoiceSetupMessage>(startTime, osmscout::NavigationVoiceType::VoiceOfMarble, ""));
     ProcessEngineMessage(std::make_shared<osmscout::RouteUpdateMessage>(startTime, routeDescription, vehicle));
 
     // Use the playback/GPS timeline for ticks. This keeps the engine's "now"
@@ -1771,7 +1772,7 @@ private:
       env->DeleteLocalRef(turnStr);
       env->DeleteLocalRef(turnsArray);
     }
-    else if (auto voiceMessage = dynamic_cast<osmscout::VoiceInstructionMessage *>(message.get());
+    else if (auto voiceMessage = dynamic_cast<osmscout::SampleVoiceInstructionMessage *>(message.get());
              voiceMessage != nullptr) {
       jsize count = static_cast<jsize>(voiceMessage->message.size());
       jintArray samples = env->NewIntArray(count);

--- a/libosmscout-client-java/src/OSMScoutClient.cpp
+++ b/libosmscout-client-java/src/OSMScoutClient.cpp
@@ -1423,7 +1423,7 @@ public:
         std::make_shared<osmscout::ArrivalEstimateAgent>(),
         std::make_shared<osmscout::SpeedAgent>(),
         std::make_shared<osmscout::LaneAgent>(),
-        std::make_shared<osmscout::VoiceInstructionAgent>(osmscout::DistanceUnitSystem::Metrics),
+        std::make_shared<osmscout::VoiceInstructionAgent>(osmscout::DistanceUnitSystem::Metrics, std::make_shared<osmscout::NoOpTTSMessageGenerator>()),
         std::make_shared<osmscout::RouteInstructionAgent<JavaRouteInstruction, JavaRouteInstructionBuilder>>()
       }
   {
@@ -1598,6 +1598,7 @@ private:
 
     auto startTime = std::chrono::system_clock::now();
     ProcessEngineMessage(std::make_shared<osmscout::InitializeMessage>(startTime));
+    ProcessEngineMessage(std::make_shared<osmscout::VoiceSetupMessage>(startTime, osmscout::NavigationVoiceType::VoiceOfMarble, ""));
     ProcessEngineMessage(std::make_shared<osmscout::RouteUpdateMessage>(startTime, routeDescription, vehicle));
 
     // Use the playback/GPS timeline for ticks. This keeps the engine's "now"
@@ -1722,7 +1723,7 @@ private:
       env->DeleteLocalRef(turnStr);
       env->DeleteLocalRef(turnsArray);
     }
-    else if (auto voiceMessage = dynamic_cast<osmscout::VoiceInstructionMessage *>(message.get());
+    else if (auto voiceMessage = dynamic_cast<osmscout::SampleVoiceInstructionMessage *>(message.get());
              voiceMessage != nullptr) {
       jsize count = static_cast<jsize>(voiceMessage->message.size());
       jintArray samples = env->NewIntArray(count);

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -59,6 +59,7 @@ set(HEADER_FILES
     include/osmscoutclientqt/AvailableVoicesModel.h
     include/osmscoutclientqt/InstalledVoicesModel.h
     include/osmscoutclientqt/TTSMessageGeneratorQt.h
+    include/osmscoutclientqt/TTSEngine.h
 )
 
 set(SOURCE_FILES
@@ -116,7 +117,14 @@ set(SOURCE_FILES
     src/osmscoutclientqt/AvailableVoicesModel.cpp
     src/osmscoutclientqt/InstalledVoicesModel.cpp
     src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
+    src/osmscoutclientqt/TTSEngine.cpp
 )
+
+# Piper TTS engine is optional, build it only when libpiper is available
+if(TARGET Piper::Piper)
+    list(APPEND HEADER_FILES include/osmscoutclientqt/PiperTTSEngine.h)
+    list(APPEND SOURCE_FILES src/osmscoutclientqt/PiperTTSEngine.cpp)
+endif()
 
 if (QT_VERSION_MAJOR EQUAL 6)
           osmscout_library_project(

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -58,6 +58,7 @@ set(HEADER_FILES
     include/osmscoutclientqt/VoiceCorePlayerImpl.h
     include/osmscoutclientqt/AvailableVoicesModel.h
     include/osmscoutclientqt/InstalledVoicesModel.h
+    include/osmscoutclientqt/TTSMessageGeneratorQt.h
 )
 
 set(SOURCE_FILES
@@ -114,6 +115,7 @@ set(SOURCE_FILES
     src/osmscoutclientqt/VoicePlayer.cpp
     src/osmscoutclientqt/AvailableVoicesModel.cpp
     src/osmscoutclientqt/InstalledVoicesModel.cpp
+    src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
 )
 
 if (QT_VERSION_MAJOR EQUAL 6)

--- a/libosmscout-client-qt/CMakeLists.txt
+++ b/libosmscout-client-qt/CMakeLists.txt
@@ -145,6 +145,10 @@ if(MARISA_FOUND)
     target_link_libraries(OSMScoutClientQt ${MARISA_LIBRARIES})
 endif()
 
+if(TARGET Piper::Piper)
+    target_link_libraries(OSMScoutClientQt Piper::Piper)
+endif()
+
 if(APPLE AND OSMSCOUT_BUILD_FRAMEWORKS)
           set_target_properties(OSMScoutClientQt PROPERTIES
                     FRAMEWORK TRUE

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -57,7 +57,13 @@ osmscoutclientqtHeader = [
             'osmscoutclientqt/AvailableVoicesModel.h',
             'osmscoutclientqt/InstalledVoicesModel.h',
             'osmscoutclientqt/TTSMessageGeneratorQt.h',
+            'osmscoutclientqt/TTSEngine.h',
           ]
+
+# Piper TTS engine is optional, its header is only used when libpiper is available
+if piperDep.found()
+  osmscoutclientqtHeader += ['osmscoutclientqt/PiperTTSEngine.h']
+endif
 
 if meson.version().version_compare('>=0.63.0')
     install_headers(osmscoutclientqtHeader,

--- a/libosmscout-client-qt/include/meson.build
+++ b/libosmscout-client-qt/include/meson.build
@@ -56,6 +56,7 @@ osmscoutclientqtHeader = [
             'osmscoutclientqt/VoiceCorePlayerImpl.h',
             'osmscoutclientqt/AvailableVoicesModel.h',
             'osmscoutclientqt/InstalledVoicesModel.h',
+            'osmscoutclientqt/TTSMessageGeneratorQt.h',
           ]
 
 if meson.version().version_compare('>=0.63.0')

--- a/libosmscout-client-qt/include/osmscoutclientqt/AvailableVoicesModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/AvailableVoicesModel.h
@@ -35,11 +35,15 @@ namespace osmscout {
 
 /**
  * List model with voices available by configured providers (see Settings::GetVoiceProviders).
- * Every voice provider have to expose list of voices by json. Json format exammple:
+ * Every voice provider have to expose list of voices by json. Two voice types are
+ * supported, distinguished by the "type" property.
+ *
+ * "VoiceOfMarble" - pre-recorded ogg sample pack. Json format example:
  *
  * <pre>
  * [
  *  {
+ *    "type": "VoiceOfMarble",
  *    "lang": "American English",
  *    "gender": "female",
  *    "name": "Alex",
@@ -47,7 +51,26 @@ namespace osmscout {
  *    "dir": "American English - Alex (female)",
  *    "author": "Alex Spehr",
  *    "description": "American English speaker"
- *  } 
+ *  }
+ * ]
+ * </pre>
+ *
+ * "Piper" - Piper TTS voice (onnx model + json config). "dir" is the server
+ * directory, "model" and "metadata" are server-relative paths. Json format
+ * example:
+ *
+ * <pre>
+ * [
+ *  {
+ *    "type": "Piper",
+ *    "dir": "Piper/ar/ar_JO/kareem/medium",
+ *    "metadata": "Piper/ar/ar_JO/kareem/medium/ar_JO-kareem-medium.onnx.json",
+ *    "model": "Piper/ar/ar_JO/kareem/medium/ar_JO-kareem-medium.onnx",
+ *    "license": "MIT",
+ *    "lang_code": "ar_JO",
+ *    "lang": "Arabic (Jordan)",
+ *    "name": "kareem"
+ *  }
  * ]
  * </pre>
  *
@@ -81,7 +104,9 @@ public:
     DirectoryRole = Qt::UserRole + 4,
     AuthorRole = Qt::UserRole + 5,
     DescriptionRole = Qt::UserRole + 6,
-    StateRole = Qt::UserRole + 7
+    StateRole = Qt::UserRole + 7,
+    TypeRole = Qt::UserRole + 8,
+    LangCodeRole = Qt::UserRole + 9
   };
   Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/ClientQtFeatures.h.cmake
+++ b/libosmscout-client-qt/include/osmscoutclientqt/ClientQtFeatures.h.cmake
@@ -1,4 +1,9 @@
 #ifndef LIBOSMSCOUT_CLIENT_QT_FEATURES
 #define LIBOSMSCOUT_CLIENT_QT_FEATURES
 
+#ifndef OSMSCOUT_HAVE_LIB_PIPER
+/* libpiper (Piper TTS) is available */
+#cmakedefine OSMSCOUT_HAVE_LIB_PIPER
+#endif
+
 #endif

--- a/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
@@ -69,7 +69,8 @@ public:
     LicenseRole = Qt::UserRole + 4,
     AuthorRole = Qt::UserRole + 5,
     DescriptionRole = Qt::UserRole + 6,
-    SelectedRole = Qt::UserRole + 7 // true when this voice is selected
+    SelectedRole = Qt::UserRole + 7, // true when this voice is selected
+    TypeRole = Qt::UserRole + 8, // VoiceOfMarble or Piper
   };
   Q_ENUM(Roles)
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
@@ -86,6 +86,10 @@ signals:
 
   void laneUpdate(osmscout::LaneAgent::Lane lane);
 
+  void initVoiceRequested(const Voice &voice);
+  void prepareMessageRequested(QString message);
+  void playMessageRequested(QString message);
+
 public slots:
   void setupRoute(QtRouteData route,
                   osmscout::Vehicle vehicle);

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
@@ -25,6 +25,7 @@
 
 #include <osmscoutclientqt/Router.h>
 #include <osmscoutclientqt/VoicePlayer.h>
+#include <osmscoutclientqt/TTSMessageGeneratorQt.h>
 
 #include <osmscout/navigation/Navigation.h>
 #include <osmscout/navigation/Engine.h>
@@ -106,7 +107,8 @@ public slots:
 public:
   NavigationModule(QThread *thread,
                    SettingsRef settings,
-                   DBThreadRef dbThread);
+                   DBThreadRef dbThread,
+                   const QString &translationDir);
 
   bool loadRoutableObjects(const GeoBox &box,
                            const Vehicle &vehicle,
@@ -118,13 +120,14 @@ public:
 private:
   void InitPlayer();
   void ProcessMessages(const std::list<osmscout::NavigationMessageRef>& messages);
-  QString sampleFile(osmscout::VoiceInstructionMessage::VoiceSample sample) const;
+  QString sampleFile(osmscout::SampleVoiceInstructionMessage::VoiceSample sample) const;
 
 private:
   QThread     *thread;
   SettingsRef settings;
   DistanceUnitSystem units{Locale::ByEnvironmentSafe().GetDistanceUnits()}; // TODO: make possible to override
   DBThreadRef dbThread;
+  QString     translationDir;
   QTimer      timer;
   std::optional<Bearing> lastBearing;
 
@@ -133,7 +136,7 @@ private:
   // player should be created in module thread, not in UI thread (constructor)
   // we setup QObject parents, objects are cleaned after Module destruction
   VoiceCorePlayer *mediaPlayer{nullptr};
-  std::vector<osmscout::VoiceInstructionMessage::VoiceSample> nextMessage;
+  std::vector<osmscout::SampleVoiceInstructionMessage::VoiceSample> nextMessage;
 
   osmscout::RouteDescriptionRef routeDescription;
 
@@ -145,7 +148,7 @@ private:
       std::make_shared<PositionAgent>(),
       std::make_shared<BearingAgent>(),
       std::make_shared<RouteInstructionAgent<RouteStep, RouteDescriptionBuilder>>(),
-      std::make_shared<VoiceInstructionAgent>(units),
+      std::make_shared<VoiceInstructionAgent>(units, std::make_shared<TTSMessageGeneratorQt>(translationDir)),
       std::make_shared<RouteStateAgent>(),
       std::make_shared<ArrivalEstimateAgent>(),
       std::make_shared<SpeedAgent>(),

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
@@ -26,6 +26,7 @@
 #include <osmscoutclientqt/Router.h>
 #include <osmscoutclientqt/VoicePlayer.h>
 #include <osmscoutclientqt/TTSMessageGeneratorQt.h>
+#include <osmscoutclientqt/TTSEngine.h>
 
 #include <osmscout/navigation/Navigation.h>
 #include <osmscout/navigation/Engine.h>
@@ -108,7 +109,8 @@ public:
   NavigationModule(QThread *thread,
                    SettingsRef settings,
                    DBThreadRef dbThread,
-                   const QString &translationDir);
+                   const QString &translationDir,
+                   const QString &espeakDataDir);
 
   bool loadRoutableObjects(const GeoBox &box,
                            const Vehicle &vehicle,
@@ -119,6 +121,7 @@ public:
 
 private:
   void InitPlayer();
+  void EnsureTTSEngine();
   void ProcessMessages(const std::list<osmscout::NavigationMessageRef>& messages);
   QString sampleFile(osmscout::SampleVoiceInstructionMessage::VoiceSample sample) const;
 
@@ -128,15 +131,20 @@ private:
   DistanceUnitSystem units{Locale::ByEnvironmentSafe().GetDistanceUnits()}; // TODO: make possible to override
   DBThreadRef dbThread;
   QString     translationDir;
+  QString     espeakDataDir;
   QTimer      timer;
   std::optional<Bearing> lastBearing;
 
   // voice route instructions
-  QString voiceDir;
+  Voice voice;
   // player should be created in module thread, not in UI thread (constructor)
-  // we setup QObject parents, objects are cleaned after Module destruction
+  // we setup QObject parents, objects are cleaned after Module destruction (Qt's parent)
   VoiceCorePlayer *mediaPlayer{nullptr};
   std::vector<osmscout::SampleVoiceInstructionMessage::VoiceSample> nextMessage;
+
+  // text-to-speech (TTS) voice instructions
+  // engine runs in its own background thread, created lazily on the first TTS message
+  TTSEngine *ttsEngine{nullptr};
 
   osmscout::RouteDescriptionRef routeDescription;
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/NavigationModule.h
@@ -109,6 +109,8 @@ public slots:
 
   void playerStateChanged(VoicePlayer::PlaybackState state);
 
+  void playAudio(const QList<QUrl> &audioFiles);
+
 public:
   NavigationModule(QThread *thread,
                    SettingsRef settings,

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -367,6 +367,7 @@ public:
   QString GetCacheLocation() const;
   size_t  GetOnlineTileCacheSize() const;
   QString GetIconDirectory() const;
+  QString GetNavigationTranslationDir() const;
 
   static void RegisterQmlTypes(const char *uri="net.sf.libosmscout.map",
                                int versionMajor=1,

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -75,6 +75,8 @@ private:
 
   QString voiceLookupDirectory;
 
+  QString navigationTranslationDir;
+
   QString styleSheetDirectory;
   bool styleSheetDirectoryConfigured{false};
 
@@ -203,6 +205,11 @@ public:
     return *this;
   }
 
+  inline OSMScoutQtBuilder& WithNavigationTranslationDir(const QString &navigationTranslationDir){
+    this->navigationTranslationDir=navigationTranslationDir;
+    return *this;
+  }
+
   bool Init();
 };
 
@@ -268,6 +275,7 @@ private:
   PixelRatioSetup     pixelRatio;
   QString             userAgent;
   std::atomic_int     liveBackgroundThreads;
+  QString             navigationTranslationDir;
 
   std::mutex          mutex;
   MapDownloaderRef    mapDownloader; // created lazy, guarded by mutex
@@ -284,7 +292,8 @@ private:
              GLPowerOfTwoTexture glPowerOfTwoTexture,
              const PixelRatioSetup &pixelRatio,
              QString userAgent,
-             QStringList customPoiTypes);
+             QStringList customPoiTypes,
+             const QString &navigationTranslationDir);
 
 public slots:
   void threadFinished();

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -77,6 +77,8 @@ private:
 
   QString navigationTranslationDir;
 
+  QString espeakDataDir;
+
   QString styleSheetDirectory;
   bool styleSheetDirectoryConfigured{false};
 
@@ -210,6 +212,14 @@ public:
     return *this;
   }
 
+  /**
+   * Directory with espeak-ng data, used by the Piper text-to-speech engine.
+   */
+  inline OSMScoutQtBuilder& WithEspeakDataDir(const QString &espeakDataDir){
+    this->espeakDataDir=espeakDataDir;
+    return *this;
+  }
+
   bool Init();
 };
 
@@ -276,6 +286,7 @@ private:
   QString             userAgent;
   std::atomic_int     liveBackgroundThreads;
   QString             navigationTranslationDir;
+  QString             espeakDataDir;
 
   std::mutex          mutex;
   MapDownloaderRef    mapDownloader; // created lazy, guarded by mutex
@@ -293,7 +304,8 @@ private:
              const PixelRatioSetup &pixelRatio,
              QString userAgent,
              QStringList customPoiTypes,
-             const QString &navigationTranslationDir);
+             const QString &navigationTranslationDir,
+             const QString &espeakDataDir);
 
 public slots:
   void threadFinished();
@@ -313,7 +325,7 @@ public:
    *         service, SLOT(init()));
    * thread->start();
    *
-   * Service should stop thread in own destructor: QThread::stop()
+   * Service should stop thread in own destructor: QThread::quit()
    *
    * @param name
    * @return thread

--- a/libosmscout-client-qt/include/osmscoutclientqt/PiperTTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/PiperTTSEngine.h
@@ -57,7 +57,7 @@ public:
    * @param player audio player used to play synthesized messages.
    * @param espeakDataDir path to the espeak-ng data directory required by Piper.
    */
-  PiperTTSEngine(VoiceCorePlayer *player, const QString &espeakDataDir);
+  explicit PiperTTSEngine(const QString &espeakDataDir);
   ~PiperTTSEngine() override;
 
   void initVoice(const Voice &voice) override;

--- a/libosmscout-client-qt/include/osmscoutclientqt/PiperTTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/PiperTTSEngine.h
@@ -1,0 +1,115 @@
+#ifndef OSMSCOUT_CLIENT_QT_PIPERTTSENGINE_H
+#define OSMSCOUT_CLIENT_QT_PIPERTTSENGINE_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+#include <osmscoutclientqt/TTSEngine.h>
+
+#include <QDir>
+#include <QHash>
+#include <QString>
+
+// forward declaration of the opaque Piper synthesizer, so that piper.h is not
+// required by users of this header
+struct piper_synthesizer;
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ *
+ * Piper (libpiper) based text-to-speech engine.
+ *
+ * Synthesis is performed with the (synchronous) Piper API on the engine
+ * background thread. Each message is rendered into a WAV file placed in the
+ * per-application cache directory (e.g. ~/.cache/... on Unix) and cached, so
+ * repeated messages are synthesized only once. Playback is delegated to the
+ * VoiceCorePlayer.
+ *
+ * Support for Piper is optional; this class is only compiled and available
+ * when the library was built with libpiper (see the CMake / Meson build
+ * files). When libpiper is missing, NavigationModule simply keeps its TTS
+ * engine unset.
+ */
+class OSMSCOUT_CLIENT_QT_API PiperTTSEngine : public TTSEngine {
+  Q_OBJECT
+
+public:
+  /**
+   * @param player audio player used to play synthesized messages.
+   * @param espeakDataDir path to the espeak-ng data directory required by Piper.
+   */
+  PiperTTSEngine(VoiceCorePlayer *player, const QString &espeakDataDir);
+  ~PiperTTSEngine() override;
+
+  void initVoice(const Voice &voice) override;
+  Voice getVoice() override;
+  void prepareMessage(QString message) override;
+  void playMessage(QString message) override;
+
+protected:
+  /**
+   * Remove the oldest synthesized WAV files when the cache directory exceeds
+   * the size limit. Called on the engine thread when the engine thread starts.
+   */
+  void cleanCache() override;
+
+private:
+  /**
+   * Synthesize the message to a cached WAV file and return its path.
+   * Returns an empty string on failure. Has to be called on the engine thread.
+   */
+  QString prepare(const QString &message);
+
+  /**
+   * Local path of the WAV file used to cache the given message. The file name
+   * is derived from a hash of both the current voice and the message, so that
+   * caches of different voices do not collide.
+   */
+  QString wavFilePath(const QString &message) const;
+
+  /**
+   * Release the Piper synthesizer (if any).
+   */
+  void closeSynthesizer();
+
+private:
+  QDir    cacheDir;       //!< cache directory holding synthesized WAV files
+  QString espeakDataPath; //!< path to the espeak-ng data directory required by Piper
+  Voice voice;
+  QString voiceId;        //!< identifier of the loaded voice (name + directory), part of the sample hash
+
+  piper_synthesizer *synthesizer{nullptr}; //!< active Piper synthesizer, nullptr when no voice is loaded
+
+  QHash<QString, QString> cache; //!< message -> WAV file path
+};
+
+}
+
+#endif // OSMSCOUT_CLIENT_QT_PIPERTTSENGINE_H
+
+
+
+
+
+
+
+

--- a/libosmscout-client-qt/include/osmscoutclientqt/RouteDescriptionBuilder.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/RouteDescriptionBuilder.h
@@ -63,9 +63,9 @@ public:
     Duration timestampPrevious;
 
   public:
-    Callback(QList<RouteStep> &routeSteps,
-             const Distance &stopAfter = Distance::Lowest(),
-             bool skipInformative=false);
+    explicit Callback(QList<RouteStep> &routeSteps,
+                      const Distance &stopAfter = Distance::Lowest(),
+                      bool skipInformative=false);
 
     ~Callback() override = default;
 

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
@@ -1,0 +1,105 @@
+#ifndef OSMSCOUT_CLIENT_QT_TTSENGINE_H
+#define OSMSCOUT_CLIENT_QT_TTSENGINE_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+#include <osmscoutclientqt/Voice.h>
+#include <osmscoutclientqt/VoicePlayer.h>
+
+#include <QObject>
+#include <QString>
+
+class QThread;
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ *
+ * Abstract text-to-speech engine. It synthesizes spoken navigation
+ * instructions and plays them through the provided VoiceCorePlayer.
+ *
+ * Speech synthesis may be a slow, synchronous operation (see PiperTTSEngine),
+ * so the engine runs in its own background thread. All operations
+ * (#initVoice, #prepareMessage, #playMessage) are executed asynchronously on
+ * that thread, they should be invoked through a queued connection
+ * (e.g. QMetaObject::invokeMethod with Qt::QueuedConnection).
+ *
+ * The background thread is created and started by the base constructor. When
+ * it starts, #cleanCache() is invoked on the engine thread (default
+ * implementation is empty, a derived class may override it to prune its cache).
+ */
+class OSMSCOUT_CLIENT_QT_API TTSEngine : public QObject {
+  Q_OBJECT
+
+protected:
+  QThread         *thread; //!< engine background thread (owns itself, deleted on finish)
+  VoiceCorePlayer *player; //!< audio player, not owned (lives in the creator thread)
+
+public:
+  /**
+   * @param player audio player used to play synthesized messages.
+   *               It is not owned by the engine and has to outlive it.
+   */
+  explicit TTSEngine(VoiceCorePlayer *player);
+
+  TTSEngine(const TTSEngine&) = delete;
+  TTSEngine(TTSEngine&&) = delete;
+  TTSEngine& operator=(const TTSEngine&) = delete;
+  TTSEngine& operator=(TTSEngine&&) = delete;
+
+  ~TTSEngine() override;
+
+  /**
+   * Initialize the engine for the given voice.
+   * Runs asynchronously on the engine thread.
+   */
+  virtual void initVoice(const Voice &voice) = 0;
+
+  virtual Voice getVoice() = 0;
+
+  /**
+   * Synthesize the message to an audio file (cached in a temporary directory)
+   * without playing it. Runs asynchronously on the engine thread.
+   */
+  virtual void prepareMessage(QString message) = 0;
+
+  /**
+   * Prepare the message (when it is not cached yet) and play it right away.
+   * Runs asynchronously on the engine thread.
+   */
+  virtual void playMessage(QString message) = 0;
+
+protected:
+  /**
+   * Called on the engine thread when the background thread starts. The default
+   * implementation does nothing; a derived class may override it to clean up
+   * its on-disk cache. Runs on the engine thread.
+   */
+  virtual void cleanCache();
+};
+
+}
+
+#endif // OSMSCOUT_CLIENT_QT_TTSENGINE_H
+
+
+

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
@@ -54,6 +54,25 @@ protected:
   QThread         *thread; //!< engine background thread (owns itself, deleted on finish)
   VoiceCorePlayer *player; //!< audio player, not owned (lives in the creator thread)
 
+public slots:
+  /**
+   * Initialize the engine for the given voice.
+   * Runs asynchronously on the engine thread.
+   */
+  virtual void initVoice(const Voice &voice) = 0;
+
+  /**
+ * Synthesize the message to an audio file (cached in a temporary directory)
+ * without playing it. Runs asynchronously on the engine thread.
+ */
+  virtual void prepareMessage(QString message) = 0;
+
+  /**
+   * Prepare the message (when it is not cached yet) and play it right away.
+   * Runs asynchronously on the engine thread.
+   */
+  virtual void playMessage(QString message) = 0;
+
 public:
   /**
    * @param player audio player used to play synthesized messages.
@@ -68,25 +87,7 @@ public:
 
   ~TTSEngine() override;
 
-  /**
-   * Initialize the engine for the given voice.
-   * Runs asynchronously on the engine thread.
-   */
-  virtual void initVoice(const Voice &voice) = 0;
-
   virtual Voice getVoice() = 0;
-
-  /**
-   * Synthesize the message to an audio file (cached in a temporary directory)
-   * without playing it. Runs asynchronously on the engine thread.
-   */
-  virtual void prepareMessage(QString message) = 0;
-
-  /**
-   * Prepare the message (when it is not cached yet) and play it right away.
-   * Runs asynchronously on the engine thread.
-   */
-  virtual void playMessage(QString message) = 0;
 
 protected:
   /**

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
@@ -52,7 +52,6 @@ class OSMSCOUT_CLIENT_QT_API TTSEngine : public QObject {
 
 protected:
   QThread         *thread; //!< engine background thread (owns itself, deleted on finish)
-  VoiceCorePlayer *player; //!< audio player, not owned (lives in the creator thread)
 
 public slots:
   /**
@@ -73,12 +72,11 @@ public slots:
    */
   virtual void playMessage(QString message) = 0;
 
+signals:
+  void playAudioFilesRequest(const QList<QUrl> &audioFiles);
+
 public:
-  /**
-   * @param player audio player used to play synthesized messages.
-   *               It is not owned by the engine and has to outlive it.
-   */
-  explicit TTSEngine(VoiceCorePlayer *player);
+  TTSEngine();
 
   TTSEngine(const TTSEngine&) = delete;
   TTSEngine(TTSEngine&&) = delete;

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSMessageGeneratorQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSMessageGeneratorQt.h
@@ -1,0 +1,85 @@
+#ifndef OSMSCOUT_CLIENT_QT_TTSMESSAGEGENERATORQT_H
+#define OSMSCOUT_CLIENT_QT_TTSMESSAGEGENERATORQT_H
+
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscout/navigation/VoiceInstructionAgent.h>
+
+#include <osmscoutclientqt/ClientQtImportExport.h>
+
+#include <QString>
+#include <QTranslator>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace osmscout {
+
+/**
+ * \ingroup QtAPI
+ *
+ * Qt based implementation of TTSMessageGenerator producing
+ * template-based messages for a TTS engine.
+ *
+ * Translations are resolved through a dedicated QTranslator instance
+ * (see SetLanguage) instead of the globally installed application
+ * translators. This makes it possible to generate voice instructions
+ * in a language that is different from the language used by the rest of
+ * the application. When no translation is available for a given source
+ * string, the (English) source text is used as a fallback.
+ */
+class OSMSCOUT_CLIENT_QT_API TTSMessageGeneratorQt : public TTSMessageGenerator {
+public:
+  //!< Translation context used for all source strings (must match lupdate context).
+  static constexpr const char *TranslationContext = "TTSMessageGeneratorQt";
+
+private:
+  QString translationDir;
+  //!< Translator dedicated to voice instructions, independent of the app UI language.
+  std::unique_ptr<QTranslator> translator;
+
+public:
+  explicit TTSMessageGeneratorQt(const QString &translationDir);
+  ~TTSMessageGeneratorQt() override = default;
+
+  bool SetLanguage(const std::string &language) override;
+
+  std::optional<std::string> GenerateMessage(const VoiceMessageStruct &message,
+                                             const VoiceMessageStruct &then) override;
+
+private:
+  /**
+   * Translate a source string using the dedicated translator, falling back
+   * to the source text when no translation is available.
+   */
+  QString Translate(const char *sourceText) const;
+
+  /**
+   * Build a translated phrase for a single maneuver. Returns an empty string
+   * for messages that should not be spoken (NoMessage, Silent).
+   */
+  QString Phrase(const VoiceMessageStruct &message) const;
+};
+
+}
+
+#endif //OSMSCOUT_CLIENT_QT_TTSMESSAGEGENERATORQT_H
+

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSMessageGeneratorQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSMessageGeneratorQt.h
@@ -55,6 +55,8 @@ private:
   QString translationDir;
   //!< Translator dedicated to voice instructions, independent of the app UI language.
   std::unique_ptr<QTranslator> translator;
+  DistanceUnitSystem units{DistanceUnitSystem::Metrics};
+  Vehicle vehicle{vehicleCar};
 
 public:
   explicit TTSMessageGeneratorQt(const QString &translationDir);
@@ -62,7 +64,12 @@ public:
 
   bool SetLanguage(const std::string &language) override;
 
-  std::optional<std::string> GenerateMessage(const VoiceMessageStruct &message,
+  void SetUnits(DistanceUnitSystem units) override;
+
+  void SetVehicle(Vehicle vehicle) override;
+
+  std::optional<std::string> GenerateMessage(const Distance &distanceFromStart,
+                                             const VoiceMessageStruct &message,
                                              const VoiceMessageStruct &then) override;
 
 private:
@@ -75,8 +82,19 @@ private:
   /**
    * Build a translated phrase for a single maneuver. Returns an empty string
    * for messages that should not be spoken (NoMessage, Silent).
+   *
+   * @param shortRoundaboutMessage when true, the "At the roundabout" part of a
+   *        roundabout exit phrase is omitted (used when the roundabout is close
+   *        or for a following "then" maneuver).
    */
-  QString Phrase(const VoiceMessageStruct &message) const;
+  QString Phrase(const VoiceMessageStruct &message, bool shortRoundaboutMessage) const;
+
+  /**
+   * Build the translated distance announcement (e.g. "After 300 meters") for
+   * the given distance, using the same distance buckets as the Voice of Marble
+   * messages. Returns an empty string when no distance should be announced.
+   */
+  QString DistancePhrase(double distanceInUnits) const;
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/Voice.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/Voice.h
@@ -28,12 +28,24 @@
 
 namespace osmscout {
 
+/**
+ * Type of the "Voice of Marble" voice packs, made of pre-recorded ogg samples.
+ */
+constexpr char const *VoiceTypeVoiceOfMarble = "VoiceOfMarble";
+
+/**
+ * Type of Piper TTS voices, made of an onnx model and its json config.
+ */
+constexpr char const *VoiceTypePiper = "Piper";
+
 class OSMSCOUT_CLIENT_QT_API AvailableVoice : public QObject {
   Q_OBJECT
 
   Q_PROPERTY(bool valid READ isValid() CONSTANT)
 
+  Q_PROPERTY(QString type READ getType() CONSTANT)
   Q_PROPERTY(QString lang READ getLang() CONSTANT)
+  Q_PROPERTY(QString langCode READ getLangCode() CONSTANT)
   Q_PROPERTY(QString gender READ getGender() CONSTANT)
   Q_PROPERTY(QString name READ getName() CONSTANT)
   Q_PROPERTY(QString license READ getLicense() CONSTANT)
@@ -46,7 +58,9 @@ private:
 
   VoiceProvider provider;
 
+  QString type;
   QString lang;
+  QString langCode;
   QString gender;
   QString name;
   QString license;
@@ -54,17 +68,25 @@ private:
   QString author;
   QString description;
 
+  // Piper specific: server-relative paths to the model and its json config
+  QString model;
+  QString metadataPath;
+
 public:
   AvailableVoice() = default;
 
   AvailableVoice(const VoiceProvider &provider,
+                 const QString &type,
                  const QString &lang,
+                 const QString &langCode,
                  const QString &gender,
                  const QString &name,
                  const QString &license,
                  const QString &directory,
                  const QString &author,
-                 const QString &description);
+                 const QString &description,
+                 const QString &model,
+                 const QString &metadataPath);
 
   AvailableVoice(const AvailableVoice& o);
 
@@ -75,9 +97,21 @@ public:
     return provider;
   }
 
+  QString getType() const
+  {
+    return type;
+  }
+  bool isPiper() const
+  {
+    return type == VoiceTypePiper;
+  }
   QString getLang() const
   {
     return lang;
+  }
+  QString getLangCode() const
+  {
+    return langCode;
   }
   QString getGender() const
   {
@@ -102,6 +136,14 @@ public:
   QString getDescription() const
   {
     return description;
+  }
+  QString getModel() const
+  {
+    return model;
+  }
+  QString getMetadataPath() const
+  {
+    return metadataPath;
   }
 
   bool isValid() const
@@ -133,9 +175,24 @@ public:
     return dir;
   }
 
+  QString getType() const
+  {
+    return type;
+  }
+
+  bool isPiper() const
+  {
+    return type == VoiceTypePiper;
+  }
+
   QString getLang() const
   {
     return lang;
+  }
+
+  QString getLangCode() const
+  {
+    return langCode;
   }
 
   QString getGender() const
@@ -163,6 +220,14 @@ public:
     return description;
   }
 
+  /**
+   * Local file name of the Piper onnx model (empty for other types).
+   */
+  QString getModelFile() const
+  {
+    return modelFile;
+  }
+
   bool isValid() const
   {
     return valid;
@@ -170,19 +235,31 @@ public:
 
   bool deleteVoice();
 
-  static QStringList files();
+  /**
+   * List of files owned by this voice (depends on its type), relative to its
+   * directory. Used for validation and removal.
+   */
+  QStringList files() const;
+
+  /**
+   * Mandatory files of a "Voice of Marble" ogg sample pack.
+   */
+  static QStringList marbleFiles();
 
 private:
   QDir dir;
   bool valid{false};
   bool metadata{false};
 
+  QString type;
   QString lang;
+  QString langCode;
   QString gender;
   QString name;
   QString license;
   QString author;
   QString description;
+  QString modelFile;
 };
 
 }

--- a/libosmscout-client-qt/include/osmscoutclientqt/meson.build
+++ b/libosmscout-client-qt/include/osmscoutclientqt/meson.build
@@ -1,4 +1,5 @@
 clientqtFeaturesCfg = configuration_data()
+clientqtFeaturesCfg.set('OSMSCOUT_HAVE_LIB_PIPER',piperDep.found(), description: 'libpiper (Piper TTS) is available')
 
 configure_file(output: 'ClientQtFeatures.h',
                install_dir: 'include/osmscoutclientqt',

--- a/libosmscout-client-qt/meson.build
+++ b/libosmscout-client-qt/meson.build
@@ -36,7 +36,7 @@ endforeach
                              osmscoutclientqtSrc,
                              include_directories: [osmscoutclientqtIncDir, osmscoutclientIncDir, osmscoutmapqtIncDir, osmscoutmapIncDir, osmscoutIncDir],
                              cpp_args: cppArgs,
-                             dependencies: [mathDep, threadDep, qtClientDep],
+                             dependencies: [mathDep, threadDep, qtClientDep, piperDep],
                              link_with: [osmscout, osmscoutmap, osmscoutmapqt, osmscoutclient],
                              version: libraryVersion,
                              install: true)

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -53,5 +53,11 @@ osmscoutclientqtSrc = [
             'src/osmscoutclientqt/AvailableVoicesModel.cpp',
             'src/osmscoutclientqt/InstalledVoicesModel.cpp',
             'src/osmscoutclientqt/TTSMessageGeneratorQt.cpp',
+            'src/osmscoutclientqt/TTSEngine.cpp',
           ]
+
+# Piper TTS engine is optional, build it only when libpiper is available
+if piperDep.found()
+  osmscoutclientqtSrc += ['src/osmscoutclientqt/PiperTTSEngine.cpp']
+endif
 

--- a/libosmscout-client-qt/src/meson.build
+++ b/libosmscout-client-qt/src/meson.build
@@ -52,5 +52,6 @@ osmscoutclientqtSrc = [
             'src/osmscoutclientqt/VoicePlayer.cpp',
             'src/osmscoutclientqt/AvailableVoicesModel.cpp',
             'src/osmscoutclientqt/InstalledVoicesModel.cpp',
+            'src/osmscoutclientqt/TTSMessageGeneratorQt.cpp',
           ]
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
@@ -28,6 +28,7 @@
 #include <QStandardPaths>
 
 #include <algorithm>
+#include <QTranslator>
 
 namespace osmscout {
 
@@ -129,6 +130,10 @@ void AvailableVoicesModel::listDownloaded(const VoiceProvider &provider, QNetwor
   }else{
     QByteArray downloadedData = reply->readAll();
     QJsonDocument doc = QJsonDocument::fromJson(downloadedData);
+
+    QString navigationTranslationDir=OSMScoutQt::GetInstance().GetNavigationTranslationDir();
+    QMap<QString,bool> langAvailable;
+
     for (const QJsonValueRef ref: doc.array()){
       if (!ref.isObject())
         continue;
@@ -160,6 +165,23 @@ void AvailableVoicesModel::listDownloaded(const VoiceProvider &provider, QNetwor
 
           qWarning() << "Invalid Piper item:" << obj;
           continue;
+        }
+
+        // do not offer Piper languages for which we cannot load the translations
+        // as TTSMessageGeneratorQt would not be able to use them
+        if (langAvailable.contains(langCode.toString())){
+          if (!langAvailable[langCode.toString()]){
+            continue;
+          }
+        } else{
+          QTranslator translator;
+          if (translator.load(langCode.toString(), navigationTranslationDir)) {
+            langAvailable[langCode.toString()] = true;
+          } else {
+            langAvailable[langCode.toString()] = false;
+            qWarning() << "Failed to load translator for language " << langCode.toString() << ", skipping Piper voice " << name.toString();
+            continue;
+          }
         }
 
         items.append(new AvailableVoice(

--- a/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
@@ -127,35 +127,81 @@ void AvailableVoicesModel::listDownloaded(const VoiceProvider &provider, QNetwor
         continue;
       QJsonObject obj=ref.toObject();
 
-      auto lang=obj.value("lang");
-      auto gender=obj.value("gender");
-      auto name=obj.value("name");
-      auto license=obj.value("license");
-      auto dir=obj.value("dir");
-      auto author=obj.value("author");
-      auto description=obj.value("description");
+      QString type=obj.value("type").toString(VoiceTypeVoiceOfMarble);
 
-      if (!lang.isString() ||
-          !gender.isString() ||
-          !name.isString() ||
-          !license.isString() ||
-          !dir.isString() ||
-          !author.isString() ||
-          !description.isString()) {
+      if (type == VoiceTypePiper) {
+        // Piper TTS voice: onnx model + json config.
+        auto lang=obj.value("lang");
+        auto langCode=obj.value("lang_code");
+        auto name=obj.value("name");
+        auto license=obj.value("license");
+        auto dir=obj.value("dir");
+        auto model=obj.value("model");
+        auto metadataPath=obj.value("metadata");
 
-        qWarning() << "Invalid item:" << obj;
-        continue;
+        if (!lang.isString() ||
+            !langCode.isString() ||
+            !name.isString() ||
+            !license.isString() ||
+            !dir.isString() ||
+            !model.isString() ||
+            !metadataPath.isString()) {
+
+          qWarning() << "Invalid Piper item:" << obj;
+          continue;
+        }
+
+        items.append(new AvailableVoice(
+            provider,
+            type,
+            lang.toString(),
+            langCode.toString(),
+            /*gender*/ "",
+            name.toString(),
+            license.toString(),
+            dir.toString(),
+            /*author*/ "",
+            /*description*/ "",
+            model.toString(),
+            metadataPath.toString()));
+      } else if (type == VoiceTypeVoiceOfMarble) {
+        // "Voice of Marble" ogg sample pack
+        auto lang=obj.value("lang");
+        auto gender=obj.value("gender");
+        auto name=obj.value("name");
+        auto license=obj.value("license");
+        auto dir=obj.value("dir");
+        auto author=obj.value("author");
+        auto description=obj.value("description");
+
+        if (!lang.isString() ||
+            !gender.isString() ||
+            !name.isString() ||
+            !license.isString() ||
+            !dir.isString() ||
+            !author.isString() ||
+            !description.isString()) {
+
+          qWarning() << "Invalid item:" << obj;
+          continue;
+            }
+
+        items.append(new AvailableVoice(
+            provider,
+            type,
+            lang.toString(),
+            /*langCode*/ "",
+            gender.toString(),
+            name.toString(),
+            license.toString(),
+            dir.toString(),
+            author.toString(),
+            description.toString(),
+            /*model*/ "",
+            /*metadataPath*/ ""));
+      } else {
+        qWarning() << "Unknown voice type:" << type;
       }
-
-      items.append(new AvailableVoice(
-          provider,
-          lang.toString(),
-          gender.toString(),
-          name.toString(),
-          license.toString(),
-          dir.toString(),
-          author.toString(),
-          description.toString()));
     }
   }
 
@@ -200,8 +246,12 @@ QVariant AvailableVoicesModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
     case NameRole:
       return item->getName();
+    case TypeRole:
+      return item->getType();
     case LangRole:
       return item->getLang();
+    case LangCodeRole:
+      return item->getLangCode();
     case GenderRole:
       return item->getGender();
     case LicenseRole:
@@ -276,6 +326,8 @@ QHash<int, QByteArray> AvailableVoicesModel::roleNames() const
 
   roles[NameRole]="name";
   roles[LangRole]="lang";
+  roles[LangCodeRole]="langCode";
+  roles[TypeRole]="type";
   roles[GenderRole]="gender";
   roles[LicenseRole]="license";
   roles[DirectoryRole]="directory";

--- a/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/AvailableVoicesModel.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <osmscoutclientqt/AvailableVoicesModel.h>
+#include <osmscoutclientqt/ClientQtFeatures.h>
 #include <osmscoutclientqt/PersistentCookieJar.h>
 #include <osmscoutclientqt/OSMScoutQt.h>
 
@@ -108,6 +109,12 @@ bool availableVoiceItemLessThan(const AvailableVoice *i1, const AvailableVoice *
   }
   return i1->getName().localeAwareCompare(i2->getName()) < 0;
 }
+
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+constexpr bool piperAvailable=true;
+#else
+constexpr bool piperAvailable=false;
+#endif
 }
 
 void AvailableVoicesModel::listDownloaded(const VoiceProvider &provider, QNetworkReply* reply)
@@ -130,6 +137,10 @@ void AvailableVoicesModel::listDownloaded(const VoiceProvider &provider, QNetwor
       QString type=obj.value("type").toString(VoiceTypeVoiceOfMarble);
 
       if (type == VoiceTypePiper) {
+        if constexpr (!piperAvailable) {
+          qDebug() << "Piper voice found but libpiper is not available, skipping:" << obj;
+          continue;
+        }
         // Piper TTS voice: onnx model + json config.
         auto lang=obj.value("lang");
         auto langCode=obj.value("lang_code");

--- a/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
@@ -107,6 +107,8 @@ QVariant InstalledVoicesModel::data(const QModelIndex &index, int role) const
     case SelectedRole:
       return (voiceDir.isEmpty() && !voice.isValid()) ||
              (voiceDir == voice.getDir().absolutePath());
+    case TypeRole:
+      return voice.getType();
     default:
       break;
   }
@@ -161,6 +163,7 @@ QHash<int, QByteArray> InstalledVoicesModel::roleNames() const
   roles[GenderRole]="gender";
   roles[ValidRole]="valid";
   roles[SelectedRole]="selected";
+  roles[TypeRole]="type";
 
   return roles;
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -102,7 +102,7 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
              nextInstruction != nullptr) {
 
       if (!nextInstruction->nextRouteInstruction.shortDescription.isEmpty()) {
-        log.Debug() << "In " << nextInstruction->nextRouteInstruction.distanceTo.AsMeter() << " m: "
+        log.Debug() << "In " << qRound(nextInstruction->nextRouteInstruction.distanceTo.AsMeter()) << " m: "
                     << nextInstruction->nextRouteInstruction.shortDescription.toStdString();
       }
       emit updateNext(nextInstruction->nextRouteInstruction);
@@ -317,11 +317,11 @@ QString NavigationModule::sampleFile(osmscout::VoiceInstructionMessage::VoiceSam
   }
 }
 
-  void NavigationModule::playerStateChanged(VoicePlayer::PlaybackState state)
-  {
-    if (thread!=QThread::currentThread()){
-      qWarning() << "Player state changed from incorrect thread;" << thread << "!=" << QThread::currentThread();
-    }
+void NavigationModule::playerStateChanged(VoicePlayer::PlaybackState state)
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "Player state changed from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
 
   qDebug() << "Voice player state:" << mediaPlayer->playbackState() << "(" << mediaPlayer->index() << "/" << mediaPlayer->queueCount() << ")";
   if (!voiceDir.isEmpty() &&

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <osmscoutclientqt/NavigationModule.h>
+#include <osmscoutclientqt/Voice.h>
 
 #include <osmscout/log/Logger.h>
 
@@ -25,6 +26,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QDebug>
+
 
 namespace osmscout {
 
@@ -239,6 +241,22 @@ void NavigationModule::onVoiceChanged(const QString dir)
   voiceDir = dir;
   if (!QDir(voiceDir).exists()){
     voiceDir.clear(); // disable voice
+  }
+
+  auto now = std::chrono::system_clock::now();
+  if (voiceDir.isEmpty()) {
+    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now,NavigationVoiceType::None)));
+  } else {
+    Voice voice(voiceDir);
+    NavigationVoiceType type = NavigationVoiceType::None;
+    if (voice.getType() == VoiceTypePiper) {
+      type = NavigationVoiceType::TextToSpeech;
+    } else if (voice.getType() == VoiceTypeVoiceOfMarble) {
+      type = NavigationVoiceType::VoiceOfMarble;
+    } else {
+      qWarning() << "Unknown voice type:" << voice.getType();
+    }
+    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now, std::move(type))));
   }
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -89,6 +89,11 @@ void NavigationModule::EnsureTTSEngine()
 #ifdef OSMSCOUT_HAVE_LIB_PIPER
     InitPlayer(); // TTS engine plays synthesized messages through the media player
     ttsEngine = new PiperTTSEngine(mediaPlayer, espeakDataDir);
+
+    connect(this, &NavigationModule::initVoiceRequested, ttsEngine, &TTSEngine::initVoice, Qt::QueuedConnection);
+    connect(this, &NavigationModule::prepareMessageRequested, ttsEngine, &TTSEngine::prepareMessage, Qt::QueuedConnection);
+    connect(this, &NavigationModule::playMessageRequested, ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
+
 #else
     // library was built without any TTS engine, keep ttsEngine unset
     log.Warn() << "No text-to-speech engine available (built without libpiper)";
@@ -98,11 +103,7 @@ void NavigationModule::EnsureTTSEngine()
 
   // (re)initialize the engine when the selected voice changed
   if (!ttsEngine->getVoice().isValid() || ttsEngine->getVoice().getDir() != voice.getDir()){
-    auto ttsVoice = voice;
-    TTSEngine *engine = ttsEngine;
-    QMetaObject::invokeMethod(engine, [engine, ttsVoice]() {
-      engine->initVoice(ttsVoice);
-    }, Qt::QueuedConnection);
+    emit(initVoiceRequested(voice));
   }
 }
 
@@ -178,11 +179,8 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
       if (voice.isValid()) {
         EnsureTTSEngine();
         if (ttsEngine!=nullptr) {
-          TTSEngine *engine = ttsEngine;
           QString msg = QString::fromStdString(ttsPrepareMessage->message);
-          QMetaObject::invokeMethod(engine, [engine, msg]() {
-            engine->prepareMessage(msg);
-          }, Qt::QueuedConnection);
+          emit prepareMessageRequested(msg);
         }
       }
     } else if (auto ttsMessage = dynamic_cast<osmscout::TTSVoiceInstructionMessage*>(message.get());
@@ -191,11 +189,8 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
       if (voice.isValid()) {
         EnsureTTSEngine();
         if (ttsEngine!=nullptr) {
-          TTSEngine *engine = ttsEngine;
           QString msg = QString::fromStdString(ttsMessage->message);
-          QMetaObject::invokeMethod(engine, [engine, msg]() {
-            engine->playMessage(msg);
-          }, Qt::QueuedConnection);
+          emit(playMessageRequested(msg));
         }
       }
     } else if (auto* laneMessage = dynamic_cast<osmscout::LaneAgent::LaneMessage*>(message.get());

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -32,8 +32,9 @@ namespace osmscout {
 
 NavigationModule::NavigationModule(QThread *thread,
                                    SettingsRef settings,
-                                   DBThreadRef dbThread):
-  thread(thread), settings(settings), dbThread(dbThread)
+                                   DBThreadRef dbThread,
+                                   const QString &translationDir):
+  thread(thread), settings(settings), dbThread(dbThread), translationDir(translationDir)
 {
   assert(settings);
   assert(dbThread);
@@ -125,7 +126,7 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
              maxSpeedMessage != nullptr) {
 
       emit maxAllowedSpeed(maxSpeedMessage->maxAllowedSpeed);
-    } else if (auto voiceInstructionMessage = dynamic_cast<osmscout::VoiceInstructionMessage*>(message.get());
+    } else if (auto voiceInstructionMessage = dynamic_cast<osmscout::SampleVoiceInstructionMessage*>(message.get());
                voiceInstructionMessage != nullptr) {
 
       if (!voiceDir.isEmpty()) {
@@ -245,10 +246,11 @@ void NavigationModule::onVoiceChanged(const QString dir)
 
   auto now = std::chrono::system_clock::now();
   if (voiceDir.isEmpty()) {
-    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now,NavigationVoiceType::None)));
+    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now,NavigationVoiceType::None, "")));
   } else {
     Voice voice(voiceDir);
     NavigationVoiceType type = NavigationVoiceType::None;
+
     if (voice.getType() == VoiceTypePiper) {
       type = NavigationVoiceType::TextToSpeech;
     } else if (voice.getType() == VoiceTypeVoiceOfMarble) {
@@ -256,13 +258,13 @@ void NavigationModule::onVoiceChanged(const QString dir)
     } else {
       qWarning() << "Unknown voice type:" << voice.getType();
     }
-    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now, std::move(type))));
+    ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now, type, voice.getLangCode().toStdString())));
   }
 }
 
-QString NavigationModule::sampleFile(osmscout::VoiceInstructionMessage::VoiceSample sample) const
+QString NavigationModule::sampleFile(osmscout::SampleVoiceInstructionMessage::VoiceSample sample) const
 {
-  using VoiceSample = osmscout::VoiceInstructionMessage::VoiceSample;
+  using VoiceSample = osmscout::SampleVoiceInstructionMessage::VoiceSample;
   switch(sample){
     case VoiceSample::After: return "After.ogg";
     case VoiceSample::AhExitLeft: return "AhExitLeft.ogg";

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -19,6 +19,10 @@
 
 #include <osmscoutclientqt/NavigationModule.h>
 #include <osmscoutclientqt/Voice.h>
+#include <osmscoutclientqt/ClientQtFeatures.h>
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+#include <osmscoutclientqt/PiperTTSEngine.h>
+#endif
 
 #include <osmscout/log/Logger.h>
 
@@ -33,8 +37,9 @@ namespace osmscout {
 NavigationModule::NavigationModule(QThread *thread,
                                    SettingsRef settings,
                                    DBThreadRef dbThread,
-                                   const QString &translationDir):
-  thread(thread), settings(settings), dbThread(dbThread), translationDir(translationDir)
+                                   const QString &translationDir,
+                                   const QString &espeakDataDir):
+  thread(thread), settings(settings), dbThread(dbThread), translationDir(translationDir), espeakDataDir(espeakDataDir)
 {
   assert(settings);
   assert(dbThread);
@@ -52,6 +57,11 @@ NavigationModule::~NavigationModule()
     qWarning() << "Destroy" << this << "from incorrect thread;" << thread << "!=" << QThread::currentThread();
   }
   qDebug() << "~NavigationModule";
+  if (ttsEngine!=nullptr){
+    // engine lives in its own thread, delete it there
+    ttsEngine->deleteLater();
+    ttsEngine=nullptr;
+  }
   if (thread!=nullptr){
     thread->quit();
   }
@@ -66,6 +76,33 @@ void NavigationModule::InitPlayer()
   if (mediaPlayer==nullptr){
     mediaPlayer = new VoiceCorePlayer(this);
     connect(mediaPlayer, SIGNAL(playbackStateChanged(VoicePlayer::PlaybackState)), this, SLOT(playerStateChanged(VoicePlayer::PlaybackState)));
+  }
+}
+
+void NavigationModule::EnsureTTSEngine()
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "TTS engine initialised from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+
+  if (ttsEngine==nullptr){
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+    InitPlayer(); // TTS engine plays synthesized messages through the media player
+    ttsEngine = new PiperTTSEngine(mediaPlayer, espeakDataDir);
+#else
+    // library was built without any TTS engine, keep ttsEngine unset
+    log.Warn() << "No text-to-speech engine available (built without libpiper)";
+    return;
+#endif
+  }
+
+  // (re)initialize the engine when the selected voice changed
+  if (!ttsEngine->getVoice().isValid() || ttsEngine->getVoice().getDir() != voice.getDir()){
+    auto ttsVoice = voice;
+    TTSEngine *engine = ttsEngine;
+    QMetaObject::invokeMethod(engine, [engine, ttsVoice]() {
+      engine->initVoice(ttsVoice);
+    }, Qt::QueuedConnection);
   }
 }
 
@@ -129,11 +166,37 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
     } else if (auto voiceInstructionMessage = dynamic_cast<osmscout::SampleVoiceInstructionMessage*>(message.get());
                voiceInstructionMessage != nullptr) {
 
-      if (!voiceDir.isEmpty()) {
+      if (voice.isValid()) {
         nextMessage = voiceInstructionMessage->message;
         InitPlayer();
         assert(mediaPlayer);
         playerStateChanged(mediaPlayer->playbackState());
+      }
+    } else if (auto ttsPrepareMessage = dynamic_cast<osmscout::TTSVoiceInstructionPrepareMessage*>(message.get());
+               ttsPrepareMessage != nullptr) {
+
+      if (voice.isValid()) {
+        EnsureTTSEngine();
+        if (ttsEngine!=nullptr) {
+          TTSEngine *engine = ttsEngine;
+          QString msg = QString::fromStdString(ttsPrepareMessage->message);
+          QMetaObject::invokeMethod(engine, [engine, msg]() {
+            engine->prepareMessage(msg);
+          }, Qt::QueuedConnection);
+        }
+      }
+    } else if (auto ttsMessage = dynamic_cast<osmscout::TTSVoiceInstructionMessage*>(message.get());
+               ttsMessage != nullptr) {
+
+      if (voice.isValid()) {
+        EnsureTTSEngine();
+        if (ttsEngine!=nullptr) {
+          TTSEngine *engine = ttsEngine;
+          QString msg = QString::fromStdString(ttsMessage->message);
+          QMetaObject::invokeMethod(engine, [engine, msg]() {
+            engine->playMessage(msg);
+          }, Qt::QueuedConnection);
+        }
       }
     } else if (auto* laneMessage = dynamic_cast<osmscout::LaneAgent::LaneMessage*>(message.get());
                laneMessage != nullptr) {
@@ -239,16 +302,16 @@ void NavigationModule::onTimeout()
 void NavigationModule::onVoiceChanged(const QString dir)
 {
   qDebug() << "Voice dir changed to:" << dir;
-  voiceDir = dir;
-  if (!QDir(voiceDir).exists()){
-    voiceDir.clear(); // disable voice
+  if (!QDir(dir).exists()){
+    voice = Voice(); // disable voice
+  } else {
+    voice = Voice(dir);
   }
 
   auto now = std::chrono::system_clock::now();
-  if (voiceDir.isEmpty()) {
+  if (!voice.isValid()) {
     ProcessMessages(engine.Process(std::make_shared<VoiceSetupMessage>(now,NavigationVoiceType::None, "")));
   } else {
-    Voice voice(voiceDir);
     NavigationVoiceType type = NavigationVoiceType::None;
 
     if (voice.getType() == VoiceTypePiper) {
@@ -344,14 +407,15 @@ void NavigationModule::playerStateChanged(VoicePlayer::PlaybackState state)
   }
 
   qDebug() << "Voice player state:" << mediaPlayer->playbackState() << "(" << mediaPlayer->index() << "/" << mediaPlayer->queueCount() << ")";
-  if (!voiceDir.isEmpty() &&
+  if (voice.isValid() &&
+      voice.getType() == VoiceTypeVoiceOfMarble &&
       !nextMessage.empty() &&
       state == VoicePlayer::StoppedState) {
 
     mediaPlayer->clearQueue();
 
     for (const auto& sample : nextMessage){
-      auto sampleUrl = QUrl::fromLocalFile(voiceDir + QDir::separator() + sampleFile(sample));
+      auto sampleUrl = QUrl::fromLocalFile(voice.getDir().filePath(sampleFile(sample)));
       qDebug() << "Adding to playlist:" << sampleUrl;
       mediaPlayer->addToQueue(sampleUrl);
     }

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -79,6 +79,25 @@ void NavigationModule::InitPlayer()
   }
 }
 
+void NavigationModule::playAudio(const QList<QUrl> &audioFiles)
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "Audio message played from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+  if (mediaPlayer==nullptr){
+    InitPlayer();
+  }
+  assert(mediaPlayer);
+
+  mediaPlayer->clearQueue();
+  for (auto const &audioFile : audioFiles){
+    qDebug() << "Adding to playlist:" << audioFile;
+    mediaPlayer->addToQueue(audioFile);
+  }
+  mediaPlayer->setCurrentIndex(0);
+  mediaPlayer->play();
+}
+
 void NavigationModule::EnsureTTSEngine()
 {
   if (thread!=QThread::currentThread()){
@@ -87,12 +106,13 @@ void NavigationModule::EnsureTTSEngine()
 
   if (ttsEngine==nullptr){
 #ifdef OSMSCOUT_HAVE_LIB_PIPER
-    InitPlayer(); // TTS engine plays synthesized messages through the media player
-    ttsEngine = new PiperTTSEngine(mediaPlayer, espeakDataDir);
+    InitPlayer();
+    ttsEngine = new PiperTTSEngine(espeakDataDir);
 
     connect(this, &NavigationModule::initVoiceRequested, ttsEngine, &TTSEngine::initVoice, Qt::QueuedConnection);
     connect(this, &NavigationModule::prepareMessageRequested, ttsEngine, &TTSEngine::prepareMessage, Qt::QueuedConnection);
     connect(this, &NavigationModule::playMessageRequested, ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
+    connect(ttsEngine, &TTSEngine::playAudioFilesRequest, this, &NavigationModule::playAudio, Qt::QueuedConnection);
 
 #else
     // library was built without any TTS engine, keep ttsEngine unset
@@ -407,16 +427,12 @@ void NavigationModule::playerStateChanged(VoicePlayer::PlaybackState state)
       !nextMessage.empty() &&
       state == VoicePlayer::StoppedState) {
 
-    mediaPlayer->clearQueue();
-
+    QList<QUrl> urls;
     for (const auto& sample : nextMessage){
       auto sampleUrl = QUrl::fromLocalFile(voice.getDir().filePath(sampleFile(sample)));
-      qDebug() << "Adding to playlist:" << sampleUrl;
-      mediaPlayer->addToQueue(sampleUrl);
+      urls.append(sampleUrl);
     }
-    nextMessage.clear();
-    mediaPlayer->setCurrentIndex(0);
-    mediaPlayer->play();
+    playAudio(urls);
   }
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -79,6 +79,25 @@ void NavigationModule::InitPlayer()
   }
 }
 
+void NavigationModule::playAudio(const QList<QUrl> &audioFiles)
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "Audio message played from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+  if (mediaPlayer==nullptr){
+    InitPlayer();
+  }
+  assert(mediaPlayer);
+
+  mediaPlayer->clearQueue();
+  for (auto const &audioFile : audioFiles){
+    qDebug() << "Adding to playlist:" << audioFile;
+    mediaPlayer->addToQueue(audioFile);
+  }
+  mediaPlayer->setCurrentIndex(0);
+  mediaPlayer->play();
+}
+
 void NavigationModule::EnsureTTSEngine()
 {
   if (thread!=QThread::currentThread()){
@@ -87,12 +106,13 @@ void NavigationModule::EnsureTTSEngine()
 
   if (ttsEngine==nullptr){
 #ifdef OSMSCOUT_HAVE_LIB_PIPER
-    InitPlayer(); // TTS engine plays synthesized messages through the media player
-    ttsEngine = new PiperTTSEngine(mediaPlayer, espeakDataDir);
+    InitPlayer();
+    ttsEngine = new PiperTTSEngine(espeakDataDir);
 
     connect(this, &NavigationModule::initVoiceRequested, ttsEngine, &TTSEngine::initVoice, Qt::QueuedConnection);
     connect(this, &NavigationModule::prepareMessageRequested, ttsEngine, &TTSEngine::prepareMessage, Qt::QueuedConnection);
     connect(this, &NavigationModule::playMessageRequested, ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
+    connect(ttsEngine, &TTSEngine::playAudioFilesRequest, this, &NavigationModule::playAudio, Qt::QueuedConnection);
 
 #else
     // library was built without any TTS engine, keep ttsEngine unset
@@ -408,16 +428,12 @@ void NavigationModule::playerStateChanged(VoicePlayer::PlaybackState state)
       !nextMessage.empty() &&
       state == VoicePlayer::StoppedState) {
 
-    mediaPlayer->clearQueue();
-
+    QList<QUrl> urls;
     for (const auto& sample : nextMessage){
       auto sampleUrl = QUrl::fromLocalFile(voice.getDir().filePath(sampleFile(sample)));
-      qDebug() << "Adding to playlist:" << sampleUrl;
-      mediaPlayer->addToQueue(sampleUrl);
+      urls.append(sampleUrl);
     }
-    nextMessage.clear();
-    mediaPlayer->setCurrentIndex(0);
-    mediaPlayer->play();
+    playAudio(urls);
   }
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/NavigationModule.cpp
@@ -89,6 +89,11 @@ void NavigationModule::EnsureTTSEngine()
 #ifdef OSMSCOUT_HAVE_LIB_PIPER
     InitPlayer(); // TTS engine plays synthesized messages through the media player
     ttsEngine = new PiperTTSEngine(mediaPlayer, espeakDataDir);
+
+    connect(this, &NavigationModule::initVoiceRequested, ttsEngine, &TTSEngine::initVoice, Qt::QueuedConnection);
+    connect(this, &NavigationModule::prepareMessageRequested, ttsEngine, &TTSEngine::prepareMessage, Qt::QueuedConnection);
+    connect(this, &NavigationModule::playMessageRequested, ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
+
 #else
     // library was built without any TTS engine, keep ttsEngine unset
     log.Warn() << "No text-to-speech engine available (built without libpiper)";
@@ -98,11 +103,7 @@ void NavigationModule::EnsureTTSEngine()
 
   // (re)initialize the engine when the selected voice changed
   if (!ttsEngine->getVoice().isValid() || ttsEngine->getVoice().getDir() != voice.getDir()){
-    auto ttsVoice = voice;
-    TTSEngine *engine = ttsEngine;
-    QMetaObject::invokeMethod(engine, [engine, ttsVoice]() {
-      engine->initVoice(ttsVoice);
-    }, Qt::QueuedConnection);
+    emit(initVoiceRequested(voice));
   }
 }
 
@@ -178,11 +179,8 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
       if (voice.isValid()) {
         EnsureTTSEngine();
         if (ttsEngine!=nullptr) {
-          TTSEngine *engine = ttsEngine;
           QString msg = QString::fromStdString(ttsPrepareMessage->message);
-          QMetaObject::invokeMethod(engine, [engine, msg]() {
-            engine->prepareMessage(msg);
-          }, Qt::QueuedConnection);
+          emit prepareMessageRequested(msg);
         }
       }
     } else if (auto ttsMessage = dynamic_cast<osmscout::TTSVoiceInstructionMessage*>(message.get());
@@ -193,9 +191,7 @@ void NavigationModule::ProcessMessages(const std::list<osmscout::NavigationMessa
         if (ttsEngine!=nullptr) {
           TTSEngine *engine = ttsEngine;
           QString msg = QString::fromStdString(ttsMessage->message);
-          QMetaObject::invokeMethod(engine, [engine, msg]() {
-            engine->playMessage(msg);
-          }, Qt::QueuedConnection);
+          emit(playMessageRequested(msg));
         }
       }
     } else if (auto* laneMessage = dynamic_cast<osmscout::LaneAgent::LaneMessage*>(message.get());

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -158,6 +158,10 @@ bool OSMScoutQtBuilder::Init()
   // setup voice
   settings->SetVoiceLookupDirectory(voiceLookupDirectory.toStdString());
 
+  if (navigationTranslationDir.isEmpty()) {
+    navigationTranslationDir = QStandardPaths::locate(QStandardPaths::AppLocalDataLocation, "translations", QStandardPaths::LocateDirectory);
+  }
+
   std::vector<std::filesystem::path> paths;
   for (const auto &dir: mapLookupDirectories) {
     paths.push_back(dir.toStdString());
@@ -183,7 +187,8 @@ bool OSMScoutQtBuilder::Init()
                                   glPowerOfTwoTexture,
                                   pixelRatio,
                                   userAgent,
-                                  customPoiTypes);
+                                  customPoiTypes,
+                                  navigationTranslationDir);
 
   return true;
 }
@@ -299,7 +304,8 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
                        GLPowerOfTwoTexture glPowerOfTwoTexture,
                        const PixelRatioSetup &pixelRatio,
                        QString userAgent,
-                       QStringList customPoiTypes):
+                       QStringList customPoiTypes,
+                       const QString &navigationTranslationDir):
         settings(settings),
         mapManager(mapManager),
         iconDirectory(iconDirectory),
@@ -309,7 +315,8 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
         glPowerOfTwoTexture(glPowerOfTwoTexture),
         pixelRatio(pixelRatio),
         userAgent(userAgent),
-        liveBackgroundThreads(0)
+        liveBackgroundThreads(0),
+        navigationTranslationDir(navigationTranslationDir)
 {
 
   std::vector<std::string> customPoiTypeVector;
@@ -484,7 +491,7 @@ NavigationModule* OSMScoutQt::MakeNavigation()
 {
   QThread *thread=makeThread("Navigation");
 
-  NavigationModule *navigation=new NavigationModule(thread,settings,dbThread);
+  NavigationModule *navigation=new NavigationModule(thread,settings,dbThread,navigationTranslationDir);
   navigation->moveToThread(thread);
   thread->start();
   return navigation;

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -520,4 +520,9 @@ QString OSMScoutQt::GetIconDirectory() const
 {
   return iconDirectory;
 }
+
+QString OSMScoutQt::GetNavigationTranslationDir() const
+{
+  return navigationTranslationDir;
+}
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -243,6 +243,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<MapProvider>("MapProvider");
   qRegisterMetaType<QmlRoutingProfileRef>("QmlRoutingProfileRef");
   qRegisterMetaType<VoicePlayer::PlaybackState>("VoicePlayer::PlaybackState");
+  qRegisterMetaType<Voice>("Voice");
 
   // register osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -82,7 +82,7 @@ OSMScoutQtBuilder::~OSMScoutQtBuilder()
 {
 }
 
-bool OSMScoutQtBuilder::Init()
+  bool OSMScoutQtBuilder::Init()
 {
   if (osmScoutInstance!=nullptr){
     return false;
@@ -188,7 +188,8 @@ bool OSMScoutQtBuilder::Init()
                                   pixelRatio,
                                   userAgent,
                                   customPoiTypes,
-                                  navigationTranslationDir);
+                                  navigationTranslationDir,
+                                  espeakDataDir);
 
   return true;
 }
@@ -305,7 +306,8 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
                        const PixelRatioSetup &pixelRatio,
                        QString userAgent,
                        QStringList customPoiTypes,
-                       const QString &navigationTranslationDir):
+                       const QString &navigationTranslationDir,
+                       const QString &espeakDataDir):
         settings(settings),
         mapManager(mapManager),
         iconDirectory(iconDirectory),
@@ -316,7 +318,8 @@ OSMScoutQt::OSMScoutQt(SettingsRef settings,
         pixelRatio(pixelRatio),
         userAgent(userAgent),
         liveBackgroundThreads(0),
-        navigationTranslationDir(navigationTranslationDir)
+        navigationTranslationDir(navigationTranslationDir),
+        espeakDataDir(espeakDataDir)
 {
 
   std::vector<std::string> customPoiTypeVector;
@@ -491,7 +494,7 @@ NavigationModule* OSMScoutQt::MakeNavigation()
 {
   QThread *thread=makeThread("Navigation");
 
-  NavigationModule *navigation=new NavigationModule(thread,settings,dbThread,navigationTranslationDir);
+  NavigationModule *navigation=new NavigationModule(thread,settings,dbThread,navigationTranslationDir,espeakDataDir);
   navigation->moveToThread(thread);
   thread->start();
   return navigation;

--- a/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
@@ -1,0 +1,299 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/PiperTTSEngine.h>
+
+#include <osmscout/log/Logger.h>
+
+#include <QCryptographicHash>
+#include <QDataStream>
+#include <QFile>
+#include <QFileInfo>
+#include <QMetaObject>
+#include <QStandardPaths>
+#include <QThread>
+#include <QUrl>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include <piper.h>
+
+namespace osmscout {
+
+namespace {
+
+/**
+ * Write 16 bit PCM mono samples into a WAV file.
+ */
+bool WriteWav(const QString &path, const std::vector<int16_t> &samples, int sampleRate)
+{
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    return false;
+  }
+
+  const uint16_t channels = 1;
+  const uint16_t bitsPerSample = 16;
+  const uint32_t byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const uint16_t blockAlign = channels * (bitsPerSample / 8);
+  const uint32_t dataSize = static_cast<uint32_t>(samples.size() * sizeof(int16_t));
+  const uint32_t riffSize = 36 + dataSize;
+
+  QDataStream out(&file);
+  out.setByteOrder(QDataStream::LittleEndian);
+
+  auto writeTag = [&](const char *tag) {
+    out.writeRawData(tag, 4);
+  };
+
+  writeTag("RIFF");
+  out << riffSize;
+  writeTag("WAVE");
+
+  writeTag("fmt ");
+  out << static_cast<uint32_t>(16);          // fmt chunk size
+  out << static_cast<uint16_t>(1);           // PCM
+  out << channels;
+  out << static_cast<uint32_t>(sampleRate);
+  out << byteRate;
+  out << blockAlign;
+  out << bitsPerSample;
+
+  writeTag("data");
+  out << dataSize;
+  if (!samples.empty()) {
+    out.writeRawData(reinterpret_cast<const char *>(samples.data()),
+                     static_cast<int>(dataSize));
+  }
+
+  file.close();
+  return out.status() == QDataStream::Ok;
+}
+
+} // namespace
+
+PiperTTSEngine::PiperTTSEngine(VoiceCorePlayer *player, const QString &espeakDataDir):
+  TTSEngine(player),
+  espeakDataPath(espeakDataDir)
+{
+  // directory for synthesized WAV files, in the per-application cache
+  // location (e.g. ~/.cache/<organization>/<app>/tts on Unix)
+  QString cacheRoot = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+  cacheDir.setPath(QDir(cacheRoot).filePath("tts"));
+  if (!cacheDir.exists()) {
+    cacheDir.mkpath(".");
+  }
+}
+
+PiperTTSEngine::~PiperTTSEngine()
+{
+  closeSynthesizer();
+}
+
+void PiperTTSEngine::closeSynthesizer()
+{
+  if (synthesizer != nullptr) {
+    piper_free(synthesizer);
+    synthesizer = nullptr;
+  }
+}
+
+void PiperTTSEngine::cleanCache()
+{
+  // TODO: make the cache size limit configurable
+  constexpr qint64 cacheSizeLimit = 50 * 1024 * 1024; // 50 MiB
+
+  // WAV files, oldest first (QDir::Time sorts newest first, so reverse)
+  QFileInfoList entries = cacheDir.entryInfoList(QStringList{"*.wav"},
+                                                 QDir::Files,
+                                                 QDir::Time | QDir::Reversed);
+
+  qint64 totalSize = 0;
+  for (const auto &entry : entries) {
+    totalSize += entry.size();
+  }
+
+  // remove the oldest samples until the cache is below the limit
+  for (const auto &entry : entries) {
+    if (totalSize <= cacheSizeLimit) {
+      break;
+    }
+    qint64 size = entry.size();
+    if (QFile::remove(entry.absoluteFilePath())) {
+      totalSize -= size;
+      log.Debug() << "PiperTTSEngine: removed cached sample " << entry.fileName().toStdString();
+    } else {
+      log.Warn() << "PiperTTSEngine: failed to remove cached sample " << entry.absoluteFilePath().toStdString();
+    }
+  }
+}
+
+void PiperTTSEngine::initVoice(const Voice &voice)
+{
+  this->voice = voice;
+  // synthesized messages of a previous voice are no longer valid
+  cache.clear();
+  voiceId.clear();
+  closeSynthesizer();
+
+  if (!voice.isValid() || !voice.isPiper()) {
+    log.Warn() << "PiperTTSEngine: voice is not a valid Piper voice";
+    return;
+  }
+
+  // identifier of the voice, mixed into the sample hash so that cached WAV
+  // files of different voices do not collide
+  voiceId = voice.getName() + "|" + voice.getDir().absolutePath();
+
+  QString modelPath = voice.getDir().filePath(voice.getModelFile());
+  QString configPath = modelPath + ".json";
+
+  if (espeakDataPath.isEmpty()) {
+    log.Warn() << "PiperTTSEngine: espeak-ng data directory was not configured, "
+                  "synthesis is likely to fail (see the --espeak-data command line option)";
+  }
+
+  synthesizer = piper_create(modelPath.toUtf8().constData(),
+                             configPath.toUtf8().constData(),
+                             espeakDataPath.toUtf8().constData());
+  if (synthesizer == nullptr) {
+    log.Error() << "PiperTTSEngine: failed to load Piper voice model " << modelPath.toStdString();
+  } else {
+    log.Debug() << "PiperTTSEngine: loaded Piper voice model " << modelPath.toStdString();
+  }
+}
+
+Voice PiperTTSEngine::getVoice()
+{
+  return voice;
+}
+
+QString PiperTTSEngine::wavFilePath(const QString &message) const
+{
+  // mix the voice identifier into the hash, so that cached samples of
+  // different voices do not collide
+  QCryptographicHash hasher(QCryptographicHash::Sha1);
+  hasher.addData(voiceId.toUtf8());
+  hasher.addData(QByteArray(1, '\0')); // separator
+  hasher.addData(message.toUtf8());
+  return cacheDir.filePath(QString::fromLatin1(hasher.result().toHex()) + ".wav");
+}
+
+QString PiperTTSEngine::prepare(const QString &message)
+{
+  if (message.isEmpty()) {
+    return {};
+  }
+
+  // already synthesized?
+  if (auto it = cache.find(message); it != cache.end()) {
+    return it.value();
+  }
+
+  QString path = wavFilePath(message);
+  if (QFile::exists(path)) {
+    cache.insert(message, path);
+    return path;
+  }
+
+  if (synthesizer == nullptr) {
+    log.Warn() << "PiperTTSEngine: no voice loaded, cannot synthesize message";
+    return {};
+  }
+
+  piper_synthesize_options options = piper_default_synthesize_options(synthesizer);
+  if (piper_synthesize_start(synthesizer, message.toUtf8().constData(), &options) != PIPER_OK) {
+    log.Error() << "PiperTTSEngine: failed to start synthesis for \"" << message.toStdString() << "\"";
+    return {};
+  }
+
+  std::vector<int16_t> samples;
+  int sampleRate = 22050; // sensible default, overwritten by the first chunk
+  piper_audio_chunk chunk;
+  int rc = PIPER_OK;
+  while ((rc = piper_synthesize_next(synthesizer, &chunk)) == PIPER_OK || rc == PIPER_DONE) {
+    if (chunk.num_samples > 0 && chunk.samples != nullptr) {
+      sampleRate = chunk.sample_rate;
+      samples.reserve(samples.size() + chunk.num_samples);
+      for (size_t i = 0; i < chunk.num_samples; ++i) {
+        float v = std::clamp(chunk.samples[i], -1.0f, 1.0f);
+        samples.push_back(static_cast<int16_t>(std::lround(v * 32767.0f)));
+      }
+    }
+    if (rc == PIPER_DONE || chunk.is_last) {
+      break;
+    }
+  }
+
+  if (rc < 0) {
+    log.Error() << "PiperTTSEngine: synthesis failed for \"" << message.toStdString() << "\"";
+    return {};
+  }
+
+  if (!WriteWav(path, samples, sampleRate)) {
+    log.Error() << "PiperTTSEngine: failed to write WAV file " << path.toStdString();
+    return {};
+  }
+
+  cache.insert(message, path);
+  return path;
+}
+
+void PiperTTSEngine::prepareMessage(QString message)
+{
+  prepare(message);
+}
+
+void PiperTTSEngine::playMessage(QString message)
+{
+  QString path = prepare(message);
+  if (path.isEmpty()) {
+    return;
+  }
+
+  QUrl url = QUrl::fromLocalFile(path);
+  // the player lives in another thread (the navigation thread); marshal the
+  // playback calls onto its thread
+  VoiceCorePlayer *p = player;
+  QMetaObject::invokeMethod(p, [p, url]() {
+    p->clearQueue();
+    p->addToQueue(url);
+    p->setCurrentIndex(0);
+    p->play();
+  }, Qt::QueuedConnection);
+}
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
@@ -91,8 +91,7 @@ bool WriteWav(const QString &path, const std::vector<int16_t> &samples, int samp
 
 } // namespace
 
-PiperTTSEngine::PiperTTSEngine(VoiceCorePlayer *player, const QString &espeakDataDir):
-  TTSEngine(player),
+PiperTTSEngine::PiperTTSEngine(const QString &espeakDataDir):
   espeakDataPath(espeakDataDir)
 {
   // directory for synthesized WAV files, in the per-application cache
@@ -278,16 +277,9 @@ void PiperTTSEngine::playMessage(QString message)
     return;
   }
 
-  QUrl url = QUrl::fromLocalFile(path);
-  // the player lives in another thread (the navigation thread); marshal the
-  // playback calls onto its thread
-  VoiceCorePlayer *p = player;
-  QMetaObject::invokeMethod(p, [p, url]() {
-    p->clearQueue();
-    p->addToQueue(url);
-    p->setCurrentIndex(0);
-    p->play();
-  }, Qt::QueuedConnection);
+  QList<QUrl> urls;
+  urls << QUrl::fromLocalFile(path);
+  emit playAudioFilesRequest(urls);
 }
 
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
@@ -19,6 +19,7 @@
 
 #include <osmscoutclientqt/PiperTTSEngine.h>
 
+#include <osmscout/io/File.h>
 #include <osmscout/log/Logger.h>
 
 #include <QCryptographicHash>
@@ -167,8 +168,16 @@ void PiperTTSEngine::initVoice(const Voice &voice)
   QString configPath = modelPath + ".json";
 
   if (espeakDataPath.isEmpty()) {
-    log.Warn() << "PiperTTSEngine: espeak-ng data directory was not configured, "
-                  "synthesis is likely to fail (see the --espeak-data command line option)";
+    log.Error() << "PiperTTSEngine: espeak-ng data directory was not configured";
+    return;
+  }
+
+  // Exit if espeak data /phontab do not exist, as libpiper do not use espeakINITIALIZE_DONT_EXIT option,
+  // Piper is aborting process when this is not found!
+  if (auto phontabFile = AppendFileToDir(espeakDataPath.toStdString(), "phontab");
+      ExistsInFilesystem(phontabFile) == false) {
+    log.Error() << "espeak-ng data directory does not contain phontab file: " << phontabFile;
+    return;
   }
 
   synthesizer = piper_create(modelPath.toUtf8().constData(),

--- a/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
@@ -90,8 +90,7 @@ bool WriteWav(const QString &path, const std::vector<int16_t> &samples, int samp
 
 } // namespace
 
-PiperTTSEngine::PiperTTSEngine(VoiceCorePlayer *player, const QString &espeakDataDir):
-  TTSEngine(player),
+PiperTTSEngine::PiperTTSEngine(const QString &espeakDataDir):
   espeakDataPath(espeakDataDir)
 {
   // directory for synthesized WAV files, in the per-application cache
@@ -270,15 +269,8 @@ void PiperTTSEngine::playMessage(QString message)
   }
 
   QUrl url = QUrl::fromLocalFile(path);
-  // the player lives in another thread (the navigation thread); marshal the
-  // playback calls onto its thread
-  VoiceCorePlayer *p = player;
-  QMetaObject::invokeMethod(p, [p, url]() {
-    p->clearQueue();
-    p->addToQueue(url);
-    p->setCurrentIndex(0);
-    p->play();
-  }, Qt::QueuedConnection);
+  QList<QUrl> urls;
+  emit playAudioFilesRequest(urls);
 }
 
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/TTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TTSEngine.cpp
@@ -1,0 +1,57 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/TTSEngine.h>
+#include <osmscoutclientqt/OSMScoutQt.h>
+
+#include <QThread>
+
+namespace osmscout {
+
+TTSEngine::TTSEngine(VoiceCorePlayer *player):
+  QObject(nullptr), // no parent, we move the engine to its own thread
+  thread(OSMScoutQt::GetInstance().makeThread("TTSEngine")),
+  player(player)
+{
+  // the engine (with all its operations) lives in its own background thread
+  moveToThread(thread);
+  // clean the cache when the engine thread starts (runs on the engine thread)
+  connect(thread, &QThread::started, this, &TTSEngine::cleanCache);
+  thread->start();
+}
+
+void TTSEngine::cleanCache()
+{
+  // default implementation does nothing, may be overridden by a derived class
+}
+
+TTSEngine::~TTSEngine()
+{
+  if (thread!=QThread::currentThread()){
+    qWarning() << "Destroy" << this << "from incorrect thread;" << thread << "!=" << QThread::currentThread();
+  }
+  // quit the event loop of our background thread. The QThread deletes itself
+  // via the finished -> deleteLater connection setup in the constructor.
+  if (thread != nullptr) {
+    thread->quit();
+  }
+}
+
+}
+

--- a/libosmscout-client-qt/src/osmscoutclientqt/TTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TTSEngine.cpp
@@ -24,10 +24,9 @@
 
 namespace osmscout {
 
-TTSEngine::TTSEngine(VoiceCorePlayer *player):
+TTSEngine::TTSEngine():
   QObject(nullptr), // no parent, we move the engine to its own thread
-  thread(OSMScoutQt::GetInstance().makeThread("TTSEngine")),
-  player(player)
+  thread(OSMScoutQt::GetInstance().makeThread("TTSEngine"))
 {
   // the engine (with all its operations) lives in its own background thread
   moveToThread(thread);

--- a/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
@@ -20,6 +20,7 @@
 #include <osmscoutclientqt/TTSMessageGeneratorQt.h>
 
 #include <osmscout/log/Logger.h>
+#include <osmscout/util/Distance.h>
 
 #include <QCoreApplication>
 #include <QLocale>
@@ -58,6 +59,16 @@ bool TTSMessageGeneratorQt::SetLanguage(const std::string &language)
   return false;
 }
 
+void TTSMessageGeneratorQt::SetUnits(DistanceUnitSystem units)
+{
+  this->units = units;
+}
+
+void TTSMessageGeneratorQt::SetVehicle(Vehicle vehicle)
+{
+  this->vehicle = vehicle;
+}
+
 QString TTSMessageGeneratorQt::Translate(const char *sourceText) const
 {
   if (translator) {
@@ -71,7 +82,7 @@ QString TTSMessageGeneratorQt::Translate(const char *sourceText) const
   return QString::fromUtf8(sourceText);
 }
 
-QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
+QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message, bool shortRoundaboutMessage) const
 {
   using Type = VoiceMessageStruct::Type;
 
@@ -102,18 +113,32 @@ QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
     case Type::LeaveMotorwayRight:
       return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Leave the motorway on the right"));
 
+    // Roundabout exits: when close (or as a "then" maneuver) the
+    // "At the roundabout" part is omitted.
     case Type::LeaveRbExit1:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the first exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the first exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the first exit"));
     case Type::LeaveRbExit2:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the second exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the second exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the second exit"));
     case Type::LeaveRbExit3:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the third exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the third exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the third exit"));
     case Type::LeaveRbExit4:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fourth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the fourth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fourth exit"));
     case Type::LeaveRbExit5:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fifth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the fifth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fifth exit"));
     case Type::LeaveRbExit6:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the sixth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the sixth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the sixth exit"));
 
     case Type::NoMessage:
     case Type::Silent:
@@ -122,25 +147,100 @@ QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
   }
 }
 
-std::optional<std::string> TTSMessageGeneratorQt::GenerateMessage(const VoiceMessageStruct &message,
+QString TTSMessageGeneratorQt::DistancePhrase(double distanceInUnits) const
+{
+  // Bucket the distance the same way the Voice of Marble messages do.
+  int value;
+  if (distanceInUnits > 800) {
+    value = 800;
+  } else if (distanceInUnits > 700) {
+    value = 700;
+  } else if (distanceInUnits > 600) {
+    value = 600;
+  } else if (distanceInUnits > 500) {
+    value = 500;
+  } else if (distanceInUnits > 400) {
+    value = 400;
+  } else if (distanceInUnits > 300) {
+    value = 300;
+  } else if (distanceInUnits > 200) {
+    value = 200;
+  } else if (distanceInUnits > 100) {
+    value = 100;
+  } else if (distanceInUnits > 80) {
+    value = 80;
+  } else {
+    value = 50;
+  }
+
+  QString unit = (units == DistanceUnitSystem::Metrics)
+      ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "meters"))
+      : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "yards"));
+
+  //: e.g. "After 300 meters/yards"
+  return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "After %1 %2"))
+      .arg(value)
+      .arg(unit);
+}
+
+std::optional<std::string> TTSMessageGeneratorQt::GenerateMessage(const Distance &distanceFromStart,
+                                                                  const VoiceMessageStruct &message,
                                                                   const VoiceMessageStruct &then)
 {
-  // TODO: distance in phrase...
-  QString phrase = Phrase(message);
-  if (phrase.isEmpty()) {
-    // Nothing to say (NoMessage / Silent).
+  using Type = VoiceMessageStruct::Type;
+
+  if (!message) {
+    // Nothing to say (NoMessage).
     return std::nullopt;
   }
 
+  // distance from the current position to the maneuver
+  Distance nextMessageDistance = message.distance - distanceFromStart;
+  double distanceInUnits = (units == DistanceUnitSystem::Metrics)
+      ? nextMessageDistance.AsMeter()
+      : nextMessageDistance.As<Yard>();
+
+  if (distanceInUnits > 900) {
+    // too far away, nothing to announce yet
+    return std::nullopt;
+  }
+
+  // when the roundabout is close, omit the "At the roundabout" part
+  bool shortRoundaboutMessage = message.type >= Type::LeaveRbExit1 &&
+                                message.type <= Type::LeaveRbExit6 &&
+                                distanceInUnits < 120;
+
+  QString maneuver = Phrase(message, shortRoundaboutMessage);
+  if (maneuver.isEmpty()) {
+    // nothing to say (Silent)
+    return std::nullopt;
+  }
+
+  QString phrase = maneuver;
+
+  // announce the distance, unless the maneuver is very close (only for cars)
+  bool skipDistanceInformation = (distanceInUnits < 80 && vehicle == vehicleCar);
+  if (!skipDistanceInformation) {
+    QString distancePhrase = DistancePhrase(distanceInUnits);
+    //: combine distance and maneuver, e.g. "After 300 meters, turn left"
+    phrase = Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "%1, %2"))
+                 .arg(distancePhrase, maneuver);
+  }
+
   if (then) {
-    // TODO: ignore when "then" phrase is too far...
-    QString thenPhrase = Phrase(then);
-    if (!thenPhrase.isEmpty()) {
-      // %1 is the following maneuver, e.g. "Turn left, then turn right".
-      phrase += Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", ", then %1"))
-                    .arg(thenPhrase);
+    // only announce the following maneuver when it is close to this one
+    Distance thenDistance = then.distance - message.distance;
+    if (thenDistance <= Meters(200)) {
+      QString thenPhrase = Phrase(then, /*shortRoundaboutMessage*/ true);
+      if (!thenPhrase.isEmpty()) {
+        //: %1 is the following maneuver, e.g. "Turn left, then turn right".
+        phrase = Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "%1, then %2"))
+                     .arg(phrase)
+                     .arg(thenPhrase);
+      }
     }
   }
+  phrase += "."; // always add end dot for better TTS phrase
 
   return phrase.toStdString();
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
@@ -1,0 +1,149 @@
+/*
+ OSMScout - a Qt backend for libosmscout and libosmscout-map
+ Copyright (C) 2026 Lukas Karas
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ */
+
+#include <osmscoutclientqt/TTSMessageGeneratorQt.h>
+
+#include <osmscout/log/Logger.h>
+
+#include <QCoreApplication>
+#include <QLocale>
+#include <QStandardPaths>
+
+namespace osmscout {
+
+TTSMessageGeneratorQt::TTSMessageGeneratorQt(const QString &translationDir):
+  translationDir(translationDir)
+{
+}
+
+bool TTSMessageGeneratorQt::SetLanguage(const std::string &language)
+{
+  // Use a fresh translator instance. QTranslator is not reusable in a way that
+  // would let us cleanly "unload" a previous translation on every platform,
+  // so we simply replace it.
+  translator = std::make_unique<QTranslator>();
+
+  QString lang = QString::fromStdString(language);
+
+  if (lang.isEmpty()) {
+    log.Warn() << "Instruction language is emtpy"; // should not happen
+    return false;
+  }
+
+  if (!translationDir.isEmpty() &&
+      translator->load(lang, translationDir)) {
+    log.Debug() << "Loaded voice instruction translation for language " << language;
+    return true;
+  }
+
+  log.Warn() << "No voice instruction translation for language \"" << language
+             << "\" (looked in " << translationDir.toStdString() << ")";
+  translator.reset();
+  return false;
+}
+
+QString TTSMessageGeneratorQt::Translate(const char *sourceText) const
+{
+  if (translator) {
+    QString translated = translator->translate(TranslationContext, sourceText);
+    if (!translated.isEmpty()) {
+      return translated;
+    }
+  }
+  // Fallback to the (English) source text. Unlike QObject::tr(), a bare
+  // QTranslator returns an empty string when no translation is found.
+  return QString::fromUtf8(sourceText);
+}
+
+QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
+{
+  using Type = VoiceMessageStruct::Type;
+
+  switch (message.type) {
+    case Type::GpsFound:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "GPS signal found"));
+    case Type::GpsLost:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "GPS signal lost"));
+
+    case Type::TargetReached:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "You have reached your destination"));
+
+    case Type::SharpLeft:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Turn sharply left"));
+    case Type::TurnLeft:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Turn left"));
+    case Type::StraightOn:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Continue straight ahead"));
+    case Type::TurnRight:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Turn right"));
+    case Type::SharpRight:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Turn sharply right"));
+
+    case Type::LeaveMotorway:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Leave the motorway"));
+    case Type::LeaveMotorwayLeft:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Leave the motorway on the left"));
+    case Type::LeaveMotorwayRight:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Leave the motorway on the right"));
+
+    case Type::LeaveRbExit1:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the first exit"));
+    case Type::LeaveRbExit2:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the second exit"));
+    case Type::LeaveRbExit3:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the third exit"));
+    case Type::LeaveRbExit4:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fourth exit"));
+    case Type::LeaveRbExit5:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fifth exit"));
+    case Type::LeaveRbExit6:
+      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the sixth exit"));
+
+    case Type::NoMessage:
+    case Type::Silent:
+    default:
+      return {};
+  }
+}
+
+std::optional<std::string> TTSMessageGeneratorQt::GenerateMessage(const VoiceMessageStruct &message,
+                                                                  const VoiceMessageStruct &then)
+{
+  // TODO: distance in phrase...
+  QString phrase = Phrase(message);
+  if (phrase.isEmpty()) {
+    // Nothing to say (NoMessage / Silent).
+    return std::nullopt;
+  }
+
+  if (then) {
+    // TODO: ignore when "then" phrase is too far...
+    QString thenPhrase = Phrase(then);
+    if (!thenPhrase.isEmpty()) {
+      // %1 is the following maneuver, e.g. "Turn left, then turn right".
+      phrase += Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", ", then %1"))
+                    .arg(thenPhrase);
+    }
+  }
+
+  return phrase.toStdString();
+}
+
+}
+

--- a/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/TTSMessageGeneratorQt.cpp
@@ -20,6 +20,7 @@
 #include <osmscoutclientqt/TTSMessageGeneratorQt.h>
 
 #include <osmscout/log/Logger.h>
+#include <osmscout/util/Distance.h>
 
 #include <QCoreApplication>
 #include <QLocale>
@@ -58,6 +59,16 @@ bool TTSMessageGeneratorQt::SetLanguage(const std::string &language)
   return false;
 }
 
+void TTSMessageGeneratorQt::SetUnits(DistanceUnitSystem units)
+{
+  this->units = units;
+}
+
+void TTSMessageGeneratorQt::SetVehicle(Vehicle vehicle)
+{
+  this->vehicle = vehicle;
+}
+
 QString TTSMessageGeneratorQt::Translate(const char *sourceText) const
 {
   if (translator) {
@@ -71,7 +82,7 @@ QString TTSMessageGeneratorQt::Translate(const char *sourceText) const
   return QString::fromUtf8(sourceText);
 }
 
-QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
+QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message, bool shortRoundaboutMessage) const
 {
   using Type = VoiceMessageStruct::Type;
 
@@ -102,18 +113,32 @@ QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
     case Type::LeaveMotorwayRight:
       return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Leave the motorway on the right"));
 
+    // Roundabout exits: when close (or as a "then" maneuver) the
+    // "At the roundabout" part is omitted.
     case Type::LeaveRbExit1:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the first exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the first exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the first exit"));
     case Type::LeaveRbExit2:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the second exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the second exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the second exit"));
     case Type::LeaveRbExit3:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the third exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the third exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the third exit"));
     case Type::LeaveRbExit4:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fourth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the fourth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fourth exit"));
     case Type::LeaveRbExit5:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fifth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the fifth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the fifth exit"));
     case Type::LeaveRbExit6:
-      return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the sixth exit"));
+      return shortRoundaboutMessage
+        ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "Take the sixth exit"))
+        : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "At the roundabout, take the sixth exit"));
 
     case Type::NoMessage:
     case Type::Silent:
@@ -122,23 +147,96 @@ QString TTSMessageGeneratorQt::Phrase(const VoiceMessageStruct &message) const
   }
 }
 
-std::optional<std::string> TTSMessageGeneratorQt::GenerateMessage(const VoiceMessageStruct &message,
+QString TTSMessageGeneratorQt::DistancePhrase(double distanceInUnits) const
+{
+  // Bucket the distance the same way the Voice of Marble messages do.
+  int value;
+  if (distanceInUnits > 800) {
+    value = 800;
+  } else if (distanceInUnits > 700) {
+    value = 700;
+  } else if (distanceInUnits > 600) {
+    value = 600;
+  } else if (distanceInUnits > 500) {
+    value = 500;
+  } else if (distanceInUnits > 400) {
+    value = 400;
+  } else if (distanceInUnits > 300) {
+    value = 300;
+  } else if (distanceInUnits > 200) {
+    value = 200;
+  } else if (distanceInUnits > 100) {
+    value = 100;
+  } else if (distanceInUnits > 80) {
+    value = 80;
+  } else {
+    value = 50;
+  }
+
+  QString unit = (units == DistanceUnitSystem::Metrics)
+      ? Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "meters"))
+      : Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "yards"));
+
+  //: e.g. "After 300 meters/yards"
+  return Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "After %1 %2"))
+      .arg(value)
+      .arg(unit);
+}
+
+std::optional<std::string> TTSMessageGeneratorQt::GenerateMessage(const Distance &distanceFromStart,
+                                                                  const VoiceMessageStruct &message,
                                                                   const VoiceMessageStruct &then)
 {
-  // TODO: distance in phrase...
-  QString phrase = Phrase(message);
-  if (phrase.isEmpty()) {
-    // Nothing to say (NoMessage / Silent).
+  using Type = VoiceMessageStruct::Type;
+
+  if (!message) {
+    // Nothing to say (NoMessage).
     return std::nullopt;
   }
 
+  // distance from the current position to the maneuver
+  Distance nextMessageDistance = message.distance - distanceFromStart;
+  double distanceInUnits = (units == DistanceUnitSystem::Metrics)
+      ? nextMessageDistance.AsMeter()
+      : nextMessageDistance.As<Yard>();
+
+  if (distanceInUnits > 900) {
+    // too far away, nothing to announce yet
+    return std::nullopt;
+  }
+
+  // when the roundabout is close, omit the "At the roundabout" part
+  bool shortRoundaboutMessage = message.type >= Type::LeaveRbExit1 &&
+                                message.type <= Type::LeaveRbExit6 &&
+                                distanceInUnits < 120;
+
+  QString maneuver = Phrase(message, shortRoundaboutMessage);
+  if (maneuver.isEmpty()) {
+    // nothing to say (Silent)
+    return std::nullopt;
+  }
+
+  QString phrase = maneuver;
+
+  // announce the distance, unless the maneuver is very close (only for cars)
+  bool skipDistanceInformation = (distanceInUnits < 80 && vehicle == vehicleCar);
+  if (!skipDistanceInformation) {
+    QString distancePhrase = DistancePhrase(distanceInUnits);
+    //: combine distance and maneuver, e.g. "After 300 meters, turn left"
+    phrase = Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", "%1, %2"))
+                 .arg(distancePhrase, maneuver);
+  }
+
   if (then) {
-    // TODO: ignore when "then" phrase is too far...
-    QString thenPhrase = Phrase(then);
-    if (!thenPhrase.isEmpty()) {
-      // %1 is the following maneuver, e.g. "Turn left, then turn right".
-      phrase += Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", ", then %1"))
-                    .arg(thenPhrase);
+    // only announce the following maneuver when it is close to this one
+    Distance thenDistance = then.distance - message.distance;
+    if (thenDistance <= Meters(200)) {
+      QString thenPhrase = Phrase(then, /*shortRoundaboutMessage*/ true);
+      if (!thenPhrase.isEmpty()) {
+        //: %1 is the following maneuver, e.g. "Turn left, then turn right".
+        phrase += Translate(QT_TRANSLATE_NOOP("TTSMessageGeneratorQt", ", then %1"))
+                      .arg(thenPhrase);
+      }
     }
   }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/Voice.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/Voice.cpp
@@ -28,23 +28,41 @@
 namespace osmscout {
 
 AvailableVoice::AvailableVoice(const VoiceProvider &provider,
+                               const QString &type,
                                const QString &lang,
+                               const QString &langCode,
                                const QString &gender,
                                const QString &name,
                                const QString &license,
                                const QString &directory,
                                const QString &author,
-                               const QString &description) :
-    valid(true), provider(provider), lang(lang), gender(gender), name(name), license(license),
-    directory(directory), author(author), description(description)
+                               const QString &description,
+                               const QString &model,
+                               const QString &metadataPath) :
+    valid(true), provider(provider), type(type), lang(lang), langCode(langCode), gender(gender),
+    name(name), license(license), directory(directory), author(author), description(description),
+    model(model), metadataPath(metadataPath)
 {
 }
 
 AvailableVoice::AvailableVoice(const AvailableVoice &o) :
-    QObject(o.parent()), valid(o.valid), provider(o.provider), lang(o.lang), gender(o.gender),
-    name(o.name), license(o.license), directory(o.directory),
-    author(o.author), description(o.description)
+    QObject(o.parent()), valid(o.valid), provider(o.provider), type(o.type), lang(o.lang),
+    langCode(o.langCode), gender(o.gender), name(o.name), license(o.license), directory(o.directory),
+    author(o.author), description(o.description), model(o.model), metadataPath(o.metadataPath)
 {}
+
+QStringList Voice::files() const
+{
+  if (isPiper()) {
+    QStringList fileNames;
+    if (!modelFile.isEmpty()) {
+      fileNames << modelFile
+                << (modelFile + ".json");
+    }
+    return fileNames;
+  }
+  return marbleFiles();
+}
 
 bool Voice::deleteVoice()
 {
@@ -70,7 +88,7 @@ bool Voice::deleteVoice()
   return result;
 }
 
-QStringList Voice::files()
+QStringList Voice::marbleFiles()
 {
   QStringList fileNames;
   fileNames << "After.ogg"
@@ -146,9 +164,36 @@ QStringList Voice::files()
 Voice::Voice(QDir dir):
     dir(dir)
 {
-  QStringList fileNames=Voice::files();
+  // metadata (read first, it also tells us the voice type)
+  if (dir.exists(MapDirectory::FileMetadata)){
+    QFile jsonFile(dir.filePath(MapDirectory::FileMetadata));
+    jsonFile.open(QFile::OpenModeFlag::ReadOnly);
+    QJsonDocument doc = QJsonDocument::fromJson(jsonFile.readAll());
+    QJsonObject metadataObject = doc.object();
+    if (metadataObject.contains("lang") &&
+        metadataObject.contains("name")){
+
+      type = metadataObject["type"].toString(VoiceTypeVoiceOfMarble);
+      lang = metadataObject["lang"].toString();
+      langCode = metadataObject["lang_code"].toString();
+      gender = metadataObject["gender"].toString();
+      name = metadataObject["name"].toString();
+      license = metadataObject["license"].toString();
+      author = metadataObject["author"].toString();
+      description = metadataObject["description"].toString();
+      modelFile = metadataObject["model"].toString();
+
+      metadata = true;
+    }
+  }
+
+  QStringList fileNames = files();
   osmscout::log.Debug() << "Checking voice files in directory " << dir.absolutePath().toStdString();
-  valid=true;
+  valid = !fileNames.isEmpty();
+  if (isPiper() && !metadata) {
+    // Piper voices can't be validated without metadata (variable file names)
+    valid = false;
+  }
   for (const auto &fileName: fileNames) {
     bool exists=dir.exists(fileName);
     if (!exists){
@@ -158,30 +203,6 @@ Voice::Voice(QDir dir):
   }
   if (!valid){
     osmscout::log.Warn() << "Can't use voice " << dir.absolutePath().toStdString() << ", some mandatory files are missing.";
-  }
-
-  // metadata
-  if (dir.exists(MapDirectory::FileMetadata)){
-    QFile jsonFile(dir.filePath(MapDirectory::FileMetadata));
-    jsonFile.open(QFile::OpenModeFlag::ReadOnly);
-    QJsonDocument doc = QJsonDocument::fromJson(jsonFile.readAll());
-    QJsonObject metadataObject = doc.object();
-    if (metadataObject.contains("lang") &&
-        metadataObject.contains("gender") &&
-        metadataObject.contains("name") &&
-        metadataObject.contains("license") &&
-        metadataObject.contains("author") &&
-        metadataObject.contains("description")){
-
-      lang = metadataObject["lang"].toString();
-      gender = metadataObject["gender"].toString();
-      name = metadataObject["name"].toString();
-      license = metadataObject["license"].toString();
-      author = metadataObject["author"].toString();
-      description = metadataObject["description"].toString();
-
-      metadata = true;
-    }
   }
 }
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/VoiceManager.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/VoiceManager.cpp
@@ -25,6 +25,7 @@
 #include <osmscoutclientqt/PersistentCookieJar.h>
 
 #include <QDirIterator>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -63,12 +64,18 @@ void VoiceDownloadJob::start()
 
   started=true;
   QJsonObject metadata;
+  metadata["type"] = voice.getType();
   metadata["lang"] = voice.getLang();
   metadata["gender"] = voice.getGender();
   metadata["name"] = voice.getName();
   metadata["license"] = voice.getLicense();
   metadata["author"] = voice.getAuthor();
   metadata["description"] = voice.getDescription();
+  if (voice.isPiper()) {
+    metadata["lang_code"] = voice.getLangCode();
+    // store the local model file name (basename of the server-side model path)
+    metadata["model"] = QFileInfo(voice.getModel()).fileName();
+  }
 
   QJsonDocument doc(metadata);
   QFile metadataFile(target.filePath(MapDirectory::FileMetadata));
@@ -82,8 +89,18 @@ void VoiceDownloadJob::start()
     return;
   }
 
-  DownloadJob::start(QString::fromStdString(voice.getProvider().getUri()) + "/" + voice.getDirectory(),
-                     Voice::files());
+  QString uri = QString::fromStdString(voice.getProvider().getUri());
+  if (voice.isPiper()) {
+    // Piper: download the onnx model and its json config from the server
+    // directory (voice.getDirectory()).
+    QStringList fileNames;
+    fileNames << QFileInfo(voice.getModel()).fileName()
+              << QFileInfo(voice.getMetadataPath()).fileName();
+    DownloadJob::start(uri + "/" + voice.getDirectory(), fileNames);
+  } else {
+    DownloadJob::start(uri + "/" + voice.getDirectory(),
+                       Voice::marbleFiles());
+  }
 }
 
 VoiceManager::VoiceManager()
@@ -169,9 +186,14 @@ bool VoiceManager::isDownloading(const AvailableVoice &voice) const
 
 void VoiceManager::download(const AvailableVoice &voice)
 {
+  // Piper: derive a unique local directory from the (unique) lang code and name.
+  QString localDir = voice.isPiper()
+      ? (voice.getLangCode() + "-" + voice.getName())
+      : voice.getDirectory();
+
   auto* job=new VoiceDownloadJob(&webCtrl,
       voice,
-      lookupDir + QDir::separator() + voice.getDirectory(),
+      lookupDir + QDir::separator() + localDir,
       /*replaceExisting*/ true);
 
   connect(job, &VoiceDownloadJob::finished, this, &VoiceManager::onJobFinished);

--- a/libosmscout/CMakeLists.txt
+++ b/libosmscout/CMakeLists.txt
@@ -419,6 +419,7 @@ if(MARISA_FOUND)
     target_link_libraries(OSMScout ${MARISA_LIBRARIES})
 endif()
 
+
 if(CMAKE_THREAD_LIBS_INIT)
     target_link_libraries(OSMScout ${CMAKE_THREAD_LIBS_INIT})
 endif()

--- a/libosmscout/include/osmscout/lib/CoreFeatures.h.cmake
+++ b/libosmscout/include/osmscout/lib/CoreFeatures.h.cmake
@@ -11,6 +11,7 @@
 #cmakedefine OSMSCOUT_HAVE_LIB_MARISA
 #endif
 
+
 #ifndef OSMSCOUT_DEBUG_ROUTING
 /* Extra debugging of routing */
 #cmakedefine OSMSCOUT_DEBUG_ROUTING

--- a/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
+++ b/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
@@ -37,13 +37,14 @@ enum class NavigationVoiceType: int
 struct OSMSCOUT_API VoiceSetupMessage CLASS_FINAL : public NavigationMessage
 {
   NavigationVoiceType type;
+  std::string languageCode;
 
-  inline VoiceSetupMessage(const Timestamp& timestamp, NavigationVoiceType &&type):
-    NavigationMessage(timestamp), type(type)
+  VoiceSetupMessage(const Timestamp& timestamp, const NavigationVoiceType &type, const std::string &languageCode):
+    NavigationMessage(timestamp), type(type), languageCode(languageCode)
   {}
 };
 
-struct OSMSCOUT_API VoiceInstructionMessage CLASS_FINAL : public NavigationMessage
+struct OSMSCOUT_API SampleVoiceInstructionMessage CLASS_FINAL : public NavigationMessage
 {
   enum class VoiceSample {
     After,
@@ -114,27 +115,33 @@ struct OSMSCOUT_API VoiceInstructionMessage CLASS_FINAL : public NavigationMessa
 
   std::vector<VoiceSample> message;
 
-  inline VoiceInstructionMessage(const Timestamp& timestamp, std::vector<VoiceSample> &&message):
+  inline SampleVoiceInstructionMessage(const Timestamp& timestamp, std::vector<VoiceSample> &&message):
     NavigationMessage(timestamp), message(message)
   {}
 };
 
-/**
- * This agent prepares voice messages for concatenation voice synthesis.
- * It follows simple pattern described on "Voice of Marble" project page:
- * https://community.kde.org/Marble/VoiceOfMarble/Translations
- *
- * Message pattern is same for all languages. There is no need for translations,
- * just concatenate samples recorded in required language.
- *
- * There are existing samples recorded by Marble community that can be used:
- * https://marble.kde.org/speakers.php
- */
-class OSMSCOUT_API VoiceInstructionAgent CLASS_FINAL : public NavigationAgent
+/** Some TTS engines may have high latency, this message signalize that message may be prepared, but not played yet. */
+struct OSMSCOUT_API TTSVoiceInstructionPrepareMessage CLASS_FINAL : public NavigationMessage
 {
-public:
+  std::string message;
 
-  enum class MessageType: int {
+  inline TTSVoiceInstructionPrepareMessage(const Timestamp& timestamp, std::string &&message):
+    NavigationMessage(timestamp), message(message)
+  {}
+};
+
+/** This message should be played right away. */
+struct OSMSCOUT_API TTSVoiceInstructionMessage CLASS_FINAL : public NavigationMessage
+{
+  std::string message;
+
+  inline TTSVoiceInstructionMessage(const Timestamp& timestamp, std::string &&message):
+    NavigationMessage(timestamp), message(message)
+  {}
+};
+
+struct VoiceMessageStruct {
+  enum class OSMSCOUT_API Type: int {
     NoMessage = 0,
 
     LeaveRbExit1,
@@ -156,56 +163,107 @@ public:
     LeaveMotorwayRight,
     LeaveMotorwayLeft,
 
+    GpsLost,
+    GpsFound,
+
     Silent
   };
 
-  struct MessageStruct {
-    MessageType type{MessageType::NoMessage};
-    Distance distance;
+  Type type{Type::NoMessage};
+  Distance distance;
 
-    MessageStruct() = default;
-    MessageStruct(const MessageStruct&) = default;
-    MessageStruct(MessageStruct &&) = default;
+  VoiceMessageStruct() = default;
+  VoiceMessageStruct(const VoiceMessageStruct&) = default;
+  VoiceMessageStruct(VoiceMessageStruct &&) = default;
 
-    MessageStruct(MessageType type, const Distance &distance):
-      type{type}, distance{distance} {}
+  VoiceMessageStruct(Type type, const Distance &distance):
+    type{type}, distance{distance} {}
 
-    ~MessageStruct() = default;
+  ~VoiceMessageStruct() = default;
 
-    MessageStruct &operator=(const MessageStruct&) = default;
-    MessageStruct &operator=(MessageStruct&&) = default;
+  VoiceMessageStruct &operator=(const VoiceMessageStruct&) = default;
+  VoiceMessageStruct &operator=(VoiceMessageStruct&&) = default;
 
-    explicit operator bool() const
-    {
-      return type != MessageType::NoMessage;
-    }
+  explicit operator bool() const
+  {
+    return type != Type::NoMessage;
+  }
 
-    bool operator==(const MessageStruct &other) const
-    {
-      return type==other.type && distance==other.distance;
-    }
+  bool operator==(const VoiceMessageStruct &other) const
+  {
+    return type==other.type && distance==other.distance;
+  }
 
-    bool operator!=(const MessageStruct &other) const
-    {
-      return !(*this==other);
-    }
+  bool operator!=(const VoiceMessageStruct &other) const
+  {
+    return !(*this==other);
+  }
+};
+
+/** Abstract class for generating template-based messages for TTS engine
+ */
+class OSMSCOUT_API TTSMessageGenerator
+{
+public:
+  virtual ~TTSMessageGenerator() = default;
+
+  /**
+   * Set the language of the generated messages
+   * @param languageCode
+   * @return true if language is supported
+   */
+  virtual bool SetLanguage(const std::string &languageCode) = 0;
+
+  virtual std::optional<std::string> GenerateMessage(const VoiceMessageStruct &message, const VoiceMessageStruct &then) = 0;
+};
+
+using TTSMessageGeneratorRef = std::shared_ptr<TTSMessageGenerator>;
+
+class OSMSCOUT_API NoOpTTSMessageGenerator : public TTSMessageGenerator
+{
+public:
+  ~NoOpTTSMessageGenerator() override = default;
+
+  bool SetLanguage([[maybe_unused]] const std::string &languageCode) override
+  {
+    return false;
   };
 
+  std::optional<std::string> GenerateMessage([[maybe_unused]] const VoiceMessageStruct &message, [[maybe_unused]] const VoiceMessageStruct &then) override
+  {
+    return std::nullopt;
+  }
+};
+
+/**
+ * This agent prepares voice messages for concatenation voice synthesis.
+ * It follows simple pattern described on "Voice of Marble" project page:
+ * https://community.kde.org/Marble/VoiceOfMarble/Translations
+ *
+ * Message pattern is same for all languages. There is no need for translations,
+ * just concatenate samples recorded in required language.
+ *
+ * There are existing samples recorded by Marble community that can be used:
+ * https://marble.kde.org/speakers.php
+ */
+class OSMSCOUT_API VoiceInstructionAgent CLASS_FINAL : public NavigationAgent
+{
 private:
   DistanceUnitSystem units{DistanceUnitSystem::Metrics};
   Vehicle vehicle{vehicleCar};
   NavigationVoiceType voiceType{NavigationVoiceType::None};
+  TTSMessageGeneratorRef ttsMessageGenerator;
 
   // state used for triggering GpsFound / GpsLost messages
   bool prevGpsSignal{true};
   Timestamp lastSeenGpsSignal{Timestamp::min()};
 
-  MessageStruct lastMessage;
-  Distance lastMessagePosition; // where we trigger last message (it is before lastMessage.disntace usually)
+  VoiceMessageStruct lastMessage;
+  Distance lastMessagePosition; // where we trigger last message (it is before lastMessage.distance usually)
 
 public:
-  explicit VoiceInstructionAgent(DistanceUnitSystem units):
-    units{units}
+  VoiceInstructionAgent(DistanceUnitSystem units, TTSMessageGeneratorRef ttsMessageGenerator):
+    units{units}, ttsMessageGenerator(ttsMessageGenerator)
   {};
 
   ~VoiceInstructionAgent() override = default;
@@ -213,13 +271,13 @@ public:
   std::list<NavigationMessageRef> Process(const NavigationMessageRef& message) override;
 
 private:
-  void toSamples(std::vector<VoiceInstructionMessage::VoiceSample> &samples,
-                 const MessageType &messageType,
+  void toSamples(std::vector<SampleVoiceInstructionMessage::VoiceSample> &samples,
+                 const VoiceMessageStruct::Type &messageType,
                  bool shortRoundaboutMessage);
 
-  std::vector<VoiceInstructionMessage::VoiceSample> toSamples(const Distance &distanceFromStart,
-                                                              const MessageStruct &message,
-                                                              const MessageStruct &then);
+  std::vector<SampleVoiceInstructionMessage::VoiceSample> toSamples(const Distance &distanceFromStart,
+                                                                    const VoiceMessageStruct &message,
+                                                                    const VoiceMessageStruct &then);
 };
 }
 

--- a/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
+++ b/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
@@ -27,6 +27,22 @@
 
 namespace osmscout {
 
+enum class NavigationVoiceType: int
+{
+  None = 0,
+  VoiceOfMarble = 1,
+  TextToSpeech = 2
+};
+
+struct OSMSCOUT_API VoiceSetupMessage CLASS_FINAL : public NavigationMessage
+{
+  NavigationVoiceType type;
+
+  inline VoiceSetupMessage(const Timestamp& timestamp, NavigationVoiceType &&type):
+    NavigationMessage(timestamp), type(type)
+  {}
+};
+
 struct OSMSCOUT_API VoiceInstructionMessage CLASS_FINAL : public NavigationMessage
 {
   enum class VoiceSample {
@@ -178,6 +194,7 @@ public:
 private:
   DistanceUnitSystem units{DistanceUnitSystem::Metrics};
   Vehicle vehicle{vehicleCar};
+  NavigationVoiceType voiceType{NavigationVoiceType::None};
 
   // state used for triggering GpsFound / GpsLost messages
   bool prevGpsSignal{true};

--- a/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
+++ b/libosmscout/include/osmscout/navigation/VoiceInstructionAgent.h
@@ -214,7 +214,30 @@ public:
    */
   virtual bool SetLanguage(const std::string &languageCode) = 0;
 
-  virtual std::optional<std::string> GenerateMessage(const VoiceMessageStruct &message, const VoiceMessageStruct &then) = 0;
+  /**
+   * Set the distance units used for the announced distances.
+   */
+  virtual void SetUnits(DistanceUnitSystem units) = 0;
+
+  /**
+   * Set the current vehicle.
+   */
+  virtual void SetVehicle(Vehicle vehicle) = 0;
+
+  /**
+   * Generate a spoken message for the given maneuver.
+   *
+   * @param distanceFromStart current position (distance from the route start).
+   *        Together with the maneuver distance it defines how far ahead the
+   *        maneuver is, which may be announced ("After 300 meters, ...") and
+   *        controls the wording (e.g. a short roundabout phrase when close).
+   * @param message the maneuver to announce
+   * @param then optional following maneuver, only announced when close enough
+   * @return the message text, or std::nullopt when there is nothing to say
+   */
+  virtual std::optional<std::string> GenerateMessage(const Distance &distanceFromStart,
+                                                     const VoiceMessageStruct &message,
+                                                     const VoiceMessageStruct &then) = 0;
 };
 
 using TTSMessageGeneratorRef = std::shared_ptr<TTSMessageGenerator>;
@@ -229,7 +252,17 @@ public:
     return false;
   };
 
-  std::optional<std::string> GenerateMessage([[maybe_unused]] const VoiceMessageStruct &message, [[maybe_unused]] const VoiceMessageStruct &then) override
+  void SetUnits([[maybe_unused]] DistanceUnitSystem units) override
+  {
+  };
+
+  void SetVehicle([[maybe_unused]] Vehicle vehicle) override
+  {
+  };
+
+  std::optional<std::string> GenerateMessage([[maybe_unused]] const Distance &distanceFromStart,
+                                             [[maybe_unused]] const VoiceMessageStruct &message,
+                                             [[maybe_unused]] const VoiceMessageStruct &then) override
   {
     return std::nullopt;
   }
@@ -264,7 +297,11 @@ private:
 public:
   VoiceInstructionAgent(DistanceUnitSystem units, TTSMessageGeneratorRef ttsMessageGenerator):
     units{units}, ttsMessageGenerator(ttsMessageGenerator)
-  {};
+  {
+    if (this->ttsMessageGenerator) {
+      this->ttsMessageGenerator->SetUnits(units);
+    }
+  };
 
   ~VoiceInstructionAgent() override = default;
 

--- a/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
@@ -348,6 +348,9 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
     lastMessage.type=VoiceMessageStruct::Type::NoMessage;
     lastMessagePosition=Distance::Zero();
     vehicle=routeUpdateMessage->vehicle;
+    if (ttsMessageGenerator) {
+      ttsMessageGenerator->SetVehicle(vehicle);
+    }
     return result;
   }
 
@@ -389,7 +392,7 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
           std::vector<VoiceSample>{VoiceSample::GpsFound}));
     } else {
       assert(voiceType==NavigationVoiceType::TextToSpeech);
-      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(VoiceMessageStruct(VoiceMessageStruct::Type::GpsFound, Distance::Zero()),VoiceMessageStruct())) {
+      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(Distance::Zero(), VoiceMessageStruct(VoiceMessageStruct::Type::GpsFound, Distance::Zero()),VoiceMessageStruct())) {
         result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
           positionMessage->timestamp, std::move(*ttsMessage)));
       }
@@ -403,7 +406,7 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
           std::vector<VoiceSample>{VoiceSample::GpsLost}));
     } else {
       assert(voiceType==NavigationVoiceType::TextToSpeech);
-      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(VoiceMessageStruct(VoiceMessageStruct::Type::GpsLost, Distance::Zero()),VoiceMessageStruct())) {
+      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(Distance::Zero(), VoiceMessageStruct(VoiceMessageStruct::Type::GpsLost, Distance::Zero()),VoiceMessageStruct())) {
         result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
           positionMessage->timestamp, std::move(*ttsMessage)));
       }
@@ -457,7 +460,7 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
           toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
       } else {
         assert(voiceType==NavigationVoiceType::TextToSpeech);
-        if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(callback.nextMessage, callback.thenMessage)) {
+        if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(distanceFromStart, callback.nextMessage, callback.thenMessage)) {
           result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
             positionMessage->timestamp, std::move(*ttsMessage)));
         }
@@ -479,7 +482,7 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
               toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
         } else {
           assert(voiceType==NavigationVoiceType::TextToSpeech);
-          if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(callback.nextMessage, callback.thenMessage)) {
+          if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(distanceFromStart, callback.nextMessage, callback.thenMessage)) {
             result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
               positionMessage->timestamp, std::move(*ttsMessage)));
           }

--- a/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
@@ -35,8 +35,8 @@ private:
   std::optional<Distance> roundaboutEnter; //<! distance of roundabout enter before nextMessage
 
 public:
-  VoiceInstructionAgent::MessageStruct nextMessage;
-  VoiceInstructionAgent::MessageStruct thenMessage;
+  VoiceMessageStruct nextMessage;
+  VoiceMessageStruct thenMessage;
 
 public:
   PostprocessorCallback(const Distance &distanceFromStart, const Distance &stopAfter):
@@ -54,23 +54,23 @@ public:
 
   void OnMotorwayLeave(const RouteDescription::DirectionDescription::Move& move)
   {
-    VoiceInstructionAgent::MessageType type;
+    VoiceMessageStruct::Type type;
     if (move==RouteDescription::DirectionDescription::sharpLeft ||
         move==RouteDescription::DirectionDescription::left ||
         move==RouteDescription::DirectionDescription::slightlyLeft) {
-      type=VoiceInstructionAgent::MessageType::LeaveMotorwayLeft;
+      type=VoiceMessageStruct::Type::LeaveMotorwayLeft;
     } else if (move==RouteDescription::DirectionDescription::sharpRight ||
                move==RouteDescription::DirectionDescription::right ||
                move==RouteDescription::DirectionDescription::slightlyRight) {
-      type=VoiceInstructionAgent::MessageType::LeaveMotorwayRight;
+      type=VoiceMessageStruct::Type::LeaveMotorwayRight;
     } else {
-      type=VoiceInstructionAgent::MessageType::LeaveMotorway;
+      type=VoiceMessageStruct::Type::LeaveMotorway;
     }
 
     if (!nextMessage){
-      nextMessage = VoiceInstructionAgent::MessageStruct{type, distance};
+      nextMessage = VoiceMessageStruct{type, distance};
     } else if (!thenMessage){
-      thenMessage = VoiceInstructionAgent::MessageStruct{type, distance};
+      thenMessage = VoiceMessageStruct{type, distance};
     }
   }
 
@@ -105,12 +105,12 @@ public:
                          [[maybe_unused]] const osmscout::RouteDescription::NameDescriptionRef& nameDescription) override
   {
     assert(roundaboutLeaveDescription);
-    using MessageType = VoiceInstructionAgent::MessageType;
+    using MessageType = VoiceMessageStruct::Type;
 
     if (!roundaboutEnter) {
       if (!nextMessage) {
         // we are on the roundabout right now, be silent until we leave it
-        nextMessage = VoiceInstructionAgent::MessageStruct{MessageType::Silent, distance};
+        nextMessage = VoiceMessageStruct{MessageType::Silent, distance};
       }
       return;
     }
@@ -141,9 +141,9 @@ public:
     }
     // say the message before entering the roundabout
     if (!nextMessage){
-      nextMessage = VoiceInstructionAgent::MessageStruct{type, *roundaboutEnter};
+      nextMessage = VoiceMessageStruct{type, *roundaboutEnter};
     } else if (!thenMessage){
-      thenMessage = VoiceInstructionAgent::MessageStruct{type, *roundaboutEnter};
+      thenMessage = VoiceMessageStruct{type, *roundaboutEnter};
     }
     roundaboutEnter = std::nullopt;
   }
@@ -151,9 +151,9 @@ public:
   void OnTargetReached(const osmscout::RouteDescription::TargetDescriptionRef& /*targetDescription*/) override
   {
     if (!nextMessage){
-      using MessageType = VoiceInstructionAgent::MessageType;
+      using MessageType = VoiceMessageStruct::Type;
       if (distance - distanceFromStart < Meters(40)) {
-        nextMessage = VoiceInstructionAgent::MessageStruct{MessageType::TargetReached, distance};
+        nextMessage = VoiceMessageStruct{MessageType::TargetReached, distance};
       }
     }
   }
@@ -166,7 +166,7 @@ public:
   {
     assert(directionDescription);
 
-    using MessageType = VoiceInstructionAgent::MessageType;
+    using MessageType = VoiceMessageStruct::Type;
     using DirectionDescription = RouteDescription::DirectionDescription;
     MessageType type = MessageType::NoMessage;
     switch (turnDescription->GetDirection()) {
@@ -196,9 +196,9 @@ public:
     }
     if (type != MessageType::NoMessage){
       if (!nextMessage) {
-        nextMessage = VoiceInstructionAgent::MessageStruct{type, distance};
+        nextMessage = VoiceMessageStruct{type, distance};
       } else if (!thenMessage) {
-        thenMessage = VoiceInstructionAgent::MessageStruct{type, distance};
+        thenMessage = VoiceMessageStruct{type, distance};
       }
     }
   }
@@ -209,62 +209,62 @@ public:
   }
 };
 
-void VoiceInstructionAgent::toSamples(std::vector<VoiceInstructionMessage::VoiceSample> &samples, const MessageType &type, bool shortRoundaboutMessage)
+void VoiceInstructionAgent::toSamples(std::vector<SampleVoiceInstructionMessage::VoiceSample> &samples, const VoiceMessageStruct::Type &type, bool shortRoundaboutMessage)
 {
-  using VoiceSample = VoiceInstructionMessage::VoiceSample;
+  using VoiceSample = SampleVoiceInstructionMessage::VoiceSample;
 
-  if (!shortRoundaboutMessage && type>=MessageType::LeaveRbExit1 && type<=MessageType::LeaveRbExit6) {
+  if (!shortRoundaboutMessage && type>=VoiceMessageStruct::Type::LeaveRbExit1 && type<=VoiceMessageStruct::Type::LeaveRbExit6) {
     samples.push_back(VoiceSample::RbCross);
   }
 
   switch (type) {
 
-    case MessageType::LeaveRbExit1:
+    case VoiceMessageStruct::Type::LeaveRbExit1:
       samples.push_back(VoiceSample::RbExit1);
       break;
-    case MessageType::LeaveRbExit2:
+    case VoiceMessageStruct::Type::LeaveRbExit2:
       samples.push_back(VoiceSample::RbExit2);
       break;
-    case MessageType::LeaveRbExit3:
+    case VoiceMessageStruct::Type::LeaveRbExit3:
       samples.push_back(VoiceSample::RbExit3);
       break;
-    case MessageType::LeaveRbExit4:
+    case VoiceMessageStruct::Type::LeaveRbExit4:
       samples.push_back(VoiceSample::RbExit4);
       break;
-    case MessageType::LeaveRbExit5:
+    case VoiceMessageStruct::Type::LeaveRbExit5:
       samples.push_back(VoiceSample::RbExit5);
       break;
-    case MessageType::LeaveRbExit6:
+    case VoiceMessageStruct::Type::LeaveRbExit6:
       samples.push_back(VoiceSample::RbExit6);
       break;
 
-    case MessageType::TargetReached:
+    case VoiceMessageStruct::Type::TargetReached:
       samples.push_back(VoiceSample::Arrive);
       break;
 
-    case MessageType::SharpLeft:
+    case VoiceMessageStruct::Type::SharpLeft:
       samples.push_back(VoiceSample::SharpLeft);
       break;
-    case MessageType::TurnLeft:
+    case VoiceMessageStruct::Type::TurnLeft:
       samples.push_back(VoiceSample::TurnLeft);
       break;
-    case MessageType::StraightOn:
+    case VoiceMessageStruct::Type::StraightOn:
       samples.push_back(VoiceSample::Straight);
       break;
-    case MessageType::TurnRight:
+    case VoiceMessageStruct::Type::TurnRight:
       samples.push_back(VoiceSample::TurnRight);
       break;
-    case MessageType::SharpRight:
+    case VoiceMessageStruct::Type::SharpRight:
       samples.push_back(VoiceSample::SharpRight);
       break;
 
-    case MessageType::LeaveMotorway:
+    case VoiceMessageStruct::Type::LeaveMotorway:
       samples.push_back(VoiceSample::MwExit);
       break;
-    case MessageType::LeaveMotorwayRight:
+    case VoiceMessageStruct::Type::LeaveMotorwayRight:
       samples.push_back(VoiceSample::MwExitRight);
       break;
-    case MessageType::LeaveMotorwayLeft:
+    case VoiceMessageStruct::Type::LeaveMotorwayLeft:
       samples.push_back(VoiceSample::MwExitLeft);
       break;
 
@@ -274,16 +274,16 @@ void VoiceInstructionAgent::toSamples(std::vector<VoiceInstructionMessage::Voice
   }
 }
 
-std::vector<VoiceInstructionMessage::VoiceSample> VoiceInstructionAgent::toSamples(const Distance &distanceFromStart,
-                                                                                   const MessageStruct &message,
-                                                                                   const MessageStruct &then)
+std::vector<SampleVoiceInstructionMessage::VoiceSample> VoiceInstructionAgent::toSamples(const Distance &distanceFromStart,
+                                                                                         const VoiceMessageStruct &message,
+                                                                                         const VoiceMessageStruct &then)
 {
-  using VoiceSample = VoiceInstructionMessage::VoiceSample;
-  std::vector<VoiceInstructionMessage::VoiceSample> samples;
+  using VoiceSample = SampleVoiceInstructionMessage::VoiceSample;
+  std::vector<SampleVoiceInstructionMessage::VoiceSample> samples;
 
   assert(message);
 
-  if (message.type == MessageType::Silent) {
+  if (message.type == VoiceMessageStruct::Type::Silent) {
     return samples;
   }
 
@@ -296,7 +296,7 @@ std::vector<VoiceInstructionMessage::VoiceSample> VoiceInstructionAgent::toSampl
   }
 
   // We are close to roundabout, we will use short roundabout message in such case.
-  bool shortRoundaboutMessage = message.type >= MessageType::LeaveRbExit1 && message.type <= MessageType::LeaveRbExit6 &&
+  bool shortRoundaboutMessage = message.type >= VoiceMessageStruct::Type::LeaveRbExit1 && message.type <= VoiceMessageStruct::Type::LeaveRbExit6 &&
     distanceInUnits < 120;
 
   if (bool skipDistanceInformation = (distanceInUnits < 80 && vehicle == vehicleCar);
@@ -345,7 +345,7 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
   if (auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage*>(message.get());
       routeUpdateMessage != nullptr){
     // reset state
-    lastMessage.type=MessageType::NoMessage;
+    lastMessage.type=VoiceMessageStruct::Type::NoMessage;
     lastMessagePosition=Distance::Zero();
     vehicle=routeUpdateMessage->vehicle;
     return result;
@@ -354,15 +354,21 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
   if (auto voiceSetup = dynamic_cast<VoiceSetupMessage*>(message.get());
       voiceSetup != nullptr){
     voiceType=voiceSetup->type;
+    if (!ttsMessageGenerator) {
+      voiceType=NavigationVoiceType::None; // no generator set, do not generate voice instructions
+    }
+    if (!ttsMessageGenerator->SetLanguage(voiceSetup->languageCode)) {
+      voiceType=NavigationVoiceType::None; // language is not supported, do not generate voice instructions
+    }
     return result;
   }
 
   auto positionMessage = dynamic_cast<PositionAgent::PositionMessage*>(message.get());
-  if (positionMessage==nullptr) {
+  if (positionMessage==nullptr || voiceType==NavigationVoiceType::None) {
     return result;
   }
 
-  using VoiceSample = VoiceInstructionMessage::VoiceSample;
+  using VoiceSample = SampleVoiceInstructionMessage::VoiceSample;
   using namespace std::chrono;
   Timestamp now = positionMessage->timestamp;
 
@@ -375,15 +381,31 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
   // and triggers GpsLost message after longer time.
   if (!prevGpsSignal && gpsSignal){
     // GpsFound
-    result.push_back(std::make_shared<VoiceInstructionMessage>(
-        positionMessage->timestamp,
-        std::vector<VoiceSample>{VoiceSample::GpsFound}));
+    if (voiceType==NavigationVoiceType::VoiceOfMarble) {
+      result.push_back(std::make_shared<SampleVoiceInstructionMessage>(
+          positionMessage->timestamp,
+          std::vector<VoiceSample>{VoiceSample::GpsFound}));
+    } else {
+      assert(voiceType==NavigationVoiceType::TextToSpeech);
+      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(VoiceMessageStruct(VoiceMessageStruct::Type::GpsFound, Distance::Zero()),VoiceMessageStruct())) {
+        result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
+          positionMessage->timestamp, std::move(*ttsMessage)));
+      }
+    }
     prevGpsSignal = gpsSignal;
   } else if (prevGpsSignal && !gpsSignal && (now - lastSeenGpsSignal) > seconds(10)){
     // GpsLost
-    result.push_back(std::make_shared<VoiceInstructionMessage>(
-        positionMessage->timestamp,
-        std::vector<VoiceSample>{VoiceSample::GpsLost}));
+    if (voiceType==NavigationVoiceType::VoiceOfMarble) {
+      result.push_back(std::make_shared<SampleVoiceInstructionMessage>(
+          positionMessage->timestamp,
+          std::vector<VoiceSample>{VoiceSample::GpsLost}));
+    } else {
+      assert(voiceType==NavigationVoiceType::TextToSpeech);
+      if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(VoiceMessageStruct(VoiceMessageStruct::Type::GpsLost, Distance::Zero()),VoiceMessageStruct())) {
+        result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
+          positionMessage->timestamp, std::move(*ttsMessage)));
+      }
+    }
     prevGpsSignal = gpsSignal;
   }
   if (gpsSignal){
@@ -426,9 +448,19 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
   if (callback.nextMessage && distanceInUnits < 900){
 
     if (callback.nextMessage != lastMessage){
-      result.push_back(std::make_shared<VoiceInstructionMessage>(
-        positionMessage->timestamp,
-        toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
+
+      if (voiceType==NavigationVoiceType::VoiceOfMarble) {
+        result.push_back(std::make_shared<SampleVoiceInstructionMessage>(
+          positionMessage->timestamp,
+          toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
+      } else {
+        assert(voiceType==NavigationVoiceType::TextToSpeech);
+        if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(callback.nextMessage, callback.thenMessage)) {
+          result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
+            positionMessage->timestamp, std::move(*ttsMessage)));
+        }
+      }
+
       lastMessage=callback.nextMessage;
       lastMessagePosition=distanceFromStart;
     } else {
@@ -439,9 +471,17 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
           (distanceInUnits < 150 && distFromLast > Meters(200)) ||
           (distanceInUnits < 60 && distFromLast > Meters(100))) {
 
-        result.push_back(std::make_shared<VoiceInstructionMessage>(
-            positionMessage->timestamp,
-            toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
+        if (voiceType==NavigationVoiceType::VoiceOfMarble) {
+          result.push_back(std::make_shared<SampleVoiceInstructionMessage>(
+              positionMessage->timestamp,
+              toSamples(distanceFromStart, callback.nextMessage, callback.thenMessage)));
+        } else {
+          assert(voiceType==NavigationVoiceType::TextToSpeech);
+          if (auto ttsMessage=ttsMessageGenerator->GenerateMessage(callback.nextMessage, callback.thenMessage)) {
+            result.push_back(std::make_shared<TTSVoiceInstructionMessage>(
+              positionMessage->timestamp, std::move(*ttsMessage)));
+          }
+        }
         lastMessage=callback.nextMessage;
         lastMessagePosition=distanceFromStart;
       }

--- a/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
@@ -342,12 +342,18 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
 {
   std::list<NavigationMessageRef> result;
 
-  auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage*>(message.get());
-  if (routeUpdateMessage != nullptr){
+  if (auto routeUpdateMessage = dynamic_cast<RouteUpdateMessage*>(message.get());
+      routeUpdateMessage != nullptr){
     // reset state
     lastMessage.type=MessageType::NoMessage;
     lastMessagePosition=Distance::Zero();
     vehicle=routeUpdateMessage->vehicle;
+    return result;
+  }
+
+  if (auto voiceSetup = dynamic_cast<VoiceSetupMessage*>(message.get());
+      voiceSetup != nullptr){
+    voiceType=voiceSetup->type;
     return result;
   }
 

--- a/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
+++ b/libosmscout/src/osmscout/navigation/VoiceInstructionAgent.cpp
@@ -354,11 +354,13 @@ std::list<NavigationMessageRef> VoiceInstructionAgent::Process(const NavigationM
   if (auto voiceSetup = dynamic_cast<VoiceSetupMessage*>(message.get());
       voiceSetup != nullptr){
     voiceType=voiceSetup->type;
-    if (!ttsMessageGenerator) {
-      voiceType=NavigationVoiceType::None; // no generator set, do not generate voice instructions
-    }
-    if (!ttsMessageGenerator->SetLanguage(voiceSetup->languageCode)) {
-      voiceType=NavigationVoiceType::None; // language is not supported, do not generate voice instructions
+    if (voiceType==NavigationVoiceType::TextToSpeech) {
+      if (!ttsMessageGenerator) {
+        voiceType=NavigationVoiceType::None; // no generator set, do not generate voice instructions
+      }
+      if (!ttsMessageGenerator->SetLanguage(voiceSetup->languageCode)) {
+        voiceType=NavigationVoiceType::None; // language is not supported, do not generate voice instructions
+      }
     }
     return result;
   }

--- a/meson.build
+++ b/meson.build
@@ -105,6 +105,58 @@ catch2MainDep = dependency('catch2-with-main', version: '>=3.0.0', required: fal
 # Optional
 marisaDep = dependency('marisa', required : false)
 
+# Piper TTS (libpiper). Upstream ships neither a pkg-config nor a CMake config
+# file, so locate the library (and the onnxruntime it depends on) and the header
+# manually. Honour the PIPER_ROOT / PIPER_HOME environment variables plus a few
+# common install locations (e.g. /opt/piper).
+piperDep = dependency('', required: false)
+if get_option('enablePiper')
+  fs = import('fs')
+
+  # Default install prefixes to probe, in addition to the user-provided piperRoot.
+  # The Unix-style paths are only meaningful (and only absolute) on non-Windows
+  # systems; on Windows they would be rejected as search directories.
+  piperRoots = [get_option('piperRoot')]
+  if host_machine.system() != 'windows'
+    piperRoots += ['/opt/piper', '/usr/local']
+  endif
+
+  piperSearchDirs = []
+  piperIncCandidates = []
+  foreach root : piperRoots
+    if root != '' and fs.is_absolute(root)
+      piperSearchDirs += [root, root / 'lib', root / 'lib64']
+      piperIncCandidates += [root / 'include', root]
+    endif
+  endforeach
+
+  piperLib = compiler.find_library('piper', dirs: piperSearchDirs, required: false)
+  # libpiper is linked against onnxruntime, which upstream ships alongside it but
+  # which is usually not on the default library search path.
+  onnxLib = compiler.find_library('onnxruntime', dirs: piperSearchDirs, required: false)
+
+  piperIncArgs = []
+  piperHeaderFound = compiler.has_header('piper.h', required: false)
+  if not piperHeaderFound
+    foreach incDir : piperIncCandidates
+      if not piperHeaderFound and fs.is_file(incDir / 'piper.h')
+        piperIncArgs = ['-I' + incDir]
+        piperHeaderFound = true
+      endif
+    endforeach
+  endif
+
+  if piperLib.found() and piperHeaderFound
+    piperLibs = [piperLib]
+    if onnxLib.found()
+      piperLibs += onnxLib
+    endif
+    piperDep = declare_dependency(dependencies: piperLibs,
+                                  compile_args: piperIncArgs)
+  endif
+endif
+
+
 # Import
 zlibDep = dependency('zlib', required : false, fallback: ['zlib','zlib_dep'])
 lzmaDep = dependency('liblzma', required : false, fallback: ['liblzma','lzma_dep'])
@@ -518,6 +570,11 @@ summary({
   'OpenMP support': openmpDep.found(),
   'C++17 execution support': stdExecutionAvailable,
   }, section: 'C++ Compiler')
+
+summary({
+  'Piper TTS (libpiper)': piperDep.found(),
+  }, section: 'Optional dependencies')
+
 
 summary({
   'Meson backend': meson.backend(),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,5 +13,9 @@ option('enableMapSvg',     type: 'boolean', value: true, description: 'Build SVG
 option('enableMapSkia',    type: 'boolean', value: true, description: 'Build Skia backend')
 option('enableClientQt',   type: 'boolean', value: true, description: 'Build Qt/QML library')
 option('enableXML',        type: 'boolean', value: true, description: 'Use libxml2')
+option('enablePiper',      type: 'boolean', value: true, description: 'Use Piper TTS (libpiper) if available')
+option('piperRoot',        type: 'string',  value: '',   description: 'Install prefix of Piper TTS (libpiper), e.g. /opt/piper')
+
+
 option('buildDemos',       type: 'boolean', value: true, description: 'Build demo applications')
 option('qtVersion', type: 'integer', value: 6, min: 5, max: 6, description: 'QT version to use (5 or 6)')


### PR DESCRIPTION
Navigation is using Voice-of-Marble pre-recorded samples for instruction messages. These instructions sounds natural and implementation is simple. But it lack of variability. There is no way howto add names to instructions or modify instructions somehow. For example for pedestrian navigation. For that reason, I decided to add support for navigation instructions generated by text-to-speech (TTS). (And keep Voice-of-Mable support for compatibility)

As TTS implementation I selected [Piper](https://github.com/OHF-Voice/piper1-gpl) (optional dependency of client-qt library). But abstraction allow to implement other clients easily.
