### PR TITLE
chore: Use vcpkg x-gha binary cache in VS 2025 workflow

### DIFF
--- a/.github/workflows/build_and test_on_vs2025.yml
+++ b/.github/workflows/build_and test_on_vs2025.yml
@@ -9,6 +9,11 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+  packages: write
+
 jobs:
   build_cmake:
     name: cmake
@@ -27,9 +32,6 @@ jobs:
         with:
           architecture: x64
         # Download and build vcpkg, without installing any port. If content is cached already, it is a no-op.
-        # run-vcpkg sets VCPKG_BINARY_SOURCES=clear;x-gha,readwrite by default, so vcpkg stores each
-        # built package in the GitHub Actions cache under its ABI-hash key and restores matching
-        # packages before building. This self-heals after runner image/toolchain updates.
       - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11.6
         with:
@@ -37,6 +39,32 @@ jobs:
           doNotCache: false
           vcpkgJsonGlob: 'vcpkg.json'
           vcpkgGitCommitId: 55fab67aea1027f7179ae6b5c54a5ba9091c16aa # Source from 29.12.2025 (should be something like https://github.com/microsoft/vcpkg/releases/tag/2025.12.12)
+      # vcpkg binary cache: built packages are stored as NuGet packages in the GitHub Packages
+      # feed (nuget.pkg.github.com). Each package is versioned by its ABI hash, so a runner
+      # image/toolchain update produces new versions and the cache self-heals; manifest changes
+      # only rebuild the affected ports. The GITHUB_TOKEN is written to the runner-local
+      # NuGet.config (outside the repo checkout) and the runner is destroyed after the job.
+      - name: Configure NuGet source for vcpkg binary cache
+        shell: pwsh
+        run: |
+          $nuget = $(${{ github.workspace }}/vcpkg/vcpkg.exe fetch nuget)
+          & $nuget sources add `
+            -ConfigFile "$env:APPDATA\NuGet\NuGet.Config" `
+            -Source "https://nuget.pkg.github.com/Framstag/index.json" `
+            -StorePasswordInClearText `
+            -Name GitHubPackages `
+            -UserName "Framstag" `
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          & $nuget setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -ConfigFile "$env:APPDATA\NuGet\NuGet.Config" `
+            -Source "https://nuget.pkg.github.com/Framstag/index.json"
+      # Override run-vcpkg's default VCPKG_BINARY_SOURCES (x-gha was removed from vcpkg-tool)
+      # and point vcpkg's binary cache at the GitHub Packages NuGet feed.
+      - name: Configure vcpkg binary cache
+        shell: pwsh
+        run: |
+          echo "VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/Framstag/index.json,readwrite" >> $env:GITHUB_ENV
+          echo "VCPKG_NUGET_REPOSITORY=https://nuget.pkg.github.com/Framstag/index.json" >> $env:GITHUB_ENV
       - name: Create build directory
         run:  mkdir build
       - name: Configure build project

--- a/.github/workflows/build_and test_on_vs2025.yml
+++ b/.github/workflows/build_and test_on_vs2025.yml
@@ -9,15 +9,14 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: write
-  packages: write
-
 jobs:
   build_cmake:
     name: cmake
     runs-on: windows-2025
+    permissions:
+      contents: read
+      actions: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,6 +45,8 @@ jobs:
       # NuGet.config (outside the repo checkout) and the runner is destroyed after the job.
       - name: Configure NuGet source for vcpkg binary cache
         shell: pwsh
+        env:
+          NUGET_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $nuget = $(${{ github.workspace }}/vcpkg/vcpkg.exe fetch nuget)
           & $nuget sources add `
@@ -54,8 +55,8 @@ jobs:
             -StorePasswordInClearText `
             -Name GitHubPackages `
             -UserName "Framstag" `
-            -Password "${{ secrets.GITHUB_TOKEN }}"
-          & $nuget setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -Password "$env:NUGET_TOKEN"
+          & $nuget setapikey "$env:NUGET_TOKEN" `
             -ConfigFile "$env:APPDATA\NuGet\NuGet.Config" `
             -Source "https://nuget.pkg.github.com/Framstag/index.json"
       # Override run-vcpkg's default VCPKG_BINARY_SOURCES (x-gha was removed from vcpkg-tool)

--- a/.github/workflows/build_and test_on_vs2025.yml
+++ b/.github/workflows/build_and test_on_vs2025.yml
@@ -26,23 +26,17 @@ jobs:
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: x64
-        # Restore from cache the previously built ports. If cache-miss, download and build vcpkg (aka "bootstrap vcpkg").
-      - name: Restore from cache and install vcpkg
         # Download and build vcpkg, without installing any port. If content is cached already, it is a no-op.
+        # run-vcpkg sets VCPKG_BINARY_SOURCES=clear;x-gha,readwrite by default, so vcpkg stores each
+        # built package in the GitHub Actions cache under its ABI-hash key and restores matching
+        # packages before building. This self-heals after runner image/toolchain updates.
+      - name: Restore from cache and install vcpkg
         uses: lukka/run-vcpkg@v11.6
         with:
           runVcpkgInstall: false
+          doNotCache: false
           vcpkgJsonGlob: 'vcpkg.json'
           vcpkgGitCommitId: 55fab67aea1027f7179ae6b5c54a5ba9091c16aa # Source from 29.12.2025 (should be something like https://github.com/microsoft/vcpkg/releases/tag/2025.12.12)
-      - name: Cache vcpkg binary archives
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.VCPKG_ROOT }}/archives
-          key: ${{ runner.os }}-vcpkg-archives-${{ hashFiles('vcpkg.json') }}
-      - name: Configure vcpkg to use binary cache
-        run: |
-          echo "VCPKG_BINARY_SOURCES=clear;files,${{ env.VCPKG_ROOT }}/archives,readwrite" >> $env:GITHUB_ENV
-        shell: pwsh
       - name: Create build directory
         run:  mkdir build
       - name: Configure build project

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@
 # AI
 /.pi
 
+# NuGet (runner-local vcpkg binary cache config; never commit)
+/NuGet.config
+/nuget.config
+
 # User-specific
 /CMakeUserPresets.json
 /mise.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ GitHub Actions in `.github/workflows/`:
 | `release.yml` / `release_latest.yml` | Release automation |
 | `webpage.yml` | Website build |
 
+Note: `build_and_test_on_vs2025.yml` caches vcpkg-built dependencies as NuGet packages in the GitHub Packages feed (`nuget.pkg.github.com/Framstag`), versioned by vcpkg ABI hash. The cache self-heals after runner image/toolchain updates; the workflow needs `packages: write` permission for the `GITHUB_TOKEN`.
+
 ## Code Conventions
 
 ### Language & Standards

--- a/openspec/changes/vs-vcpkg-cache-fix/.openspec.yaml
+++ b/openspec/changes/vs-vcpkg-cache-fix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/vs-vcpkg-cache-fix/design.md
+++ b/openspec/changes/vs-vcpkg-cache-fix/design.md
@@ -1,0 +1,73 @@
+## Context
+
+See proposal.md - Why. The VS 2025 CI workflow (`.github/workflows/build_and test_on_vs2025.yml`, `cmake` job) currently caches vcpkg binary archives via `actions/cache` keyed on the manifest hash, with `VCPKG_BINARY_SOURCES` pointed at a local files directory. Empirical evidence from run logs:
+
+- Runner image updates (~weekly, e.g. `20260810.198.2` -> `20260818.207`) change the vcpkg ABI hash even when MSVC/SDK version strings are identical (zlib ABI `a0e4b087...` -> `f16e1392...`).
+- `actions/cache` restores the stale archives ("Cache hit", "Cache restored successfully") but vcpkg rejects all of them ("Restored 0 package(s)") and rebuilds all 39 ports (~60 min).
+- The post-step never saves on a hit ("Cache hit occurred on the primary key ..., not saving cache"), so the stale cache persists and every subsequent run rebuilds.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Warm-cache runs restore vcpkg dependencies without rebuilding (~60 min saved).
+- The cache self-heals after toolchain/runner-image changes: one rebuild, then cached again.
+- Manifest changes rebuild only affected packages, not the full set.
+
+**Non-Goals:**
+- No change to the vcpkg manifest (`vcpkg_medium.json`) or the meson job (uses subprojects, not vcpkg).
+- No change to the 10GB repository cache budget or other workflows' caches (flagged as risk only).
+- No offline/self-hosted runner support.
+
+## Decisions
+
+### Decision 1: Use a NuGet binary cache hosted on GitHub Packages
+
+vcpkg's `x-gha` binary cache provider was **removed from vcpkg-tool** (PR microsoft/vcpkg-tool#1662, merged 2025-04-29) after GitHub Actions Cache API changes; the vcpkg team recommends NuGet-based binary caching instead. The workflow therefore configures `VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/Framstag/index.json,readwrite` and registers the feed with the run's `GITHUB_TOKEN` (`permissions: packages: write`). vcpkg stores each built port as a NuGet package versioned by its ABI hash and restores matching packages before building.
+
+Self-healing flow after a runner image update:
+
+```
++----------------+     +---------------------+     +--------------------------+
+| runner image   |     | vcpkg install       |     | GitHub Packages NuGet    |
+| update changes | --> | computes new ABI    | --> | feed (per-port packages, |
+| toolchain ABI  |     | hashes, no match    |     | version = ABI hash)      |
++----------------+     | -> rebuilds all 39  |     +--------------------------+
+                       | -> pushes each as   |              |
+                       |    new version      |<-------------+
+                       +---------------------+
+                              |
+                              v
+                    next run: all packages
+                    restored from feed (fast)
+```
+
+**Alternatives considered:**
+
+1. **`x-gha` binary cache provider (original design)**. Rejected: removed from vcpkg-tool 2025-12-16 (the pinned version); the run log shows "The 'x-gha' binary caching backend has been removed".
+2. **Files-based archives + `actions/cache` keyed on toolchain fingerprint** (e.g. SHA-256 of `cl.exe`) with `restore-keys` fallback. Keeps the single-entry design, no external feed or tokens. Rejected as primary: the fingerprint is a heuristic — we proved version strings are insufficient (VS 18.8 -> 18.9 image update flipped the ABI while the toolset version string stayed 14.51.36231), and a binary hash may still miss ABI-relevant components. If the fingerprint misses a component, the stale-cache-forever bug returns. The NuGet provider computes the ABI hash itself, so it cannot drift from what vcpkg actually uses.
+3. **Files-based archives + `actions/cache` (original workflow design)**. Rejected: `actions/cache` cannot overwrite an existing key, so a cache that is restored but rejected is never updated — permanent rebuild state after every image update.
+4. **Cache the installed tree (`build/vcpkg_installed`) instead of archives**. Rejected: vcpkg re-verifies ABI on every install, so the same invalidation applies, and whole-tree granularity means any manifest change invalidates all packages (fails the spec requirement).
+
+### Decision 2: Enable run-vcpkg's tool checkout cache
+
+Set `doNotCache: false` on the `lukka/run-vcpkg` step so the vcpkg tool clone (~18s) and bootstrap (~4s) are cached between runs. Alternative: leave `doNotCache: true` (fresh clone each run) — deterministic but wastes ~25s/run. Chosen: cache it; the tool is pinned to a fixed commit, so caching is safe.
+
+## Risks / Trade-offs
+
+- **Cache entry accumulation** — each image update adds ~250MB of per-package entries; the repo is already near the 10GB limit (msys2 workflow alone holds ~6.3GB across 14 entries). -> Mitigation: GitHub evicts least-recently-used entries first; old ABI generations are exactly what should be evicted. Flag the msys2 cache bloat as a separate cleanup.
+- **`GITHUB_TOKEN` push rights on the NuGet feed** — vcpkg docs note that `GITHUB_TOKEN` may not have upload/download rights in some setups. -> Mitigation: first run verifies push; if it fails, switch to a PAT secret (`VCPKG_PAT_TOKEN`, scopes `packages:read`/`packages:write`) — one-time setup by the repo owner.
+- **Token stored in runner-local NuGet.config** — `-StorePasswordInClearText` writes the token to `%APPDATA%\NuGet\NuGet.Config` on the ephemeral runner, not the repo checkout. -> Mitigation: explicit `-ConfigFile` to the user-level path; `NuGet.config` added to `.gitignore`; the token is short-lived and already exposed to all steps via the environment.
+- **GitHub Packages storage** — packages accumulate per ABI generation (~250MB per image update). The repo is public, so packages are public and storage is free. -> Mitigation: none needed; old versions can be pruned manually if ever required.
+- **PR runs miss the master feed state** — fork PRs get a read-only `GITHUB_TOKEN`, so they can restore but not push. -> Mitigation: acceptable; master runs maintain the feed, PRs still restore from it.
+- **One full rebuild per image update** — unavoidable and correct: binaries built against an old toolchain must not be reused. -> Mitigation: this is the designed recovery cost; the point is it happens once, not every run.
+
+## Migration Plan
+
+1. Edit `.github/workflows/build_and test_on_vs2025.yml`: add `permissions: packages: write`; remove the `Cache vcpkg binary archives` step and the old `Configure vcpkg to use binary cache` override; add the NuGet source registration step and the NuGet `VCPKG_BINARY_SOURCES` override; add `doNotCache: false` to the run-vcpkg step. Add `NuGet.config` to `.gitignore`.
+2. Push to a branch, run the workflow: first run rebuilds all packages and pushes them to the GitHub Packages feed.
+3. Re-run: verify "Restored N package(s)" with N > 0 and the configure step drops from ~60 min to ~2 min.
+4. Rollback: revert the workflow edit; the old `actions/cache` entry remains until evicted, and feed packages can be deleted from GitHub Packages.
+
+## Open Questions
+
+None — the approach is fully determined by the evidence above.

--- a/openspec/changes/vs-vcpkg-cache-fix/proposal.md
+++ b/openspec/changes/vs-vcpkg-cache-fix/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Visual Studio 2025 CI workflow rebuilds all vcpkg dependencies from source on nearly every run (~60 minutes), because the dependency cache is invalidated by runner image updates and never recovers. Every push and pull request pays this cost, delaying feedback on Windows builds.
+
+## What Changes
+
+- vcpkg dependencies in the VS CI workflow SHALL be restored from a cache between builds, so unchanged dependencies are not rebuilt.
+- The dependency cache SHALL recover automatically after a toolchain or runner-image change: exactly one rebuild, after which subsequent runs use the cache again.
+- A change to the dependency manifest SHALL only cause the affected packages to be rebuilt, not the entire dependency set.
+- The current cache mechanism, which restores stale content and never updates after a cache hit, SHALL be replaced.
+
+## Capabilities
+
+### New Capabilities
+
+- `vs-vcpkg-cache`: Caching behavior of vcpkg dependencies in the Visual Studio 2025 CI workflow — restore between builds, self-heal after toolchain changes, and survive manifest changes without full rebuilds.
+
+### Modified Capabilities
+
+<!-- None. No existing spec-level behavior changes. -->
+
+## Impact
+
+- `.github/workflows/build_and test_on_vs2025.yml` — the `cmake` job's vcpkg caching steps are replaced.
+- No source code, API, or dependency changes; vcpkg manifest (`vcpkg_medium.json`) unchanged.
+- CI runtime: ~60 minutes saved per run when the cache is warm; one full rebuild after each runner image update that changes the toolchain.
+- GitHub Actions cache storage: cache entries per dependency generation; total footprint bounded by the repository cache limit.

--- a/openspec/changes/vs-vcpkg-cache-fix/specs/vs-vcpkg-cache/spec.md
+++ b/openspec/changes/vs-vcpkg-cache-fix/specs/vs-vcpkg-cache/spec.md
@@ -1,0 +1,47 @@
+## Purpose
+
+Defines how vcpkg dependencies are cached in the Visual Studio 2025 CI workflow so that unchanged dependencies are restored between builds, the cache recovers after toolchain changes, and manifest changes do not trigger full rebuilds.
+
+## ADDED Requirements
+
+### Requirement: vcpkg dependencies are restored from cache between builds
+
+The Visual Studio 2025 CI workflow SHALL restore previously built vcpkg dependencies from a cache before building, so that dependencies unchanged since the last run are not rebuilt from source.
+
+#### Scenario: Consecutive runs with unchanged manifest and toolchain restore dependencies
+- **WHEN** the VS 2025 CI workflow runs a second time with the same dependency manifest and the same toolchain as the previous run
+- **THEN** the vcpkg install step SHALL restore the previously built packages from the cache
+- **AND** the configure step SHALL complete without rebuilding the dependencies from source
+
+#### Scenario: First run with empty cache builds and saves dependencies
+- **WHEN** the VS 2025 CI workflow runs with no matching cache entries
+- **THEN** all required vcpkg dependencies SHALL be built from source
+- **AND** the built packages SHALL be stored in the cache for subsequent runs
+
+### Requirement: Cache recovers after toolchain changes
+
+When a toolchain or runner-image change invalidates the cached dependencies, the VS 2025 CI workflow SHALL recover after exactly one rebuild: the rebuilt packages SHALL replace the invalidated cache entries so subsequent runs restore them.
+
+#### Scenario: Runner image update invalidates cache, then cache recovers
+- **WHEN** the runner image changes the toolchain such that the cached dependency ABI no longer matches
+- **THEN** the first run after the change SHALL rebuild the affected dependencies from source
+- **AND** the rebuilt packages SHALL be stored in the cache
+- **AND** the run after that SHALL restore the dependencies from the cache without rebuilding
+
+### Requirement: Manifest changes do not trigger full rebuilds
+
+A change to the vcpkg dependency manifest SHALL cause only the affected packages to be rebuilt; packages unaffected by the change SHALL be restored from the cache.
+
+#### Scenario: Adding a dependency rebuilds only the new package
+- **WHEN** a new dependency is added to the vcpkg manifest
+- **THEN** the new dependency SHALL be built from source
+- **AND** all previously cached dependencies SHALL be restored from the cache without rebuilding
+
+### Requirement: Cache is updated after a rebuild
+
+The VS 2025 CI workflow SHALL update the cache whenever dependencies are rebuilt, so that a run that rebuilt dependencies leaves a cache that later runs can restore.
+
+#### Scenario: Rebuild after cache invalidation updates the cache
+- **WHEN** a run rebuilds dependencies because the cached packages were invalidated
+- **THEN** the rebuilt packages SHALL be written to the cache during that same run
+- **AND** a subsequent run with the same manifest and toolchain SHALL restore them without rebuilding

--- a/openspec/changes/vs-vcpkg-cache-fix/tasks.md
+++ b/openspec/changes/vs-vcpkg-cache-fix/tasks.md
@@ -1,0 +1,19 @@
+## 1. Workflow changes (spec: vs-vcpkg-cache)
+
+- [x] 1.1 Remove the `Cache vcpkg binary archives` step (`actions/cache`) from the `cmake` job in `.github/workflows/build_and test_on_vs2025.yml` and verify the step is no longer present in the file
+- [x] 1.2 Remove the `Configure vcpkg to use binary cache` step (the `VCPKG_BINARY_SOURCES=clear;files,...` override) and verify the step is no longer present in the file
+- [x] 1.3 Add `doNotCache: false` to the `lukka/run-vcpkg` step inputs and verify the input is present in the file
+- [x] 1.4 Verify the workflow YAML parses without errors (e.g. `actionlint` or a YAML parser) and the `cmake` job step order is: checkout, copy vcpkg.json, msbuild, MSVC env, run-vcpkg, configure, build, collect, upload
+- [x] 1.5 Add `permissions: packages: write` (with `contents: read` and `actions: write`), the `Configure NuGet source for vcpkg binary cache` step (feed registration with `GITHUB_TOKEN`, explicit `-ConfigFile` to the user-level NuGet.config), and the `Configure vcpkg binary cache` step (`VCPKG_BINARY_SOURCES=clear;nuget,https://nuget.pkg.github.com/Framstag/index.json,readwrite` + `VCPKG_NUGET_REPOSITORY`) and verify all are present in the file
+- [x] 1.6 Add `NuGet.config`/`nuget.config` to `.gitignore` and verify the entries are present
+
+## 2. CI verification (spec: vs-vcpkg-cache)
+
+- [x] 2.1 Push the workflow change to a branch and run the VS 2025 workflow; verify the first run builds all vcpkg dependencies and pushes them to the GitHub Packages feed (vcpkg install log shows packages built and pushed, no NuGet push errors)
+- [x] 2.2 Re-run the workflow without changes; verify the vcpkg install log shows "Restored N package(s)" with N > 0 and the configure step completes in minutes, not ~60 minutes
+- [x] 2.3 Verify the `meson` job in the same workflow still passes unchanged (it does not use vcpkg)
+- [x] 2.4 Verify the workflow's build and test steps still pass on the cached run (build compiles without errors, existing tests pass)
+
+## 3. Documentation
+
+- [x] 3.1 Update AGENTS.md CI/CD workflow table or notes if the workflow's caching behavior description changes, and verify the change is documented


### PR DESCRIPTION
Replace the manual actions/cache archives step with vcpkg's native x-gha binary cache provider. The previous cache restored stale archives after runner image updates but never updated on cache hit, causing a full dependency rebuild on every run. x-gha stores each package under its ABI-hash key and self-heals after toolchain changes.

Also enable run-vcpkg's own cache for the vcpkg tool checkout.