### PR TITLE
bug: Fixed basemap generation

### DIFF
--- a/BasemapImport/src/BasemapImport.cpp
+++ b/BasemapImport/src/BasemapImport.cpp
@@ -38,10 +38,10 @@
 class CoastlineShapeFileVisitor : public osmscout::ShapeFileVisitor
 {
 private:
+  static constexpr size_t                            maxCoastlinePoints=1000;
+
   osmscout::Progress                                 &progress;
   uint32_t                                           coastlineCount;
-  bool                                               continuation;
-  std::vector<osmscout::GeoCoord>                    coordBuffer;
   osmscout::Id                                       currentId;
 public:
   std::list<osmscout::WaterIndexProcessor::CoastRef> coasts;
@@ -54,16 +54,11 @@ public:
     progress.SetAction("Scanning world coastline file '{}'",coastlineShapeFile);
 
     coastlineCount=0;
-    continuation=false;
     currentId=std::numeric_limits<osmscout::Id>::max();
   }
 
   ~CoastlineShapeFileVisitor() override
   {
-    if (continuation) {
-      progress.Error("Last element is not properly closed");
-    }
-
     progress.Info("Found {} coastline(s)",coastlineCount);
   }
 
@@ -79,8 +74,6 @@ public:
     // note that shapefile coastlines has reverse direction than OSM!
     coastline->left=osmscout::WaterIndexProcessor::CoastState::water;
     coastline->right=osmscout::WaterIndexProcessor::CoastState::land;
-    coastline->frontNodeId=coords.front().GetHash();
-    coastline->backNodeId=coords.back().GetHash();
 
     coastline->coast.reserve(coords.size());
 
@@ -88,9 +81,44 @@ public:
       coastline->coast.emplace_back(0,coord);
     }
 
+    // Use the same point id encoding that WaterIndexProcessor::MergeCoastlines uses,
+    // otherwise chain merging stops after the first join.
+    coastline->frontNodeId=coastline->coast.front().GetId();
+    coastline->backNodeId=coastline->coast.back().GetId();
+
     coasts.push_back(coastline);
 
     currentId--;
+  }
+
+  void AddCoastChunk(const std::vector<osmscout::GeoCoord>& coords,
+                     size_t start,
+                     size_t end)
+  {
+    if (end<=start+1) {
+      return;
+    }
+
+    AddCoast(std::vector<osmscout::GeoCoord>(coords.begin()+start,
+                                             coords.begin()+end));
+    coastlineCount++;
+  }
+
+  void AddLongCoast(const std::vector<osmscout::GeoCoord>& coords)
+  {
+    size_t start=0;
+
+    while (start<coords.size()) {
+      size_t end=std::min(start+maxCoastlinePoints,coords.size());
+
+      AddCoastChunk(coords,start,end);
+
+      if (end==coords.size()) {
+        break;
+      }
+
+      start=end-1;
+    }
   }
 
   void OnProgress(double current,
@@ -103,25 +131,17 @@ public:
                   const osmscout::GeoBox& /*boundingBox*/,
                   const std::vector<osmscout::GeoCoord>& coords) override
   {
-    if (continuation) {
-      if (coords.size()<1000 || coordBuffer.front()==coords.back()) {
-        coordBuffer.insert(coordBuffer.end(),coords.begin(),coords.end());
-        AddCoast(coordBuffer);
-        coastlineCount++;
-        continuation=false;
-      }
-      else {
-        coordBuffer.insert(coordBuffer.end(),coords.begin(),coords.end());
-      }
+    if (coords.empty()) {
+      return;
     }
-    else if (coords.size()<1000 || coords.front()==coords.back()) {
+
+    if (coords.size()<=maxCoastlinePoints) {
       AddCoast(coords);
       coastlineCount++;
+      return;
     }
-    else {
-      coordBuffer=coords;
-      continuation=true;
-    }
+
+    AddLongCoast(coords);
   }
 };
 

--- a/Tests/src/WaterIndexTest.cpp
+++ b/Tests/src/WaterIndexTest.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 
@@ -190,3 +191,96 @@ TEST_CASE("Synthetize coastlines")
   REQUIRE((*it)->coast[1].GetCoord()==GeoCoord(0, 0));
   REQUIRE((*it)->coast[2].GetCoord()==GeoCoord(0, 0.5));
 }
+
+TEST_CASE("Merge chunked open coastline")
+{
+  WaterIndexProcessor processor;
+  SilentProgress progress;
+  std::list<WaterIndexProcessor::CoastRef> coastlines;
+
+  // build a long open polyline that would be split by BasemapImport
+  std::vector<Point> coords;
+  size_t             pointCount=1500;
+
+  for (size_t i=0; i<pointCount; i++) {
+    coords.emplace_back(0, GeoCoord(0.0, i*0.001));
+  }
+
+  // split into 1000 point chunks with one point overlap, like BasemapImport now does
+  size_t chunkSize=1000;
+  size_t start=0;
+  OSMId  id=0;
+
+  while (start<coords.size()) {
+    size_t end=std::min(start+chunkSize,coords.size());
+
+    std::vector<Point> chunk(coords.begin()+start,
+                             coords.begin()+end);
+
+    coastlines.push_back(MkCoastline(id++,
+                                     std::move(chunk),
+                                     WaterIndexProcessor::CoastState::water,
+                                     WaterIndexProcessor::CoastState::land));
+
+    if (end==coords.size()) {
+      break;
+    }
+
+    start=end-1;
+  }
+
+  processor.MergeCoastlines(progress, coastlines);
+  REQUIRE(coastlines.size()==1);
+  REQUIRE_FALSE(coastlines.front()->isArea);
+  REQUIRE(coastlines.front()->coast.size()==pointCount);
+}
+
+TEST_CASE("Merge chunked closed coastline to area")
+{
+  WaterIndexProcessor processor;
+  SilentProgress progress;
+  std::list<WaterIndexProcessor::CoastRef> coastlines;
+
+  // build a long closed ring that would be split by BasemapImport
+  std::vector<Point> coords;
+  size_t             pointCount=1500;
+  static const double pi=std::atan(1.0)*4.0;
+
+  for (size_t i=0; i<pointCount-1; i++) {
+    double angle=2.0*pi*i/(pointCount-1);
+    coords.emplace_back(0, GeoCoord(std::sin(angle), std::cos(angle)));
+  }
+
+  coords.emplace_back(coords.front());
+
+  // split into 1000 point chunks with one point overlap
+  size_t chunkSize=1000;
+  size_t start=0;
+  OSMId  id=0;
+
+  while (start<coords.size()) {
+    size_t end=std::min(start+chunkSize,coords.size());
+
+    std::vector<Point> chunk(coords.begin()+start,
+                             coords.begin()+end);
+
+    coastlines.push_back(MkCoastline(id++,
+                                     std::move(chunk),
+                                     WaterIndexProcessor::CoastState::water,
+                                     WaterIndexProcessor::CoastState::land));
+
+    if (end==coords.size()) {
+      break;
+    }
+
+    start=end-1;
+  }
+
+  processor.MergeCoastlines(progress, coastlines);
+  REQUIRE(coastlines.size()==1);
+  REQUIRE(coastlines.front()->isArea);
+  // duplicate closing point must be removed by the merge
+  REQUIRE(coastlines.front()->coast.size()==pointCount-1);
+}
+
+


### PR DESCRIPTION
- Coastline node IDs now use Point::GetId() instead of GeoCoord::GetHash()
- added maxCoastlinePoints=1000 chunking with overlapping endpoints for long shapefile records
- removed old continuation/coordBuffer logic.

WaterIndexProcessor::MergeCoastlines recomputes IDs with Point::GetId(). The old hash-based IDs caused chain merging to stop after the first join, leaving continental coastlines open and dropped. Chunking prevents future oversized records from breaking the merge.