### PR TITLE
Fix: Fix label fickering on paning in OSMScout2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ include order, comments, formatting, header guards, templates, and error handlin
 - **Tests**: `Tests/` for unit tests, `libosmscout-test/` for test utilities
 
 ### Common Patterns
+- After any code change, run the `verify-build-and-tests` skill (build both CMake `build/` and Meson `debug/`, evaluate exit codes, report diagnostics; use `--with-tests` for full test suites). Do not mark work complete with build errors or warnings.
 - No DI framework — objects are constructed manually
 - Most classes accept `osmscout::TypeConfigRef` for type information
 - File I/O uses custom scanner/writer classes in `osmscout::io`

--- a/OSMScout2/qml/main.qml
+++ b/OSMScout2/qml/main.qml
@@ -120,6 +120,33 @@ Window {
             id: map
             Layout.fillWidth: true
             Layout.fillHeight: true
+
+            // TEMPORARY diagnostics: programmatic pan left/right to drive
+            // the label flicker reproduction (see change
+            // label-collision-stability). Remove after investigation.
+            Timer {
+                id: debugPanTimer
+                interval: 150
+                running: true
+                repeat: true
+                property double lon: 0
+                property int step: 0
+                Component.onCompleted: console.log("[debugPan] timer created, running=" + running)
+                onTriggered: {
+                    if (!map.databaseLoaded) {
+                        console.log("[debugPan] skip: database not loaded")
+                        return
+                    }
+                    step++
+                    var dir = (Math.floor((step-1)/10) % 2 === 0) ? -0.00025 : 0.00025
+                    if (step > 40) {
+                        dir = 0
+                        running = false
+                    }
+                    console.log("[debugPan] step " + step + " dir " + dir + " lat " + map.view.lat + " lon " + map.view.lon)
+                    map.debugPan(dir)
+                }
+            }
             focus: true
             renderingType: "plane" // or "tiled"
             interactiveIcons: true

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -185,6 +185,13 @@ else()
 	message("Skip ScreenMask test, libosmscout-map is missing.")
 endif()
 
+#---- LabelLayouter
+if(${OSMSCOUT_BUILD_MAP} AND TARGET OSMScout::Map)
+  osmscout_test_project(NAME LabelLayouterTest SOURCES src/LabelLayouterTest.cpp TARGET OSMScout::Map)
+else()
+	message("Skip LabelLayouter test, libosmscout-map is missing.")
+endif()
+
 #---- StringUtils
 osmscout_test_project(NAME StringUtilsTest SOURCES src/StringUtilsTest.cpp)
 

--- a/Tests/meson.build
+++ b/Tests/meson.build
@@ -621,6 +621,16 @@ ScreenMaskTest = executable('ScreenMaskTest',
 
 test('Check ScreenMask functionality', ScreenMaskTest)
 
+LabelLayouterTest = executable('LabelLayouterTest',
+                       'src/LabelLayouterTest.cpp',
+                       include_directories: [testIncDir, osmscoutmapIncDir, osmscoutIncDir],
+                       dependencies: [mathDep, openmpDep, catch2MainDep],
+                       link_with: [osmscoutmap, osmscout],
+                       install: true,
+                       install_dir: testInstallDir)
+
+test('Check LabelLayouter functionality', LabelLayouterTest)
+
 SignalTest = executable('SignalTest',
                     'src/SignalTest.cpp',
                     include_directories: [testIncDir, osmscoutIncDir],

--- a/Tests/src/LabelLayouterTest.cpp
+++ b/Tests/src/LabelLayouterTest.cpp
@@ -1,0 +1,837 @@
+/*
+  This source is part of the libosmscout library
+  Copyright (C) 2025 Tim Teulings
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+*/
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <osmscoutmap/LabelLayouter.h>
+
+#include <osmscoutmap/MapParameter.h>
+
+#include <osmscout/GeoCoord.h>
+#include <osmscout/ObjectRef.h>
+#include <osmscout/projection/MercatorProjection.h>
+#include <osmscout/util/Magnification.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace osmscout;
+
+namespace {
+
+constexpr double viewWidth=800.0;
+constexpr double viewHeight=600.0;
+
+/**
+ * Native glyph/label types for the fake text layouter. They carry no
+ * rendering information, only enough structure to instantiate the
+ * LabelLayouter template.
+ */
+struct FakeGlyph {
+  char c{'?'};
+};
+
+struct FakeLabel {
+  // empty: no native label data
+};
+
+/**
+ * Mock of the backend text layouter contract documented on LabelLayouter
+ * (see the template documentation of LabelLayouter). Metrics are
+ * deterministic and derived from the text content only:
+ * width = 20.0 * character count, height = 20.0.
+ */
+class FakeTextLayouter
+{
+public:
+  using NativeGlyph=FakeGlyph;
+  using NativeLabel=FakeLabel;
+
+  std::shared_ptr<Label<FakeGlyph,FakeLabel>> Layout(const Projection& /*projection*/,
+                                                     const MapParameter& /*parameter*/,
+                                                     const std::string& text,
+                                                     double /*fontSize*/,
+                                                     double /*objectWidth*/,
+                                                     bool /*enableWrapping*/=false,
+                                                     bool /*contourLabel*/=false)
+  {
+    std::shared_ptr<Label<FakeGlyph,FakeLabel>> label=
+        std::make_shared<Label<FakeGlyph,FakeLabel>>();
+
+    label->width=20.0*static_cast<double>(text.size());
+    label->height=20.0;
+    label->fontSize=10.0;
+    label->text=text;
+
+    return label;
+  }
+
+  ScreenVectorRectangle GlyphBoundingBox(const FakeGlyph& /*glyph*/) const
+  {
+    return ScreenVectorRectangle(0.0,0.0,20.0,20.0);
+  }
+};
+
+struct LabelSpec
+{
+  ObjectFileRef ref;
+  size_t        priority;
+  std::string   text;
+  double        x;
+  double        y;
+};
+
+struct PlacedLabel
+{
+  double x;
+  double y;
+  double width;
+  double height;
+};
+
+bool operator==(const PlacedLabel& a, const PlacedLabel& b)
+{
+  return a.x==b.x && a.y==b.y && a.width==b.width && a.height==b.height;
+}
+
+LabelData CreateTextData(const LabelSpec& spec)
+{
+  LabelData data;
+
+  data.type=LabelData::Type::Text;
+  data.priority=spec.priority;
+  data.alpha=1.0;
+  data.fontSize=10.0;
+  data.style=std::make_shared<TextStyle>();
+  data.text=spec.text;
+
+  return data;
+}
+
+/**
+ * Execute one full label layout round for the given labels and viewport
+ * with the shared LabelLayouter, without any rendering backend.
+ * Returns the position of every label that survived collision resolution,
+ * keyed by its object reference.
+ */
+std::map<ObjectFileRef,PlacedLabel> RunLayout(const Projection& projection,
+                                              const MapParameter& parameter,
+                                              const ScreenVectorRectangle& viewport,
+                                              const std::vector<LabelSpec>& labels,
+                                              double shiftX,
+                                              double shiftY)
+{
+  FakeTextLayouter                                    textLayouter;
+  LabelLayouter<FakeGlyph,FakeLabel,FakeTextLayouter> layouter(&textLayouter);
+
+  layouter.SetViewport(viewport);
+  layouter.SetLayoutOverlap(0);
+
+  for (const LabelSpec& spec : labels) {
+    layouter.RegisterLabel(projection,
+                           parameter,
+                           /*basemap*/ false,
+                           spec.ref,
+                           Vertex2D(spec.x+shiftX,spec.y+shiftY),
+                           std::vector<LabelData>{CreateTextData(spec)});
+  }
+
+  layouter.Layout(projection,parameter);
+
+  std::map<ObjectFileRef,PlacedLabel> result;
+
+  for (const auto& instance : layouter.Labels()) {
+    for (const auto& element : instance.elements) {
+      result[instance.priority.ref]=PlacedLabel(element.x,
+                                                element.y,
+                                                element.label->width,
+                                                element.label->height);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * A layout session keeps one LabelLayouter instance across multiple
+ * frames, exactly like the renderers do (DrawLabels -> Reset -> next
+ * draw). It provides the object identity across frames that the
+ * visible-label hysteresis of the layouter works on.
+ */
+class LayoutSession
+{
+public:
+  LayoutSession(const Projection& projection, MapParameter& parameter)
+  : layouter(&textLayouter),
+    projection(projection),
+    parameter(parameter)
+  {
+  }
+
+  std::map<ObjectFileRef,PlacedLabel> Frame(const ScreenVectorRectangle& viewport,
+                                            const std::vector<LabelSpec>& labels,
+                                            double shiftX=0.0,
+                                            double shiftY=0.0)
+  {
+    layouter.Reset();
+    layouter.SetViewport(viewport);
+    layouter.SetLayoutOverlap(0);
+
+    for (const LabelSpec& spec : labels) {
+      layouter.RegisterLabel(projection,
+                             parameter,
+                             /*basemap*/ false,
+                             spec.ref,
+                             Vertex2D(spec.x+shiftX,spec.y+shiftY),
+                             std::vector<LabelData>{CreateTextData(spec)});
+    }
+
+    layouter.Layout(projection,parameter);
+
+    std::map<ObjectFileRef,PlacedLabel> result;
+
+    for (const auto& instance : layouter.Labels()) {
+      for (const auto& element : instance.elements) {
+        result[instance.priority.ref]=PlacedLabel(element.x,
+                                                  element.y,
+                                                  element.label->width,
+                                                  element.label->height);
+      }
+    }
+
+    return result;
+  }
+
+private:
+  FakeTextLayouter                                    textLayouter;
+  LabelLayouter<FakeGlyph,FakeLabel,FakeTextLayouter> layouter;
+  const Projection&                                   projection;
+  MapParameter&                                       parameter;
+};
+
+LabelSpec MakeSpec(size_t id,
+                   size_t priority,
+                   const std::string& text,
+                   double x,
+                   double y)
+{
+  return LabelSpec{ObjectFileRef(id,refNode),priority,text,x,y};
+}
+
+bool IsFullyInside(const LabelSpec& spec,
+                   double visibleWidth,
+                   double visibleHeight)
+{
+  double labelWidth=20.0*static_cast<double>(spec.text.size());
+
+  return spec.x-labelWidth/2>=0.0 &&
+         spec.x+labelWidth/2<=visibleWidth &&
+         spec.y-10.0>=0.0 &&
+         spec.y+10.0<=visibleHeight;
+}
+
+/**
+ * Assert that a label survives layout in both runs and that its position
+ * in the shifted run equals its baseline position plus the shift.
+ */
+void RequireStableLabel(const std::map<ObjectFileRef,PlacedLabel>& baseline,
+                        const std::map<ObjectFileRef,PlacedLabel>& shifted,
+                        const LabelSpec& spec,
+                        double shiftX,
+                        double shiftY)
+{
+  auto baseIter=baseline.find(spec.ref);
+  auto shiftedIter=shifted.find(spec.ref);
+
+  INFO("Label ref " << spec.ref.GetName() << " text '" << spec.text << "' priority " << spec.priority);
+  INFO("Shift by (" << shiftX << ", " << shiftY << ")");
+
+  if (baseIter==baseline.end()) {
+    FAIL("Label not visible in baseline layout");
+  }
+
+  if (shiftedIter==shifted.end()) {
+    FAIL("Label visible in baseline layout but invisible in shifted layout");
+  }
+
+  PlacedLabel expected{baseIter->second.x+shiftX,
+                       baseIter->second.y+shiftY,
+                       baseIter->second.width,
+                       baseIter->second.height};
+
+  if (!(shiftedIter->second==expected)) {
+    FAIL("Position in shifted layout differs from shifted baseline position");
+  }
+}
+
+std::unique_ptr<Projection> CreateProjection(double width, double height)
+{
+  auto projection=std::make_unique<MercatorProjection>();
+
+  REQUIRE(projection->Set(GeoCoord(51.0,7.0),
+                          /*angle*/ 0.0,
+                          Magnification(Magnification::magClose),
+                          /*dpi*/ 96.0,
+                          static_cast<size_t>(width),
+                          static_cast<size_t>(height)));
+
+  return projection;
+}
+
+/**
+ * Four well separated labels, all fully inside an 800x600 viewport,
+ * with clear space between each other.
+ */
+std::vector<LabelSpec> CreateSpreadScene()
+{
+  std::vector<LabelSpec> labels;
+
+  labels.push_back(MakeSpec(1,1,"Alpha",150.0,150.0));   // 100..200 x 140..160
+  labels.push_back(MakeSpec(2,2,"Beta",400.0,300.0));    // 360..440 x 290..310
+  labels.push_back(MakeSpec(3,3,"Gamma",600.0,450.0));   // 550..650 x 440..460
+  labels.push_back(MakeSpec(4,4,"Delta",350.0,550.0));   // 300..400 x 540..560
+
+  return labels;
+}
+
+} // namespace
+
+TEST_CASE("LabelLayouter: layout without a rendering backend returns label placements", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  // No rendering backend, graphics context or font subsystem is created.
+  // The layouter only works on label data and viewport geometry.
+  std::map<ObjectFileRef,PlacedLabel> layout=RunLayout(*projection,
+                                                       parameter,
+                                                       ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                       labels,
+                                                       0,0);
+
+  REQUIRE(layout.size()==labels.size());
+
+  for (const LabelSpec& spec : labels) {
+    auto iter=layout.find(spec.ref);
+
+    REQUIRE(iter!=layout.end());
+
+    double labelWidth=20.0*static_cast<double>(spec.text.size());
+
+    // label is centered on its given point
+    REQUIRE(iter->second.x==Catch::Approx(spec.x-labelWidth/2));
+    REQUIRE(iter->second.y==Catch::Approx(spec.y-10.0));
+    REQUIRE(iter->second.width==Catch::Approx(labelWidth));
+    REQUIRE(iter->second.height==Catch::Approx(20.0));
+  }
+}
+
+TEST_CASE("LabelLayouter: repeated layout with identical viewport is deterministic", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+
+  // two competing labels
+  std::vector<LabelSpec> labels;
+
+  labels.push_back(MakeSpec(1,1,"Alpha",400.0,300.0)); // spans 350..450
+  labels.push_back(MakeSpec(2,2,"Beta",430.0,300.0));  // spans 390..470, overlaps "Alpha"
+
+  std::map<ObjectFileRef,PlacedLabel> first=RunLayout(*projection,
+                                                      parameter,
+                                                      ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                      labels,
+                                                      0,0);
+  std::map<ObjectFileRef,PlacedLabel> second=RunLayout(*projection,
+                                                       parameter,
+                                                       ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                       labels,
+                                                       0,0);
+
+  REQUIRE(first.size()==second.size());
+
+  for (const auto& entry : first) {
+    auto iter=second.find(entry.first);
+
+    REQUIRE(iter!=second.end());
+    REQUIRE(iter->second==entry.second);
+  }
+}
+namespace {
+
+/**
+ * Pan the scene: all labels and the viewport origin are shifted by the
+ * same delta, which is equivalent to panning the map view. Returns the
+ * layout of the panned scene relative to its shifted viewport.
+ */
+std::map<ObjectFileRef,PlacedLabel> RunPannedLayout(const Projection& projection,
+                                                    const MapParameter& parameter,
+                                                    const std::vector<LabelSpec>& labels,
+                                                    double viewX,
+                                                    double viewY,
+                                                    double shiftX,
+                                                    double shiftY)
+{
+  return RunLayout(projection,
+                   parameter,
+                   ScreenVectorRectangle(viewX+shiftX,viewY+shiftY,viewWidth,viewHeight),
+                   labels,
+                   shiftX,
+                   shiftY);
+}
+
+} // namespace
+
+TEST_CASE("LabelLayouter: horizontal pan does not change visibility of fully visible labels", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  std::map<ObjectFileRef,PlacedLabel> baseline=RunLayout(*projection,
+                                                         parameter,
+                                                         ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                         labels,
+                                                         0,0);
+  std::map<ObjectFileRef,PlacedLabel> shifted=RunPannedLayout(*projection,
+                                                              parameter,
+                                                              labels,
+                                                              0,0,
+                                                              50.0,0.0);
+
+  REQUIRE(baseline.size()==labels.size());
+  REQUIRE(shifted.size()==labels.size());
+
+  for (const LabelSpec& spec : labels) {
+    REQUIRE(IsFullyInside(spec,viewWidth,viewHeight));
+    RequireStableLabel(baseline,shifted,spec,50.0,0.0);
+  }
+}
+
+TEST_CASE("LabelLayouter: vertical pan does not change visibility of fully visible labels", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  std::map<ObjectFileRef,PlacedLabel> baseline=RunLayout(*projection,
+                                                         parameter,
+                                                         ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                         labels,
+                                                         0,0);
+  std::map<ObjectFileRef,PlacedLabel> shifted=RunPannedLayout(*projection,
+                                                              parameter,
+                                                              labels,
+                                                              0,0,
+                                                              0.0,50.0);
+
+  REQUIRE(baseline.size()==labels.size());
+  REQUIRE(shifted.size()==labels.size());
+
+  for (const LabelSpec& spec : labels) {
+    REQUIRE(IsFullyInside(spec,viewWidth,viewHeight));
+    RequireStableLabel(baseline,shifted,spec,0.0,50.0);
+  }
+}
+
+TEST_CASE("LabelLayouter: sub-pixel pan does not change visibility of fully visible labels", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  std::map<ObjectFileRef,PlacedLabel> baseline=RunLayout(*projection,
+                                                         parameter,
+                                                         ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                         labels,
+                                                         0,0);
+
+  // sub-pixel steps are the typical increments while the map is sliding
+  std::map<ObjectFileRef,PlacedLabel> shifted=RunPannedLayout(*projection,
+                                                              parameter,
+                                                              labels,
+                                                              0,0,
+                                                              0.5,0.25);
+
+  REQUIRE(baseline.size()==labels.size());
+  REQUIRE(shifted.size()==labels.size());
+
+  for (const LabelSpec& spec : labels) {
+    REQUIRE(IsFullyInside(spec,viewWidth,viewHeight));
+    RequireStableLabel(baseline,shifted,spec,0.5,0.25);
+  }
+}
+
+TEST_CASE("LabelLayouter: enlarged viewport around the same visible center does not change layout", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  // no map content exists outside the 800x600 visible area in this scene
+  std::map<ObjectFileRef,PlacedLabel> baseline=RunLayout(*projection,
+                                                         parameter,
+                                                         ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                         labels,
+                                                         0,0);
+
+  // a 1200x900 canvas centered on the same central point as the 800x600
+  // viewport: origin (-200,-150); all label points shift accordingly
+  double shiftX=200.0;
+  double shiftY=150.0;
+
+  std::map<ObjectFileRef,PlacedLabel> enlarged=RunLayout(*projection,
+                                                          parameter,
+                                                          ScreenVectorRectangle(-200,-150,1200,900),
+                                                          labels,
+                                                          shiftX,shiftY);
+
+  REQUIRE(baseline.size()==labels.size());
+  REQUIRE(enlarged.size()==labels.size());
+
+  for (const LabelSpec& spec : labels) {
+    RequireStableLabel(baseline,enlarged,spec,shiftX,shiftY);
+  }
+}
+
+TEST_CASE("LabelLayouter: collision winner with distinct priorities is independent of pan", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+
+  // two labels of adjacent priorities at the same y position, their
+  // rectangles overlap:
+  // "Alpha" spans 350..450, "Beta" spans 390..470
+  std::vector<LabelSpec> labels;
+
+  labels.push_back(MakeSpec(1,1,"Alpha",400.0,300.0));
+  labels.push_back(MakeSpec(2,2,"Beta",430.0,300.0));
+
+  std::map<ObjectFileRef,PlacedLabel> baseline=RunLayout(*projection,
+                                                         parameter,
+                                                         ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                         labels,
+                                                         0,0);
+  std::map<ObjectFileRef,PlacedLabel> shifted=RunPannedLayout(*projection,
+                                                              parameter,
+                                                              labels,
+                                                              0,0,
+                                                              50.0,0.0);
+
+  // both labels are fully inside both viewports, the pan must not
+  // influence which of them wins the collision
+  REQUIRE(baseline.find(labels[0].ref)!=baseline.end());
+  REQUIRE(baseline.find(labels[1].ref)==baseline.end());
+  REQUIRE(shifted.find(labels[0].ref)!=shifted.end());
+  REQUIRE(shifted.find(labels[1].ref)==shifted.end());
+}
+
+namespace {
+
+/**
+ * 5 priority classes over the label set to make the competition realistic.
+ */
+size_t workerPriority(size_t id)
+{
+  return 1+id%5;
+}
+
+/**
+ * Fixed-width label text (4 alphabetic + 2 digit characters), so that
+ * every label of the dense scene has identical 120px width.
+ */
+std::string PaddedShopName(size_t id)
+{
+  std::string idText=std::to_string(id);
+
+  if (idText.size()<2) {
+    idText="0"+idText;
+  }
+
+  return "Shop"+idText;
+}
+
+/**
+ * Dense scene (simulating a city center with many competing shop
+ * labels): a 9x7 grid of labels, each 120px wide ("ShopNN"), label
+ * centers at a horizontal spacing of 70px, so that horizontally
+ * adjacent labels overlap heavily. All labels are fully inside the
+ * 800x600 viewport.
+ */
+std::vector<LabelSpec> CreateDenseScene()
+{
+  std::vector<LabelSpec> labels;
+  size_t id=1;
+
+  for (size_t row=0; row<7; row++) {
+    for (size_t col=0; col<9; col++) {
+      double x=120.0+static_cast<double>(col)*70.0;
+      double y=45.0+static_cast<double>(row)*80.0;
+
+      labels.push_back(MakeSpec(id, workerPriority(id), PaddedShopName(id), x, y));
+
+      id++;
+    }
+  }
+
+  return labels;
+}
+
+/**
+ * Additional labels outside the 800x600 visible viewport but inside the
+ * 1600x1200 enlarged canvas: the oversized canvases rendered by the
+ * plane renderer contain such off-screen content, and every such label
+ * takes part in collision resolution.
+ */
+std::vector<LabelSpec> CreateOffViewportLabels()
+{
+  std::vector<LabelSpec> labels;
+  size_t id=100;
+
+  // rows above and below the visible viewport
+  for (size_t col=0; col<16; col++) {
+    double x=-380.0+static_cast<double>(col)*105.0;
+
+    labels.push_back(MakeSpec(id,workerPriority(id), PaddedShopName(id), x, -15.0));
+
+    id++;
+
+    labels.push_back(MakeSpec(id,workerPriority(id), PaddedShopName(id), x, 615.0));
+
+    id++;
+  }
+
+  // columns at the viewport border: their rectangles reach into the
+  // visible region and overlap the labels of the dense scene's first
+  // and last column. These model content that is present in one
+  // oversized render (image swap n) and absent in the next one
+  // (image swap n+1) because the request bounding box moved.
+  for (size_t row=0; row<7; row++) {
+    double y=45.0+static_cast<double>(row)*80.0;
+
+    labels.push_back(MakeSpec(id,0, PaddedShopName(id), 10.0, y));
+
+    id++;
+
+    labels.push_back(MakeSpec(id,0, PaddedShopName(id), 790.0, y));
+
+    id++;
+  }
+
+  return labels;
+}
+
+} // namespace
+
+TEST_CASE("LabelLayouter: dense scene visibility is stable when the candidate set grows between frames", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> denseLabels=CreateDenseScene();
+  std::vector<LabelSpec> offViewport=CreateOffViewportLabels();
+
+  // the renderer keeps one layouter across frames. Frame 1: layout
+  // viewport equals the visible viewport, candidates are only the
+  // labels of the dense scene.
+  LayoutSession session(*projection,parameter);
+
+  std::map<ObjectFileRef,PlacedLabel> baseline=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                             denseLabels);
+
+  // frame 2 (next swap of the oversized canvas): layout viewport is
+  // 1600x1200 centered on the same central point (origin -400,-300) and
+  // contains additional label content near the border
+  std::vector<LabelSpec> allLabels=denseLabels;
+
+  allLabels.insert(allLabels.end(),offViewport.begin(),offViewport.end());
+
+  std::map<ObjectFileRef,PlacedLabel> enlarged=session.Frame(ScreenVectorRectangle(-400,-300,1600,1200),
+                                                             allLabels,
+                                                             400.0,300.0);
+
+  size_t vanished=0;
+
+  for (const LabelSpec& spec : denseLabels) {
+    REQUIRE(IsFullyInside(spec,viewWidth,viewHeight));
+
+    if (baseline.find(spec.ref)==baseline.end()) {
+      // baseline itself lost the label (dense scene): not part of the
+      // stability assertion, the baseline visible set is the reference
+      continue;
+    }
+
+    if (enlarged.find(spec.ref)==enlarged.end()) {
+      vanished++;
+      INFO("Visible label disappeared when the layout viewport was "
+           "enlarged with additional border content: ref " << spec.ref.GetName()
+           << " text '" << spec.text << "'");
+    }
+    else {
+      RequireStableLabel(baseline,enlarged,spec,400.0,300.0);
+    }
+  }
+
+  INFO("Labels vanished due to additional border content: " << vanished);
+
+  REQUIRE(vanished==0);
+}
+
+TEST_CASE("LabelLayouter: previously visible label precedes new overlapping candidate", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+
+  // frame 1: label A visible alone
+  std::vector<LabelSpec> frame1;
+
+  frame1.push_back(MakeSpec(1,1,"Alpha",400.0,300.0)); // 120px wide: 340..460
+
+  LayoutSession session(*projection,parameter);
+
+  auto baseline=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame1);
+
+  REQUIRE(baseline.find(frame1[0].ref)!=baseline.end());
+
+  // frame 2: new candidate N with the best priority (0), overlapping A,
+  // placed next to it. Without hysteresis the priority order would draw
+  // N first and hide A.
+  std::vector<LabelSpec> frame2=frame1;
+
+  frame2.push_back(MakeSpec(2,0,"Novum",460.0,300.0)); // 400..520: overlaps A
+
+  auto next=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame2);
+
+  REQUIRE(next.find(frame1[0].ref)!=next.end());
+  REQUIRE(next.find(frame2[1].ref)==next.end());
+
+  // frame 3: both previously visible -> priority decides within the group
+  std::vector<LabelSpec> frame3;
+
+  frame3.push_back(MakeSpec(1,2,"Alpha",400.0,300.0));
+  frame3.push_back(MakeSpec(3,0,"Ceterum",430.0,300.0));
+
+  // "Ceterum" was not visible in frame 2 -> it lands in the newcomer
+  // group behind "Alpha" (visible) although its priority is better
+  auto third=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame3);
+
+  REQUIRE(third.find(frame1[0].ref)!=third.end());
+  REQUIRE(third.find(frame3[1].ref)==third.end());
+}
+
+TEST_CASE("LabelLayouter: session state survives reset and follows the last layout", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+
+  std::vector<LabelSpec> frame1;
+
+  frame1.push_back(MakeSpec(1,1,"Alpha",150.0,150.0));
+  frame1.push_back(MakeSpec(2,2,"Beta",450.0,300.0));
+
+  LayoutSession session(*projection,parameter);
+
+  auto first=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame1);
+
+  REQUIRE(first.find(frame1[0].ref)!=first.end());
+  REQUIRE(first.find(frame1[1].ref)!=first.end());
+
+  // frame 2: same content -> same visible set; the reset between the
+  // frames must not have discarded the hysteresis state
+  auto second=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame1);
+
+  REQUIRE(second==first);
+
+  // frame 3: Beta is not registered anymore (left the viewport/asks gone).
+  // The state must follow the visible set of the last layout: the layout
+  // without Beta must equal a fresh instance layout of the same content.
+  std::vector<LabelSpec> frame3;
+
+  frame3.push_back(MakeSpec(1,1,"Alpha",150.0,150.0));
+  frame3.push_back(MakeSpec(3,3,"Gamma",400.0,150.0));
+
+  auto third=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame3);
+
+  std::map<ObjectFileRef,PlacedLabel> fresh=RunLayout(*projection,
+                                                      parameter,
+                                                      ScreenVectorRectangle(0,0,viewWidth,viewHeight),
+                                                      frame3,
+                                                      0,0);
+
+  REQUIRE(third==fresh);
+}
+
+TEST_CASE("LabelLayouter: session rounds stay identical for identical input", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+  std::vector<LabelSpec> labels=CreateSpreadScene();
+
+  LayoutSession session(*projection,parameter);
+
+  auto first=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),labels);
+  auto second=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),labels);
+  auto third=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),labels);
+
+  REQUIRE(first==second);
+  REQUIRE(second==third);
+}
+
+TEST_CASE("LabelLayouter: previously visible labels survive single-pixel mask jitter", "[labelLayouter]")
+{
+  std::unique_ptr<Projection> projection=CreateProjection(viewWidth,viewHeight);
+  MapParameter parameter;
+
+  // no padding: the mask rectangles are plain truncations of the label
+  // positions -> deterministic reproduction of the jitter mechanism
+  parameter.SetLabelPadding(0.0);
+
+  // two labels 100px wide, masks exactly adjacent in frame 1:
+  // A covers 400..499 (element x 400.3), B covers 500..599 (element x 500.0)
+  std::vector<LabelSpec> frame1;
+
+  frame1.push_back(MakeSpec(1,1,"Alpha",400.3,300.0));
+  frame1.push_back(MakeSpec(2,2,"Berta",500.0,300.0));
+
+  LayoutSession session(*projection,parameter);
+
+  auto first=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame1);
+
+  REQUIRE(first.find(frame1[0].ref)!=first.end());
+  REQUIRE(first.find(frame1[1].ref)!=first.end());
+
+  // the identical scene shifted by fractional deltas: the truncation of
+  // the fractional positions moves the two masks +-1px against each other
+  // (A crosses a pixel boundary while B does not, and vice versa) ->
+  // the masks collide in single frames although the real label distance
+  // is unchanged (~50px). Without tolerance B flips visible/hidden.
+  for (double shift : {0.8, 2.0, 0.8, 2.0}) {
+    std::vector<LabelSpec> frame=frame1;
+
+    std::map<ObjectFileRef,PlacedLabel> round=session.Frame(ScreenVectorRectangle(0,0,viewWidth,viewHeight),frame,shift,0.0);
+
+    INFO("shift " << shift);
+
+    REQUIRE(round.find(frame1[0].ref)!=round.end());
+    REQUIRE(round.find(frame1[1].ref)!=round.end());
+  }
+}

--- a/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
+++ b/libosmscout-client-qt/include/osmscoutclientqt/MapWidget.h
@@ -83,6 +83,7 @@ class OSMSCOUT_CLIENT_QT_API MapWidget : public QQuickPaintedItem
   Q_PROPERTY(bool preventMouseStealing READ isPreventMouseStealing WRITE setPreventMouseStealing)
 
   Q_PROPERTY(bool stylesheetHasErrors           READ stylesheetHasErrors              NOTIFY styleErrorsChanged)
+  Q_INVOKABLE void debugPan(double dLon);
   Q_PROPERTY(int stylesheetErrorLine            READ firstStylesheetErrorLine         NOTIFY styleErrorsChanged)
   Q_PROPERTY(int stylesheetErrorColumn          READ firstStylesheetErrorColumn       NOTIFY styleErrorsChanged)
   Q_PROPERTY(QString stylesheetErrorDescription READ firstStylesheetErrorDescription  NOTIFY styleErrorsChanged)

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapRenderer.cpp
@@ -384,8 +384,19 @@ void DBRenderJob::Run(const DBInstanceRef& basemapDatabase,
     }
   }
 
-  // draw databases
-  success &= mapPainter->DrawMap(renderProjection,
+    // draw databases
+    if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+      size_t tileCnt=0;
+
+      for (const auto &dbTiles : tiles) {
+        tileCnt+=dbTiles.size();
+      }
+
+      osmscout::log.Warn() << "[PlaneMapRenderer] render: tiles=" << tileCnt
+                           << " centers=" << renderProjection.GetCenter().GetDisplayText();
+    }
+
+    success &= mapPainter->DrawMap(renderProjection,
                                  *drawParameter,
                                  batch,
                                  p);

--- a/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp
@@ -209,6 +209,24 @@ void MapWidget::redraw()
     update();
 }
 
+/** temporary diagnostics helper: programmatic pan to reproduce label flicker */
+void MapWidget::debugPan(double dLon)
+{
+    if (view==nullptr || !view->IsValid()) {
+        return;
+    }
+    osmscout::GeoCoord center(view->center);
+    center.Set(center.GetLat(), center.GetLon()+dLon);
+    setupInputHandler(new InputHandler(MapView(center,
+                                               view->angle,
+                                               view->magnification,
+                                               view->mapDpi)));
+    changeView(MapView(center,
+                       view->angle,
+                       view->magnification,
+                       view->mapDpi));
+}
+
 void MapWidget::changeView(const MapView &updated)
 {
     //qDebug() << "viewChanged: " << QString::fromStdString(updated.center.GetDisplayText()) << "   level: " << updated.magnification.GetLevel();

--- a/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
+++ b/libosmscout-client-qt/src/osmscoutclientqt/PlaneMapRenderer.cpp
@@ -54,6 +54,10 @@ PlaneMapRenderer::PlaneMapRenderer(QThread *thread,
 {
   pendingRenderingTimer.setSingleShot(true);
 
+  if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+    osmscout::log.Warn() << "[PlaneMapRenderer] diagnostics ACTIVE (renderer lib with tile gate, jitter tolerance, contour stickiness)";
+  }
+
   //
   // Make sure that we decouple caller and receiver if SLOT method acquire locks,
   // even if they are running in the same thread
@@ -107,6 +111,9 @@ void PlaneMapRenderer::FlushVisualCaches(const std::chrono::milliseconds &idleMs
     QMutexLocker finishedLocker(&finishedMutex);
     if (std::chrono::steady_clock::now() - finishedLastUsage > idleMs) {
       osmscout::log.Debug() << "Flush finished image";
+      if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+        osmscout::log.Warn() << "[PlaneMapRenderer] finished image flushed (idle cache flush)";
+      }
       finishedImage = nullptr;
     }
   }
@@ -324,9 +331,36 @@ void PlaneMapRenderer::DrawMap()
 {
   {
     QMutexLocker locker(&lock);
+
     if (loadJob==nullptr){
       return;
     }
+
+    if (!loadJob->IsFinished()){
+      {
+        QMutexLocker finishedLocker(&finishedMutex);
+        if (finishedImage!=nullptr) {
+          // Do not churn the finished image with a partially loaded tile
+          // set: rendering with incomplete data makes the visible label set
+          // flicker (candidates appear/disappear while tiles are loading).
+          // The next tile state change or the timer re-triggers rendering.
+          if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+            osmscout::log.Warn() << "[PlaneMapRenderer] skip render (tiles pending="
+                                 << loadJob->GetAllTiles().size() << " loaded, job epoch="
+                                 << currentEpoch << ")";
+          }
+          if (!pendingRenderingTimer.isActive()) {
+            pendingRenderingTimer.start(UPDATED_DATA_RENDERING_TIMEOUT);
+          }
+          return;
+        }
+        if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+          osmscout::log.Warn() << "[PlaneMapRenderer] first render with partial data (tiles="
+                               << loadJob->GetAllTiles().size() << ")";
+        }
+      }
+    }
+
     osmscout::log.Debug() << "DrawMap()";
     if (thread!=QThread::currentThread()){
       osmscout::log.Warn() << "Incorrect thread!";
@@ -436,6 +470,16 @@ void PlaneMapRenderer::DrawMap()
       osmscout::log.Error() << "*** Rendering of data has error or was interrupted";
       return;
     }
+
+    if (!qEnvironmentVariableIsEmpty("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")) {
+      osmscout::log.Warn() << "[PlaneMapRenderer] swap enter: image="
+                           << (currentImage!=nullptr ? currentImage->width() : -1)
+                           << "x" << (currentImage!=nullptr ? currentImage->height() : -1)
+                           << " center=" << currentCoord.GetDisplayText()
+                           << " mag=" << currentMagnification.GetLevel()
+                           << " epoch=" << currentEpoch;
+    }
+
     {
       QMutexLocker finishedLocker(&finishedMutex);
       std::swap(currentImage,finishedImage);

--- a/libosmscout-map/include/osmscoutmap/LabelLayouter.h
+++ b/libosmscout-map/include/osmscoutmap/LabelLayouter.h
@@ -218,11 +218,35 @@ constexpr bool debugLabelLayouter = false;
   };
 
   template <class NativeGlyph, class NativeLabel>
-  static bool LabelInstanceSorter(const LabelInstance<NativeGlyph, NativeLabel> &a,
-                                  const LabelInstance<NativeGlyph, NativeLabel> &b)
+  class LabelInstanceSorter CLASS_FINAL
   {
-    return a.priority < b.priority;
-  }
+  public:
+    explicit LabelInstanceSorter(const std::set<ObjectFileRef> &visibleRefs)
+      : visibleRefs(visibleRefs)
+    {
+    }
+
+    bool operator()(const LabelInstance<NativeGlyph, NativeLabel> &a,
+                    const LabelInstance<NativeGlyph, NativeLabel> &b) const
+    {
+      // Labels that were already visible in the previous layout round claim
+      // their space first. This makes the visibility of labels stable against
+      // growth of the candidate set (e.g. when the render bounding box of the
+      // previous asynchronous rendering differs from the current one). Within
+      // the two groups the ordering is the (priority,basemap,ref) tuple.
+      const bool aWasVisible=visibleRefs.count(a.priority.ref)>0;
+      const bool bWasVisible=visibleRefs.count(b.priority.ref)>0;
+
+      if (aWasVisible!=bWasVisible) {
+        return aWasVisible;
+      }
+
+      return a.priority < b.priority;
+    }
+
+  private:
+    const std::set<ObjectFileRef> &visibleRefs;
+  };
 
   template <class NativeGlyph>
   static bool ContourLabelSorter(const ContourLabel<NativeGlyph> &a,
@@ -271,6 +295,20 @@ constexpr bool debugLabelLayouter = false;
     explicit LabelLayouter(TextLayouter *textLayouter):
         textLayouter(textLayouter)
     {};
+    /**
+     * Temporary diagnostics for label stability investigation: enabled by
+     * the environment variable OSMSCOUT_DEBUG_LABEL_HYSTERESIS. For
+     * every layout round that loses a label that was visible in the
+     * previous round, the reason is reported: not registered anymore
+     * (candidate/data churn) or hidden by collision despite previously
+     * visible (resolution churn).
+     */
+    static bool IsHysteresisDebug()
+    {
+      static const bool enabled=std::getenv("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")!=nullptr;
+
+      return enabled;
+    }
 
     void SetViewport(const ScreenVectorRectangle& v)
     {
@@ -287,6 +325,14 @@ constexpr bool debugLabelLayouter = false;
       layoutViewport.y = visibleViewport.y - overlap;
     }
 
+    /**
+     * Clears all registered labels and layout results of the current
+     * draw. The previous-round visibility state is intentionally kept:
+     * it provides stable label visibility when the candidate set
+     * changes between draw calls (rendering of shifted bounding boxes,
+     * asynchronous tile loading). The state is refreshed by every
+     * Layout() call.
+     */
     void Reset()
     {
       contourLabelInstances.clear();
@@ -323,10 +369,17 @@ constexpr bool debugLabelLayouter = false;
       ScreenMask labelCanvas;
       ScreenMask overlayCanvas;
 
+      const std::set<ObjectFileRef> &visibleRefs;
+      const std::set<ObjectFileRef> &visibleContourRefs;
+
       LayoutJob(const ScreenVectorRectangle &layoutViewport,
                 const Projection& projection,
-                const MapParameter& parameter):
+                const MapParameter& parameter,
+                const std::set<ObjectFileRef> &visibleRefs,
+                const std::set<ObjectFileRef> &visibleContourRefs):
               layoutViewport(layoutViewport),
+              visibleRefs(visibleRefs),
+              visibleContourRefs(visibleContourRefs),
               iconPadding(projection.ConvertWidthToPixel(parameter.GetIconPadding())),
               labelPadding(projection.ConvertWidthToPixel(parameter.GetLabelPadding())),
               shieldLabelPadding(projection.ConvertWidthToPixel(parameter.GetPlateLabelPadding())),
@@ -356,7 +409,7 @@ constexpr bool debugLabelLayouter = false;
         // sort labels by priority and position (to be deterministic)
         std::stable_sort(allSortedLabels.begin(),
                          allSortedLabels.end(),
-                         LabelInstanceSorter<NativeGlyph, NativeLabel>);
+                         LabelInstanceSorter<NativeGlyph, NativeLabel>(visibleRefs));
         std::stable_sort(allSortedContourLabels.begin(),
                          allSortedContourLabels.end(),
                          ContourLabelSorter<NativeGlyph>);
@@ -391,8 +444,11 @@ constexpr bool debugLabelLayouter = false;
         return &labelCanvas;
       }
 
+      static constexpr int hysteresisTolerancePx=2;
+
       void ProcessLabelInstance(const LabelInstanceType &currentLabel,
-                                std::vector<LabelInstanceType> &labelInstances)
+                                std::vector<LabelInstanceType> &labelInstances,
+                                bool hysteresisTolerance)
 
       {
         size_t elementCount = currentLabel.elements.size();       // Number of elements in label
@@ -448,6 +504,26 @@ constexpr bool debugLabelLayouter = false;
 
           bool collision = canvas->HasCollision(mask);
 
+          if (collision && hysteresisTolerance && hysteresisTolerancePx>0) {
+            // Previously visible labels must not flip their visibility due to
+            // the +-1px jitter of the rasterized mask rectangles (integer
+            // truncation of fractional positions) while the map slides.
+            // Ignore collisions that disappear when the rectangle is shrunk
+            // by a small tolerance. Real overlaps survive the shrink and are
+            // resolved by priority as usual.
+            ScreenPixelRectangle shrunkRectangle{rectangle.x+hysteresisTolerancePx,
+                                                 rectangle.y+hysteresisTolerancePx,
+                                                 rectangle.width-2*hysteresisTolerancePx,
+                                                 rectangle.height-2*hysteresisTolerancePx};
+
+            if (shrunkRectangle.width>0 && shrunkRectangle.height>0) {
+              ScreenRectMask shrunkMask(layoutViewport.width,
+                                        shrunkRectangle);
+
+              collision=canvas->HasCollision(shrunkMask);
+            }
+          }
+
           if (!collision) {
             visibleElements.push_back(element);
             canvases[eli]=canvas;
@@ -476,7 +552,8 @@ constexpr bool debugLabelLayouter = false;
       }
 
       void ProcessLabelContourLabel(const ContourLabelType &currentContourLabel,
-                                    std::vector<ContourLabelType> &contourLabelInstances)
+                                    std::vector<ContourLabelType> &contourLabelInstances,
+                                    bool hysteresisTolerance)
       {
         int glyphCnt=currentContourLabel.glyphs.size();
 
@@ -500,6 +577,24 @@ constexpr bool debugLabelLayouter = false;
                                    rect);
 
           if (labelCanvas.HasCollision(masks[gi])) {
+            if (hysteresisTolerance && hysteresisTolerancePx>0) {
+              // single-pixel rasterization jitter of previously visible
+              // path labels must not toggle their visibility
+              ScreenPixelRectangle shrunkRectangle{rect.x+hysteresisTolerancePx,
+                                                   rect.y+hysteresisTolerancePx,
+                                                   rect.width-2*hysteresisTolerancePx,
+                                                   rect.height-2*hysteresisTolerancePx};
+
+              if (shrunkRectangle.width>0 && shrunkRectangle.height>0) {
+                ScreenRectMask shrunkMask(layoutViewport.width,
+                                          shrunkRectangle);
+
+                if (!labelCanvas.HasCollision(shrunkMask)) {
+                  continue; // jitter only, tolerate
+                }
+              }
+            }
+
             collision=true;
             break;
           }
@@ -529,18 +624,41 @@ constexpr bool debugLabelLayouter = false;
         auto labelIter = allSortedLabels.begin();
         auto contourLabelIter = allSortedContourLabels.begin();
 
-        // While both lists are not completely processed...
-        //   Process first all contour labels of a priority and then all normal labels of the same priority
+        // Phase 0: labels that were visible in the previous round claim
+        // their space first, with hysteresis tolerance. They must not be
+        // displaced by contour label claims or by new candidates in order
+        // to keep the visible set stable while the map slides.
+        while (labelIter != allSortedLabels.end() &&
+               visibleRefs.count(labelIter->priority.ref)>0) {
+          ProcessLabelInstance(*labelIter,
+                               labelInstances,
+                               /*hysteresisTolerance*/ true);
+          labelIter++;
+        }
+
+        // Phase 1: contour labels of ways that were visible in the previous
+        // round (with hysteresis tolerance): street names must not flip
+        // because of the rasterization jitter of their glyphs.
+        while (contourLabelIter != allSortedContourLabels.end() &&
+               visibleContourRefs.count(contourLabelIter->priority.ref)>0) {
+          ProcessLabelContourLabel(*contourLabelIter,
+                                   contourLabelInstances,
+                                   /*hysteresisTolerance*/ true);
+          contourLabelIter++;
+        }
+
+        // Phase 2: the remaining contour labels and the remaining regular
+        // labels (new candidates), merged by priority...
 
         while (labelIter != allSortedLabels.end() &&
            contourLabelIter != allSortedContourLabels.end()) {
 
           if (contourLabelIter->priority<=labelIter->priority) {
-            ProcessLabelContourLabel(*contourLabelIter, contourLabelInstances);
+            ProcessLabelContourLabel(*contourLabelIter, contourLabelInstances, false);
             contourLabelIter++;
           }
           else {
-            ProcessLabelInstance(*labelIter, labelInstances);
+            ProcessLabelInstance(*labelIter, labelInstances, false);
             labelIter++;
           }
 
@@ -549,12 +667,12 @@ constexpr bool debugLabelLayouter = false;
         // Process all the rest... (there should only be one of the two lists left)
 
         while (contourLabelIter != allSortedContourLabels.end()) {
-          ProcessLabelContourLabel(*contourLabelIter, contourLabelInstances);
+          ProcessLabelContourLabel(*contourLabelIter, contourLabelInstances, false);
           contourLabelIter++;
         }
 
         while (labelIter != allSortedLabels.end()) {
-          ProcessLabelInstance(*labelIter, labelInstances);
+          ProcessLabelInstance(*labelIter, labelInstances, false);
           labelIter++;
         }
       }
@@ -564,10 +682,101 @@ constexpr bool debugLabelLayouter = false;
                 const MapParameter& parameter)
     {
       // compute collisions, hide some labels
-      LayoutJob job(layoutViewport, projection, parameter);
+      LayoutJob job(layoutViewport, projection, parameter, lastVisibleRefs, lastVisibleContourRefs);
       job.Swap(labelInstances, contourLabelInstances);
       job.SortLabels();
       job.ProcessLabels(labelInstances, contourLabelInstances);
+
+      // refresh the previous-round visibility state: it defines which
+      // labels claim their space first in the next round. This must run
+      // for every layout, independent of the diagnostics.
+      std::set<ObjectFileRef> registeredRefs;
+      const size_t allSortedContourLabelCount=job.allSortedContourLabels.size();
+
+      for (const LabelInstanceType &instance : job.allSortedLabels) {
+        registeredRefs.insert(instance.priority.ref);
+      }
+
+      for (const LabelInstanceType &instance : labelInstances) {
+        registeredRefs.insert(instance.priority.ref);
+      }
+
+      if (IsHysteresisDebug()) {
+        std::vector<ObjectFileRef> hiddenByCollision;
+        std::vector<ObjectFileRef> notRegistered;
+        size_t keptVisible=0;
+
+        for (const ObjectFileRef &ref : lastVisibleRefs) {
+          if (registeredRefs.count(ref)>0) {
+            bool isVisible=std::any_of(labelInstances.begin(),labelInstances.end(),[ref](const LabelInstanceType &instance) {
+              return instance.priority.ref==ref;
+            });
+
+            if (isVisible) {
+              keptVisible++;
+            }
+            else {
+              hiddenByCollision.push_back(ref);
+            }
+          }
+          else {
+            notRegistered.push_back(ref);
+          }
+        }
+
+        std::set<ObjectFileRef> placedContourRefs;
+
+        for (const ContourLabelType &cLabel : contourLabelInstances) {
+          placedContourRefs.insert(cLabel.priority.ref);
+        }
+
+        size_t lostContours=0;
+
+        for (const ObjectFileRef &ref : lastVisibleContourRefs) {
+          if (placedContourRefs.count(ref)==0) {
+            lostContours++;
+          }
+        }
+
+        if (!hiddenByCollision.empty() || !notRegistered.empty() ||
+            lostContours>0) {
+          std::cout << "[LabelHysteresis] viewport=" << layoutViewport.width << "x"
+                    << layoutViewport.height << "+" << layoutViewport.x << "+"
+                    << layoutViewport.y << " registered=" << registeredRefs.size()
+                    << " visible=" << labelInstances.size()
+                    << " prevVisible=" << lastVisibleRefs.size()
+                    << " kept=" << keptVisible
+                    << " hiddenByCollision=" << hiddenByCollision.size()
+                    << " notRegistered=" << notRegistered.size()
+                    << " contoursRegistered=" << allSortedContourLabelCount
+                    << " prevVisibleContours=" << lastVisibleContourRefs.size()
+                    << " lostContours=" << lostContours
+                    << std::endl;
+
+          for (const ObjectFileRef &ref : hiddenByCollision) {
+            std::cout << "[LabelHysteresis]   hidden-by-collision: "
+                      << ref.GetName();
+            std::cout << std::endl;
+          }
+
+          for (const ObjectFileRef &ref : notRegistered) {
+            std::cout << "[LabelHysteresis]   not-registered (candidate/data churn): "
+                      << ref.GetName() << std::endl;
+          }
+        }
+      }
+
+      lastVisibleRefs.clear();
+
+      for (const LabelInstanceType &instance : labelInstances) {
+        lastVisibleRefs.insert(instance.priority.ref);
+      }
+
+      lastVisibleContourRefs.clear();
+
+      for (const ContourLabelType &cLabel : contourLabelInstances) {
+        lastVisibleContourRefs.insert(cLabel.priority.ref);
+      }
     }
 
     template<class Painter>
@@ -932,6 +1141,8 @@ constexpr bool debugLabelLayouter = false;
     TextLayouter *textLayouter;
     std::vector<ContourLabelType> contourLabelInstances;
     std::vector<LabelInstanceType> labelInstances;
+    std::set<ObjectFileRef> lastVisibleRefs; //!< refs of the labels visible in the previous round
+    std::set<ObjectFileRef> lastVisibleContourRefs; //!< refs of the ways with visible path labels in the previous round
     ScreenVectorRectangle visibleViewport{0,0,0,0};
     ScreenVectorRectangle layoutViewport{0,0,0,0};
     uint32_t layoutOverlap=0; // overlap [pixels] used for label layouting

--- a/libosmscout-map/include/osmscoutmap/MapPainter.h
+++ b/libosmscout-map/include/osmscoutmap/MapPainter.h
@@ -314,6 +314,23 @@ namespace osmscout {
     std::vector<DatabaseCacheEntry> databaseCache;
 
     /**
+     * Stable label anchors for areas: the label anchor of an area is
+     * computed once (from the - potentially at the canvas edge clipped -
+     * area geometry) and then kept stable in map space while the map is
+     * panned. Without this cache the anchor of areas that reach over
+     * multiple tiles moves with the visibility of the tile pieces and
+     * labels flicker while sliding the map. The cache is cleared when
+     * the magnification level changes.
+     */
+    struct AreaAnchorEntry {
+      GeoCoord coord;
+    };
+    static constexpr size_t MaxAreaAnchorCacheSize=4096;
+    size_t            areaAnchorMagnificationLevel{0};
+    bool              areaAnchorCacheValid{false};
+    std::map<size_t,std::map<ObjectFileRef,AreaAnchorEntry>> areaAnchorCache;
+
+    /**
       Presets, precalculations and similar
      */
     //@{

--- a/libosmscout-map/src/osmscoutmap/MapPainter.cpp
+++ b/libosmscout-map/src/osmscoutmap/MapPainter.cpp
@@ -572,14 +572,72 @@ constexpr bool debugGroundTiles = false;
     projection.BoundingBoxToPixel(areaData.boundingBox,
                                   areaScreenBox);
 
-    Vertex2D areaCenter;
+    // resolve the area label anchor. The clip-state dependent fallback
+    // (center of the area bounding box of the potentially clipped
+    // pieces) moves with every change of the visible tiles and makes
+    // labels flicker while the map is sliding. To keep the label
+    // position stable the anchor is kept in map space per area and
+    // magnification level (the anchor was computed with the same
+    // fallback on the round the area appeared first during this
+    // session).
+    if (!areaAnchorCacheValid ||
+        areaAnchorMagnificationLevel!=projection.GetMagnification().GetLevel()) {
+      areaAnchorCache.clear();
+      areaAnchorMagnificationLevel=projection.GetMagnification().GetLevel();
+      areaAnchorCacheValid=true;
+    }
 
-    if (areaData.center.has_value()){
-      projection.GeoToPixel(areaData.center.value(),
-                            areaCenter);
+    GeoCoord areaAnchor;
+
+    if (areaData.center.has_value()) {
+      areaAnchor=areaData.center.value();
     }
     else {
-      areaCenter=areaScreenBox.GetCenter();
+      areaAnchor=areaData.boundingBox.GetCenter();
+    }
+
+    auto &anchorCache=areaAnchorCache[areaData.dbIndex];
+    auto anchorIter=anchorCache.find(areaData.ref);
+
+    if (anchorIter!=anchorCache.end()) {
+      areaAnchor=anchorIter->second.coord;
+    }
+    else {
+      if (anchorCache.size()>MaxAreaAnchorCacheSize) {
+        anchorCache.clear();
+      }
+
+      anchorCache[areaData.ref]=AreaAnchorEntry{areaAnchor};
+    }
+
+    Vertex2D areaCenter;
+
+    projection.GeoToPixel(areaAnchor,
+                          areaCenter);
+
+    // TEMP diagnostics: log jumps of the resolved area label anchor of
+    // areas with a stable style center; their pixel position follows
+    // GeoToPixel and must move smoothly while panning.
+    {
+      static const bool debugAnchors=std::getenv("OSMSCOUT_DEBUG_LABEL_HYSTERESIS")!=nullptr;
+      static std::map<size_t,std::map<ObjectFileRef,Vertex2D>> lastAnchorPixel;
+
+      if (debugAnchors && areaData.center.has_value()) {
+        auto &lastPix=lastAnchorPixel[areaData.dbIndex][areaData.ref];
+
+        if (lastPix.x!=0.0 || lastPix.y!=0.0) {
+          double dx=lastPix.x-areaCenter.x;
+          double dy=lastPix.y-areaCenter.y;
+
+          if (fabs(dx)>0.5 || fabs(dy)>0.5) {
+            osmscout::log.Warn() << "[AnchorJump] ref=" << areaData.ref.GetName()
+                                 << " d=(" << dx << "," << dy << ")"
+                                 << " at " << areaCenter.x << "," << areaCenter.y;
+          }
+        }
+
+        lastPix=areaCenter;
+      }
     }
 
     LayoutPointLabels(styleConfig,

--- a/openspec/changes/label-collision-stability/.openspec.yaml
+++ b/openspec/changes/label-collision-stability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/label-collision-stability/STATUS-snapshot.md
+++ b/openspec/changes/label-collision-stability/STATUS-snapshot.md
@@ -1,0 +1,75 @@
+# STATUS SNAPSHOT — 2026-08-30
+
+State of the label flicker investigation at the switch to another topic.
+Everything below is verified with logged evidence, either from the user's
+OSMScout2 sessions (`label.txt` variants) or from the local headless pan
+harness.
+
+## Current build state
+
+- All code changes compile clean on CMake and Meson; **test suite green:
+  12 cases / 145 assertions** (`ctest -R LabelLayouterTest`).
+- Working tree contains (in addition to committed state):
+  - `MapPainter.h/.cpp` — area anchor cache + [AnchorJump] probe (gated by
+    `OSMSCOUT_DEBUG_LABEL_HYSTERESIS`)
+  - `MapWidget.cpp/.h`, `main.qml` — temporary `debugPan` helper + QML
+    auto-pan timer (TEMPORARY, must be reverted before archive)
+  - `PlaneMapRenderer.cpp` — tile gate + swap/skip/flush logs
+  - `MapRenderer.cpp` — render tile-count log (gated)
+  - `LabelLayouter.h` — hysteresis (2 groups), jitter tolerance (2px),
+    contour stickiness (3 phases), gated diagnostics
+  - `Tests/`: label layout session tests + build registration
+  - `openspec/changes/label-collision-stability/` — full change docs
+  - `harness-run.log` — last headless pan session
+
+## Verified conclusions (evidence-backed)
+
+1. Label layouter is deterministic and translation invariant for fixed
+   candidate sets (synthetic sessions).
+2. Renderer gate for partial tile sets works (harness: `render: tiles=6`
+   stable, skip logic verified locally; user's 155/243-spike rounds came
+   from renders on incomplete tile data).
+3. Area label anchors are now stable per zoom level (AnchorJump probe:
+   **0 jumps**) — yet flicker persists.
+4. Strict alternation: `Area 127329304` loses even rounds, `Area 127329670`
+   loses ODD rounds (and symmetrical partner chains for node labels).
+   Pure group-based hysteresis + tolerance cannot break a parity
+   oscillation of two previously visible labels.
+
+## Remaining root cause (to fix after switch back)
+
+The alternation is a **collision decision toggle between two claims whose
+overlap hovers around the 2px tolerance boundary** (mask overlap oscillates
+between tolerated and contention across rounds). The clean fix is pairwise
+decision persistence ("who won last time keeps winning") as designed in
+design.md as the rejected Alternative B — it now needs to be revisited:
+
+- Option A: pairwise decision cache `map<pair<refA,refB>, winner>` in
+  `LabelLayouter`, checked before greedy priority resolution (bigger
+  change, fully deterministic), OR
+- Option B (quick experiment, may visually degrade): raise
+  `hysteresisTolerancePx` from 2 to a value above the measured
+  overlap band (~4-6px). One-line change, verify in harness.
+
+NOT the cause (all measured smooth): tile gate, area anchor jumps
+(0 jumps), contour stickiness, style/data presence for stable rounds.
+
+## Remaining known issues
+
+- `notRegistered` spikes up to ~243 rounds still possible when a new
+  render request replaces the load job (needs investigation of the
+  request/job lifecycle; the gate holds during a single request)
+- temp artifacts to revert before archive:
+  - `OSMScout2/qml/main.qml` (debugPan Timer)
+  - `libosmscout-client-qt/.../MapWidget.{h,cpp}` (debugPan)
+  - `[AnchorJump]` probe block in `MapPainter.cpp`
+  - `[LabelHysteresis]` diagnostics + `IsHysteresisDebug()` in
+    LabelLayouter.h (gate via env var, keep until fix is proven)
+
+## Reproduction tooling
+
+- `/tmp/panharness/main.cpp` + `/tmp/panharness/build.sh` — headless pan
+  harness (throwaway)
+- Run:
+  `OSMSCOUT_DEBUG_LABEL_HYSTERESIS=1 QT_QPA_PLATFORM=offscreen ./PanHarness maps/nordrhein-westfalen stylesheets/standard.oss`
+- User reproduces with: `OSMSCOUT_DEBUG_LABEL_HYSTERESIS=1 ./OSMScout2/OSMScout2 ...`

--- a/openspec/changes/label-collision-stability/design.md
+++ b/openspec/changes/label-collision-stability/design.md
@@ -1,0 +1,111 @@
+# Design: Label Collision Stability
+
+## Context
+
+See proposal.md and specs/label-collision-stability/spec.md. Root cause evidence: `openspec/changes/label-layout-stability-tests/tests-result.md`.
+
+Current mechanism (all in `libosmscout-map/include/osmscoutmap/LabelLayouter.h`):
+
+- `Layout()` swaps registered instances into a `LayoutJob`, sorts everything by `LabelPriority` (one flat order), then greedily claims `ScreenMask` canvas space.
+- Winner set = f(candidate set). Candidate set churn between oversized-canvas swaps (panning, tile loading) flips winners -> on-screen labels flicker.
+- `MapPainterQt`/other backends keep one `labelLayouter` member per painter and call `labelLayouter.Reset()` after every draw (`DrawLabels()` -> `Layout()`, `DrawLabels()`, `Reset()`), so the instance survives frames; only its instance lists are cleared.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Visibility of a previously visible label survives candidate-set growth (hysteresis).
+- Determinism and translation invariance are preserved.
+- No public API change; confined to the shared `LabelLayouter`.
+
+**Non-Goals:**
+
+- Cross-process/cross-frame canvas mask memory (positions move every frame; pixel anchoring is impossible without map-space reasoning).
+- Contour (path) labels stickiness — they depend on path geometry; separate follow-up if flicker remains on roads.
+- Changing `PlaneMapRenderer` swap cadence or overrun size.
+
+## Decisions
+
+### D4: Rasterization jitter tolerance and contour ordering (chosen)
+
+Log evidence from the real OSMScout2 scene (`tests-result.md`, 787 diagnostics): 479
+labels lost per `hidden-by-collision` although the collision partners were
+previously visible and the candidate data was identical between rounds.
+Root cause: mask rectangles are integer truncations of fractional pixel
+positions; as the map slides, the effective distance between two adjacent
+labels jitters by +-1px, so mask overlaps toggle frame by frame. In dense
+scenes many pairs sit exactly at the collision threshold.
+
+Resolution: (a) the collision check of previously visible labels tolerates
+collisions that vanish when the rectangle is shrunk by 2px (jitter is not
+contention, real overlaps still resolve by priority); (b) previously visible
+regular labels claim their space in a phase 0 before contour labels are
+processed (jiggling street path labels must not flip point labels).
+
+- **Alternative A - round mask positions to nearest pixel instead of truncating**: rejected; relative distances between two labels still jitter when their fractional parts cross pixel boundaries at different times.
+- **Alternative B - pairwise conflict graph instead of canvas masks**: rejected as an architectural rewrite; the tolerance addresses the measured jitter mechanism directly.
+- **Alternative C - renderer-side stabilization (bigger overrun, longer initial rendering timeout)**: complementary for the `not-registered` churn (244 labels lost in a single frame in the log), tracked separately; it cannot address collision flips.
+
+Risks: previously visible labels may render with up to 2px visual overlap
+(accepted, matches navigation label behavior); tolerance applies only to
+previously visible labels, newcomer disputes stay exact.
+
+### D1: Two-group priority resolution with previous-round visibility (chosen)
+
+Regular labels are sorted with a two-level key:
+
+```
+group 0: ref was visible in the previous layout round
+group 1: everything else
+        within each group: LabelPriority (priority, basemap, ref)
+```
+
+Implementation: `LabelLayouter` keeps `std::set<ObjectFileRef> lastVisibleRefs`, refreshed at the end of `Layout()` from the final visible instances. `Reset()` keeps it. `LayoutJob::SortLabels()` uses a comparator that reads the set (passed by reference into the job).
+
+- **Alternative A — pixel-anchored frame-to-frame masks**: rejected; canvas pixel positions shift with the projection every frame, so previous masks are meaningless without keeping map-space geometry in the layouter, which is a much bigger architectural change.
+- **Alternative B — pairwise negotiation instead of global greedy marking**: rejected as a rewrite of the resolution algorithm with the same chain-dependence problem (winner sets depend on chains, not only direct overlaps); higher regression risk with no stability gain.
+- **Alternative C — renderer-level mitigation (bigger canvasOverrun, swap throttling in PlaneMapRenderer)**: rejected; reduces frequency but leaves the mechanism in place, costs memory and render latency, and leaves backends beside Qt unprotected.
+
+Chosen alternative: hysteresis group ordering. Small, local, no new data structures beyond a ref set; emulates the label stickiness that navigation products (including JavaScout's stable sliding) exhibit.
+
+Staleness bound: a previously visible label only keeps its space against *new* candidates; if two previously visible labels overlap (zoom change), priority decides inside the group. Labels leaving the render set are not re-registered and disappear from `lastVisibleRefs` on refresh, so state never grows beyond the last round's visible set.
+
+### D2: State refresh semantics
+
+`lastVisibleRefs` is set after every `Layout()` to exactly the labels visible in that layout. Consequence: a label hidden once (because a previously visible label must win) stays in `lastVisibleRefs` only if it was visible in the previous round; a label hidden in two consecutive rounds while merely squeezed is a deliberate simplification (documented risk).
+
+### D3: Multi-round test harness in the existing test program
+
+Extend `Tests/src/LabelLayouterTest.cpp` with a `LayoutSession` (one `LabelLayouter` instance, several `Frame()` calls through `RegisterLabel` + `Layout`) mirroring the real per-draw sequence `DrawLabels -> Reset -> next frame`. The candidate-growth diagnostic switches from two fresh layouter runs to two frames of one session.
+
+- **Alternative — keep the diagnostic on fresh instances and add the state only inside the renderer**: rejected; the renderer cannot stabilize what the layouter recomputes from scratch, and a session harness is exactly how the real renderer uses the layouter.
+
+## Flow
+
+```
+Frame n-1: Layout() -> visible set  ──> lastVisibleRefs (kept across Reset)
+                                             |
+Frame n:   RegisterLabel(...)                |
+           Reset() cleared instances         v
+           SortLabels:  group(prev visible) -> group(new), priority inside
+           ProcessLabels: greedy mask filling in that order
+           -> visible set -> lastVisibleRefs refresh
+```
+
+## Risks / Trade-offs
+
+- [Priority inversion: a weak previously visible label can block a strong newcomer (new label appears only when the old one leaves screen)] → Accepted trade-off for navigation-grade stability; matches visible-label stickiness in navigation products. Bounded automatically: state lives only until the label leaves the viewport or collides with another previously visible label.
+- [Cross-round state hides real priority changes after a style reload] → Mitigation: style changes create a fresh painter/layouter instance (existing behavior: painters are recreated with the style config), clearing hysteresis.
+- [Zoom changes: label pixel size changes between rounds while refs persist] → Mask claim happens with the new size; only the group precedence persists. Zoom in/out behaves like a pan plus new candidates; worst case a previously visible label keeps space for one extra round — accepted trade-off, tested by the session determinism scenarios.
+- [Memory: `std::set<ObjectFileRef>` grows unbounded] → Refreshed to the last round's visible set (bounded by on-screen labels); no accumulation.
+
+## Migration Plan
+
+1. Implement header change (pure in-place, no build system changes).
+2. Extend tests: session harness + scenarios of this change; switch the dense diagnostic of `label-layout-stability-tests` to the session harness.
+3. Both builds green, no warnings in changed files; all existing tests green.
+Rollback: revert header + tests; no data, API, or build structure changes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/label-collision-stability/harness-run.log
+++ b/openspec/changes/label-collision-stability/harness-run.log
@@ -1,0 +1,2579 @@
+Lookup databases
+Scanning maps lookup directory: maps/nordrhein-westfalen
+  found valid map 'nordrhein-westfalen' at maps/nordrhein-westfalen (no metadata)
+Lookup directory maps/nordrhein-westfalen scan complete: 1 candidates, 1 valid, 0 invalid
+Total installed maps found: 1
+[PlaneMapRenderer] diagnostics ACTIVE (renderer lib with tile gate, jitter tolerance, contour stickiness)
+46,13 Warning: Unknown type '_track'
+52,13 Warning: Unknown type '_route_start'
+53,13 Warning: Unknown type '_route_end'
+60,13 Warning: Unknown type '_favorite'
+61,13 Warning: Unknown type '_search_selected'
+30,9 Warning: Unknown type 'basemap_boundary_country'
+104,11 Warning: Unknown type 'basemap_boundary_country'
+81,9 Warning: Unknown type 'place_ocean'
+82,9 Warning: Unknown type 'place_sea'
+83,9 Warning: Unknown type 'place_sea'
+132,9 Warning: Unknown type 'place_ocean'
+138,9 Warning: Unknown type 'place_sea'
+76,15 Warning: Unknown type 'natural_waterfall'
+122,15 Warning: Unknown type 'natural_waterfall'
+157,15 Warning: Unknown type 'natural_waterfall'
+175,15 Warning: Unknown type 'natural_waterfall'
+[PlaneMapRenderer] first render with partial data (tiles=1)
+[PlaneMapRenderer] render: tiles=6 centers=51.51440 N 7.46497 E
+Data: 0+0 4571 1006
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Draw: [51.51276 N 7.46339 E - 51.51604 N 7.46655 E] 205313x/17 480x800 100.00000 DPI
+Bounding box hit rate for file nodes.dat is only 6% (62/962)
+Bounding box hit rate for file nodes.dat is only 8% (86/982)
+Draw areas: 124 (pcs) 0.004 (s)
+Bounding box hit rate for file nodes.dat is only 4% (92/1856)
+Bounding box hit rate for file nodes.dat is only 5% (107/1897)
+Bounding box hit rate for file nodes.dat is only 8% (81/958)
+Bounding box hit rate for file nodes.dat is only 9% (92/995)
+Draw ways: 78 (pcs) 0.003 (s)
+Loaded icon 'parking' from "libosmscout/data/icons/svg/standard/parking.svg"
+Draw area labels: 124 (pcs) 0.003(s)
+[PlaneMapRenderer] swap enter: image=480x800 center=51.51440 N 7.46497 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=6 centers=51.51440 N 7.46497 E
+Data: 520+0 4571 1006
+Database 0:
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Draw: [51.51276 N 7.46339 E - 51.51604 N 7.46655 E] 205313x/17 480x800 100.00000 DPI
+Draw areas: 124 (pcs) 0.004 (s)
+Draw ways: 78 (pcs) 0.003 (s)
+Loaded icon 'restaurant' from "libosmscout/data/icons/svg/standard/restaurant.svg"
+Loaded icon 'fast_food' from "libosmscout/data/icons/svg/standard/fast_food.svg"
+Loaded icon 'pharmacy' from "libosmscout/data/icons/svg/standard/pharmacy.svg"
+Prepare node labels: 0.004(s)
+[PlaneMapRenderer] swap enter: image=480x800 center=51.51440 N 7.46497 E mag=17 epoch=1
+Bounding box hit rate for file nodes.dat is only 9% (94/1008)
+Bounding box hit rate for file nodes.dat is only 6% (68/990)
+Bounding box hit rate for file nodes.dat is only 9% (93/955)
+Bounding box hit rate for file nodes.dat is only 11% (115/960)
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46494 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46257 E - 51.51686 N 7.46731 E] 205313x/17 720x1200 100.00000 DPI
+Loaded pattern 'scrub' from "libosmscout/data/icons/svg/standard/scrub.svg"
+Loaded pattern 'garden' from "libosmscout/data/icons/svg/standard/garden.svg"
+Draw areas: 354 (pcs) 0.012 (s)
+Draw ways: 251 (pcs) 0.011 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Draw area labels: 354 (pcs) 0.002(s)
+Loaded icon 'bus_stop' from "libosmscout/data/icons/svg/standard/bus_stop.svg"
+Prepare node labels: 0.007(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1056 visible=852 prevVisible=413 kept=378 hiddenByCollision=35 notRegistered=0 contoursRegistered=73 prevVisibleContours=31 lostContours=13
+[LabelHysteresis]   hidden-by-collision: Node 27606322
+[LabelHysteresis]   hidden-by-collision: Node 27616132
+[LabelHysteresis]   hidden-by-collision: Node 27617167
+[LabelHysteresis]   hidden-by-collision: Node 27617765
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 27624629
+[LabelHysteresis]   hidden-by-collision: Node 27625226
+[LabelHysteresis]   hidden-by-collision: Node 27626073
+[LabelHysteresis]   hidden-by-collision: Node 27626174
+[LabelHysteresis]   hidden-by-collision: Node 27627369
+[LabelHysteresis]   hidden-by-collision: Node 27627415
+[LabelHysteresis]   hidden-by-collision: Node 28041260
+[LabelHysteresis]   hidden-by-collision: Node 28041839
+[LabelHysteresis]   hidden-by-collision: Node 28052617
+[LabelHysteresis]   hidden-by-collision: Node 28052714
+[LabelHysteresis]   hidden-by-collision: Node 28055020
+[LabelHysteresis]   hidden-by-collision: Area 127323274
+[LabelHysteresis]   hidden-by-collision: Area 127323324
+[LabelHysteresis]   hidden-by-collision: Area 127323988
+[LabelHysteresis]   hidden-by-collision: Area 127324018
+[LabelHysteresis]   hidden-by-collision: Area 127324042
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[LabelHysteresis]   hidden-by-collision: Area 127329606
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127330225
+[LabelHysteresis]   hidden-by-collision: Area 127434892
+[LabelHysteresis]   hidden-by-collision: Area 127435091
+[LabelHysteresis]   hidden-by-collision: Area 127442978
+[LabelHysteresis]   hidden-by-collision: Area 127443007
+[LabelHysteresis]   hidden-by-collision: Area 127443496
+[LabelHysteresis]   hidden-by-collision: Area 127443515
+[LabelHysteresis]   hidden-by-collision: Area 127443715
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46494 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46491 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46254 E - 51.51686 N 7.46728 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 355 (pcs) 0.016 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=849 prevVisible=706 kept=689 hiddenByCollision=17 notRegistered=0 contoursRegistered=73 prevVisibleContours=43 lostContours=10
+[LabelHysteresis]   hidden-by-collision: Node 27594360
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28050448
+[LabelHysteresis]   hidden-by-collision: Node 28060102
+[LabelHysteresis]   hidden-by-collision: Node 28061279
+[LabelHysteresis]   hidden-by-collision: Node 28061292
+[LabelHysteresis]   hidden-by-collision: Node 28062260
+[LabelHysteresis]   hidden-by-collision: Area 127318552
+[LabelHysteresis]   hidden-by-collision: Area 127319531
+[LabelHysteresis]   hidden-by-collision: Area 127324873
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329826
+[LabelHysteresis]   hidden-by-collision: Area 127435361
+[LabelHysteresis]   hidden-by-collision: Area 127435443
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46491 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46488 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46251 E - 51.51686 N 7.46725 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 353 (pcs) 0.012 (s)
+Draw ways: 250 (pcs) 0.009 (s)
+Draw way contour labels: 94 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=855 prevVisible=703 kept=697 hiddenByCollision=5 notRegistered=1 contoursRegistered=72 prevVisibleContours=34 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27625058
+[LabelHysteresis]   hidden-by-collision: Node 27625948
+[LabelHysteresis]   hidden-by-collision: Node 28052150
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127444821
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46488 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46485 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46248 E - 51.51686 N 7.46722 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 349 (pcs) 0.012 (s)
+Draw ways: 248 (pcs) 0.009 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1052 visible=851 prevVisible=709 kept=704 hiddenByCollision=4 notRegistered=1 contoursRegistered=73 prevVisibleContours=33 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Node 28061652
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328971
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46485 E mag=17 epoch=1
+Bounding box hit rate for file nodes.dat is only 2% (22/922)
+Bounding box hit rate for file nodes.dat is only 8% (80/961)
+Bounding box hit rate for file nodes.dat is only 4% (80/1860)
+Bounding box hit rate for file nodes.dat is only 6% (62/946)
+Bounding box hit rate for file nodes.dat is only 5% (56/965)
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46482 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46245 E - 51.51686 N 7.46719 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 348 (pcs) 0.011 (s)
+Draw ways: 245 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1350 visible=1112 prevVisible=705 kept=700 hiddenByCollision=2 notRegistered=3 contoursRegistered=73 prevVisibleContours=33 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27614991
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329647
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447536
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448579
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46482 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46479 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46242 E - 51.51686 N 7.46716 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 345 (pcs) 0.013 (s)
+Draw ways: 245 (pcs) 0.011 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1348 visible=1103 prevVisible=966 kept=952 hiddenByCollision=13 notRegistered=1 contoursRegistered=75 prevVisibleContours=31 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27614336
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28040990
+[LabelHysteresis]   hidden-by-collision: Node 28041852
+[LabelHysteresis]   hidden-by-collision: Node 28047836
+[LabelHysteresis]   hidden-by-collision: Area 127329164
+[LabelHysteresis]   hidden-by-collision: Area 127329263
+[LabelHysteresis]   hidden-by-collision: Area 127433547
+[LabelHysteresis]   hidden-by-collision: Area 127436008
+[LabelHysteresis]   hidden-by-collision: Area 127447892
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448045
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46479 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46476 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46239 E - 51.51686 N 7.46713 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 344 (pcs) 0.015 (s)
+Draw ways: 243 (pcs) 0.008 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1348 visible=1106 prevVisible=957 kept=948 hiddenByCollision=9 notRegistered=0 contoursRegistered=75 prevVisibleContours=35 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614060
+[LabelHysteresis]   hidden-by-collision: Node 27614189
+[LabelHysteresis]   hidden-by-collision: Node 28039881
+[LabelHysteresis]   hidden-by-collision: Node 28047797
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28062260
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127436078
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46476 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46473 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46236 E - 51.51686 N 7.46710 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 341 (pcs) 0.011 (s)
+Draw ways: 244 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1345 visible=1101 prevVisible=960 kept=947 hiddenByCollision=11 notRegistered=2 contoursRegistered=74 prevVisibleContours=33 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27623153
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[LabelHysteresis]   hidden-by-collision: Area 127329209
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127324507
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127444518
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46473 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46470 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46233 E - 51.51686 N 7.46707 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 333 (pcs) 0.011 (s)
+Draw ways: 244 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1341 visible=1104 prevVisible=955 kept=945 hiddenByCollision=7 notRegistered=3 contoursRegistered=73 prevVisibleContours=32 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27611077
+[LabelHysteresis]   hidden-by-collision: Node 27611090
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   hidden-by-collision: Area 127436564
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328895
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127442816
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447190
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46470 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46467 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46230 E - 51.51686 N 7.46704 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 335 (pcs) 0.019 (s)
+Draw ways: 245 (pcs) 0.016 (s)
+Draw way contour labels: 90 (pcs) 0.001(s)
+Draw area labels: 335 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1104 prevVisible=958 kept=950 hiddenByCollision=8 notRegistered=0 contoursRegistered=73 prevVisibleContours=32 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28041355
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127442911
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46467 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46464 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46227 E - 51.51686 N 7.46701 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 337 (pcs) 0.022 (s)
+Draw ways: 247 (pcs) 0.018 (s)
+Draw way contour labels: 90 (pcs) 0.001(s)
+Draw area labels: 337 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1098 prevVisible=958 kept=946 hiddenByCollision=12 notRegistered=0 contoursRegistered=73 prevVisibleContours=35 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608405
+[LabelHysteresis]   hidden-by-collision: Node 27614049
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28047012
+[LabelHysteresis]   hidden-by-collision: Node 28062024
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46464 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46461 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46224 E - 51.51686 N 7.46698 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 336 (pcs) 0.023 (s)
+Draw ways: 241 (pcs) 0.013 (s)
+Draw way contour labels: 86 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1100 prevVisible=952 kept=941 hiddenByCollision=10 notRegistered=1 contoursRegistered=71 prevVisibleContours=33 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27605353
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Node 28062275
+[LabelHysteresis]   hidden-by-collision: Area 127320089
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127441363
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46461 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46458 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46221 E - 51.51686 N 7.46695 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.027 (s)
+Draw ways: 235 (pcs) 0.013 (s)
+Draw way contour labels: 84 (pcs) 0.001(s)
+Draw area labels: 339 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1106 prevVisible=954 kept=950 hiddenByCollision=4 notRegistered=0 contoursRegistered=69 prevVisibleContours=32 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614819
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27625205
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46458 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46455 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46218 E - 51.51686 N 7.46692 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 338 (pcs) 0.024 (s)
+Draw ways: 233 (pcs) 0.016 (s)
+Draw way contour labels: 82 (pcs) 0.001(s)
+Draw area labels: 338 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1345 visible=1102 prevVisible=960 kept=952 hiddenByCollision=8 notRegistered=0 contoursRegistered=67 prevVisibleContours=29 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   hidden-by-collision: Area 127433902
+[LabelHysteresis]   hidden-by-collision: Area 127439824
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46455 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46452 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46215 E - 51.51686 N 7.46689 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.029 (s)
+Draw ways: 233 (pcs) 0.018 (s)
+Draw way contour labels: 81 (pcs) 0.002(s)
+Draw area labels: 339 (pcs) 0.002(s)
+Prepare node labels: 0.010(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1099 prevVisible=956 kept=942 hiddenByCollision=14 notRegistered=0 contoursRegistered=66 prevVisibleContours=28 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27603500
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28041308
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127323451
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127453009
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46452 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46449 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46212 E - 51.51686 N 7.46686 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.043 (s)
+Draw ways: 235 (pcs) 0.021 (s)
+Draw way contour labels: 81 (pcs) 0.001(s)
+Draw area labels: 339 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1105 prevVisible=953 kept=943 hiddenByCollision=10 notRegistered=0 contoursRegistered=66 prevVisibleContours=29 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27603397
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28047787
+[LabelHysteresis]   hidden-by-collision: Node 28047826
+[LabelHysteresis]   hidden-by-collision: Node 28054797
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46449 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46446 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46209 E - 51.51686 N 7.46683 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.034 (s)
+Draw ways: 238 (pcs) 0.020 (s)
+Draw way contour labels: 80 (pcs) 0.001(s)
+Draw area labels: 339 (pcs) 0.001(s)
+Prepare node labels: 0.008(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1109 prevVisible=959 kept=955 hiddenByCollision=4 notRegistered=0 contoursRegistered=65 prevVisibleContours=28 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 28040128
+[LabelHysteresis]   hidden-by-collision: Node 28052150
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46446 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46443 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46206 E - 51.51686 N 7.46680 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 338 (pcs) 0.037 (s)
+Draw ways: 238 (pcs) 0.023 (s)
+Draw way contour labels: 76 (pcs) 0.001(s)
+Draw area labels: 338 (pcs) 0.001(s)
+Prepare node labels: 0.007(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1106 prevVisible=963 kept=956 hiddenByCollision=6 notRegistered=1 contoursRegistered=62 prevVisibleContours=27 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27592284
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27610918
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329209
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46443 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46440 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46203 E - 51.51686 N 7.46677 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 336 (pcs) 0.034 (s)
+Draw ways: 239 (pcs) 0.022 (s)
+Draw way contour labels: 76 (pcs) 0.002(s)
+Draw area labels: 336 (pcs) 0.002(s)
+Prepare node labels: 0.007(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1104 prevVisible=960 kept=952 hiddenByCollision=6 notRegistered=2 contoursRegistered=62 prevVisibleContours=26 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27614991
+[LabelHysteresis]   hidden-by-collision: Node 28038981
+[LabelHysteresis]   hidden-by-collision: Node 28039321
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329164
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127443650
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46440 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46557 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46320 E - 51.51686 N 7.46794 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 353 (pcs) 0.030 (s)
+Draw ways: 259 (pcs) 0.018 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Draw area labels: 353 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=848 prevVisible=959 kept=673 hiddenByCollision=14 notRegistered=272 contoursRegistered=76 prevVisibleContours=27 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27601152
+[LabelHysteresis]   hidden-by-collision: Node 27608045
+[LabelHysteresis]   hidden-by-collision: Node 27617765
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27624629
+[LabelHysteresis]   hidden-by-collision: Node 27625226
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 27627369
+[LabelHysteresis]   hidden-by-collision: Node 28052714
+[LabelHysteresis]   hidden-by-collision: Node 28061422
+[LabelHysteresis]   hidden-by-collision: Node 28062238
+[LabelHysteresis]   hidden-by-collision: Node 28062566
+[LabelHysteresis]   hidden-by-collision: Node 28062600
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591177
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591186
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591196
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591206
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591365
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591404
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591414
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591433
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591460
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591485
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591495
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591507
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591544
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591584
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591697
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591803
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27591909
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27592015
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27592121
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27592236
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27592275
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602572
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602606
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602616
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602654
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602690
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602728
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602846
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602858
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602899
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602936
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27602984
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603007
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603049
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603100
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603142
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603179
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603225
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603256
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603292
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603305
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603409
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603512
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603586
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603598
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603610
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603622
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603638
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603726
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603757
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603789
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603825
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603861
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603880
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603934
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27603972
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604006
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604026
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604042
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604082
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604121
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604162
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604180
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604218
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604276
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604314
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604346
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604365
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604384
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604458
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604507
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604535
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604573
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604730
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604769
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604916
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27604929
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605035
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605070
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605093
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605122
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605287
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605331
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27605363
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27608866
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27608940
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609027
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609067
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609095
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609229
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609310
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609329
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609342
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609421
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609447
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609477
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609588
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609670
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609703
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609746
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609781
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609791
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609801
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609813
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609825
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609837
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609849
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609859
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609871
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609893
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609922
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27609943
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610044
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610139
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610218
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610264
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610274
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610287
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610300
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610352
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610365
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610397
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610406
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610418
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610428
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610450
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610463
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610486
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610499
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610521
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610558
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610605
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610642
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610735
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610745
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610755
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610879
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610892
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610905
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27610958
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611077
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611090
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611119
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611242
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611297
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611370
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611417
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611461
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611500
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611528
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611576
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611587
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611729
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611792
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611804
+[LabelHysteresis]   not-registered (candidate/data churn): Node 27611823
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038472
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038482
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038492
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038608
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038618
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038628
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038714
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038724
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038737
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038752
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038789
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038854
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038869
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28038953
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039031
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039059
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039089
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039148
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039161
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039221
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039269
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039362
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039523
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039545
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039567
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039637
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039767
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28039891
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040027
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040052
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040080
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040167
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040258
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040329
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040341
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040360
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040468
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040487
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040526
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040555
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040574
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040602
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040769
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040822
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040839
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040941
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28040970
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045353
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045363
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045373
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045385
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045586
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045598
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045766
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045776
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045788
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045832
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045844
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045856
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28045875
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046028
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046169
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046352
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046362
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046444
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046548
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046560
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046597
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046620
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046639
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046924
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046934
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28046991
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047012
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047042
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047083
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047093
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047117
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047127
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047137
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047166
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047185
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047236
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047245
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047280
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047299
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047318
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047346
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047405
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047520
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047654
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047691
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047737
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047826
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047836
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28047994
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28048071
+[LabelHysteresis]   not-registered (candidate/data churn): Node 28048121
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127316726
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127317467
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127317549
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127321653
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127322195
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127322291
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127433589
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127433704
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127433902
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127435554
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127435859
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127436078
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127436888
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127438410
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127439129
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127439824
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127439929
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127452235
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46557 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46554 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46317 E - 51.51686 N 7.46791 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 353 (pcs) 0.034 (s)
+Draw ways: 259 (pcs) 0.021 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Draw area labels: 353 (pcs) 0.001(s)
+Prepare node labels: 0.013(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=849 prevVisible=702 kept=696 hiddenByCollision=6 notRegistered=0 contoursRegistered=76 prevVisibleContours=40 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27600773
+[LabelHysteresis]   hidden-by-collision: Node 28060977
+[LabelHysteresis]   hidden-by-collision: Node 28061193
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   hidden-by-collision: Area 127330119
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46554 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46551 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46314 E - 51.51686 N 7.46788 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 355 (pcs) 0.033 (s)
+Draw ways: 257 (pcs) 0.019 (s)
+Draw way contour labels: 97 (pcs) 0.002(s)
+Draw area labels: 355 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=851 prevVisible=703 kept=699 hiddenByCollision=4 notRegistered=0 contoursRegistered=76 prevVisibleContours=41 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Area 127328926
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46551 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46548 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46311 E - 51.51686 N 7.46785 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 357 (pcs) 0.028 (s)
+Draw ways: 254 (pcs) 0.020 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Draw area labels: 357 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=838 prevVisible=705 kept=687 hiddenByCollision=17 notRegistered=1 contoursRegistered=74 prevVisibleContours=42 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27614049
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 27626118
+[LabelHysteresis]   hidden-by-collision: Node 28042741
+[LabelHysteresis]   hidden-by-collision: Node 28049566
+[LabelHysteresis]   hidden-by-collision: Node 28049623
+[LabelHysteresis]   hidden-by-collision: Node 28062024
+[LabelHysteresis]   hidden-by-collision: Area 127330119
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127324815
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46548 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46545 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46308 E - 51.51686 N 7.46782 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 358 (pcs) 0.026 (s)
+Draw ways: 248 (pcs) 0.022 (s)
+Draw way contour labels: 93 (pcs) 0.002(s)
+Draw area labels: 358 (pcs) 0.003(s)
+Prepare node labels: 0.013(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1058 visible=850 prevVisible=692 kept=686 hiddenByCollision=6 notRegistered=0 contoursRegistered=72 prevVisibleContours=38 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Area 127320089
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46545 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46542 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46305 E - 51.51686 N 7.46779 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 354 (pcs) 0.031 (s)
+Draw ways: 244 (pcs) 0.019 (s)
+Draw way contour labels: 91 (pcs) 0.002(s)
+Draw area labels: 354 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1054 visible=848 prevVisible=704 kept=696 hiddenByCollision=6 notRegistered=2 contoursRegistered=71 prevVisibleContours=36 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27618005
+[LabelHysteresis]   hidden-by-collision: Node 27625205
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127448106
+[LabelHysteresis]   hidden-by-collision: Area 127448579
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329328
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127330588
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46542 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46539 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46302 E - 51.51686 N 7.46776 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 354 (pcs) 0.031 (s)
+Draw ways: 244 (pcs) 0.019 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Draw area labels: 354 (pcs) 0.001(s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=845 prevVisible=702 kept=692 hiddenByCollision=10 notRegistered=0 contoursRegistered=71 prevVisibleContours=36 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Node 28052150
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46539 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46536 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46299 E - 51.51686 N 7.46773 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 352 (pcs) 0.025 (s)
+Draw ways: 244 (pcs) 0.016 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Draw area labels: 352 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=843 prevVisible=699 kept=687 hiddenByCollision=12 notRegistered=0 contoursRegistered=72 prevVisibleContours=34 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127453009
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46536 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46533 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46296 E - 51.51686 N 7.46770 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 352 (pcs) 0.024 (s)
+Draw ways: 245 (pcs) 0.016 (s)
+Draw way contour labels: 92 (pcs) 0.002(s)
+Draw area labels: 352 (pcs) 0.002(s)
+Prepare node labels: 0.007(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=843 prevVisible=697 kept=687 hiddenByCollision=10 notRegistered=0 contoursRegistered=72 prevVisibleContours=36 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28050448
+[LabelHysteresis]   hidden-by-collision: Node 28054797
+[LabelHysteresis]   hidden-by-collision: Node 28061292
+[LabelHysteresis]   hidden-by-collision: Node 28062260
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[LabelHysteresis]   hidden-by-collision: Area 127329826
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46533 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46530 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46293 E - 51.51686 N 7.46767 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 351 (pcs) 0.018 (s)
+Draw ways: 247 (pcs) 0.012 (s)
+Draw way contour labels: 93 (pcs) 0.001(s)
+Draw area labels: 351 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=854 prevVisible=697 kept=696 hiddenByCollision=1 notRegistered=0 contoursRegistered=73 prevVisibleContours=36 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Area 127323217
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46530 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46527 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46290 E - 51.51686 N 7.46764 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 350 (pcs) 0.017 (s)
+Draw ways: 249 (pcs) 0.010 (s)
+Draw way contour labels: 93 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1054 visible=850 prevVisible=708 kept=702 hiddenByCollision=5 notRegistered=1 contoursRegistered=73 prevVisibleContours=37 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Node 28061652
+[LabelHysteresis]   hidden-by-collision: Area 127330119
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127327304
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46527 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46524 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46287 E - 51.51686 N 7.46761 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 348 (pcs) 0.014 (s)
+Draw ways: 250 (pcs) 0.010 (s)
+Draw way contour labels: 94 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1052 visible=849 prevVisible=704 kept=698 hiddenByCollision=5 notRegistered=1 contoursRegistered=73 prevVisibleContours=36 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27614991
+[LabelHysteresis]   hidden-by-collision: Node 28062287
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127443496
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127330206
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46524 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46521 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46284 E - 51.51686 N 7.46758 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 352 (pcs) 0.012 (s)
+Draw ways: 253 (pcs) 0.008 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1054 visible=844 prevVisible=703 kept=694 hiddenByCollision=9 notRegistered=0 contoursRegistered=72 prevVisibleContours=34 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Area 127329164
+[LabelHysteresis]   hidden-by-collision: Area 127329263
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127447892
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46521 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46518 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46281 E - 51.51686 N 7.46755 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 355 (pcs) 0.012 (s)
+Draw ways: 255 (pcs) 0.010 (s)
+Draw way contour labels: 97 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1056 visible=851 prevVisible=698 kept=692 hiddenByCollision=5 notRegistered=1 contoursRegistered=72 prevVisibleContours=38 lostContours=8
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 28042939
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28062260
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448225
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46518 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46515 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46278 E - 51.51686 N 7.46752 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 354 (pcs) 0.021 (s)
+Draw ways: 256 (pcs) 0.012 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Draw area labels: 354 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=848 prevVisible=705 kept=699 hiddenByCollision=5 notRegistered=1 contoursRegistered=74 prevVisibleContours=31 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[LabelHysteresis]   hidden-by-collision: Area 127329209
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448106
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46515 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46512 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46275 E - 51.51686 N 7.46749 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 354 (pcs) 0.018 (s)
+Draw ways: 254 (pcs) 0.012 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Draw area labels: 354 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1056 visible=852 prevVisible=702 kept=700 hiddenByCollision=2 notRegistered=0 contoursRegistered=74 prevVisibleContours=35 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46512 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46509 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46272 E - 51.51686 N 7.46746 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 353 (pcs) 0.016 (s)
+Draw ways: 252 (pcs) 0.010 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1056 visible=847 prevVisible=706 kept=698 hiddenByCollision=8 notRegistered=0 contoursRegistered=74 prevVisibleContours=35 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27618005
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127328926
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46509 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46506 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46269 E - 51.51686 N 7.46743 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 351 (pcs) 0.013 (s)
+Draw ways: 252 (pcs) 0.009 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1053 visible=837 prevVisible=701 kept=687 hiddenByCollision=12 notRegistered=2 contoursRegistered=74 prevVisibleContours=38 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27614049
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28049566
+[LabelHysteresis]   hidden-by-collision: Node 28049623
+[LabelHysteresis]   hidden-by-collision: Node 28062024
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329884
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127330162
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46506 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46503 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46266 E - 51.51686 N 7.46740 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 351 (pcs) 0.012 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Draw way contour labels: 98 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1053 visible=841 prevVisible=691 kept=684 hiddenByCollision=7 notRegistered=0 contoursRegistered=74 prevVisibleContours=34 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Area 127320089
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46503 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46500 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46263 E - 51.51686 N 7.46737 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 349 (pcs) 0.013 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Draw way contour labels: 97 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1052 visible=843 prevVisible=695 kept=689 hiddenByCollision=5 notRegistered=1 contoursRegistered=73 prevVisibleContours=36 lostContours=6
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27618005
+[LabelHysteresis]   hidden-by-collision: Node 27625205
+[LabelHysteresis]   hidden-by-collision: Area 127448579
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329030
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46500 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46497 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46260 E - 51.51686 N 7.46734 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 349 (pcs) 0.015 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1053 visible=842 prevVisible=697 kept=689 hiddenByCollision=7 notRegistered=1 contoursRegistered=73 prevVisibleContours=32 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127442428
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46497 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46494 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46257 E - 51.51686 N 7.46731 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 354 (pcs) 0.012 (s)
+Draw ways: 251 (pcs) 0.008 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1056 visible=843 prevVisible=696 kept=684 hiddenByCollision=12 notRegistered=0 contoursRegistered=73 prevVisibleContours=33 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127453009
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46494 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46491 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46254 E - 51.51686 N 7.46728 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 355 (pcs) 0.013 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Draw way contour labels: 95 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1057 visible=845 prevVisible=697 kept=686 hiddenByCollision=11 notRegistered=0 contoursRegistered=73 prevVisibleContours=34 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28050448
+[LabelHysteresis]   hidden-by-collision: Node 28054797
+[LabelHysteresis]   hidden-by-collision: Node 28061292
+[LabelHysteresis]   hidden-by-collision: Node 28062275
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329826
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46491 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46488 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46251 E - 51.51686 N 7.46725 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 353 (pcs) 0.012 (s)
+Draw ways: 250 (pcs) 0.008 (s)
+Draw way contour labels: 94 (pcs) 0.001(s)
+Prepare node labels: 0.003(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1055 visible=853 prevVisible=699 kept=695 hiddenByCollision=3 notRegistered=1 contoursRegistered=72 prevVisibleContours=34 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127442816
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127444821
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46488 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=10 centers=51.51440 N 7.46485 E
+Data: 890+0 4571 1231
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46248 E - 51.51686 N 7.46722 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 349 (pcs) 0.013 (s)
+Draw ways: 248 (pcs) 0.009 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1052 visible=849 prevVisible=707 kept=702 hiddenByCollision=4 notRegistered=1 contoursRegistered=73 prevVisibleContours=33 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Node 28061652
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328971
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46485 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46482 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46245 E - 51.51686 N 7.46719 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 348 (pcs) 0.013 (s)
+Draw ways: 245 (pcs) 0.008 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1350 visible=1110 prevVisible=703 kept=698 hiddenByCollision=2 notRegistered=3 contoursRegistered=73 prevVisibleContours=33 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27614991
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329647
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447536
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448579
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46482 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46479 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46242 E - 51.51686 N 7.46716 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 345 (pcs) 0.012 (s)
+Draw ways: 245 (pcs) 0.009 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1348 visible=1102 prevVisible=964 kept=951 hiddenByCollision=12 notRegistered=1 contoursRegistered=75 prevVisibleContours=31 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27614336
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28041852
+[LabelHysteresis]   hidden-by-collision: Node 28047836
+[LabelHysteresis]   hidden-by-collision: Area 127329164
+[LabelHysteresis]   hidden-by-collision: Area 127329263
+[LabelHysteresis]   hidden-by-collision: Area 127433547
+[LabelHysteresis]   hidden-by-collision: Area 127436008
+[LabelHysteresis]   hidden-by-collision: Area 127447892
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448045
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46479 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46476 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46239 E - 51.51686 N 7.46713 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 344 (pcs) 0.014 (s)
+Draw ways: 243 (pcs) 0.011 (s)
+Draw way contour labels: 92 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1348 visible=1105 prevVisible=956 kept=947 hiddenByCollision=9 notRegistered=0 contoursRegistered=75 prevVisibleContours=35 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614060
+[LabelHysteresis]   hidden-by-collision: Node 27614189
+[LabelHysteresis]   hidden-by-collision: Node 28039881
+[LabelHysteresis]   hidden-by-collision: Node 28047797
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28062260
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127436078
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46476 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46473 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46236 E - 51.51686 N 7.46710 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 341 (pcs) 0.014 (s)
+Draw ways: 244 (pcs) 0.009 (s)
+Draw way contour labels: 91 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1345 visible=1100 prevVisible=959 kept=946 hiddenByCollision=11 notRegistered=2 contoursRegistered=74 prevVisibleContours=33 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27623153
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[LabelHysteresis]   hidden-by-collision: Area 127329209
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127324507
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127444518
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46473 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46470 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46233 E - 51.51686 N 7.46707 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 333 (pcs) 0.013 (s)
+Draw ways: 244 (pcs) 0.009 (s)
+Draw way contour labels: 90 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1341 visible=1104 prevVisible=954 kept=945 hiddenByCollision=6 notRegistered=3 contoursRegistered=73 prevVisibleContours=32 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27611077
+[LabelHysteresis]   hidden-by-collision: Node 27611090
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328895
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127442816
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447190
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46470 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46467 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46230 E - 51.51686 N 7.46704 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 335 (pcs) 0.013 (s)
+Draw ways: 245 (pcs) 0.008 (s)
+Draw way contour labels: 90 (pcs) 0.001(s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1105 prevVisible=958 kept=951 hiddenByCollision=7 notRegistered=0 contoursRegistered=73 prevVisibleContours=32 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28041355
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46467 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46464 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46227 E - 51.51686 N 7.46701 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 337 (pcs) 0.016 (s)
+Draw ways: 247 (pcs) 0.010 (s)
+Draw way contour labels: 90 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1099 prevVisible=959 kept=947 hiddenByCollision=12 notRegistered=0 contoursRegistered=73 prevVisibleContours=35 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27614049
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28047012
+[LabelHysteresis]   hidden-by-collision: Node 28062024
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46464 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46461 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46224 E - 51.51686 N 7.46698 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 336 (pcs) 0.015 (s)
+Draw ways: 241 (pcs) 0.009 (s)
+Draw way contour labels: 86 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1101 prevVisible=953 kept=942 hiddenByCollision=10 notRegistered=1 contoursRegistered=71 prevVisibleContours=33 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27605353
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Node 28062275
+[LabelHysteresis]   hidden-by-collision: Area 127320089
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127441363
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46461 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46458 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46221 E - 51.51686 N 7.46695 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.015 (s)
+Draw ways: 235 (pcs) 0.010 (s)
+Draw way contour labels: 84 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1108 prevVisible=955 kept=952 hiddenByCollision=3 notRegistered=0 contoursRegistered=69 prevVisibleContours=32 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27625205
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46458 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46455 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46218 E - 51.51686 N 7.46692 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 338 (pcs) 0.013 (s)
+Draw ways: 233 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1345 visible=1104 prevVisible=962 kept=954 hiddenByCollision=8 notRegistered=0 contoursRegistered=67 prevVisibleContours=29 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   hidden-by-collision: Area 127433902
+[LabelHysteresis]   hidden-by-collision: Area 127439824
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46455 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46452 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46215 E - 51.51686 N 7.46689 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.013 (s)
+Draw ways: 233 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1101 prevVisible=958 kept=944 hiddenByCollision=14 notRegistered=0 contoursRegistered=66 prevVisibleContours=28 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27603500
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28041308
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127323451
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127453009
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46452 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46449 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46212 E - 51.51686 N 7.46686 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.012 (s)
+Draw ways: 235 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1107 prevVisible=955 kept=945 hiddenByCollision=10 notRegistered=0 contoursRegistered=66 prevVisibleContours=29 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27603397
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625387
+[LabelHysteresis]   hidden-by-collision: Node 28047787
+[LabelHysteresis]   hidden-by-collision: Node 28047826
+[LabelHysteresis]   hidden-by-collision: Node 28054797
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46449 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46446 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46209 E - 51.51686 N 7.46683 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 339 (pcs) 0.012 (s)
+Draw ways: 238 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1111 prevVisible=961 kept=957 hiddenByCollision=4 notRegistered=0 contoursRegistered=65 prevVisibleContours=28 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 28040128
+[LabelHysteresis]   hidden-by-collision: Node 28052150
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46446 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46443 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46206 E - 51.51686 N 7.46680 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 338 (pcs) 0.012 (s)
+Draw ways: 238 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1346 visible=1107 prevVisible=965 kept=958 hiddenByCollision=6 notRegistered=1 contoursRegistered=62 prevVisibleContours=27 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27592284
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27610918
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329209
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46443 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46440 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46203 E - 51.51686 N 7.46677 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 336 (pcs) 0.013 (s)
+Draw ways: 239 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1105 prevVisible=961 kept=953 hiddenByCollision=6 notRegistered=2 contoursRegistered=62 prevVisibleContours=26 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27614991
+[LabelHysteresis]   hidden-by-collision: Node 28038981
+[LabelHysteresis]   hidden-by-collision: Node 28039321
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329164
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127443650
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46440 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46437 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46200 E - 51.51686 N 7.46674 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 334 (pcs) 0.014 (s)
+Draw ways: 237 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1344 visible=1109 prevVisible=960 kept=958 hiddenByCollision=2 notRegistered=0 contoursRegistered=61 prevVisibleContours=27 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27614336
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46437 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46434 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46197 E - 51.51686 N 7.46671 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 333 (pcs) 0.019 (s)
+Draw ways: 232 (pcs) 0.009 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1107 prevVisible=964 kept=960 hiddenByCollision=3 notRegistered=1 contoursRegistered=61 prevVisibleContours=29 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614060
+[LabelHysteresis]   hidden-by-collision: Node 27614189
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127442545
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46434 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46431 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46194 E - 51.51686 N 7.46668 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 333 (pcs) 0.017 (s)
+Draw ways: 230 (pcs) 0.010 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1101 prevVisible=962 kept=950 hiddenByCollision=12 notRegistered=0 contoursRegistered=59 prevVisibleContours=27 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27611077
+[LabelHysteresis]   hidden-by-collision: Node 27611090
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27623153
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 27625885
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46431 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46428 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46191 E - 51.51686 N 7.46665 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 334 (pcs) 0.017 (s)
+Draw ways: 227 (pcs) 0.009 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1111 prevVisible=956 kept=950 hiddenByCollision=6 notRegistered=0 contoursRegistered=56 prevVisibleContours=23 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27610892
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46428 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46425 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46188 E - 51.51686 N 7.46662 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 330 (pcs) 0.013 (s)
+Draw ways: 226 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1343 visible=1111 prevVisible=966 kept=959 hiddenByCollision=7 notRegistered=0 contoursRegistered=55 prevVisibleContours=23 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28041355
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46425 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46422 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46185 E - 51.51686 N 7.46659 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 329 (pcs) 0.015 (s)
+Draw ways: 229 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1342 visible=1103 prevVisible=966 kept=953 hiddenByCollision=12 notRegistered=1 contoursRegistered=56 prevVisibleContours=25 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27610745
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28047012
+[LabelHysteresis]   hidden-by-collision: Node 28062024
+[LabelHysteresis]   hidden-by-collision: Area 127329304
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328331
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46422 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46419 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46182 E - 51.51686 N 7.46656 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 327 (pcs) 0.014 (s)
+Draw ways: 231 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1341 visible=1106 prevVisible=958 kept=950 hiddenByCollision=8 notRegistered=0 contoursRegistered=56 prevVisibleContours=25 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Area 127320089
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46419 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46416 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46179 E - 51.51686 N 7.46653 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 326 (pcs) 0.012 (s)
+Draw ways: 232 (pcs) 0.009 (s)
+Draw way contour labels: 71 (pcs) 0.001(s)
+Draw area labels: 326 (pcs) 0.001(s)
+Prepare node labels: 0.007(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1109 prevVisible=961 kept=955 hiddenByCollision=6 notRegistered=0 contoursRegistered=56 prevVisibleContours=25 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27610735
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623184
+[LabelHysteresis]   hidden-by-collision: Node 27623622
+[LabelHysteresis]   hidden-by-collision: Node 27625205
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46416 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46413 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46176 E - 51.51686 N 7.46650 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.015 (s)
+Draw ways: 236 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1338 visible=1104 prevVisible=964 kept=952 hiddenByCollision=11 notRegistered=1 contoursRegistered=57 prevVisibleContours=24 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27610486
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127329851
+[LabelHysteresis]   hidden-by-collision: Area 127439824
+[LabelHysteresis]   hidden-by-collision: Area 127439881
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447707
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46413 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46410 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46173 E - 51.51686 N 7.46647 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 321 (pcs) 0.012 (s)
+Draw ways: 241 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1337 visible=1097 prevVisible=959 kept=942 hiddenByCollision=17 notRegistered=0 contoursRegistered=56 prevVisibleContours=23 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28038752
+[LabelHysteresis]   hidden-by-collision: Node 28041308
+[LabelHysteresis]   hidden-by-collision: Node 28051670
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28051967
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127323451
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   hidden-by-collision: Area 127453009
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46410 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46407 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46170 E - 51.51686 N 7.46644 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 321 (pcs) 0.014 (s)
+Draw ways: 251 (pcs) 0.009 (s)
+Prepare node labels: 0.006(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1337 visible=1111 prevVisible=952 kept=946 hiddenByCollision=6 notRegistered=0 contoursRegistered=60 prevVisibleContours=23 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 28061292
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46407 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46404 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46167 E - 51.51686 N 7.46641 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 322 (pcs) 0.011 (s)
+Draw ways: 250 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1338 visible=1116 prevVisible=966 kept=964 hiddenByCollision=2 notRegistered=0 contoursRegistered=61 prevVisibleContours=21 lostContours=0
+[LabelHysteresis]   hidden-by-collision: Node 27625058
+[LabelHysteresis]   hidden-by-collision: Area 127329489
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46404 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46401 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46164 E - 51.51686 N 7.46638 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 320 (pcs) 0.011 (s)
+Draw ways: 254 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1336 visible=1113 prevVisible=971 kept=965 hiddenByCollision=4 notRegistered=2 contoursRegistered=61 prevVisibleContours=25 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27610450
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329263
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127441125
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46401 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46398 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46161 E - 51.51686 N 7.46635 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 320 (pcs) 0.012 (s)
+Draw ways: 256 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1336 visible=1111 prevVisible=968 kept=959 hiddenByCollision=8 notRegistered=1 contoursRegistered=61 prevVisibleContours=23 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27626118
+[LabelHysteresis]   hidden-by-collision: Node 27626816
+[LabelHysteresis]   hidden-by-collision: Node 28038981
+[LabelHysteresis]   hidden-by-collision: Node 28039321
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127436525
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329851
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46398 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46395 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46158 E - 51.51686 N 7.46632 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 321 (pcs) 0.014 (s)
+Draw ways: 259 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1338 visible=1119 prevVisible=966 kept=961 hiddenByCollision=5 notRegistered=0 contoursRegistered=61 prevVisibleContours=22 lostContours=0
+[LabelHysteresis]   hidden-by-collision: Node 27614336
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28040487
+[LabelHysteresis]   hidden-by-collision: Node 28053237
+[LabelHysteresis]   hidden-by-collision: Area 127436231
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46395 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46392 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46155 E - 51.51686 N 7.46629 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 322 (pcs) 0.016 (s)
+Draw ways: 256 (pcs) 0.012 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1338 visible=1117 prevVisible=974 kept=967 hiddenByCollision=7 notRegistered=0 contoursRegistered=61 prevVisibleContours=26 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27614060
+[LabelHysteresis]   hidden-by-collision: Node 27614189
+[LabelHysteresis]   hidden-by-collision: Node 28040128
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127435859
+[LabelHysteresis]   hidden-by-collision: Area 127435902
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46392 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46389 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46152 E - 51.51686 N 7.46626 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 324 (pcs) 0.012 (s)
+Draw ways: 256 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1113 prevVisible=972 kept=959 hiddenByCollision=13 notRegistered=0 contoursRegistered=61 prevVisibleContours=25 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27611077
+[LabelHysteresis]   hidden-by-collision: Node 27611090
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27615226
+[LabelHysteresis]   hidden-by-collision: Node 27623153
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 27625885
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46389 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46386 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46149 E - 51.51686 N 7.46623 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 324 (pcs) 0.011 (s)
+Draw ways: 260 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1117 prevVisible=968 kept=959 hiddenByCollision=9 notRegistered=0 contoursRegistered=61 prevVisibleContours=21 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27610879
+[LabelHysteresis]   hidden-by-collision: Node 27610905
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127323347
+[LabelHysteresis]   hidden-by-collision: Area 127323948
+[LabelHysteresis]   hidden-by-collision: Area 127436146
+[LabelHysteresis]   hidden-by-collision: Area 127448508
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46386 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46383 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46146 E - 51.51686 N 7.46620 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.012 (s)
+Draw ways: 262 (pcs) 0.009 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1114 prevVisible=972 kept=959 hiddenByCollision=12 notRegistered=1 contoursRegistered=62 prevVisibleContours=24 lostContours=0
+[LabelHysteresis]   hidden-by-collision: Node 27618214
+[LabelHysteresis]   hidden-by-collision: Node 27618236
+[LabelHysteresis]   hidden-by-collision: Node 27618730
+[LabelHysteresis]   hidden-by-collision: Node 27619314
+[LabelHysteresis]   hidden-by-collision: Node 27619323
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28038714
+[LabelHysteresis]   hidden-by-collision: Node 28041355
+[LabelHysteresis]   hidden-by-collision: Node 28045832
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127442934
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447572
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46383 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46380 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46143 E - 51.51686 N 7.46617 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.012 (s)
+Draw ways: 262 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1119 prevVisible=969 kept=961 hiddenByCollision=8 notRegistered=0 contoursRegistered=62 prevVisibleContours=27 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27594626
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27600307
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[LabelHysteresis]   hidden-by-collision: Area 127457619
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46380 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46377 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46140 E - 51.51686 N 7.46614 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 325 (pcs) 0.013 (s)
+Draw ways: 263 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1342 visible=1120 prevVisible=974 kept=963 hiddenByCollision=11 notRegistered=0 contoursRegistered=62 prevVisibleContours=26 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27605070
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27616155
+[LabelHysteresis]   hidden-by-collision: Node 27616184
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28042939
+[LabelHysteresis]   hidden-by-collision: Node 28049234
+[LabelHysteresis]   hidden-by-collision: Node 28051588
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127436888
+[LabelHysteresis]   hidden-by-collision: Area 127448537
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46377 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46374 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46137 E - 51.51686 N 7.46611 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 322 (pcs) 0.012 (s)
+Draw ways: 265 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1339 visible=1122 prevVisible=975 kept=965 hiddenByCollision=8 notRegistered=2 contoursRegistered=63 prevVisibleContours=24 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27592121
+[LabelHysteresis]   hidden-by-collision: Node 27611242
+[LabelHysteresis]   hidden-by-collision: Node 27611370
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27613991
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623184
+[LabelHysteresis]   hidden-by-collision: Node 27623622
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127328615
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127442934
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46374 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46371 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46134 E - 51.51686 N 7.46608 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.011 (s)
+Draw ways: 267 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1117 prevVisible=977 kept=962 hiddenByCollision=14 notRegistered=1 contoursRegistered=64 prevVisibleContours=27 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27591697
+[LabelHysteresis]   hidden-by-collision: Node 27591803
+[LabelHysteresis]   hidden-by-collision: Node 27591909
+[LabelHysteresis]   hidden-by-collision: Node 27592015
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28050855
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Node 28055132
+[LabelHysteresis]   hidden-by-collision: Area 127319281
+[LabelHysteresis]   hidden-by-collision: Area 127322291
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[LabelHysteresis]   hidden-by-collision: Area 127439824
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127325413
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46371 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46368 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46131 E - 51.51686 N 7.46605 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.011 (s)
+Draw ways: 267 (pcs) 0.008 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1341 visible=1117 prevVisible=972 kept=955 hiddenByCollision=16 notRegistered=1 contoursRegistered=64 prevVisibleContours=27 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27611823
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28038482
+[LabelHysteresis]   hidden-by-collision: Node 28041308
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28051967
+[LabelHysteresis]   hidden-by-collision: Node 28061834
+[LabelHysteresis]   hidden-by-collision: Node 28062080
+[LabelHysteresis]   hidden-by-collision: Area 127318915
+[LabelHysteresis]   hidden-by-collision: Area 127319002
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127319052
+[LabelHysteresis]   hidden-by-collision: Area 127323451
+[LabelHysteresis]   hidden-by-collision: Area 127329462
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127456979
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46368 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46365 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46128 E - 51.51686 N 7.46602 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 323 (pcs) 0.014 (s)
+Draw ways: 267 (pcs) 0.010 (s)
+Draw way contour labels: 78 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1340 visible=1133 prevVisible=972 kept=962 hiddenByCollision=8 notRegistered=2 contoursRegistered=64 prevVisibleContours=28 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27610521
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27623850
+[LabelHysteresis]   hidden-by-collision: Area 127318895
+[LabelHysteresis]   hidden-by-collision: Area 127437758
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447892
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448508
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46365 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46362 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46125 E - 51.51686 N 7.46599 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 321 (pcs) 0.013 (s)
+Draw ways: 271 (pcs) 0.010 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1339 visible=1141 prevVisible=988 kept=986 hiddenByCollision=2 notRegistered=0 contoursRegistered=64 prevVisibleContours=26 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 28043169
+[LabelHysteresis]   hidden-by-collision: Node 28045776
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46362 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46359 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46122 E - 51.51686 N 7.46596 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 317 (pcs) 0.014 (s)
+Draw ways: 271 (pcs) 0.010 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1338 visible=1140 prevVisible=996 kept=990 hiddenByCollision=6 notRegistered=0 contoursRegistered=62 prevVisibleContours=28 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27606899
+[LabelHysteresis]   hidden-by-collision: Node 27608288
+[LabelHysteresis]   hidden-by-collision: Node 27609588
+[LabelHysteresis]   hidden-by-collision: Node 27615954
+[LabelHysteresis]   hidden-by-collision: Node 28043828
+[LabelHysteresis]   hidden-by-collision: Area 127329670
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46359 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46356 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46119 E - 51.51686 N 7.46593 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 313 (pcs) 0.014 (s)
+Draw ways: 270 (pcs) 0.012 (s)
+Draw way contour labels: 74 (pcs) 0.001(s)
+Draw area labels: 313 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1337 visible=1144 prevVisible=995 kept=991 hiddenByCollision=4 notRegistered=0 contoursRegistered=60 prevVisibleContours=27 lostContours=6
+[LabelHysteresis]   hidden-by-collision: Node 27614745
+[LabelHysteresis]   hidden-by-collision: Node 27626118
+[LabelHysteresis]   hidden-by-collision: Node 27626816
+[LabelHysteresis]   hidden-by-collision: Area 127436525
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46356 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46353 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46116 E - 51.51686 N 7.46590 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 314 (pcs) 0.016 (s)
+Draw ways: 270 (pcs) 0.010 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1336 visible=1147 prevVisible=999 kept=991 hiddenByCollision=7 notRegistered=1 contoursRegistered=60 prevVisibleContours=23 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27614336
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28040487
+[LabelHysteresis]   hidden-by-collision: Node 28053237
+[LabelHysteresis]   hidden-by-collision: Node 28054032
+[LabelHysteresis]   hidden-by-collision: Node 28060967
+[LabelHysteresis]   hidden-by-collision: Area 127436231
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127448537
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46353 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46350 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46113 E - 51.51686 N 7.46587 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 314 (pcs) 0.016 (s)
+Draw ways: 272 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1337 visible=1152 prevVisible=1002 kept=997 hiddenByCollision=5 notRegistered=0 contoursRegistered=60 prevVisibleContours=27 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27614060
+[LabelHysteresis]   hidden-by-collision: Node 27614189
+[LabelHysteresis]   hidden-by-collision: Node 28040128
+[LabelHysteresis]   hidden-by-collision: Area 127435859
+[LabelHysteresis]   hidden-by-collision: Area 127435902
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46350 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46347 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46110 E - 51.51686 N 7.46584 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 311 (pcs) 0.012 (s)
+Draw ways: 273 (pcs) 0.009 (s)
+Draw way contour labels: 74 (pcs) 0.001(s)
+Draw area labels: 311 (pcs) 0.001(s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1335 visible=1150 prevVisible=1007 kept=996 hiddenByCollision=9 notRegistered=2 contoursRegistered=60 prevVisibleContours=25 lostContours=5
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Node 27615226
+[LabelHysteresis]   hidden-by-collision: Node 27623153
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 27625691
+[LabelHysteresis]   hidden-by-collision: Node 27625712
+[LabelHysteresis]   hidden-by-collision: Node 27625885
+[LabelHysteresis]   hidden-by-collision: Node 28039472
+[LabelHysteresis]   hidden-by-collision: Node 28059175
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329462
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127457619
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46347 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46344 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46107 E - 51.51686 N 7.46581 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 310 (pcs) 0.015 (s)
+Draw ways: 272 (pcs) 0.012 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1334 visible=1151 prevVisible=1005 kept=996 hiddenByCollision=9 notRegistered=0 contoursRegistered=60 prevVisibleContours=22 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27610428
+[LabelHysteresis]   hidden-by-collision: Node 27610879
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 27623862
+[LabelHysteresis]   hidden-by-collision: Node 28038737
+[LabelHysteresis]   hidden-by-collision: Area 127319022
+[LabelHysteresis]   hidden-by-collision: Area 127323347
+[LabelHysteresis]   hidden-by-collision: Area 127323948
+[LabelHysteresis]   hidden-by-collision: Area 127436146
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46344 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46341 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46104 E - 51.51686 N 7.46578 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 309 (pcs) 0.013 (s)
+Draw ways: 273 (pcs) 0.013 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1334 visible=1153 prevVisible=1006 kept=997 hiddenByCollision=9 notRegistered=0 contoursRegistered=60 prevVisibleContours=25 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27610264
+[LabelHysteresis]   hidden-by-collision: Node 27618214
+[LabelHysteresis]   hidden-by-collision: Node 27618236
+[LabelHysteresis]   hidden-by-collision: Node 27623217
+[LabelHysteresis]   hidden-by-collision: Node 28041355
+[LabelHysteresis]   hidden-by-collision: Node 28045586
+[LabelHysteresis]   hidden-by-collision: Node 28050833
+[LabelHysteresis]   hidden-by-collision: Node 28050917
+[LabelHysteresis]   hidden-by-collision: Area 127321765
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46341 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46338 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46101 E - 51.51686 N 7.46575 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 307 (pcs) 0.016 (s)
+Draw ways: 272 (pcs) 0.010 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1333 visible=1156 prevVisible=1008 kept=1004 hiddenByCollision=4 notRegistered=0 contoursRegistered=58 prevVisibleContours=27 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27608475
+[LabelHysteresis]   hidden-by-collision: Node 27614349
+[LabelHysteresis]   hidden-by-collision: Node 28038618
+[LabelHysteresis]   hidden-by-collision: Area 127435467
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46338 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46335 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46098 E - 51.51686 N 7.46572 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 306 (pcs) 0.013 (s)
+Draw ways: 272 (pcs) 0.011 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1333 visible=1145 prevVisible=1011 kept=995 hiddenByCollision=15 notRegistered=1 contoursRegistered=58 prevVisibleContours=26 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27605070
+[LabelHysteresis]   hidden-by-collision: Node 27613483
+[LabelHysteresis]   hidden-by-collision: Node 27625610
+[LabelHysteresis]   hidden-by-collision: Node 28040574
+[LabelHysteresis]   hidden-by-collision: Node 28042939
+[LabelHysteresis]   hidden-by-collision: Node 28045856
+[LabelHysteresis]   hidden-by-collision: Node 28045875
+[LabelHysteresis]   hidden-by-collision: Node 28047236
+[LabelHysteresis]   hidden-by-collision: Node 28047280
+[LabelHysteresis]   hidden-by-collision: Node 28047299
+[LabelHysteresis]   hidden-by-collision: Node 28047318
+[LabelHysteresis]   hidden-by-collision: Node 28051588
+[LabelHysteresis]   hidden-by-collision: Area 127435327
+[LabelHysteresis]   hidden-by-collision: Area 127436888
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127329429
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46335 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46332 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46095 E - 51.51686 N 7.46569 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 305 (pcs) 0.011 (s)
+Draw ways: 273 (pcs) 0.009 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1333 visible=1149 prevVisible=1000 kept=989 hiddenByCollision=11 notRegistered=0 contoursRegistered=59 prevVisibleContours=24 lostContours=3
+[LabelHysteresis]   hidden-by-collision: Node 27611242
+[LabelHysteresis]   hidden-by-collision: Node 27611370
+[LabelHysteresis]   hidden-by-collision: Node 27613451
+[LabelHysteresis]   hidden-by-collision: Node 27613991
+[LabelHysteresis]   hidden-by-collision: Node 27614968
+[LabelHysteresis]   hidden-by-collision: Node 27623184
+[LabelHysteresis]   hidden-by-collision: Node 27623622
+[LabelHysteresis]   hidden-by-collision: Node 28038714
+[LabelHysteresis]   hidden-by-collision: Node 28045353
+[LabelHysteresis]   hidden-by-collision: Node 28047117
+[LabelHysteresis]   hidden-by-collision: Node 28047127
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46332 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46329 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46092 E - 51.51686 N 7.46566 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 300 (pcs) 0.011 (s)
+Draw ways: 270 (pcs) 0.010 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1331 visible=1157 prevVisible=1004 kept=996 hiddenByCollision=7 notRegistered=1 contoursRegistered=58 prevVisibleContours=25 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27614882
+[LabelHysteresis]   hidden-by-collision: Node 27618298
+[LabelHysteresis]   hidden-by-collision: Node 28047137
+[LabelHysteresis]   hidden-by-collision: Node 28053787
+[LabelHysteresis]   hidden-by-collision: Node 28053900
+[LabelHysteresis]   hidden-by-collision: Area 127322291
+[LabelHysteresis]   hidden-by-collision: Area 127439824
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127443631
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46329 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46326 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46089 E - 51.51686 N 7.46563 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 301 (pcs) 0.011 (s)
+Draw ways: 271 (pcs) 0.010 (s)
+Prepare node labels: 0.005(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1332 visible=1162 prevVisible=1012 kept=1006 hiddenByCollision=6 notRegistered=0 contoursRegistered=59 prevVisibleContours=25 lostContours=2
+[LabelHysteresis]   hidden-by-collision: Node 27611823
+[LabelHysteresis]   hidden-by-collision: Node 27623696
+[LabelHysteresis]   hidden-by-collision: Node 27623739
+[LabelHysteresis]   hidden-by-collision: Node 28041308
+[LabelHysteresis]   hidden-by-collision: Node 28051845
+[LabelHysteresis]   hidden-by-collision: Node 28051967
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46326 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46323 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46086 E - 51.51686 N 7.46560 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 300 (pcs) 0.013 (s)
+Draw ways: 276 (pcs) 0.011 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1330 visible=1164 prevVisible=1017 kept=1010 hiddenByCollision=5 notRegistered=2 contoursRegistered=60 prevVisibleContours=25 lostContours=4
+[LabelHysteresis]   hidden-by-collision: Node 27600194
+[LabelHysteresis]   hidden-by-collision: Node 27600275
+[LabelHysteresis]   hidden-by-collision: Node 27611461
+[LabelHysteresis]   hidden-by-collision: Node 27613878
+[LabelHysteresis]   hidden-by-collision: Area 127437758
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447953
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127447974
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46323 E mag=17 epoch=1
+[PlaneMapRenderer] render: tiles=15 centers=51.51440 N 7.46320 E
+Data: 1190+0 4571 1519
+Database 0:
+Type : boundary_protected_area has 49478 coords (performance limit: 20000)
+Type : boundary_administrative has 106965 coords (performance limit: 20000)
+Type : boundary_county has 119333 coords (performance limit: 20000)
+Type : boundary_state has 41103 coords (performance limit: 20000)
+Draw: [51.51194 N 7.46083 E - 51.51686 N 7.46557 E] 205313x/17 720x1200 100.00000 DPI
+Draw areas: 298 (pcs) 0.012 (s)
+Draw ways: 277 (pcs) 0.010 (s)
+Prepare node labels: 0.004(s)
+[LabelHysteresis] viewport=956x1436+-118+-118 registered=1328 visible=1166 prevVisible=1019 kept=1015 hiddenByCollision=3 notRegistered=1 contoursRegistered=60 prevVisibleContours=23 lostContours=1
+[LabelHysteresis]   hidden-by-collision: Node 27615379
+[LabelHysteresis]   hidden-by-collision: Node 28043169
+[LabelHysteresis]   hidden-by-collision: Area 127443036
+[LabelHysteresis]   not-registered (candidate/data churn): Area 127325242
+[PlaneMapRenderer] swap enter: image=720x1200 center=51.51440 N 7.46320 E mag=17 epoch=1
+[PanHarness] done
+Some resources still acquired by other components

--- a/openspec/changes/label-collision-stability/proposal.md
+++ b/openspec/changes/label-collision-stability/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: Label Collision Stability
+
+## Why
+
+In dense label scenes (city centers), the visibility of fully visible labels changes between renders although the label content on screen is unchanged: every swap of the oversized render canvas in the plane renderer changes the render bounding box and therefore the set of label candidates that take part in collision resolution. The resulting flicker removes the reliability users need for navigation. The defect is reproduced and pinned by the diagnostic test of the change `label-layout-stability-tests` (17 of 63 labels lose visibility when border candidates are added).
+
+## What Changes
+
+- The label layouter resolves collisions in two groups: labels that were visible in the previous layout round claim their space first (within their group ordered by priority), newly arriving candidates are resolved afterwards.
+- The previous-round visibility state is kept per layouter instance across draw calls; a per-draw reset no longer discards it.
+- Labels keep the same visible state as long as the label content does not contradict it (they disappear only when leaving the viewport or when they collide with another previously visible label).
+- The existing diagnostic test for candidate-set growth in the `label-layout-stability-tests` change turns from red to green.
+- No public API signatures change.
+
+## Capabilities
+
+### New Capabilities
+
+- `label-collision-stability`: Conflict resolution behavior of the label layouter: visibility decisions must be stable against candidate-set growth between layout rounds (last-rendered-visible labels keep their space first).
+
+### Modified Capabilities
+
+- `label-layout-stability-tests`: The diagnostic scenario pins the new contract and turns green once the layouter is stable; its expected outcome (defect reproduced, red) changes to stable.
+
+## Impact
+
+- Modified: `libosmscout-map/include/osmscoutmap/LabelLayouter.h` (layout job sorting, previous-round visibility state, documentation of the reset semantics).
+- Modified: `Tests/src/LabelLayouterTest.cpp` (layout session harness for multi-round scenarios, diagnostic test driving two frames through one layouter instance).
+- Behavior of all rendering backends via the shared layouter: visibility decisions gain stickiness for previously visible labels. No signature changes; no backend code changes.
+- Follows `label-layout-stability-tests`, which documents the reproduced defect.

--- a/openspec/changes/label-collision-stability/specs/label-collision-stability/spec.md
+++ b/openspec/changes/label-collision-stability/specs/label-collision-stability/spec.md
@@ -1,0 +1,91 @@
+# Label Collision Stability
+
+## Purpose
+
+Defines the contract for stable label conflict resolution across layout rounds: a label that was visible in the previous round keeps its space first, so that the visibility of labels inside the visible region does not flip when the candidate set changes between renders.
+
+## ADDED Requirements
+
+### Requirement: Previous visibility precedence in collision resolution
+
+The label layouter SHALL resolve collisions in two ordered groups: labels that were visible in the previous layout round are processed before all labels that were not visible in the previous round. Within each group the existing priority ordering applies.
+
+#### Scenario: Previously visible label precedes new candidate
+
+- **GIVEN** a layout ran once and a label L was visible
+- **WHEN** a second layout is executed with the same visible content plus a new candidate N whose rectangle overlaps L's rectangle
+- **THEN** L keeps its visibility and N is hidden (or partially resolved) independent of the priority values of L and N
+
+#### Scenario: New candidates resolve between themselves by priority
+
+- **GIVEN** a layout ran once with labels A and B overlapping (A visible, B hidden)
+- **WHEN** a new label C overlapping B arrives while A stays registered
+- **THEN** the relative order of A and B is unchanged
+- **AND** C is resolved against the space already claimed by previously visible labels and by remaining newcomers by priority
+
+#### Scenario: Previously visible labels survive rasterization jitter
+
+- **GIVEN** two labels laid out in a session whose mask rectangles are adjacent (no overlap) in one round
+- **WHEN** the same scene is laid out again with a fractional position shift under which integer truncation of the mask rectangles produces an overlap of at most 2 pixels
+- **THEN** both labels stay visible in that round
+- **AND** overlaps larger than the tolerance are still resolved by priority
+
+### Requirement: Previous visibility state survives the per-draw reset
+
+The layouter SHALL keep the previous-round visibility state when the layout instances are reset for the next draw, and SHALL refresh it to the visible set of the most recent layout.
+
+#### Scenario: Reset keeps state, next round refreshes it
+
+- **GIVEN** a label L was visible in the last layout
+- **WHEN** the layout results are reset and a new layout is executed in which L is fully inside the viewport
+- **THEN** L is treated as previously visible for the collision resolution of that new round
+
+#### Scenario: Unregistered labels lose their state
+
+- **GIVEN** a label L was visible in the last layout
+- **WHEN** the next layout runs without L registered (it left the viewport or the render request)
+- **THEN** L's previous visibility entry is not carried beyond that round
+- **THEN** the visible set of that layout defines the state for the following round
+
+### Requirement: Rendering uses complete tile data
+
+The plane map renderer SHALL NOT exchange its finished render with a render produced from a partially loaded tile set while a previously finished render exists. Rendering SHALL be retried when more tile data has arrived (tile state change or update timer).
+
+#### Scenario: Tile load churn does not replace the finished render
+
+- **GIVEN** a finished render exists and a new render request is loading its tile data
+- **WHEN** re-rendering is triggered while some requested tiles are still loading
+- **THEN** the finished render stays in place
+- **AND** rendering happens once the load job reports all tiles loaded
+
+#### Scenario: First render works on partial data
+
+- **GIVEN** no finished render exists yet
+- **WHEN** the first render request is triggered while tiles are still loading
+- **THEN** rendering proceeds with the available data (first image must appear quickly)
+
+### Requirement: Deterministic and translation-invariant sticky resolution
+
+The combined first-group/second-group resolution SHALL stay deterministic and translation invariant: the same label scene laid out twice in the same session yields identical results, and panning the scene does not change any visibility decision apart from positions.
+
+#### Scenario: Session stability under pan
+
+- **GIVEN** a session of two layout rounds over the same label set
+- **WHEN** in the second round the viewport and all label points are shifted by a common offset
+- **THEN** the visible label set and the relative positions are identical to the first round
+
+#### Scenario: Repeated rounds are identical
+
+- **GIVEN** a session with identical rounds
+- **WHEN** the same round is executed repeatedly
+- **THEN** every round reports the same visible set and positions
+
+### Requirement: Stability under changed layout candidate set (pinned from label-layout-stability-tests)
+
+In a dense label scene, the visibility of a label inside the visible region SHALL depend only on its own claim and the claims of labels that overlap it, not on label content that merely coexists in the same layout round. Adding further candidates must not flip the visibility of previously resolved, non-overlapping labels.
+
+#### Scenario: Dense scene survives candidate growth
+
+- **GIVEN** a dense 9x7 label grid laid out in a session, and a second round of the same session with additional border labels whose rectangles reach into the visible region
+- **THEN** every label visible after the first round whose rectangle does not overlap any of the added border labels is still visible after the second round
+- **AND** the diagnostic test of the change `label-layout-stability-tests` passes

--- a/openspec/changes/label-collision-stability/tasks.md
+++ b/openspec/changes/label-collision-stability/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Label Collision Stability
+
+Parent spec: `specs/label-collision-stability/spec.md` (capability `label-collision-stability`).
+
+## 1. Layouter implementation
+
+- [x] 1.1 Add previous-round visibility state (`lastVisibleRefs`) to `LabelLayouter`, refresh it at the end of `Layout()`, and keep it across `Reset()` (parent spec: "Previous visibility state survives the per-draw reset"). Verify: file compiles.
+- [x] 1.2 Implement two-group sorting in `LayoutJob::SortLabels()` via a comparator that orders previously visible refs before new candidates, priority inside each group (parent spec: "Previous visibility precedence in collision resolution"). Verify: existing LabelLayouterTest still compiles and passes for fresh-instance scenarios.
+
+## 2. Test updates (existing test program from label-layout-stability-tests)
+
+- [x] 2.1 Add a `LayoutSession` harness (one layouter instance, multiple `Frame()` calls) to `Tests/src/LabelLayouterTest.cpp` mirroring the renderer sequence Layout -> Reset -> next frame. Verify: harness compiles, dummy frame runs.
+- [x] 2.2 Session scenarios: previously visible label precedes new overlapping candidate; state survives reset; unregistered labels lose state (parent spec requirements 1 and 2). Verify: test cases execute.
+- [x] 2.3 Session determinism scenarios: identical rounds, and pan between rounds (parent spec: "Deterministic and translation-invariant sticky resolution"). Verify: test cases green.
+- [x] 2.4 Update the dense-scene diagnostic test of `label-layout-stability-tests` to run its two layouts as two frames of one session. Verify: diagnostic turns green (was red with 17/63 vanished labels).
+
+## 3. Verification of the whole change
+
+- [x] 3.1 Build CMake `build/` and Meson `debug/` without errors and without new warnings in changed files. Verify: clean build output in both systems.
+- [x] 3.2 Run test subset `ctest -R "LabelLayouterTest|ScreenMaskTest"` plus Meson equivalents; all green (parent spec: all scenarios). Verify: ctest and meson test outputs.
+- [x] 3.3 Record outcome in a result summary artifact in this change directory (parent spec traceability and archive guidance). Verify: artifact exists.
+- [x] 3.4 Add gated diagnostics logging (OSMSCOUT_DEBUG_LABEL_HYSTERESIS) for layout rounds and renderer swaps to collect real-world evidence. Verify: log lines appear with the env var set.
+- [x] 3.5 Renderer-side stabilization: PlaneMapRenderer skips renders from partially loaded tile sets while a finished render exists (parent spec: "Rendering uses complete tile data"). Verify: OSMScout2 target compiles; manual retest shows no notRegistered churn spikes.
+- [x] 3.6 Path label hysteresis: previously visible contour labels claim their space before new candidates, with the same 2px jitter tolerance (parent spec: "Previous visibility precedence in collision resolution"). Verify: label suite green.

--- a/openspec/changes/label-collision-stability/tests-result.md
+++ b/openspec/changes/label-collision-stability/tests-result.md
@@ -1,0 +1,119 @@
+# Result Summary
+
+## Round 3b: contour label stickiness + diagnostics v2
+
+Second log round (16:44): hiddenByCollision still 10..47 per round, plus one
+243-spike frame. Street names had no stickiness at all (contour labels were
+resolved in the flat order, glyph jitter toggles winners). Diagnostics v2
+added: per-round contour counters (`contoursRegistered`,
+`prevVisibleContours`, `lostContours`) to attribute the remaining losses.
+
+Changes:
+
+1. Previously visible contour labels (way refs) claim their space in phase 1
+   before the merged newcomer phase, with the same glyph-level 2px jitter
+   tolerance. State kept across Reset(), refreshed by Layout().
+2. Layout diagnostics extended with contour registration/loss counters.
+
+Build/test: label suite green (12 cases / 145 assertions), OSMScout2 rebuilt
+(16:51, both libs fresh).
+
+## Round 3: renderer-side tile churn fix (newest)
+
+Log re-analysis: labels oscillate over rounds (`Node 27611461` hidden in
+rounds 10,13,15,20,29,31,34,36,41) while `registered` jumps by hundreds
+between rounds. The plane renderer re-renders with whatever partial tile
+set has arrived (INITIAL_DATA_RENDERING_TIMEOUT=10ms, per tile change 200ms).
+The candidate set churns -> previously stable group0 membership churns ->
+blockers appear/vanish -> downstream labels flip. Layouter-level hysteresis
+cannot compensate for candidates that are absent from a round.
+
+Fix (design D4 Alternative C, chosen and implemented):
+`PlaneMapRenderer::DrawMap` skips rendering while the load job has not
+finished ALL requested tiles, unless no finished image exists (first render
+still uses partial data). Retry via tile state changes or the update timer.
+Effect: the finished image and its labels stay stable while tiles load; the
+label set is recomputed once per complete tile set.
+
+Spec: new requirement "Rendering uses complete tile data". Task 3.5.
+Build/test: 12 cases / 145 assertions green both systems, warnings baseline,
+OSMScout2 target built.
+
+## Round 2: real-world log analysis (label.txt) and jitter tolerance
+
+Log evidence collected with OSMSCOUT_DEBUG_LABEL_HYSTERESIS=1 (first
+label.txt session):
+
+- `hiddenByCollision` on EVERY round: 29..69 labels (479 total), although
+  collision partners were previously visible and the candidate data was
+  identical between rounds. Cause: mask rectangles are integer truncations
+  of fractional pixel positions; while the map slides the effective
+  distance between adjacent labels jitters by +/-1px and mask overlaps
+  toggle between rounds. Both partners previously visible -> priority
+  decides inside the visible group -> the loser alternates -> flicker.
+- `notRegistered` spikes (294 total): tile data churn (see Round 3).
+
+Fixes added:
+
+1. Hysteresis tolerance (2px): collision check of previously visible
+   labels ignores collisions that vanish when the rectangle is shrunk by
+   2px; real overlaps keep priority resolution.
+2. Phase 0 ordering: previously visible regular labels claim their space
+   before contour labels are processed.
+
+Test suite additions: regression case "previously visible labels survive
+single-pixel mask jitter" (adjacent 100px labels, fractional shifts
+0.8/2.0px, previously flipped, now stable).
+
+## Round 1: synthetic diagnostics (layouter core, first implementation)
+
+Date: 2026-08-29. GCC 13 / Linux, CMake (`build/`) and Meson (`debug/`).
+
+`libosmscout-map/include/osmscoutmap/LabelLayouter.h`:
+
+- `LabelLayouter` keeps `lastVisibleRefs` (object refs visible in the
+  previous layout round). Preserved across `Reset()`, refreshed by every
+  `Layout()`.
+- `LayoutJob` sorting: two-group resolution. Previously visible labels
+  claim their space first (`LabelInstanceSorter`), then all other labels;
+  the `(priority, basemap, ref)` order rules inside each group. Prior
+  behavior: one flat priority order over the whole candidate set.
+
+## Test outcome
+
+`Tests/src/LabelLayouterTest.cpp`: **11 test cases, 134 assertions — all
+pass** on both build systems (ctest + meson test).
+
+| Test case                                              | Result |
+|---------------------------------------------------------|--------|
+| backend-independent execution/result query              | PASS   |
+| determinism (fresh instances, competing labels)         | PASS   |
+| horizontal pan, fully visible labels                    | PASS   |
+| vertical pan, fully visible labels                      | PASS   |
+| sub-pixel pan                                           | PASS   |
+| enlarged viewport, no content outside                   | PASS   |
+| collision winner independent of pan                     | PASS   |
+| **dense scene, candidate growth between frames (was red: 17/63 vanished)** | **PASS** |
+| previously visible label precedes new candidate         | PASS   |
+| session state survives reset, follows last layout       | PASS   |
+| session rounds identical                                | PASS   |
+
+The dense-scene diagnostic now passes: adding 60 border-ring candidates
+(14 overlapping the outermost grid column) no longer removes any of the
+labels visible in the first frame of the session.
+
+## Behavior change (intended trade-offs, see design.md)
+
+- A label visible in the previous round keeps its space against *new*
+  candidates even when the new candidate has a better style priority.
+  It disappears when it leaves the viewport/render set or collides with
+  another previously visible label.
+- Cross-round state lives only in the painter-owned layouter instance;
+  a fresh painter (style reload) starts without hysteresis.
+- Contour (path) labels keep the previous flat resolution (no stickiness).
+
+## Build warnings
+
+Pre-existing baseline unchanged (CMake: 51, Meson: 22 - all in
+`libosmscout-map-opengl` and `libosmscout-client-qt`). Zero warnings in
+changed files.

--- a/openspec/changes/label-collision-stability/worktree-diff-stat.txt
+++ b/openspec/changes/label-collision-stability/worktree-diff-stat.txt
@@ -1,0 +1,12 @@
+ AGENTS.md                                          |   1 +
+ OSMScout2/qml/main.qml                             |  27 +++
+ Tests/CMakeLists.txt                               |   7 +
+ Tests/meson.build                                  |  10 +
+ .../include/osmscoutclientqt/MapWidget.h           |   1 +
+ .../src/osmscoutclientqt/MapRenderer.cpp           |  15 +-
+ .../src/osmscoutclientqt/MapWidget.cpp             |  18 ++
+ .../src/osmscoutclientqt/PlaneMapRenderer.cpp      |  44 ++++
+ .../include/osmscoutmap/LabelLayouter.h            | 241 +++++++++++++++++++--
+ libosmscout-map/include/osmscoutmap/MapPainter.h   |  17 ++
+ libosmscout-map/src/osmscoutmap/MapPainter.cpp     |  68 +++++-
+ 11 files changed, 427 insertions(+), 22 deletions(-)

--- a/openspec/changes/label-layout-stability-tests/.openspec.yaml
+++ b/openspec/changes/label-layout-stability-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/label-layout-stability-tests/design.md
+++ b/openspec/changes/label-layout-stability-tests/design.md
@@ -1,0 +1,99 @@
+# Design: Label Layout Stability Tests
+
+## Context
+
+See proposal.md and specs/label-layout-stability-tests/spec.md.
+
+Relevant existing code:
+
+- `libosmscout-map/include/osmscoutmap/LabelLayouter.h` — class template `LabelLayouter<NativeGlyph, NativeLabel, TextLayouter>`; drives registration (`RegisterLabel`), collision resolution (`Layout()` → `LayoutJob::ProcessLabels`), result access (`Labels()`, `ContourLabels()`), and drawing (`DrawLabels<Painter>`, not needed here).
+- `libosmscout-map/include/osmscoutmap/LabelLayouterHelper.h` — `ScreenMask`/`ScreenRectMask` primitives; collision marking (already unit-tested in `Tests/src/ScreenMaskTest.cpp`, but only at pixel-mask level, not at label level).
+- Label registration needs a `Projection` and `MapParameter` for the text layouter call chain; positions are given directly in pixel coordinates (`Vertex2D`).
+
+Constraint: the test must not instantiate Qt, Cairo, Skia or any other backend, and must not depend on font files or icon directories.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Execute the label layouter end-to-end from label registration to the final visibility/position result, without a rendering backend.
+- Reproducible synthetic label scenes that expose viewport-dependent instability (pan shift, enlarged canvas, sub-pixel shift, collision flip).
+- Test that is fast (pure CPU, no I/O) and portable to all CI platforms.
+
+**Non-Goals:**
+
+- Fixing the layouter or the Qt plane renderer pipeline.
+- Reproducing the full `PlaneMapRenderer` async pipeline (image swap logic is out of scope).
+- Path/contour label layout testing (glyph paths require real font metrics; separate follow-up).
+
+## Decisions
+
+### D1: Daemon-free layouter instantiation with mock text layouter
+
+Implement a minimal `FakeTextLayouter` inside the test that implements the contract documented on `LabelLayouter` (see the template doc-comment in `LabelLayouter.h:610`): `Layout(projection, parameter, text, fontSize, objectWidth, enableWrapping, contourLabel)` returning a `std::shared_ptr<Label<FakeGlyph, FakeLabel>>` with fixed deterministic width/height derived from the text string, and `GlyphBoundingBox()`.
+
+- **Alternative A — reuse an existing backend's text layouter (e.g. `MapPainterNoOp` or the Qt `TextLayouter`)**: rejected; pulls in Qt/font initialization, breaks backend independence, and makes measured widths platform-dependent — tests would not be reproducible across CI machines.
+- **Alternative B — drive a real renderer with pixel comparison of output images**: rejected as an integration-style probe of a different seam; it cannot distinguish layouter instability from drawing instability, and it needs GPU/display resource handling (see existing GUI test infrastructure).
+
+Chosen A/B alternative: custom mock. Deterministic metrics, zero dependencies, and it isolates viewport sensitivity, which lives entirely in `LabelLayouter`.
+
+### D2: Position labels in pixel coordinates via `RegisterLabel`, no map projection math
+
+`RegisterLabel` takes a `Vertex2D` in projection pixel coordinates and the shared code path only forwards it to the text layouter. The test constructs a valid `MercatorProjection` (via `Set()` with a center coordinate, level 10 magnification, 96 DPI, viewport size) and a default-constructed `MapParameter`, then places labels at chosen pixel positions. This mirrors exactly how `MapPainter` base calls the layouter during real renders.
+
+- **Alternative A — emulate painter-side culling and pass geographic coordinates through a real projection**: rejected; the behavior under test (viewport dependence of collision resolution) only depends on pixel geometry, and a real projection would add Mercator rounding noise to the experiment.
+- **Alternative B — test only `ScreenMask` collisions and skip `LabelLayouter`**: rejected; existing `ScreenMaskTest.cpp` already covers mask primitives, but the reported defect operates at the `LayoutJob`/priority level which masks alone cannot capture.
+
+Chosen alternative: direct pixel-coordinate registration with a real (initialized but otherwise unused) projection object.
+
+### D3: Read results through `Labels()` accessor, not a drawing callback
+
+The rule under test is *which labels survive collision resolution*. `LabelLayouter::Labels()` returns `LabelInstanceType` elements with `x`/`y`/`label->width`/`label->height` — fully sufficient to assert visibility (instance present or absent) and positions.
+
+- **Alternative A — implement a counting `Painter` and pass it to `DrawLabels<Painter>()`**: viable, but `DrawLabels` additionally filters by `visibleViewport.Intersects()` at draw time, which would conflate layout-level visibility with the separate draw-time clipping decision. Layout-level assertions are the sharper instrument.
+- **Alternative B — compare intermediate `ScreenMask` canvas state**: rejected; `LayoutJob` internals are local to `Layout()` and not exposed.
+
+Chosen alternative: assert on `Labels()` (sorted, priority-stable), keeping draw-time clipping out of the test.
+
+### D4: Failure policy of the stability assertions
+
+The stability scenarios form the executable specification; if the observed behavior contradicts them today (labels flip when only the viewport shifts), the test failure is the accepted outcome that demonstrates the defect. Failures report the label identity, both viewport origins, and per-run visibility to make flickering reproducible and diagnosable. The tests stay in the suite either way (user decision); they are not skipped or marked `MAY_FAIL`.
+
+- **Alternative A — mark stability checks as "expected failure" until the layouter is fixed**: rejected; per user requirement the tests remain plain, asserting regression coverage stays in place after a fix.
+- **Alternative B — split diagnostics out into a manually-run demo binary**: rejected; CI coverage is the point.
+
+## Flow
+
+```
++----------------+   RegisterLabel()     +--------------------+
+| Test builds    |  for each label,  --> | LabelLayouter      |
+| synthetic set  |  fixed pixel point    | (LabelInstances)   |
++----------------+                       +---------+----------+
+        ^                                          |
+        | SetViewport(V)                           v
+        |                                Layout() -> LayoutJob
+        +---- runs 2..N with ---->       - sort by priority+ref
+             shifted viewport            - greedy ScreenMask filling
+                                                   |
+                                                   v
+                                        Labels() --> assertions:
+                                        visibility x positions per run
+```
+
+## Risks / Trade-offs
+
+- [LabelLayouter internals change (e.g. different padding defaults) → tests break] → Mitigation: assertions compare *two runs of the same code against each other*, not absolute pixel values; only scenario fixtures (positions, sizes, viewport deltas) are fixed.
+- [Single-winning-label scenarios may hide mid-priority resolution quirks] → Mitigation: collision scenario uses a priority distance of 1 (adjacent priorities) to make order resolution observable.
+- [Platform differences in Qt/Catch2 numeric formatting] → Mitigation: all arithmetic is integer pixel math; no floating-point comparisons except positions passed in, which are the test's own inputs.
+- [Mock metrics diverge from real font behavior (no glyph overhang)] → Accepted: the defect class under test is geometric viewport sensitivity, which exists independently of glyph shape. Real-metric follow-up can extend the mock.
+
+## Migration Plan
+
+1. Add `Tests/src/LabelLayouterTest.cpp`, register in `Tests/CMakeLists.txt` and `Tests/meson.build`.
+2. Build via CMake and Meson, run `ctest -R LabelLayouterTest` / `meson test`.
+3. Result interpretation: passing = current layouter stable under the tested shifts (still valuable regression net); failing = reproduction artifact for the flicker defect, to be linked from the follow-up fix change.
+Rollback: delete test file and the two build system registrations; no library code touched.
+
+## Open Questions
+
+None — the layouter can be instantiated without a projection's derived values being meaningful, as verified by reading `LabelLayouter.h` registration/collision paths. If the mock approach hits an unexpected compile-time dependency on a concrete backend, fall back to instantiating the layouter the way `MapPainterNoOp` does.

--- a/openspec/changes/label-layout-stability-tests/proposal.md
+++ b/openspec/changes/label-layout-stability-tests/proposal.md
@@ -1,0 +1,33 @@
+# Proposal: Label Layout Stability Tests
+
+## Why
+
+When panning the visible map area (for example in OSMScout2 with the plane renderer), label visibility flickers: labels that are visible before the pan and again after the pan can disappear during the pan. The label layout result appears to depend on the bounding box of the render request, not only on the map content that is actually visible. There is currently no test that exercises the label layouter directly, so viewport-dependent instability cannot be reproduced, demonstrated, or guarded against by regression tests.
+
+## What Changes
+
+- Add unit tests that drive the label layouter directly with synthetic label data and in-process font metrics, without invoking any drawing backend.
+- The tests check the layout result (which labels are visible, at which positions) for the same fixed set of labels under different layout viewports:
+  - identical viewports (baseline determinism),
+  - horizontally/vertically shifted viewports (simulated panning),
+  - an enlarged layout viewport around an unchanged visible center (simulated oversized render canvases),
+  - sub-pixel shifted viewports (simulated sliding positions with fractional pixel coordinates).
+- The tests are accepted whether they demonstrate the instability or confirm stability; they remain as regression coverage for future layouter work.
+- No library code is modified by this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `label-layout-stability-tests`: Executable specification that label layout results are verifiable without a rendering backend, and defines the required stability properties (determinism, shift invariance for fully visible labels) that the layouter must expose when the same labels are laid out with different viewports.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- New file: `Tests/src/LabelLayouterTest.cpp` (Catch2 test program).
+- Modified: `Tests/CMakeLists.txt` and `Tests/meson.build` (test registration in both build systems).
+- Depends on (read-only, no modification): `libosmscout-map/include/osmscoutmap/LabelLayouter.h` (`LabelLayouter`, `LabelData`, `LabelInstance`, `LabelPriority`), `libosmscout-map/include/osmscoutmap/LabelPath.h`, `libosmscout/include/osmscout/projection` (`MercatorProjection`) and `MapParameter`.
+- No changes to public library API, no changes to any map rendering backend, no changes to the Qt client rendering pipeline.

--- a/openspec/changes/label-layout-stability-tests/specs/label-layout-stability-tests/spec.md
+++ b/openspec/changes/label-layout-stability-tests/specs/label-layout-stability-tests/spec.md
@@ -1,0 +1,84 @@
+# Label Layout Stability Tests
+
+## Purpose
+
+Defines the executable contract for verifying label layout results without any rendering backend: the label layouter must be drivable with synthetic label data and produce verifiable visibility and position results, and equal label content laid out under different layout viewports must expose its stability properties.
+
+## ADDED Requirements
+
+### Requirement: Backend-independent label layout execution
+
+The test suite SHALL be able to execute the label layouter on synthetic label data (labels with type, priority, text and fixed font metrics) without instantiating any rendering backend or drawing any pixels.
+
+#### Scenario: Layout runs without a rendering backend
+
+- **GIVEN** a set of synthetic text labels with registered priorities and a viewport of 800x600 pixels
+- **WHEN** the label layout is executed
+- **THEN** it returns a set of visible labels determined only by label data, priorities, and the viewport
+- **AND** no rendering backend, graphics context, or font rendering subsystem was instantiated
+
+#### Scenario: Layout result is queryable
+
+- **WHEN** the label layout has been executed
+- **THEN** the result reports for each label whether it is visible
+- **AND** for each visible label its top-left pixel position and its measured width and height are available
+
+### Requirement: Deterministic layout for identical inputs
+
+The label layouter SHALL produce identical layout results when the same label set is laid out twice with the same viewport.
+
+#### Scenario: Repeated layout produces identical result
+
+- **GIVEN** a synthetic label set with at least two labels competing for the same space
+- **WHEN** the layout is executed twice with the identical viewport
+- **THEN** both runs report the same set of visible labels with the same positions
+
+### Requirement: Stability of fully visible labels under panning
+
+For a given label set, every label that is fully contained in the visible area in both of two panned viewports SHALL keep its visibility and its map-relative position in both layouts.
+
+#### Scenario: Horizontal pan preserves visible labels
+
+- **GIVEN** a synthetic label set with non-competing labels in the center region and a viewport of 800x600 pixels
+- **WHEN** the layout is executed once with viewport origin (0,0) and once with viewport origin (50,0)
+- **THEN** every label that is fully inside both viewports is reported visible in both runs
+- **AND** each such label's position in the second run equals its position in the first run shifted by exactly (-50, 0)
+
+#### Scenario: Vertical pan preserves visible labels
+
+- **GIVEN** a synthetic label set with non-competing labels in the center region and a viewport of 800x600 pixels
+- **WHEN** the layout is executed once with viewport origin (0,0) and once with viewport origin (0,50)
+- **THEN** every label that is fully inside both viewports is reported visible in both runs
+- **AND** each such label's position in the second run equals its position in the first run shifted by exactly (0, -50)
+
+### Requirement: Stability under enlarged layout viewport
+
+When the layout viewport is enlarged around an unchanged visible center, the layout of labels within the original visible viewport SHALL NOT change if the enlarged viewport introduces no map content other than empty space around the original viewport.
+
+#### Scenario: Enlarged canvas preserves visible labels
+
+- **GIVEN** a synthetic label set placed inside an 800x600 visible viewport with no labels outside that viewport
+- **WHEN** the layout is executed with the 800x600 viewport and again with a 1200x900 viewport centered on the same central point
+- **THEN** all labels fully inside the 800x600 viewport keep their visibility and their positions shifted by the equal central offset
+
+### Requirement: Stability under changed layout candidate set
+
+In a dense label scene, the visibility of a label inside the visible region SHALL depend only on its priority and the labels that overlap it, not on label content that is absent from the layout run. When the layout candidate set is extended without moving any already-present label, labels that were visible in the smaller candidate set and do not overlap any of the newly introduced labels SHALL stay visible.
+
+#### Scenario: Dense scene with additionally available border labels
+
+- **GIVEN** a dense label scene with labels covering an 800x600 visible viewport, and additional labels near the viewport border of a 1600x1200 viewport centered on the same central point, whose rectangles reach into the visible region and overlap labels of the dense scene
+- **WHEN** the layout is executed with the 800x600 viewport over the dense scene alone and again with the 1600x1200 viewport over the extended candidate set
+- **THEN** labels that are visible in the first run, are fully inside the 800x600 viewport, and do not overlap any of the additional labels keep their visibility and their positions apart from the central offset
+- **AND** labels that additionally lose their visibility through the new candidates are reported, so that the number of labels whose visibility changed by the candidate set extension is observable
+
+### Requirement: Stability of competing labels under viewport shift
+
+For a given label set whose labels collide, the winner of a collision SHALL be determined by label priority and shall not flip as a function of the viewport origin.
+
+#### Scenario: Collision winner independent of pan
+
+- **GIVEN** a synthetic label set with two competing labels of distinct priorities, both fully inside two viewports 800x600 that are offset horizontally by 50 pixels
+- **WHEN** the layout is executed for both viewports
+- **THEN** the same label (the one with the higher priority) is reported visible in both runs
+- **AND** the lower-priority label is reported hidden in both runs

--- a/openspec/changes/label-layout-stability-tests/tasks.md
+++ b/openspec/changes/label-layout-stability-tests/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Label Layout Stability Tests
+
+Parent spec: `specs/label-layout-stability-tests/spec.md` (capability `label-layout-stability-tests`).
+
+## 1. Test infrastructure
+
+- [x] 1.1 Create `Tests/src/LabelLayouterTest.cpp` with `FakeTextLayouter` (mock text layouter implementing the `LabelLayouter` contract from design.md D1: fixed deterministic width/height per text, no Qt/fonts) and supporting `FakeGlyph`/`FakeLabel` types. Verify: file compiles standalone together with existing test headers.
+- [x] 1.2 Implement the test harness that builds a synthetic label scene (labels at fixed pixel positions with priorities), constructs an initialized `MercatorProjection` + `MapParameter`, sets up `LabelLayouter` with a viewport (parent spec: "Backend-independent label layout execution", scenario "Layout runs without a rendering backend"), and exposes result inspection (visibility + top-left position + width/height) from `Labels()`. Verify: helper compiles, single dummy scenario runs.
+- [x] 1.3 Register the new test program in `Tests/CMakeLists.txt` and `Tests/meson.build` following existing test registration patterns. Verify: `cmake -B build && cmake --build build` and `meson setup debug && meson compile -C debug` both succeed without errors or warnings.
+
+## 2. Stability scenarios (parent spec requirements)
+
+- [x] 2.1 Determinism test: lay out a competing label set twice with the identical viewport, assert identical visible set and positions (parent spec: "Deterministic layout for identical inputs"). Verify: `ctest -R LabelLayouterTest` executes the case.
+- [x] 2.2 Pan-shift invariance tests: same label set with viewport origin (0,0) vs (50,0) and vs (0,50); assert labels fully inside both viewports keep visibility and shift by exactly the origin delta (parent spec: "Stability of fully visible labels under panning"). Verify: test case green, or documents the defect with per-label visibility report.
+- [x] 2.3 Enlarged-viewport stability test: same label set inside 800x600 with no labels outside, re-layout with 1200x900 canvas centered on the same point; assert unchanged visibility and positions within the original viewport (parent spec: "Stability under enlarged layout viewport"). Verify: test case green, or documents the defect.
+- [x] 2.4 Collision-winner stability test: two competing labels of distinct adjacent priorities offset by 50 px pan; assert the same label stays visible in both runs (parent spec: "Stability of competing labels under viewport shift"). Verify: test case green, or documents the defect with winner report.
+- [x] 2.5 Dense-scene diagnostic: extended candidate set of border labels overlapping a dense label grid; assert labels visible in the smaller candidate set remain visible (parent spec: "Stability under changed layout candidate set"). Verify: test case green, or documents the defect with the number of vanished labels. (Outcome: 17/63 labels vanish — defect reproduced.)
+
+## 3. Verification of whole change
+
+- [x] 3.1 Build CMake `build/` and Meson `debug/` without errors or warnings (per operations guidance). Verify: clean build output in both systems.
+- [x] 3.2 Run existing test suite subset around map painting/layout (`ctest -R "LabelLayouterTest|ScreenMaskTest"`) and confirm no regressions in registered tests. Verify: all green.
+- [x] 3.3 Record observed outcome of the stability scenarios (stable vs. defect reproduced) in the change notes for later reference by the follow-up fix. Verify: artifact file with result summary exists in the change directory.

--- a/openspec/changes/label-layout-stability-tests/tests-result.md
+++ b/openspec/changes/label-layout-stability-tests/tests-result.md
@@ -1,0 +1,79 @@
+# Result Summary
+
+## Observed outcome of the stability scenarios
+
+Dates: 2026-08-29 (initial), 2026-08-29 (dense-scene diagnostic added)
+
+GCC 13 / Linux, CMake (`build/`) and Meson (`debug/`).
+
+### Sparse scenes — all stability properties hold
+
+| Scenario                                   | Result                                        |
+|--------------------------------------------|-----------------------------------------------|
+| Backend-independent execution + result query | PASS                                        |
+| Determinism (identical viewport, competing labels) | PASS                                  |
+| Horizontal pan (50 px), fully visible labels | PASS (visibility + exact position shift)    |
+| Vertical pan (50 px)                        | PASS                                          |
+| Sub-pixel pan (0.5, 0.25 px)                | PASS                                          |
+| Enlarged viewport (800x600 -> 1200x900), same visible center, no content outside | PASS      |
+| Collision winner with distinct priorities under pan | PASS                                 |
+
+### Dense scene diagnostic ("Dortmund center" case) — DEFECT REPRODUCED
+
+Test case: "dense scene visibility is stable when enlarged viewport adds
+off-viewport competitors (diagnostic)".
+
+Scene: 9x7 grid of 120px-wide "ShopNN" labels (63 labels), horizontal
+spacing 70 px -> heavy horizontal overlap, 5 priority classes. Baseline
+layout: 800x600 viewport over the grid alone. Second run: 1600x1200
+viewport, same center, plus 60 additional labels in the border ring, 14
+of which are border-column labels that reach ~60 px into the visible
+region and overlap the first/last grid column.
+
+Result: **17 of 63 labels (27%) lose their visibility** in the second run
+alone by adding border candidates, e.g. `Shop01` (ref Node 1) is visible
+in the baseline run and invisible in the extended run. The failing test
+reports `Labels vanished due to additional border content: 17`.
+
+This reproduces the observed OSMScout2 behavior in Dortmund center: while
+panning, every swap of the oversized render canvas changes the render
+request bounding box and with it the set of label candidates that
+participate in collision resolution. Labels visible before and after a
+pan disappear when the candidate set of the intermediate renders differs,
+and reappear later.
+
+## Interpretation
+
+- The label layouter itself is deterministic and translation-invariant for
+  fixed content (all pan/enlargement without candidate change tests pass).
+- The flicker mechanism lives in the **candidate-set dependence of the
+  greedy collision resolution**: the winner set changes whenever the set
+  of registered labels changes, even if the newly added labels overlap
+  only the outermost visible labels and the label content inside the
+  visible region is otherwise identical. Real renders make this worse,
+  because every image swap has a different stale bounding box (1.5x
+  canvasOverrun), progressively loaded tile data, and derived parameters
+  (e.g. `SetLabelLineFitToWidth(width/1.5)`).
+- Fix direction for a follow-up change: make collision decisions stable
+  against candidate-set growth (e.g. carry previous decisions as
+  constraints, or resolve competitions anchored to map objects instead
+  of per-render canvas runs).
+
+The stability requirement `Stability under changed layout candidate set`
+documents the desired contract; the diagnostic test currently fails
+against it and pins the defect until a follow-up fix change resolves it.
+
+## Follow-up resolution note
+
+2026-08-29: the diagnostic was switched to a multi-frame session harness
+and now passes: the change `label-collision-stability` implemented
+visible-label hysteresis in `LabelLayouter` (`lastVisibleRefs`, two-group
+collision resolution). All 11 test cases pass on both build systems; see
+`openspec/changes/label-collision-stability/tests-result.md`.
+
+## Build warnings (pre-existing, unrelated to this change)
+
+- `libosmscout-map-opengl/src/osmscoutmapopengl/MapPainterOpenGL.cpp:464` unused variable `lineOffset`
+- `libosmscout-client-qt/src/osmscoutclientqt/MapWidget.cpp` several deprecated Qt touch/hover APIs and enum mismatches
+
+New code in this change builds warning-free on both build systems.


### PR DESCRIPTION
- AI did analyse and reproduce the problem
- AI did start some actions to avoid flicker
- AI claims to have reduced flicker but not completely fixed it
- No code review or impact analysis has happend up to now by human
- AI: glm-3.8-flash + openspec
- AI is burning tokens as hell, so we snapshot and return later...