### PR TITLE
Fix Caspian sea basemap

### DIFF
--- a/Tests/src/WaterIndexTest.cpp
+++ b/Tests/src/WaterIndexTest.cpp
@@ -283,4 +283,82 @@ TEST_CASE("Merge chunked closed coastline to area")
   REQUIRE(coastlines.front()->coast.size()==pointCount-1);
 }
 
+WaterIndexProcessor::CoastlineDataRef MkCoastlineData(Id id,
+                                                      std::vector<GeoCoord> points)
+{
+  auto coastline=std::make_shared<WaterIndexProcessor::CoastlineData>();
+
+  coastline->id=id;
+  coastline->isArea=true;
+  coastline->isCompletelyInCell=false;
+  coastline->points=std::move(points);
+  coastline->left=WaterIndexProcessor::CoastState::land;
+  coastline->right=WaterIndexProcessor::CoastState::water;
+
+  GetBoundingBox(coastline->points, coastline->boundingBox);
+
+  return coastline;
+}
+
+TEST_CASE("FilterEncapsulatedCoastlines removes a real island encapsulated in a bigger island")
+{
+  WaterIndexProcessor processor;
+  SilentProgress progress;
+
+  // "continent" - a counter-clockwise square ring, as a landmass/island is
+  // digitised under the natural=coastline convention (sea on the way's
+  // right, land on its left; walking with land as the interior is CCW).
+  // Verified by hand: shoelace sum over (lon,lat) points (0,0)->(10,0)->
+  // (10,10)->(0,10) is +200, i.e. counter-clockwise.
+  auto continent=MkCoastlineData(1, {
+    GeoCoord(0,0), GeoCoord(0,10), GeoCoord(10,10), GeoCoord(10,0), GeoCoord(0,0)
+  });
+
+  // A small ring with the *same* CCW winding, fully nested inside the
+  // continent - a redundant island that should still be filtered out.
+  auto island=MkCoastlineData(2, {
+    GeoCoord(1,1), GeoCoord(1,2), GeoCoord(2,2), GeoCoord(2,1), GeoCoord(1,1)
+  });
+
+  std::vector<WaterIndexProcessor::CoastlineDataRef> coastlines{continent, island};
+
+  processor.FilterEncapsulatedCoastlines(progress, coastlines);
+
+  REQUIRE(coastlines.size()==1);
+  REQUIRE(coastlines[0]->id==1);
+}
+
+TEST_CASE("FilterEncapsulatedCoastlines keeps an enclosed sea encapsulated in a landmass")
+{
+  WaterIndexProcessor processor;
+  SilentProgress progress;
+
+  // Same "continent" ring as above (CCW, land interior).
+  auto continent=MkCoastlineData(1, {
+    GeoCoord(0,0), GeoCoord(0,10), GeoCoord(10,10), GeoCoord(10,0), GeoCoord(0,0)
+  });
+
+  // A smaller ring with the *opposite* (clockwise) winding, fully nested
+  // inside the continent - an enclosed sea like the Caspian Sea, digitised
+  // the same way a mapper would trace any shoreline (land on the left,
+  // water on the right) but around a body of water instead of a landmass.
+  // Verified by hand: shoelace sum over (lon,lat) points (3,3)->(3,7)->
+  // (7,7)->(7,3) is -32, i.e. clockwise.
+  //
+  // This must NOT be treated as a redundant island and removed - this is
+  // the Caspian Sea bug reproduction. It currently FAILS because
+  // FilterEncapsulatedCoastlines only checks left==CoastState::land, which
+  // is true for both rings (it's a hardcoded constant, not derived from
+  // geometry) and does not yet consult the ring's actual winding.
+  auto sea=MkCoastlineData(2, {
+    GeoCoord(3,3), GeoCoord(7,3), GeoCoord(7,7), GeoCoord(3,7), GeoCoord(3,3)
+  });
+
+  std::vector<WaterIndexProcessor::CoastlineDataRef> coastlines{continent, sea};
+
+  processor.FilterEncapsulatedCoastlines(progress, coastlines);
+
+  REQUIRE(coastlines.size()==2);
+}
+
 

--- a/Tests/src/WaterIndexTest.cpp
+++ b/Tests/src/WaterIndexTest.cpp
@@ -367,23 +367,31 @@ TEST_CASE("IsWaterArea detects ring orientation, including with a duplicated clo
   // duplicated at the end exactly as TransformCoastlines stores it. The
   // extreme (minimum-latitude) point of this ring is index 0, which is
   // exactly the degenerate case IsWaterArea must handle correctly.
-  std::vector<GeoCoord> land{
+  WaterIndexProcessor::CoastlineData land;
+  land.left = WaterIndexProcessor::CoastState::land;
+  land.right = WaterIndexProcessor::CoastState::water;
+  land.points = {
     GeoCoord(0,0), GeoCoord(0,10), GeoCoord(10,10), GeoCoord(10,0), GeoCoord(0,0)
   };
   REQUIRE_FALSE(WaterIndexProcessor::IsWaterArea(land));
 
   // Clockwise square (water interior), also with a duplicated closing point.
-  std::vector<GeoCoord> sea{
+  WaterIndexProcessor::CoastlineData sea;
+  sea.left = WaterIndexProcessor::CoastState::land;
+  sea.right = WaterIndexProcessor::CoastState::water;
+  sea.points = {
     GeoCoord(3,3), GeoCoord(7,3), GeoCoord(7,7), GeoCoord(3,7), GeoCoord(3,3)
   };
   REQUIRE(WaterIndexProcessor::IsWaterArea(sea));
 
   // Same rings without the duplicated closing point must give the same
   // answer.
-  std::vector<GeoCoord> landNoDup{land.begin(),land.end()-1};
+  auto landNoDup = land;
+  landNoDup.points = {land.points.begin(),land.points.end()-1};
   REQUIRE_FALSE(WaterIndexProcessor::IsWaterArea(landNoDup));
 
-  std::vector<GeoCoord> seaNoDup{sea.begin(),sea.end()-1};
+  auto seaNoDup = sea;
+  seaNoDup.points = {sea.points.begin(),sea.points.end()-1};
   REQUIRE(WaterIndexProcessor::IsWaterArea(seaNoDup));
 }
 

--- a/Tests/src/WaterIndexTest.cpp
+++ b/Tests/src/WaterIndexTest.cpp
@@ -361,4 +361,30 @@ TEST_CASE("FilterEncapsulatedCoastlines keeps an enclosed sea encapsulated in a 
   REQUIRE(coastlines.size()==2);
 }
 
+TEST_CASE("IsWaterArea detects ring orientation, including with a duplicated closing point")
+{
+  // Counter-clockwise square (land interior), with the closing point
+  // duplicated at the end exactly as TransformCoastlines stores it. The
+  // extreme (minimum-latitude) point of this ring is index 0, which is
+  // exactly the degenerate case IsWaterArea must handle correctly.
+  std::vector<GeoCoord> land{
+    GeoCoord(0,0), GeoCoord(0,10), GeoCoord(10,10), GeoCoord(10,0), GeoCoord(0,0)
+  };
+  REQUIRE_FALSE(WaterIndexProcessor::IsWaterArea(land));
+
+  // Clockwise square (water interior), also with a duplicated closing point.
+  std::vector<GeoCoord> sea{
+    GeoCoord(3,3), GeoCoord(7,3), GeoCoord(7,7), GeoCoord(3,7), GeoCoord(3,3)
+  };
+  REQUIRE(WaterIndexProcessor::IsWaterArea(sea));
+
+  // Same rings without the duplicated closing point must give the same
+  // answer.
+  std::vector<GeoCoord> landNoDup{land.begin(),land.end()-1};
+  REQUIRE_FALSE(WaterIndexProcessor::IsWaterArea(landNoDup));
+
+  std::vector<GeoCoord> seaNoDup{sea.begin(),sea.end()-1};
+  REQUIRE(WaterIndexProcessor::IsWaterArea(seaNoDup));
+}
+
 

--- a/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
@@ -660,7 +660,7 @@ public:
                                       std::vector<CoastlineDataRef> &transformedCoastlines);
 
     /**
-     * Returns true if the closed ring described by `points` encloses water
+     * Returns true if the closed ring described by `coastline` encloses water
      * (an inland sea or lake) rather than land (an island or continent).
      *
      * natural=coastline convention keeps the sea on the right of the way in
@@ -670,10 +670,11 @@ public:
      * sea) is a clockwise traversal instead. See AreaIsClockwise() in
      * Geometry.h.
      *
-     * `points` may or may not include an explicit closing point
-     * (points.front()==points.back()); both forms are handled correctly.
+     * `coastline.points` may or may not include an explicit closing point
+     * (coastline.points.front()==coastline.points.back()); both forms
+     * are handled correctly.
      */
-    static bool IsWaterArea(const std::vector<GeoCoord>& points);
+    static bool IsWaterArea(const CoastlineData& coastline);
 
     /**
      * Merge short coastline ways to bigger one and create areas if possible.

--- a/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
@@ -660,6 +660,22 @@ public:
                                       std::vector<CoastlineDataRef> &transformedCoastlines);
 
     /**
+     * Returns true if the closed ring described by `points` encloses water
+     * (an inland sea or lake) rather than land (an island or continent).
+     *
+     * natural=coastline convention keeps the sea on the right of the way in
+     * its digitised direction. Walking a ring with land kept on the left is
+     * a counter-clockwise traversal when land is the interior (an island);
+     * walking a ring the same way when water is the interior (an enclosed
+     * sea) is a clockwise traversal instead. See AreaIsClockwise() in
+     * Geometry.h.
+     *
+     * `points` may or may not include an explicit closing point
+     * (points.front()==points.back()); both forms are handled correctly.
+     */
+    static bool IsWaterArea(const std::vector<GeoCoord>& points);
+
+    /**
      * Merge short coastline ways to bigger one and create areas if possible.
      */
     void MergeCoastlines(Progress& progress,

--- a/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
+++ b/libosmscout-import/include/osmscoutimport/WaterIndexProcessor.h
@@ -629,9 +629,6 @@ namespace osmscout {
     void FilterIntersectCoastlines(Progress& progress,
                                    std::vector<CoastlineDataRef> &transformedCoastlines);
 
-    void FilterEncapsulatedCoastlines(Progress& progress,
-                                      std::vector<CoastlineDataRef> &transformedCoastlines);
-
     void ComputeCoveredTiles(Progress& progress,
                            const StateMap& stateMap,
                            Data& data,
@@ -643,6 +640,25 @@ namespace osmscout {
     static bool CoastlineGeoSizeSorter(const CoastlineDataRef &a, const CoastlineDataRef &b);
 
 public:
+    /**
+     * Removes coastline areas ("islands") that are fully contained within a
+     * bigger coastline area and therefore redundant to render at the current
+     * zoom level.
+     *
+     * Every raw coastline is assigned a uniform left=land/right=water state
+     * at load time (see WaterIndexGenerator::LoadCoastlines), so left/right
+     * alone cannot tell a real island apart from an enclosed sea or lake
+     * whose ring happens to sit inside a landmass's outer ring (e.g. the
+     * Caspian Sea sitting inside the merged Africa-Europe-Asia coastline).
+     * IsWaterArea() is used to make that distinction from the ring's actual
+     * geometry before discarding anything.
+     *
+     * Exposed as public (rather than private) so it can be unit tested
+     * directly without needing a full Projection/StateMap setup.
+     */
+    void FilterEncapsulatedCoastlines(Progress& progress,
+                                      std::vector<CoastlineDataRef> &transformedCoastlines);
+
     /**
      * Merge short coastline ways to bigger one and create areas if possible.
      */

--- a/libosmscout-import/src/osmscoutimport/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscoutimport/WaterIndexProcessor.cpp
@@ -1292,6 +1292,28 @@ constexpr bool debugTiling = false;
         transformedCoastlines.end());
   }
 
+  bool WaterIndexProcessor::IsWaterArea(const std::vector<GeoCoord>& points)
+  {
+    if (points.size()<4) {
+      return false;
+    }
+
+    // AreaIsClockwise() picks the vertex with the minimum latitude and
+    // inspects its two neighbours to determine winding. CoastlineData
+    // rings store an explicit duplicated closing point (points.front()==
+    // points.back(), added by TransformCoastlines); if that shared point
+    // happens to be the minimum-latitude one, one of its "neighbours" is a
+    // zero-length duplicate of itself and the orientation test degenerates
+    // to a meaningless answer. Strip the duplicate first to avoid this.
+    if (points.front()==points.back()) {
+      std::vector<GeoCoord> ring(points.begin(),points.end()-1);
+
+      return AreaIsClockwise(ring);
+    }
+
+    return AreaIsClockwise(points);
+  }
+
   void WaterIndexProcessor::FilterEncapsulatedCoastlines(Progress& progress,
                                                          std::vector<CoastlineDataRef> &transformedCoastlines){
 
@@ -1346,7 +1368,7 @@ constexpr bool debugTiling = false;
       for (size_t index=0; index<transformedCoastlines.size(); index++) {
         CoastlineDataRef coastline = transformedCoastlines[index];
 
-        if (coastline && coastline->isArea) {
+        if (coastline && coastline->isArea && !IsWaterArea(coastline->points)) {
           if (landBox.Intersects(coastline->boundingBox, false) &&
               IsAreaCompletelyInArea(coastline->points, land)){
             progress.Warning("Island " + std::to_string(coastline->id) + " is encapsulated in land");
@@ -1369,7 +1391,8 @@ constexpr bool debugTiling = false;
         CoastlineDataRef b = transformedCoastlines[bi];
         assert(ai!=bi);
 
-        if (a && b && a->isArea && b->isArea && b->left == CoastState::land) {
+        if (a && b && a->isArea && b->isArea && b->left == CoastState::land &&
+            !IsWaterArea(b->points)) {
           if (a->boundingBox.Intersects(b->boundingBox, false) &&
               IsAreaCompletelyInArea(b->points, a->points)){
             progress.Warning("Island " + std::to_string(b->id) + " is encapsulated in island " + std::to_string(a->id));

--- a/libosmscout-import/src/osmscoutimport/WaterIndexProcessor.cpp
+++ b/libosmscout-import/src/osmscoutimport/WaterIndexProcessor.cpp
@@ -1292,9 +1292,11 @@ constexpr bool debugTiling = false;
         transformedCoastlines.end());
   }
 
-  bool WaterIndexProcessor::IsWaterArea(const std::vector<GeoCoord>& points)
+  bool WaterIndexProcessor::IsWaterArea(const CoastlineData& c)
   {
-    if (points.size()<4) {
+    assert(c.left==CoastState::land);
+    assert(c.right==CoastState::water);
+    if (c.points.size()<4) {
       return false;
     }
 
@@ -1305,13 +1307,13 @@ constexpr bool debugTiling = false;
     // happens to be the minimum-latitude one, one of its "neighbours" is a
     // zero-length duplicate of itself and the orientation test degenerates
     // to a meaningless answer. Strip the duplicate first to avoid this.
-    if (points.front()==points.back()) {
-      std::vector<GeoCoord> ring(points.begin(),points.end()-1);
+    if (c.points.front()==c.points.back()) {
+      std::vector<GeoCoord> ring(c.points.begin(),c.points.end()-1);
 
       return AreaIsClockwise(ring);
     }
 
-    return AreaIsClockwise(points);
+    return AreaIsClockwise(c.points);
   }
 
   void WaterIndexProcessor::FilterEncapsulatedCoastlines(Progress& progress,
@@ -1368,7 +1370,7 @@ constexpr bool debugTiling = false;
       for (size_t index=0; index<transformedCoastlines.size(); index++) {
         CoastlineDataRef coastline = transformedCoastlines[index];
 
-        if (coastline && coastline->isArea && !IsWaterArea(coastline->points)) {
+        if (coastline && coastline->isArea && !IsWaterArea(*coastline)) {
           if (landBox.Intersects(coastline->boundingBox, false) &&
               IsAreaCompletelyInArea(coastline->points, land)){
             progress.Warning("Island " + std::to_string(coastline->id) + " is encapsulated in land");
@@ -1392,7 +1394,7 @@ constexpr bool debugTiling = false;
         assert(ai!=bi);
 
         if (a && b && a->isArea && b->isArea && b->left == CoastState::land &&
-            !IsWaterArea(b->points)) {
+            !IsWaterArea(*b)) {
           if (a->boundingBox.Intersects(b->boundingBox, false) &&
               IsAreaCompletelyInArea(b->points, a->points)){
             progress.Warning("Island " + std::to_string(b->id) + " is encapsulated in island " + std::to_string(a->id));


### PR DESCRIPTION
Current world-scale import drops Caspian sea, as this sea is fully enclosed by the Euro-asia land. This change is fixing that and allow sea areas to be enclosed by the land...