### PR TITLE
implement play-sample method for Piper voices

### DIFF
--- a/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
@@ -24,6 +24,7 @@
 
 #include <osmscoutclientqt/VoiceManager.h>
 #include <osmscoutclientqt/Voice.h>
+#include <osmscoutclientqt/TTSEngine.h>
 #include <osmscoutclientqt/ClientQtImportExport.h>
 
 #include <QAbstractListModel>
@@ -35,7 +36,6 @@
 namespace osmscout {
 
 class VoiceCorePlayer;
-class TTSEngine;
 class TTSMessageGeneratorQt;
 
 /**
@@ -48,6 +48,11 @@ class TTSMessageGeneratorQt;
  */
 class OSMSCOUT_CLIENT_QT_API InstalledVoicesModel : public QAbstractListModel {
   Q_OBJECT
+
+  //!< localized, human readable description of the current TTS engine state
+  //!< (e.g. "Synthesizing voice sample…"), useful for showing synthesis
+  //!< progress in the UI as the initial synthesis may take some time.
+  Q_PROPERTY(QString ttsStateText READ getTTSStateText NOTIFY ttsStateChanged)
 
 private:
   Slot<std::string> voiceDirSlot{
@@ -62,10 +67,17 @@ signals:
   void initTTSVoiceRequested(const Voice &voice);
   void playTTSMessageRequested(QString message);
 
+  //!< emitted whenever getTTSStateText() changes
+  void ttsStateChanged();
+
 public slots:
   void update();
   void onVoiceChanged(const QString&);
   void playTTSAudio(const QList<QUrl> &audioFiles);
+
+private slots:
+  void onTTSStateChange(osmscout::TTSEngineState state);
+  void onTTSError(const QString &message);
 
 public:
   InstalledVoicesModel();
@@ -101,6 +113,14 @@ public:
    * invalid) voices, or when the library was built without libpiper support.
    */
   Q_INVOKABLE void playTTSSample(const QModelIndex &index);
+
+  /**
+   * Localized, human readable description of the current TTS engine state
+   * (see osmscout::TTSEngineState). Reads as "Ready" before any Piper sample
+   * was requested (or when the library was built without libpiper support).
+   */
+  QString getTTSStateText() const;
+
 private:
   void EnsureTTSEngine();
 
@@ -118,6 +138,10 @@ private:
   TTSEngine *ttsEngine{nullptr};
   std::shared_ptr<TTSMessageGeneratorQt> ttsMessageGenerator;
   QString ttsMessageLanguage; // language currently loaded into ttsMessageGenerator
+
+  // state of ttsEngine, mirrored here to expose it as a Qt property
+  TTSEngineState ttsState{TTSEngineState::Idle};
+  QString ttsErrorMessage; // last error reported by ttsEngine (not localized)
 };
 }
 #endif //OSMSCOUT_CLIENT_QT_INSTALLEDVOICESMODEL_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/InstalledVoicesModel.h
@@ -28,10 +28,15 @@
 
 #include <QAbstractListModel>
 #include <QList>
+#include <QUrl>
+
+#include <memory>
 
 namespace osmscout {
 
 class VoiceCorePlayer;
+class TTSEngine;
+class TTSMessageGeneratorQt;
 
 /**
  * Model providing access to currently installed voices on device
@@ -52,9 +57,15 @@ private:
 signals:
   void voiceChanged(const QString);
 
+  // Piper TTS engine runs asynchronously on its own thread, these signals are
+  // used to invoke it (via queued connections) from playTTSSample().
+  void initTTSVoiceRequested(const Voice &voice);
+  void playTTSMessageRequested(QString message);
+
 public slots:
   void update();
   void onVoiceChanged(const QString&);
+  void playTTSAudio(const QList<QUrl> &audioFiles);
 
 public:
   InstalledVoicesModel();
@@ -81,6 +92,18 @@ public:
 
   Q_INVOKABLE void select(const QModelIndex &index);
   Q_INVOKABLE void playSample(const QModelIndex &index, const QStringList &sample);
+
+  /**
+   * Play a synthesized voice sample for a Piper TTS voice at the given index.
+   * Unlike playSample() (which plays pre-recorded "Voice of Marble" ogg
+   * files), this synthesizes a short, representative navigation message using
+   * TTSMessageGeneratorQt and PiperTTSEngine. It is a no-op for non-Piper (or
+   * invalid) voices, or when the library was built without libpiper support.
+   */
+  Q_INVOKABLE void playTTSSample(const QModelIndex &index);
+private:
+  void EnsureTTSEngine();
+
 private:
   QString voiceDir;
   QList<Voice> voices;
@@ -89,6 +112,12 @@ private:
 
   // we setup QObject parents, objects are cleaned after Module destruction
   VoiceCorePlayer *mediaPlayer{nullptr};
+
+  // Piper TTS sample playback: the engine lives in its own background
+  // thread (see TTSEngine), created lazily on first use.
+  TTSEngine *ttsEngine{nullptr};
+  std::shared_ptr<TTSMessageGeneratorQt> ttsMessageGenerator;
+  QString ttsMessageLanguage; // language currently loaded into ttsMessageGenerator
 };
 }
 #endif //OSMSCOUT_CLIENT_QT_INSTALLEDVOICESMODEL_H

--- a/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/OSMScoutQt.h
@@ -368,6 +368,7 @@ public:
   size_t  GetOnlineTileCacheSize() const;
   QString GetIconDirectory() const;
   QString GetNavigationTranslationDir() const;
+  QString GetEspeakDataDir() const;
 
   static void RegisterQmlTypes(const char *uri="net.sf.libosmscout.map",
                                int versionMajor=1,

--- a/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/TTSEngine.h
@@ -31,6 +31,21 @@ class QThread;
 
 namespace osmscout {
 
+Q_NAMESPACE
+
+/**
+ * \ingroup QtAPI
+ *
+ * State of a TTSEngine, useful for showing synthesis progress in the UI
+ * (initial synthesis of a message may take a noticeable amount of time).
+ */
+enum class TTSEngineState {
+  Idle,         //!< engine is idle, not synthesizing anything at the moment
+  Synthesizing, //!< engine is currently synthesizing a message
+  Error,        //!< the last operation failed (see TTSEngine::error signal for details)
+};
+Q_ENUM_NS(TTSEngineState)
+
 /**
  * \ingroup QtAPI
  *
@@ -49,9 +64,11 @@ namespace osmscout {
  */
 class OSMSCOUT_CLIENT_QT_API TTSEngine : public QObject {
   Q_OBJECT
+  Q_PROPERTY(osmscout::TTSEngineState state READ getState NOTIFY stateChange)
 
 protected:
   QThread         *thread; //!< engine background thread (owns itself, deleted on finish)
+  TTSEngineState   state{TTSEngineState::Idle};  //!< current state of the engine
 
 public slots:
   /**
@@ -75,6 +92,20 @@ public slots:
 signals:
   void playAudioFilesRequest(const QList<QUrl> &audioFiles);
 
+  /**
+   * Emitted when the engine encounters an error (e.g. synthesis or voice
+   * loading failure). @p message is a localized, human readable
+   * description suitable for direct display in the UI.
+   */
+  void error(const QString &message);
+
+  /**
+   * Emitted whenever the engine's state changes, e.g. when it starts or
+   * finishes synthesizing a message. Useful for showing synthesis progress
+   * in the UI, as the initial synthesis of a message may take a while.
+   */
+  void stateChange(osmscout::TTSEngineState state);
+
 public:
   TTSEngine();
 
@@ -84,6 +115,11 @@ public:
   TTSEngine& operator=(TTSEngine&&) = delete;
 
   ~TTSEngine() override;
+
+  TTSEngineState getState() const
+  {
+    return state;
+  }
 
   virtual Voice getVoice() = 0;
 
@@ -97,6 +133,8 @@ protected:
 };
 
 }
+
+Q_DECLARE_METATYPE(osmscout::TTSEngineState)
 
 #endif // OSMSCOUT_CLIENT_QT_TTSENGINE_H
 

--- a/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
@@ -189,8 +189,45 @@ void InstalledVoicesModel::EnsureTTSEngine()
             ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
     connect(ttsEngine, &TTSEngine::playAudioFilesRequest,
             this, &InstalledVoicesModel::playTTSAudio, Qt::QueuedConnection);
+    connect(ttsEngine, &TTSEngine::stateChange,
+            this, &InstalledVoicesModel::onTTSStateChange, Qt::QueuedConnection);
+    connect(ttsEngine, &TTSEngine::error,
+            this, &InstalledVoicesModel::onTTSError, Qt::QueuedConnection);
   }
 #endif
+}
+
+void InstalledVoicesModel::onTTSStateChange(osmscout::TTSEngineState state)
+{
+  ttsState = state;
+  if (state != TTSEngineState::Error) {
+    // keep the last error message around while in the Error state, clear it
+    // once the engine recovers
+    ttsErrorMessage.clear();
+  }
+  emit ttsStateChanged();
+}
+
+void InstalledVoicesModel::onTTSError(const QString &message)
+{
+  ttsErrorMessage = message;
+  // note: the accompanying stateChange(Error) signal (emitted right after
+  // this one by the engine) triggers the ttsStateChanged() notification
+}
+
+QString InstalledVoicesModel::getTTSStateText() const
+{
+  switch (ttsState) {
+    case TTSEngineState::Synthesizing:
+      return tr("Synthesizing voice sample…");
+    case TTSEngineState::Error:
+      return ttsErrorMessage.isEmpty()
+        ? tr("Voice synthesis failed")
+        : tr("Voice synthesis failed: %1").arg(ttsErrorMessage);
+    case TTSEngineState::Idle:
+    default:
+      return tr("Ready");
+  }
 }
 
 void InstalledVoicesModel::playTTSAudio(const QList<QUrl> &audioFiles)

--- a/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/InstalledVoicesModel.cpp
@@ -20,8 +20,23 @@
 #include <osmscoutclientqt/InstalledVoicesModel.h>
 #include <osmscoutclientqt/OSMScoutQt.h>
 #include <osmscoutclientqt/VoicePlayer.h>
+#include <osmscoutclientqt/ClientQtFeatures.h>
+#include <osmscoutclientqt/TTSEngine.h>
+#include <osmscoutclientqt/TTSMessageGeneratorQt.h>
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+#include <osmscoutclientqt/PiperTTSEngine.h>
+#endif
+
+#include <osmscout/navigation/VoiceInstructionAgent.h>
+#include <osmscout/util/Locale.h>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) /* For compatibility with QT 5.6 */
+#include <QRandomGenerator>
+#endif
 
 #include <algorithm>
+#include <array>
+#include <utility>
 
 namespace osmscout {
 
@@ -42,7 +57,13 @@ InstalledVoicesModel::InstalledVoicesModel()
 }
 
 InstalledVoicesModel::~InstalledVoicesModel()
-{}
+{
+  if (ttsEngine != nullptr) {
+    // engine lives in its own thread, delete it there
+    ttsEngine->deleteLater();
+    ttsEngine = nullptr;
+  }
+}
 
 namespace {
 bool voiceItemLessThan(const Voice &i1, const Voice &i2)
@@ -153,6 +174,95 @@ void InstalledVoicesModel::playSample(const QModelIndex &index, const QStringLis
 
   mediaPlayer->setCurrentIndex(0);
   mediaPlayer->play();
+}
+
+void InstalledVoicesModel::EnsureTTSEngine()
+{
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+  if (ttsEngine==nullptr){
+    ttsEngine = new PiperTTSEngine(OSMScoutQt::GetInstance().GetEspeakDataDir());
+
+    // ttsEngine lives in its own background thread, invoke it asynchronously
+    connect(this, &InstalledVoicesModel::initTTSVoiceRequested,
+            ttsEngine, &TTSEngine::initVoice, Qt::QueuedConnection);
+    connect(this, &InstalledVoicesModel::playTTSMessageRequested,
+            ttsEngine, &TTSEngine::playMessage, Qt::QueuedConnection);
+    connect(ttsEngine, &TTSEngine::playAudioFilesRequest,
+            this, &InstalledVoicesModel::playTTSAudio, Qt::QueuedConnection);
+  }
+#endif
+}
+
+void InstalledVoicesModel::playTTSAudio(const QList<QUrl> &audioFiles)
+{
+  if (mediaPlayer==nullptr){
+    mediaPlayer = new VoiceCorePlayer(this);
+  }
+
+  mediaPlayer->clearQueue();
+  for (const auto &audioFile : audioFiles){
+    qDebug() << "Adding to playlist:" << audioFile;
+    mediaPlayer->addToQueue(audioFile);
+  }
+  mediaPlayer->setCurrentIndex(0);
+  mediaPlayer->play();
+}
+
+void InstalledVoicesModel::playTTSSample([[maybe_unused]] const QModelIndex &index)
+{
+#ifdef OSMSCOUT_HAVE_LIB_PIPER
+  if (index.row() < 0 || index.row() >= voices.size()){
+    return;
+  }
+  auto voice=voices.at(index.row());
+  if (!voice.isValid() || !voice.isPiper() || !voice.getDir().exists()){
+    return;
+  }
+
+  EnsureTTSEngine();
+  assert(ttsEngine!=nullptr);
+
+  if (ttsMessageGenerator==nullptr){
+    ttsMessageGenerator = std::make_shared<TTSMessageGeneratorQt>(OSMScoutQt::GetInstance().GetNavigationTranslationDir());
+  }
+  if (ttsMessageLanguage != voice.getLangCode()){
+    ttsMessageGenerator->SetLanguage(voice.getLangCode().toStdString());
+    ttsMessageLanguage = voice.getLangCode();
+  }
+  ttsMessageGenerator->SetUnits(Locale::ByEnvironmentSafe().GetDistanceUnits());
+
+  if (ttsEngine->getVoice().getDir() != voice.getDir()){
+    emit initTTSVoiceRequested(voice);
+  }
+
+  // A handful of representative maneuver combinations, in the same spirit as
+  // the "Voice of Marble" sample sets used above for pre-recorded voices.
+  using Type = VoiceMessageStruct::Type;
+  static const std::array<std::pair<VoiceMessageStruct, VoiceMessageStruct>, 5> samples{{
+    {VoiceMessageStruct(Type::TurnRight, Meters(500)), VoiceMessageStruct()},
+    {VoiceMessageStruct(Type::LeaveRbExit3, Meters(50)), VoiceMessageStruct(Type::StraightOn, Meters(100))},
+    {VoiceMessageStruct(Type::LeaveMotorwayRight, Meters(800)), VoiceMessageStruct()},
+    {VoiceMessageStruct(Type::TurnLeft, Meters(300)), VoiceMessageStruct()},
+    {VoiceMessageStruct(Type::LeaveMotorwayLeft, Meters(1500)), VoiceMessageStruct()}
+  }};
+
+  size_t sampleIndex;
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0) /* For compatibility with QT 5.6 */
+  sampleIndex = qrand() % samples.size();
+#else
+  sampleIndex = QRandomGenerator::global()->bounded(int(samples.size()));
+#endif
+
+  const auto &sample = samples[sampleIndex];
+  auto text = ttsMessageGenerator->GenerateMessage(Meters(0), sample.first, sample.second);
+  if (!text.has_value()){
+    return;
+  }
+
+  emit playTTSMessageRequested(QString::fromStdString(*text));
+#else
+  qWarning() << "Piper TTS support not built, cannot play synthesized sample";
+#endif
 }
 QHash<int, QByteArray> InstalledVoicesModel::roleNames() const
 {

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -525,4 +525,9 @@ QString OSMScoutQt::GetNavigationTranslationDir() const
 {
   return navigationTranslationDir;
 }
+
+QString OSMScoutQt::GetEspeakDataDir() const
+{
+  return espeakDataDir;
+}
 }

--- a/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/OSMScoutQt.cpp
@@ -244,6 +244,7 @@ void OSMScoutQt::RegisterQmlTypes(const char *uri,
   qRegisterMetaType<QmlRoutingProfileRef>("QmlRoutingProfileRef");
   qRegisterMetaType<VoicePlayer::PlaybackState>("VoicePlayer::PlaybackState");
   qRegisterMetaType<Voice>("Voice");
+  qRegisterMetaType<osmscout::TTSEngineState>("TTSEngineState");
 
   // register osmscout types for usage in QML
   qmlRegisterType<AvailableMapsModel>(uri, versionMajor, versionMinor, "AvailableMapsModel");

--- a/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PiperTTSEngine.cpp
@@ -156,6 +156,9 @@ void PiperTTSEngine::initVoice(const Voice &voice)
 
   if (!voice.isValid() || !voice.isPiper()) {
     log.Warn() << "PiperTTSEngine: voice is not a valid Piper voice";
+    emit error(tr("The selected voice is not a valid Piper voice."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return;
   }
 
@@ -168,6 +171,9 @@ void PiperTTSEngine::initVoice(const Voice &voice)
 
   if (espeakDataPath.isEmpty()) {
     log.Error() << "PiperTTSEngine: espeak-ng data directory was not configured";
+    emit error(tr("The espeak-ng data directory was not configured."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return;
   }
 
@@ -176,6 +182,9 @@ void PiperTTSEngine::initVoice(const Voice &voice)
   if (auto phontabFile = AppendFileToDir(espeakDataPath.toStdString(), "phontab");
       ExistsInFilesystem(phontabFile) == false) {
     log.Error() << "espeak-ng data directory does not contain phontab file: " << phontabFile;
+    emit error(tr("The espeak-ng data directory does not contain the required data files."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return;
   }
 
@@ -184,8 +193,13 @@ void PiperTTSEngine::initVoice(const Voice &voice)
                              espeakDataPath.toUtf8().constData());
   if (synthesizer == nullptr) {
     log.Error() << "PiperTTSEngine: failed to load Piper voice model " << modelPath.toStdString();
+    emit error(tr("Failed to load the voice model \"%1\".").arg(voice.getName()));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
   } else {
     log.Debug() << "PiperTTSEngine: loaded Piper voice model " << modelPath.toStdString();
+    state = TTSEngineState::Idle;
+    emit stateChange(state);
   }
 }
 
@@ -224,12 +238,23 @@ QString PiperTTSEngine::prepare(const QString &message)
 
   if (synthesizer == nullptr) {
     log.Warn() << "PiperTTSEngine: no voice loaded, cannot synthesize message";
+    emit error(tr("No voice is loaded, cannot synthesize the message."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return {};
   }
+
+  // actual synthesis is about to start, this may take a while for the first
+  // message of a voice (model warm-up), let the UI know
+  state = TTSEngineState::Synthesizing;
+  emit stateChange(state);
 
   piper_synthesize_options options = piper_default_synthesize_options(synthesizer);
   if (piper_synthesize_start(synthesizer, message.toUtf8().constData(), &options) != PIPER_OK) {
     log.Error() << "PiperTTSEngine: failed to start synthesis for \"" << message.toStdString() << "\"";
+    emit error(tr("Failed to start voice synthesis."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return {};
   }
 
@@ -253,15 +278,23 @@ QString PiperTTSEngine::prepare(const QString &message)
 
   if (rc < 0) {
     log.Error() << "PiperTTSEngine: synthesis failed for \"" << message.toStdString() << "\"";
+    emit error(tr("Voice synthesis failed."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return {};
   }
 
   if (!WriteWav(path, samples, sampleRate)) {
     log.Error() << "PiperTTSEngine: failed to write WAV file " << path.toStdString();
+    emit error(tr("Failed to write the synthesized audio file."));
+    state = TTSEngineState::Error;
+    emit stateChange(state);
     return {};
   }
 
   cache.insert(message, path);
+  state = TTSEngineState::Idle;
+  emit stateChange(state);
   return path;
 }
 


### PR DESCRIPTION
Installled voice model provides playSample method that is able to play voice sample from the QML, but just for voice-of-marble voices.

New playTTSSample method allow the same for Piper voices, mirroring playSample()'s API shape but building the message differently:

 - Text generation: picks a random one of 4 representative maneuver combos (VoiceMessageStruct pairs), translates them via TTSMessageGeneratorQt (loading the voice's langCode, matching the current locale's distance units).

 - Synthesis + playback: lazily creates a PiperTTSEngine (own background thread, like NavigationModule), invoked asynchronously via new signals initTTSVoiceRequested/playTTSMessageRequested (Qt::QueuedConnection), and its playAudioFilesRequest result is routed to the existing VoiceCorePlayer via a new playTTSAudio slot.

 - Added OSMScoutQt::GetEspeakDataDir() getter (previously private-only) so the model can construct the PiperTTSEngine.

 - Whole Piper path is guarded by #ifdef OSMSCOUT_HAVE_LIB_PIPER; without libpiper it's a safe no-op with a warning.